### PR TITLE
feat(common): add octo_assistant_uids to appconfig response

### DIFF
--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -381,6 +381,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 	// 后者是收敛后的真源 key（与 octo-web ChannelSearch、octo-admin messages_search
 	// 命名一致）。两个分支共用同一计算结果，避免 Resolve 被调用多次。
 	searchEnabled := searchbackend.Resolve(cn.ctx.GetConfig().ZincSearch.SearchOn).SearchEnabled()
+	octoAssistantUIDs := parseOctoAssistantUIDs()
 	messageReaction := buildMessageReactionCapability(
 		cn.systemSettings.MessageReactionReadEnabled(),
 		cn.systemSettings.MessageReactionWriteEnabled(),
@@ -403,6 +404,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 			DmloopOn:               cn.systemSettings.DmloopEnabled(),
 			DmpersonalOn:           cn.systemSettings.DmpersonalEnabled(),
 			TrackingEnabled:        cn.systemSettings.TrackingEnabled(),
+			OctoAssistantUIDs:      octoAssistantUIDs,
 			MessageReaction:        messageReaction,
 			// Sticker 上限:短路分支同样下发,让老客户端在管理台放宽/收窄后
 			// 也能立刻拿到最新值。
@@ -457,6 +459,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 		DmloopOn:               cn.systemSettings.DmloopEnabled(),
 		DmpersonalOn:           cn.systemSettings.DmpersonalEnabled(),
 		TrackingEnabled:        cn.systemSettings.TrackingEnabled(),
+		OctoAssistantUIDs:      octoAssistantUIDs,
 		MessageReaction:        messageReaction,
 		// Sticker 上限:客户端本地预校验用,兜底仍在服务端 modules/file 侧。
 		StickerUploadLimits: buildStickerUploadLimitsResp(cn.systemSettings),
@@ -477,6 +480,29 @@ func buildStickerUploadLimitsResp(s *SystemSettings) stickerUploadLimitsResp {
 		MaxDimension:   s.StickerUploadMaxDimension(),
 		AllowedFormats: s.StickerUploadAllowedFormats(),
 	}
+}
+
+// parseOctoAssistantUIDs 从 env DM_OCTO_ASSISTANT_UIDS 解析 Octo Assistant UID
+// 列表。逗号分隔,过滤空串。env 未设或为空时返回空切片(不是 nil,保证 JSON
+// 序列化为 [] 而非 null,前端 Array.isArray 判断一致)。
+//
+// 与 DM_OIDC_* 系列 env 同形态:运维在部署清单里配 UID 列表,后端作为单一真源
+// 通过 appconfig 下发,前端据此判别 octo_assistant_opened vs app_opened 事件。
+func parseOctoAssistantUIDs() []string {
+	raw := os.Getenv("DM_OCTO_ASSISTANT_UIDS")
+	if raw == "" {
+		return []string{}
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
 }
 
 // oidcProviders 返回 OIDC provider 元数据数组,让前端不再硬编码 provider id/name/authorize_path。
@@ -873,6 +899,16 @@ type appConfigResp struct {
 	// 只表达采集策略，不承担服务端鉴权(collector 自身鉴权)。与 app_config.version 解耦的原因
 	// 同 DocsOn：运维切策略后老客户端命中 version 短路分支也须拿到最新值，故两分支都下发。
 	TrackingEnabled bool `json:"tracking_enabled"`
+
+	// OctoAssistantUIDs 下发 Octo Assistant 的 UID 列表，供前端判别当前打开的
+	// 应用 bot 是否为 Octo Assistant（YUJ-277 / octo-dap S3 埋点）。前端根据此
+	// 列表决定发 octo_assistant_opened 还是 app_opened 事件。
+	//
+	// 来源：env DM_OCTO_ASSISTANT_UIDS（逗号分隔），解析时过滤空串。默认 []
+	// （env 未设或为空）。与 app_config.version 解耦的原因同 TrackingEnabled：
+	// 运维调整 UID 列表后老客户端命中 version 短路分支也必须拿到最新值，故两个
+	// 分支都下发。
+	OctoAssistantUIDs []string `json:"octo_assistant_uids"`
 
 	// MessageReaction is the deployment-wide default capability for ordinary
 	// Web/iOS/Android clients. It is intentionally identity-agnostic because

--- a/modules/common/api_test.go
+++ b/modules/common/api_test.go
@@ -1256,3 +1256,71 @@ func TestGetAppConfig_StickerUploadLimits_OnVersionShortCircuit(t *testing.T) {
 	body := w.Body.String()
 	assert.Contains(t, body, `"sticker_upload_limits":{"max_size_kb":3072,"max_dimension":900,"allowed_formats":[".png",".jpg"]}`)
 }
+
+// appconfig 必须下发 octo_assistant_uids:env 未设时返回空数组(不是 null,前端
+// Array.isArray 判断一致)。前端据此判别 octo_assistant_opened vs app_opened。
+func TestGetAppConfig_OctoAssistantUIDs_DefaultEmpty(t *testing.T) {
+	t.Setenv("DM_OCTO_ASSISTANT_UIDS", "")
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"octo_assistant_uids":[]`)
+}
+
+// env DM_OCTO_ASSISTANT_UIDS 设值后 appconfig 下发解析后的 UID 数组。
+func TestGetAppConfig_OctoAssistantUIDs_EnvSet(t *testing.T) {
+	t.Setenv("DM_OCTO_ASSISTANT_UIDS", "uid-octo-1,uid-octo-2")
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `"octo_assistant_uids":["uid-octo-1","uid-octo-2"]`)
+}
+
+// env 含空串(连续逗号/前后空格)时过滤掉空串,只下发有效 UID。
+func TestGetAppConfig_OctoAssistantUIDs_FiltersEmpty(t *testing.T) {
+	t.Setenv("DM_OCTO_ASSISTANT_UIDS", "uid-1,, uid-2 ,")
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `"octo_assistant_uids":["uid-1","uid-2"]`)
+}
+
+// version 短路分支同样要下发 octo_assistant_uids:UID 列表需与 app_config.version
+// 解耦,避免运维调整后老客户端命中版本短路而继续用旧值(同 tracking_enabled)。
+func TestGetAppConfig_OctoAssistantUIDs_OnVersionShortCircuit(t *testing.T) {
+	t.Setenv("DM_OCTO_ASSISTANT_UIDS", "uid-octo-1")
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig?version=99999999", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"octo_assistant_uids":["uid-octo-1"]`)
+}


### PR DESCRIPTION
## What

Add `octo_assistant_uids` to the `/v1/common/appconfig` response.

The web client uses this list to tell an **Octo Assistant** bot apart from an
ordinary app bot when a conversation opens, choosing between the
`octo_assistant_opened` and `app_opened` analytics events (octo-dap S3 / YUJ-277).

## Changes

- `modules/common/api.go`
  - New `parseOctoAssistantUIDs()` reads env `DM_OCTO_ASSISTANT_UIDS`
    (comma-separated), trims and filters empty entries, and returns `[]string`.
    Returns an empty slice (not `nil`) when unset so the field serializes as `[]`
    rather than `null`.
  - `appConfigResp` gains `OctoAssistantUIDs []string` (`json:"octo_assistant_uids"`).
  - Emitted on **both** the normal response and the `version` short-circuit branch,
    matching the existing `tracking_enabled` handling, so ops changes to the UID
    list reach clients that hit the version short-circuit.

## Why env-sourced

The Octo Assistant UID set differs per deployment; it is an ops/config concern,
so it is delivered as a single backend source of truth (same shape as the
`DM_OIDC_*` env family) rather than hardcoded on the client.

## Tests

`modules/common/api_test.go` adds coverage for: default empty (`[]`), env set,
empty-entry filtering, and the `version` short-circuit branch.


Fixes #783
