### PR TITLE
feat(group): notify group avatar changes

### DIFF
--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -707,6 +707,7 @@ func (g *Group) avatarPalette(c *wkhttp.Context) {
 
 func (g *Group) avatarUpload(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
+	loginName := c.GetLoginName()
 	groupNo := c.Param("group_no")
 	if groupNo == "" {
 		respondGroupRequestInvalid(c, "group_no")
@@ -763,21 +764,19 @@ func (g *Group) avatarUpload(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrGroupStoreFailed, nil, nil)
 		return
 	}
-	// 发送群头像更新命令
-	err = g.ctx.SendCMD(config.MsgCMDReq{
+	// 落库已成功：系统消息与 CMD 都是 best-effort，失败不能让客户端重传已成功的上传。
+	if err := sendGroupAvatarChangedMessage(g.ctx, groupNo, loginUID, loginName); err != nil {
+		g.Error("发送群头像变更系统消息失败！", zap.String("groupNo", groupNo), zap.Error(err))
+	}
+	if err := g.ctx.SendCMD(config.MsgCMDReq{
 		ChannelID:   groupNo,
 		ChannelType: common.ChannelTypeGroup.Uint8(),
 		CMD:         common.CMDGroupAvatarUpdate,
 		Param: map[string]interface{}{
 			"group_no": groupNo,
 		},
-	})
-	if err != nil {
+	}); err != nil {
 		g.Error("发送群头像更新命令失败！", zap.String("groupNo", groupNo), zap.Error(err))
-		// The avatar object and DB version are already committed; the IM
-		// notification is best-effort so clients do not retry a successful upload.
-		c.ResponseOK()
-		return
 	}
 	c.ResponseOK()
 }

--- a/modules/group/avatar_notify.go
+++ b/modules/group/avatar_notify.go
@@ -1,0 +1,39 @@
+package group
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+)
+
+// sendGroupAvatarChangedMessage 在群头像实际变更后发一条与改名同款的系统消息。
+//
+// 文案走 GroupUpdate(1005) + "{0}修改了群头像" + extra 操作者，客户端 SystemCell
+// 会把 {0} 替换成 extra[0].name，呈现为「XXX修改了群头像」。不改 octo-lib 的
+// SendGroupUpdate：那边没有 avatar 分支，未知 attr 只会发出 "{0}"（只有用户名、
+// 没有动作文案）。CMD groupAvatarUpdate / channelUpdate 仍负责即时刷头像，本消息
+// 只进会话历史。best-effort：调用方在落库成功后发送，失败只打日志。
+func sendGroupAvatarChangedMessage(ctx *config.Context, groupNo, operatorUID, operatorName string) error {
+	if ctx == nil || groupNo == "" {
+		return nil
+	}
+	return ctx.SendMessage(&config.MsgSendReq{
+		Header: config.MsgHeader{
+			NoPersist: 0,
+			RedDot:    1,
+			SyncOnce:  0,
+		},
+		ChannelID:   groupNo,
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		Payload: []byte(util.ToJson(map[string]interface{}{
+			"content": "{0}修改了群头像",
+			"extra": []config.UserBaseVo{
+				{
+					UID:  operatorUID,
+					Name: operatorName,
+				},
+			},
+			"type": common.GroupUpdate,
+		})),
+	})
+}

--- a/modules/group/avatar_notify_test.go
+++ b/modules/group/avatar_notify_test.go
@@ -1,0 +1,279 @@
+package group
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/stretchr/testify/require"
+)
+
+type imCapture struct {
+	mu       sync.Mutex
+	messages []capturedIMMessage
+	server   *httptest.Server
+}
+
+type capturedIMMessage struct {
+	request config.MsgSendReq
+	payload map[string]any
+}
+
+func startIMCapture(t *testing.T, ctx *config.Context) *imCapture {
+	t.Helper()
+	cap := &imCapture{}
+	cap.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req config.MsgSendReq
+		_ = json.Unmarshal(body, &req)
+		var payload map[string]any
+		_ = json.Unmarshal(req.Payload, &payload)
+		cap.mu.Lock()
+		cap.messages = append(cap.messages, capturedIMMessage{request: req, payload: payload})
+		cap.mu.Unlock()
+		_, _ = w.Write([]byte(`{"data":{"message_id":1,"message_seq":1,"client_msg_no":"ok"}}`))
+	}))
+	t.Cleanup(cap.server.Close)
+	ctx.GetConfig().WuKongIM.APIURL = cap.server.URL
+	return cap
+}
+
+func (c *imCapture) findAvatarChanged() map[string]any {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, message := range c.messages {
+		content, _ := message.payload["content"].(string)
+		if content == "{0}修改了群头像" {
+			return message.payload
+		}
+	}
+	return nil
+}
+
+func (c *imCapture) findAvatarChangedRequest() *config.MsgSendReq {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, message := range c.messages {
+		content, _ := message.payload["content"].(string)
+		if content == "{0}修改了群头像" {
+			return &message.request
+		}
+	}
+	return nil
+}
+
+func (c *imCapture) countAvatarChanged() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := 0
+	for _, message := range c.messages {
+		content, _ := message.payload["content"].(string)
+		if content == "{0}修改了群头像" {
+			n++
+		}
+	}
+	return n
+}
+
+func newAvatarNotifyContext(t *testing.T) *config.Context {
+	t.Helper()
+	cfg := config.New()
+	cfg.Test = true
+	cfg.EventPoolSize = 1
+	cfg.Push.PushPoolSize = 1
+	return config.NewContext(cfg)
+}
+
+func TestSendGroupAvatarChangedMessagePayload(t *testing.T) {
+	ctx := newAvatarNotifyContext(t)
+	cap := startIMCapture(t, ctx)
+
+	require.NoError(t, sendGroupAvatarChangedMessage(ctx, "g_avatar_tip", "u_op", "Alice"))
+	payload := cap.findAvatarChanged()
+	require.NotNil(t, payload, "should send GroupUpdate system message")
+	require.Equal(t, "{0}修改了群头像", payload["content"])
+	require.Equal(t, float64(common.GroupUpdate), payload["type"])
+	extra, ok := payload["extra"].([]any)
+	require.True(t, ok)
+	require.Len(t, extra, 1)
+	op, ok := extra[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "u_op", op["uid"])
+	require.Equal(t, "Alice", op["name"])
+	request := cap.findAvatarChangedRequest()
+	require.NotNil(t, request)
+	require.Equal(t, "g_avatar_tip", request.ChannelID)
+	require.Equal(t, common.ChannelTypeGroup.Uint8(), request.ChannelType)
+	require.Equal(t, 1, request.Header.RedDot)
+}
+
+func TestSendGroupAvatarChangedMessageNoop(t *testing.T) {
+	ctx := newAvatarNotifyContext(t)
+	cap := startIMCapture(t, ctx)
+	require.NoError(t, sendGroupAvatarChangedMessage(nil, "g_avatar_tip", "u_op", "Alice"))
+	require.NoError(t, sendGroupAvatarChangedMessage(ctx, "", "u_op", "Alice"))
+	require.Equal(t, 0, cap.countAvatarChanged())
+}
+
+func TestGroupUpdateAvatarCustomSendsSystemMessage(t *testing.T) {
+	_, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	g := New(ctx)
+	cap := startIMCapture(t, ctx)
+	r := newAvatarNotifyGroupUpdateRouter(t, ctx, g)
+
+	const groupNo = "avatar_tip_custom"
+	seedCreatorGroup(t, g, groupNo, "原始群名")
+
+	w := putGroupUpdate(t, r, groupNo, map[string]string{
+		attrKeyAvatarText:  "研发",
+		attrKeyAvatarColor: "5",
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	payload := cap.findAvatarChanged()
+	require.NotNil(t, payload, "custom avatar save should emit 修改了群头像")
+	require.Equal(t, float64(common.GroupUpdate), payload["type"])
+	request := cap.findAvatarChangedRequest()
+	require.NotNil(t, request)
+	require.Equal(t, groupNo, request.ChannelID)
+	require.Equal(t, common.ChannelTypeGroup.Uint8(), request.ChannelType)
+	require.Equal(t, 1, request.Header.RedDot)
+	require.Equal(t, 1, cap.countAvatarChanged(), "one save should emit one system message")
+}
+
+func TestGroupUpdateNameDoesNotSendAvatarSystemMessage(t *testing.T) {
+	_, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	g := New(ctx)
+	cap := startIMCapture(t, ctx)
+	r := newAvatarNotifyGroupUpdateRouter(t, ctx, g)
+
+	const groupNo = "avatar_tip_name_only"
+	seedCreatorGroup(t, g, groupNo, "原始群名")
+
+	w := putGroupUpdate(t, r, groupNo, map[string]string{"name": "新群名"})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Nil(t, cap.findAvatarChanged(), "rename must not emit avatar system message")
+}
+
+func TestGroupUpdateAvatarCustomSuppressesNoVisibleChange(t *testing.T) {
+	_, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	g := New(ctx)
+	cap := startIMCapture(t, ctx)
+	r := newAvatarNotifyGroupUpdateRouter(t, ctx, g)
+
+	const groupNo = "avatar_tip_no_visible_change"
+	seedCreatorGroup(t, g, groupNo, "原始群名")
+	model, err := g.db.QueryWithGroupNo(groupNo)
+	require.NoError(t, err)
+	require.NoError(t, g.db.updateAvatar("uploaded.png", model.AvatarVersion+1, groupNo))
+
+	w := putGroupUpdate(t, r, groupNo, map[string]string{
+		attrKeyAvatarText:  "研发",
+		attrKeyAvatarColor: "5",
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Zero(t, cap.countAvatarChanged(), "custom avatar fields hidden by uploaded avatar must not emit")
+}
+
+func TestGroupUpdateAvatarCustomClearsUploadedAvatarAndSendsSystemMessage(t *testing.T) {
+	_, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	g := New(ctx)
+	cap := startIMCapture(t, ctx)
+	r := newAvatarNotifyGroupUpdateRouter(t, ctx, g)
+
+	const groupNo = "avatar_tip_clear_upload"
+	seedCreatorGroup(t, g, groupNo, "原始群名")
+	model, err := g.db.QueryWithGroupNo(groupNo)
+	require.NoError(t, err)
+	require.NoError(t, g.db.updateAvatar("uploaded.png", model.AvatarVersion+1, groupNo))
+
+	w := putGroupUpdate(t, r, groupNo, map[string]string{
+		attrKeyAvatarText:          "研发",
+		attrKeyAvatarColor:         "5",
+		attrKeyClearUploadedAvatar: "true",
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Equal(t, 1, cap.countAvatarChanged(), "clearing uploaded avatar should emit one system message")
+}
+
+func newAvatarNotifyGroupUpdateRouter(t *testing.T, ctx *config.Context, f *Group) http.Handler {
+	t.Helper()
+	r := wkhttp.New()
+	grp := r.Group("/v1/groups", ctx.AuthMiddleware(r))
+	grp.PUT("/:group_no", f.groupUpdate)
+	return r
+}
+
+func TestGroupAvatarUploadSendsSystemMessage(t *testing.T) {
+	_, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	cap := startIMCapture(t, ctx)
+
+	f := New(ctx)
+	f.fileService = &mockAvatarUploadFileService{}
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: testutil.UID, Name: "user-c", ShortNo: "uc_avatar_tip"}))
+	const groupNo = "g-avatar-tip-upload"
+	require.NoError(t, f.db.Insert(&Model{
+		GroupNo: groupNo,
+		Name:    "avatar tip upload",
+		Creator: testutil.UID,
+		Status:  GroupStatusNormal,
+		Version: 1,
+	}))
+	require.NoError(t, f.db.InsertMember(&MemberModel{
+		GroupNo: groupNo,
+		UID:     testutil.UID,
+		Role:    MemberRoleCreator,
+		Status:  1,
+		Version: 1,
+		Vercode: "avatar-tip-upload@1",
+	}))
+
+	r := wkhttp.New()
+	r.POST("/v1/groups/:group_no/avatar", ctx.AuthMiddleware(r), f.avatarUpload)
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile("file", "avatar.png")
+	require.NoError(t, err)
+	_, err = fw.Write([]byte("png"))
+	require.NoError(t, err)
+	require.NoError(t, mw.Close())
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("POST", "/v1/groups/"+groupNo+"/avatar", &buf)
+	require.NoError(t, err)
+	req.Header.Set("token", testutil.Token)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	payload := cap.findAvatarChanged()
+	require.NotNil(t, payload, "avatar upload should emit 修改了群头像")
+	require.Equal(t, float64(common.GroupUpdate), payload["type"])
+	request := cap.findAvatarChangedRequest()
+	require.NotNil(t, request)
+	require.Equal(t, groupNo, request.ChannelID)
+	require.Equal(t, common.ChannelTypeGroup.Uint8(), request.ChannelType)
+	require.Equal(t, 1, request.Header.RedDot)
+	extra, ok := payload["extra"].([]any)
+	require.True(t, ok)
+	require.Len(t, extra, 1)
+	op, ok := extra[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, testutil.UID, op["uid"])
+	require.Equal(t, "test", op["name"])
+}

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -2030,6 +2030,12 @@ func (s *Service) UpdateGroupAvatarCustom(req *UpdateGroupAvatarCustomServiceReq
 		return errors.New("group not found or disbanded")
 	}
 
+	if avatarVisibleChange(groupModel, req) {
+		if err := sendGroupAvatarChangedMessage(s.ctx, req.GroupNo, req.OperatorUID, req.OperatorName); err != nil {
+			s.Error("send group avatar changed message failed", zap.String("group_no", req.GroupNo), zap.Error(err))
+		}
+	}
+
 	// 通知客户端刷新频道信息 → 重新拉取头像。
 	s.ctx.SendChannelUpdateToGroup(req.GroupNo)
 	if req.ClearUploadedAvatar {
@@ -2046,6 +2052,37 @@ func (s *Service) UpdateGroupAvatarCustom(req *UpdateGroupAvatarCustomServiceReq
 	}
 
 	return nil
+}
+
+func avatarVisibleChange(before *Model, req *UpdateGroupAvatarCustomServiceReq) bool {
+	if before == nil {
+		return false
+	}
+	uploadedBefore := before.IsUploadAvatar == 1
+	uploadedAfter := uploadedBefore && !req.ClearUploadedAvatar
+	if uploadedBefore != uploadedAfter {
+		return true
+	}
+	if uploadedAfter {
+		return false
+	}
+
+	textAfter := before.AvatarText
+	if req.AvatarText != nil {
+		textAfter = *req.AvatarText
+	}
+	colorAfter := before.AvatarColor
+	if req.SetAvatarColor {
+		colorAfter = req.AvatarColor
+	}
+	return textAfter != before.AvatarText || !avatarColorEqual(colorAfter, before.AvatarColor)
+}
+
+func avatarColorEqual(a, b *int) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }
 
 // ---------- Service internal helpers (thread sync, no thread package import) ----------


### PR DESCRIPTION
## Summary
- Emit a persisted `GroupUpdate` system message when a group avatar visibly changes.
- Show the operator as `XXX修改了群头像` using the existing `content` + `extra` client rendering contract.
- Cover uploaded-image avatars and generated text/color avatars while preserving live-refresh behavior.
- Suppress the message when generated-avatar fields are saved while an uploaded avatar still takes rendering precedence; clearing an active uploaded avatar emits it.
- Keep the notification best-effort after the avatar database write succeeds.

## Testing
- `go test ./modules/group -count=1`
- `go test ./modules/group -shuffle=on -count=1`
- `git diff --check`
- CI passes Build, Lint, Vet, Unit Test, and all E2E shards, including the previously failing `E2E Test (3/4)`.

## Notes
- No web changes are required; Web/iOS system-message renderers interpolate `{0}` from `extra` and display the supplied content directly.
- The existing `groupAvatarUpdate` CMD and channel refresh behavior remain responsible for immediate avatar cache/UI refresh.