### PR TITLE
ci: reach mysql and redis through the service containers, dropping the apt install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,9 +222,19 @@ jobs:
         env:
           MYSQL_CID: ${{ job.services.mysql.id }}
         run: |
+          # This is the first consumer of the id, so it has to be the one that
+          # names an unresolved one. A service rename empties the context
+          # property silently, and `docker exec "" ...` fails instantly, so
+          # without this the loop would burn its full 60s and then report
+          # "mysql did not become ready" — the wrong cause, which is the exact
+          # diagnose-the-symptom failure this lane was cleaned up to stop.
+          [ -n "$MYSQL_CID" ] || {
+            echo "::error title=Missing service container id::MYSQL_CID is empty; job.services.mysql.id did not resolve" >&2
+            exit 1
+          }
           for _ in $(seq 1 30); do
             if docker exec "$MYSQL_CID" mysqladmin ping -h 127.0.0.1 -uroot -pdemo --silent \
-              && timeout 1 bash -c 'exec 3<>/dev/tcp/127.0.0.1/3306'; then
+              && timeout 1 bash -c 'exec 3<>/dev/tcp/127.0.0.1/3306' 2>/dev/null; then
               echo "mysql ready (server up, published port reachable)"
               exit 0
             fi
@@ -253,7 +263,12 @@ jobs:
         # tracked upstream.
         env:
           MYSQL_CID: ${{ job.services.mysql.id }}
-        run: docker exec "$MYSQL_CID" mysql -h 127.0.0.1 -uroot -pdemo -e "SET GLOBAL max_connections = 1000;"
+        run: |
+          [ -n "$MYSQL_CID" ] || {
+            echo "::error title=Missing service container id::MYSQL_CID is empty; job.services.mysql.id did not resolve" >&2
+            exit 1
+          }
+          docker exec "$MYSQL_CID" mysql -h 127.0.0.1 -uroot -pdemo -e "SET GLOBAL max_connections = 1000;"
 
       - name: Wait for WuKongIM
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,41 +199,6 @@ jobs:
             go.sum
             .github/go-cache-key/e2e-test
 
-      - name: Install MySQL/Redis client tooling
-        # Bounded so a stuck apt cannot silently eat the job. Unbounded, this
-        # step consumed the full 30-minute budget of two shards on 2026-08-19
-        # while `Run E2E shard` never started, costing the whole matrix with
-        # zero tests executed. Five minutes is ~3x the observed healthy time
-        # (69-104s on the shards that completed that day).
-        timeout-minutes: 5
-        run: |
-          # mysql + redis-cli are needed below to reset the shared `test`
-          # database between Go packages; ubuntu-latest's preinstall set
-          # is not stable across runner image rolls so install fresh.
-          #
-          # Three guards, each for a failure this step hit unprotected:
-          #   - DPkg::Lock::Timeout: apt waits for the dpkg/apt lock *forever*
-          #     by default, and the hosted image runs unattended-upgrades on
-          #     boot. Losing that race is a hang, not an error, so it has to be
-          #     given a deadline rather than left to the step timeout.
-          #   - the retry loop: a lost lock or a mirror hiccup is transient and
-          #     self-heals in seconds; failing the shard for it wastes a full
-          #     re-run of the matrix.
-          #   - -q instead of -qq: the quieter form printed nothing at all, so
-          #     a stalled run gave no evidence of *which* half was stuck. Keep
-          #     enough output to tell update from install next time.
-          export DEBIAN_FRONTEND=noninteractive
-          for attempt in 1 2 3; do
-            if sudo apt-get -o DPkg::Lock::Timeout=60 update -q \
-              && sudo apt-get -o DPkg::Lock::Timeout=60 install -y -q mysql-client redis-tools; then
-              exit 0
-            fi
-            echo "::warning title=apt attempt ${attempt} failed::retrying" >&2
-            sleep $((attempt * 10))
-          done
-          echo "::error title=apt install failed::mysql-client/redis-tools unavailable after 3 attempts" >&2
-          exit 1
-
       - name: Wait for MySQL
         # mysql:8.0 defaults the server collation to utf8mb4_0900_ai_ci, but
         # we recreate the `test` database with utf8mb4_general_ci before
@@ -243,9 +208,15 @@ jobs:
         # the 8.0 default). Tables created without explicit COLLATE inherit
         # the database default; using general_ci keeps them aligned with
         # the rest of the schema and avoids "Illegal mix of collations".
+        #
+        # The client runs inside the service container rather than on the
+        # runner. mysql:8.0 ships mysqladmin, so there is nothing to install
+        # and no network dependency between the runner and a package mirror.
+        env:
+          MYSQL_CID: ${{ job.services.mysql.id }}
         run: |
           for _ in $(seq 1 30); do
-            if mysqladmin ping -h 127.0.0.1 -uroot -pdemo --silent; then
+            if docker exec "$MYSQL_CID" mysqladmin ping -h 127.0.0.1 -uroot -pdemo --silent; then
               echo "mysql ready"
               exit 0
             fi
@@ -269,10 +240,12 @@ jobs:
         # plateaus near the observed peak (~300) and stays green.
         #
         # max_connections is a dynamic GLOBAL, so set it at runtime (root is
-        # available and mysql-client is installed above). This unblocks every
-        # package at once; the proper O(1) fix — idle-reap in octo-lib testutil
-        # — is tracked upstream.
-        run: mysql -h 127.0.0.1 -uroot -pdemo -e "SET GLOBAL max_connections = 1000;"
+        # available inside the service container). This unblocks every package
+        # at once; the proper O(1) fix — idle-reap in octo-lib testutil — is
+        # tracked upstream.
+        env:
+          MYSQL_CID: ${{ job.services.mysql.id }}
+        run: docker exec "$MYSQL_CID" mysql -h 127.0.0.1 -uroot -pdemo -e "SET GLOBAL max_connections = 1000;"
 
       - name: Wait for WuKongIM
         run: |
@@ -323,6 +296,12 @@ jobs:
         # `t.Skip("OCTO migration TODO: ...issues/17")` marker in-source
         # — see issue #17 for the cleanup tracker. Grep for `OCTO migration
         # TODO` to find the suppressed tests.
+        #
+        # The per-package reset reaches mysql/redis through these container
+        # ids instead of runner-local clients; see ci/run-e2e-shard.sh.
+        env:
+          MYSQL_CID: ${{ job.services.mysql.id }}
+          REDIS_CID: ${{ job.services.redis.id }}
         run: ci/run-e2e-shard.sh "${{ matrix.shard }}" "${{ matrix.total }}"
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,12 +212,20 @@ jobs:
         # The client runs inside the service container rather than on the
         # runner. mysql:8.0 ships mysqladmin, so there is nothing to install
         # and no network dependency between the runner and a package mirror.
+        #
+        # Two probes, because the in-container ping alone would be a weaker gate
+        # than the runner-side client it replaced: it proves mysqld is up, but
+        # the Go tests connect from the runner to the published 127.0.0.1:3306,
+        # and a ping on the container's own loopback can pass while that mapping
+        # is not serving yet. The bash /dev/tcp probe covers the published port
+        # without reintroducing a client on the runner.
         env:
           MYSQL_CID: ${{ job.services.mysql.id }}
         run: |
           for _ in $(seq 1 30); do
-            if docker exec "$MYSQL_CID" mysqladmin ping -h 127.0.0.1 -uroot -pdemo --silent; then
-              echo "mysql ready"
+            if docker exec "$MYSQL_CID" mysqladmin ping -h 127.0.0.1 -uroot -pdemo --silent \
+              && timeout 1 bash -c 'exec 3<>/dev/tcp/127.0.0.1/3306'; then
+              echo "mysql ready (server up, published port reachable)"
               exit 0
             fi
             sleep 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,12 +200,39 @@ jobs:
             .github/go-cache-key/e2e-test
 
       - name: Install MySQL/Redis client tooling
+        # Bounded so a stuck apt cannot silently eat the job. Unbounded, this
+        # step consumed the full 30-minute budget of two shards on 2026-08-19
+        # while `Run E2E shard` never started, costing the whole matrix with
+        # zero tests executed. Five minutes is ~3x the observed healthy time
+        # (69-104s on the shards that completed that day).
+        timeout-minutes: 5
         run: |
           # mysql + redis-cli are needed below to reset the shared `test`
           # database between Go packages; ubuntu-latest's preinstall set
           # is not stable across runner image rolls so install fresh.
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq mysql-client redis-tools
+          #
+          # Three guards, each for a failure this step hit unprotected:
+          #   - DPkg::Lock::Timeout: apt waits for the dpkg/apt lock *forever*
+          #     by default, and the hosted image runs unattended-upgrades on
+          #     boot. Losing that race is a hang, not an error, so it has to be
+          #     given a deadline rather than left to the step timeout.
+          #   - the retry loop: a lost lock or a mirror hiccup is transient and
+          #     self-heals in seconds; failing the shard for it wastes a full
+          #     re-run of the matrix.
+          #   - -q instead of -qq: the quieter form printed nothing at all, so
+          #     a stalled run gave no evidence of *which* half was stuck. Keep
+          #     enough output to tell update from install next time.
+          export DEBIAN_FRONTEND=noninteractive
+          for attempt in 1 2 3; do
+            if sudo apt-get -o DPkg::Lock::Timeout=60 update -q \
+              && sudo apt-get -o DPkg::Lock::Timeout=60 install -y -q mysql-client redis-tools; then
+              exit 0
+            fi
+            echo "::warning title=apt attempt ${attempt} failed::retrying" >&2
+            sleep $((attempt * 10))
+          done
+          echo "::error title=apt install failed::mysql-client/redis-tools unavailable after 3 attempts" >&2
+          exit 1
 
       - name: Wait for MySQL
         # mysql:8.0 defaults the server collation to utf8mb4_0900_ai_ci, but

--- a/ci/run-e2e-shard.sh
+++ b/ci/run-e2e-shard.sh
@@ -41,6 +41,21 @@ printf '  %s\n' "${packages[@]}"
 # MYSQL_CID / REDIS_CID are set by the workflow from `job.services.<name>.id`.
 # When they are absent the script falls back to local binaries, so running it
 # outside CI against a hand-started MySQL/Redis still works.
+#
+# In Actions that fallback would be a trap rather than a convenience: an absent
+# context property renders as the empty string with no error, so a service
+# rename or a step that forgets its `env:` block would silently select the
+# branch whose binaries CI no longer installs. Fail there instead, naming the
+# cause, rather than surfacing later as `redis-cli: command not found`.
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+  for var in MYSQL_CID REDIS_CID; do
+    if [ -z "$(eval "printf '%s' \"\${$var:-}\"")" ]; then
+      echo "::error title=Missing service container id::$var is empty; the workflow must pass job.services.<name>.id" >&2
+      exit 1
+    fi
+  done
+fi
+
 mysql_exec() {
   if [ -n "${MYSQL_CID:-}" ]; then
     docker exec "$MYSQL_CID" mysql -h 127.0.0.1 -uroot -pdemo -e "$1"
@@ -49,11 +64,19 @@ mysql_exec() {
   fi
 }
 
+# `-e` is load-bearing, not decoration: redis-cli writes server error replies to
+# *stdout* and still exits 0, so the previous `redis-cli FLUSHALL >/dev/null`
+# swallowed the message and returned success. A write-blocking reply such as
+# MISCONF under runner disk pressure would have left the next package running
+# against un-flushed Redis, surfacing as an unrelated flaky failure. Verified on
+# redis 7.0.15: an error reply gives exit 0 bare and exit 1 with `-e`. The output
+# is kept (one `OK` per package) for the same reason -- a fully silenced step can
+# only be diagnosed by noticing a missing timestamp.
 redis_flush() {
   if [ -n "${REDIS_CID:-}" ]; then
-    docker exec "$REDIS_CID" redis-cli FLUSHALL >/dev/null
+    docker exec "$REDIS_CID" redis-cli -e FLUSHALL
   else
-    redis-cli -h 127.0.0.1 -p 6379 FLUSHALL >/dev/null
+    redis-cli -h 127.0.0.1 -p 6379 -e FLUSHALL
   fi
 }
 

--- a/ci/run-e2e-shard.sh
+++ b/ci/run-e2e-shard.sh
@@ -49,7 +49,7 @@ printf '  %s\n' "${packages[@]}"
 # cause, rather than surfacing later as `redis-cli: command not found`.
 if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
   for var in MYSQL_CID REDIS_CID; do
-    if [ -z "$(eval "printf '%s' \"\${$var:-}\"")" ]; then
+    if [ -z "${!var:-}" ]; then
       echo "::error title=Missing service container id::$var is empty; the workflow must pass job.services.<name>.id" >&2
       exit 1
     fi

--- a/ci/run-e2e-shard.sh
+++ b/ci/run-e2e-shard.sh
@@ -31,12 +31,38 @@ fi
 printf 'E2E packages for shard %s/%s (%d):\n' "$shard" "$total" "${#packages[@]}"
 printf '  %s\n' "${packages[@]}"
 
+# The mysql and redis clients live inside the service containers, so CI reaches
+# them with `docker exec` rather than installing mysql-client/redis-tools onto
+# the runner. That install was an unbounded apt call with no lock timeout: on
+# 2026-08-19 it hung two shards for 29.5 minutes each and both were cancelled by
+# the job timeout without running a single test. Nothing here depends on a
+# package mirror any more.
+#
+# MYSQL_CID / REDIS_CID are set by the workflow from `job.services.<name>.id`.
+# When they are absent the script falls back to local binaries, so running it
+# outside CI against a hand-started MySQL/Redis still works.
+mysql_exec() {
+  if [ -n "${MYSQL_CID:-}" ]; then
+    docker exec "$MYSQL_CID" mysql -h 127.0.0.1 -uroot -pdemo -e "$1"
+  else
+    mysql -h 127.0.0.1 -uroot -pdemo -e "$1"
+  fi
+}
+
+redis_flush() {
+  if [ -n "${REDIS_CID:-}" ]; then
+    docker exec "$REDIS_CID" redis-cli FLUSHALL >/dev/null
+  else
+    redis-cli -h 127.0.0.1 -p 6379 FLUSHALL >/dev/null
+  fi
+}
+
 fail=0
 failed=()
 
 for pkg in "${packages[@]}"; do
-  mysql -h 127.0.0.1 -uroot -pdemo -e "DROP DATABASE IF EXISTS test; CREATE DATABASE test CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;"
-  redis-cli -h 127.0.0.1 -p 6379 FLUSHALL >/dev/null
+  mysql_exec "DROP DATABASE IF EXISTS test; CREATE DATABASE test CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;"
+  redis_flush
   echo "::group::go test $pkg"
   if ! go test -race -shuffle=on -count=1 -timeout 5m "$pkg"; then
     fail=1


### PR DESCRIPTION
## Summary

The E2E lane installed `mysql-client` and `redis-tools` onto the runner with apt on every shard. apt waits for the dpkg/apt lock **forever** by default and the hosted image runs `unattended-upgrades` on boot, so losing that race is a hang rather than an error — and with the step unbounded it consumed the job's entire 30-minute budget before `Run E2E shard` ever started.

Both clients already exist **inside the service containers**. Reaching them with `docker exec` removes the failure class instead of bounding it, and leaves the lane with no package-mirror dependency at all.

> **Approach changed after the first review round.** The first commit bounded apt (lock timeout, retry, step cap) and was approved, with both reviewers naming the container route as the durable fix. The maintainer opted to supersede rather than defer it, so the second commit removes the install entirely. The guard commit is kept in history so the incident and the reasoning stay on the record. Commits three and four apply review findings on the container approach.

## Related Issue

None — filed directly from a live occurrence, evidence below.

## Linked Spec

Not applicable: CI-only change, no product behavior touched.

## The occurrence

Run `32230284869`, 2026-08-19:

| shard | install step | outcome |
|---|---|---|
| 1/4 | 69s | ✅ tests ran, passed |
| 2/4 | 104s | ✅ tests ran, passed |
| 3/4 | **never finished** | ⛔ cancelled at 29.5 min by the job timeout |
| 4/4 | **never finished** | ⛔ cancelled at 29.5 min by the job timeout |

Both hung shards show the step group opening, 29.5 minutes of nothing, then `##[error]The operation was canceled.` — `Run E2E shard` never started on either. A re-run reproduced it identically on fresh runners. Neither run left any evidence of *why*, because `-qq` suppressed apt's output entirely.

## Changes

**Removing the dependency**

- **Removed** the `Install MySQL/Redis client tooling` step.
- `Wait for MySQL` → `docker exec "$MYSQL_CID" mysqladmin ping …`. `mysql:8.0` ships `mysqladmin`; this is the same command the service's own `--health-cmd` already runs in-container.
- `Raise MySQL max_connections` → `docker exec "$MYSQL_CID" mysql …`.
- `Run E2E shard` passes `MYSQL_CID` / `REDIS_CID` from `job.services.<name>.id`.
- `ci/run-e2e-shard.sh` gains `mysql_exec` / `redis_flush`, which use `docker exec` when the ids are set. **Outside Actions** they fall back to local binaries, so running the script against a hand-started MySQL/Redis still works; **inside Actions an empty id is a hard error**, because a service rename or a missing `env:` block would otherwise silently select the branch whose binaries CI no longer installs.

**Keeping the replacements loud** — three gaps found in review, each the same shape as the original incident: a step that consumes something without saying so.

- `redis_flush` uses `redis-cli -e` and no longer discards stdout. redis-cli writes server error replies to **stdout and still exits 0**, so `redis-cli FLUSHALL >/dev/null` swallowed the message and returned success — a write-blocking reply such as `MISCONF` under runner disk pressure would have left the next package running against un-flushed Redis. Dropping the redirect alone is not enough: without `-e` the exit code stays 0 and `set -e` never fires. (`-e` requires redis-cli ≥ 6.0; the pinned `redis:7-alpine` has it, and the note matters only for the local fallback.)
- `Wait for MySQL` gained a runner-side `timeout 1 bash -c 'exec 3<>/dev/tcp/127.0.0.1/3306'` probe **alongside** the in-container ping, so the gate again proves both *mysqld up* and *published port reachable* — coverage the removed runner-side client used to provide. Its stderr is silenced so a port still coming up does not log connection-refused lines per iteration.
- **Unresolved container ids fail fast and name themselves**, at every consumer: `Wait for MySQL` and `Raise MySQL max_connections` each check the id before use, and `ci/run-e2e-shard.sh` requires both when `GITHUB_ACTIONS=true`. The workflow guard matters because `Wait for MySQL` reads the id first — without it, a rename would spend the loop's full 60s and then report "mysql did not become ready", naming the wrong cause.

Side benefit: 10–100s per shard of install time disappears, on four shards per run.

## Testing

- `yaml.safe_load` parses the workflow — 11 jobs, unchanged count. `sanity / actionlint` passes.
- `bash -n` on `ci/run-e2e-shard.sh` passes.
- **Fallback branch exercised against a live MySQL/Redis**: `mysql_exec` recreated the database and `SELECT @@collation_database` returned `utf8mb4_general_ci`; `redis_flush` returned `OK` / exit 0.
- **`redis-cli` exit-code claim reproduced** on Redis 7.0.15: an error reply gives stdout `NOAUTH Authentication required.` with **exit 0** bare, and **exit 1** with `-e`. Reviewers confirmed identical behaviour on the tag the job actually pulls (`redis:7-alpine`, currently 7.4.x), so the conclusion holds for the image in use even though the local reproduction was on 7.0.
- **TCP probe verified both directions**: exit 0 on a listening port, non-zero on a closed one, and the combined `&&` gate fails when the ping succeeds but the port is unreachable.
- **Id assertions verified**: reject at the first empty variable, accept a set pair, stay skipped outside `GITHUB_ACTIONS` so local runs keep the fallback, and report immediately rather than after 60s of polling.
- The container path's real validation is **this PR's own E2E lane**: both changed files satisfy the `changes` job's `code` filter, so all four shards run the modified steps. Green on every head since the switch — most recently run `32244348439`, four shards in 4m38s–7m01s, with `Wait for MySQL` clearing both probes on its first iteration in 0.09s.

- [x] Unit tests added/updated — not applicable; the workflow is its own test surface
- [x] Manually verified

## Known residuals (not addressed here)

- `mysqladmin`'s `--connect-timeout` defaults to 43200s, so the `docker exec … mysqladmin ping` inside the readiness loop is not itself time-bounded and a wedged-but-connectable mysqld could block one iteration past the comment's stated 60s ceiling. Pre-existing — the runner-side client it replaced carried the same default — and orthogonal to the apt removal, so it is left for a follow-up rather than widened into this PR.
- `redis-cli -e` requires ≥ 6.0, which affects only the local fallback on distributions still shipping `redis-tools` 5.x.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes — see Testing; no product code to test
- [x] Updated documentation — the rationale lives in comments at each call site
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUPba8mg3MkF7j7gdPg3Mt