### PR TITLE
fix(agent-mail): buffer HTTP/2 responses safely

### DIFF
--- a/.octospec/tasks/agent-mail-http2-response/brief.md
+++ b/.octospec/tasks/agent-mail-http2-response/brief.md
@@ -1,0 +1,54 @@
+---
+type: Task
+title: "Task: agent-mail-http2-response"
+description: "Allow bounded unknown-length Agent Mail responses to reach HTTP/2 browser clients."
+tags: ["agent-mail", "gateway", "wire-contract", "error-response", "testing"]
+timestamp: 2026-08-19T06:55:00Z
+slug: agent-mail-http2-response
+source: user
+upstream: "https://github.com/Mininglamp-OSS/octo-server/issues/789"
+---
+
+# Task: agent-mail-http2-response
+
+## Goal
+
+Fix the Agent Mail gateway returning 502 for valid octo-mail responses whose
+length is unknown when the downstream hop reaching the gateway uses HTTP/2.
+
+## Background
+
+octo-mail can return dynamically generated message details without a known
+`Content-Length`. The gateway currently streams such responses only to HTTP/1.1
+clients and rejects them for HTTP/2, which makes larger external HTML messages
+unreadable even though octo-mail received and parsed them successfully.
+
+## Load-bearing list
+
+- **Response integrity**: an incomplete or oversized upstream body must never be
+  exposed as a successful complete HTTP/2 response.
+- **Response limit**: retain the existing 64 MiB Agent Mail response limit.
+- **Aggregate memory bound**: cap concurrent HTTP/2 response buffering so one
+  account cannot multiply the per-response limit without bound.
+- **Wire contract**: preserve upstream status, headers, and body for successful
+  responses; preserve the existing localized gateway error for failures.
+- **HTTP/1.1 streaming**: keep the existing streaming behavior for self-delimited
+  HTTP/1.1 responses.
+
+## Out of scope
+
+- No octo-mail, Web, API, authentication, Space, or mailbox behavior changes.
+- No deployment configuration or timeout changes.
+- No change to known-length response streaming.
+
+## Acceptance
+
+- A real HTTP/2 client connected to the gateway handler receives a valid
+  unknown-length response with status 200, its complete body, and a computed
+  `Content-Length`.
+- A failed unknown-length upstream read returns the existing 502 error envelope
+  before any partial upstream body is sent to an HTTP/2 client.
+- Concurrent response buffering has an aggregate budget, and waiting for it
+  honors request cancellation.
+- Existing HTTP/1.1 streaming and response-size protections remain green.
+- `go test ./modules/agentmailgateway/... -count=1` and `golangci-lint` pass.

--- a/.octospec/tasks/agent-mail-http2-response/context.yaml
+++ b/.octospec/tasks/agent-mail-http2-response/context.yaml
@@ -1,0 +1,23 @@
+brief: .octospec/tasks/agent-mail-http2-response/brief.md
+injected:
+  - id: space-isolation
+    source: repo
+    reason: "The existing authenticated, Space-scoped gateway must remain unchanged."
+  - id: error-handling
+    source: repo
+    reason: "Upstream failures must keep the localized gateway error envelope."
+  - id: rate-limit
+    source: repo
+    reason: "The existing authenticated route middleware must remain unchanged."
+  - id: testing
+    source: repo
+    reason: "The HTTP/2 success and truncated-response failure paths need regression coverage."
+  - id: commit-style
+    source: repo
+    reason: "Repository-wide change convention."
+files_expected:
+  - modules/agentmailgateway/README.md
+  - modules/agentmailgateway/gateway.go
+  - modules/agentmailgateway/gateway_test.go
+  - .octospec/tasks/agent-mail-identity-gateway/verification.md
+updated_at: 2026-08-19T10:48:23Z

--- a/.octospec/tasks/agent-mail-identity-gateway/verification.md
+++ b/.octospec/tasks/agent-mail-identity-gateway/verification.md
@@ -1,5 +1,10 @@
 # Verification
 
+> Historical verification note: the non-HTTP/1.1 response behavior recorded
+> below describes the original task head. It is superseded for handler-facing
+> HTTP/2 connections by `.octospec/tasks/agent-mail-http2-response/brief.md`,
+> which validates and bounded-buffers unknown-length responses before commit.
+
 - Rules checked: `space-isolation`, `trust-boundary`, `error-handling`,
   `rate-limit`, `testing`, `commit-style`.
 - Commands run:
@@ -15,12 +20,15 @@
     lifetime, and nonce.
   - octo-server exposes no Bot Draft-send bridge; owner confirmation and scoped
     delivery remain in the Mail Plugin and octo-mail boundary.
-  - Known-length and self-delimiting unknown-length responses stream with
-    client-visible truncation on HTTP/1.1; ambiguous close-delimited and
-    non-HTTP/1.1 unknown-length responses fail before status commit.
+  - At the original task head, known-length and self-delimiting unknown-length
+    responses streamed with client-visible truncation on HTTP/1.1; ambiguous
+    close-delimited and non-HTTP/1.1 unknown-length responses failed before
+    status commit. Handler-facing HTTP/2 behavior is now superseded as noted
+    above.
   - Upstream compression negotiation is fixed to `identity`, so a gzip response
-    retains its known wire length and succeeds over an HTTP/2 downstream while
-    genuinely unknown-length HTTP/2 responses remain fail-closed.
+    retains its known wire length and succeeds over an HTTP/2 downstream. At
+    the original task head, genuinely unknown-length HTTP/2 responses remained
+    fail-closed; that behavior is now superseded as noted above.
   - Request buffering has per-request, concurrent-buffering, aggregate
     accounted-byte, and progress-time bounds. Real stalled and over-limit
     unknown-length network bodies produce explicit errors and release the

--- a/modules/agentmailgateway/README.md
+++ b/modules/agentmailgateway/README.md
@@ -62,11 +62,19 @@ caller even though their gateway URLs are otherwise identical.
   it cannot end as a clean chunked success.
 - HTTP/1.x close-delimited responses are rejected before their status is
   committed because EOF cannot distinguish completion from truncation.
-  Unknown-length responses are also rejected for HTTP/1.0 and HTTP/2 downstream
-  clients, where this handler cannot reliably surface a mid-stream failure.
+  Unknown-length responses remain rejected for HTTP/1.0 downstream clients.
+- When the downstream hop reaching this handler uses HTTP/2, unknown-length
+  responses are fully validated before status commit and then forwarded with a
+  computed `Content-Length`. The gateway retains them in 256 KiB chunks to
+  avoid geometric whole-body reallocations. Each response reserves its full
+  64 MiB allowance from a process-wide 256 MiB budget until the buffered body
+  is written downstream, allowing at most four such responses concurrently.
+  A request that cannot obtain a reservation within five seconds receives the
+  localized `503 err.server.agent_mail_gateway.unavailable` response.
 - Request and response bodies each have a 64 MiB per-request limit. Four slots
-  bound concurrent large-body buffering. Bodies over 1 MiB additionally use a
-  256 MiB weighted budget until the upstream transport closes its request body.
+  bound concurrent large request-body buffering. Request bodies over 1 MiB
+  additionally use a 256 MiB weighted budget until the upstream transport
+  closes its request body.
   Closing that body drops the transport-visible reference to the buffered bytes
   before releasing the reservation, so a slow browser response cannot retain
   unrelated upload capacity. Smaller bodies bypass that large-body budget.

--- a/modules/agentmailgateway/gateway.go
+++ b/modules/agentmailgateway/gateway.go
@@ -507,18 +507,28 @@ func readBoundedResponseBody(reader io.Reader, limit int64) (io.Reader, int64, e
 			chunkSize = remaining
 		}
 		chunk := make([]byte, int(chunkSize))
-		n, err := io.ReadFull(reader, chunk)
-		if n > 0 {
-			total += int64(n)
-			chunks = append(chunks, bytes.NewReader(chunk[:n]))
+		filled := 0
+		cleanEOF := false
+		for filled < len(chunk) {
+			n, err := reader.Read(chunk[filled:])
+			filled += n
+			if err == nil {
+				continue
+			}
+			if !errors.Is(err, io.EOF) {
+				return nil, 0, err
+			}
+			cleanEOF = true
+			break
 		}
-		if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
-			return nil, 0, err
+		if filled > 0 {
+			total += int64(filled)
+			chunks = append(chunks, bytes.NewReader(chunk[:filled]))
 		}
 		if total > limit {
 			return nil, 0, errBodyTooLarge
 		}
-		if err != nil {
+		if cleanEOF {
 			return io.MultiReader(chunks...), total, nil
 		}
 	}

--- a/modules/agentmailgateway/gateway.go
+++ b/modules/agentmailgateway/gateway.go
@@ -33,16 +33,20 @@ const (
 	envGatewaySecret  = "OCTO_MAIL_GATEWAY_SECRET"
 	envGatewayTimeout = "OCTO_MAIL_GATEWAY_TIMEOUT"
 
-	gatewayRoutePrefix          = "/v1/mail-gateway"
-	mailAPIPrefix               = "/webapi/v0"
-	maxRequestBytes             = int64(64 << 20)
-	maxResponseBytes            = int64(64 << 20)
-	largeRequestThreshold       = int64(1 << 20)
-	maxConcurrentLargeRequests  = 4
-	maxInFlightRequestBodyBytes = maxConcurrentLargeRequests * maxRequestBytes
-	defaultLargeRequestSlotWait = 5 * time.Second
-	defaultTimeout              = 30 * time.Second
-	provisioningCacheEntries    = 4096
+	gatewayRoutePrefix             = "/v1/mail-gateway"
+	mailAPIPrefix                  = "/webapi/v0"
+	maxRequestBytes                = int64(64 << 20)
+	maxResponseBytes               = int64(64 << 20)
+	largeRequestThreshold          = int64(1 << 20)
+	maxConcurrentLargeRequests     = 4
+	maxConcurrentBufferedResponses = 4
+	maxInFlightRequestBodyBytes    = maxConcurrentLargeRequests * maxRequestBytes
+	maxInFlightResponseBodyBytes   = maxConcurrentBufferedResponses * maxResponseBytes
+	responseBufferChunkBytes       = 256 << 10
+	defaultLargeRequestSlotWait    = 5 * time.Second
+	defaultResponseBodyBudgetWait  = 5 * time.Second
+	defaultTimeout                 = 30 * time.Second
+	provisioningCacheEntries       = 4096
 )
 
 var allowedMethods = map[string]struct{}{
@@ -52,10 +56,11 @@ var allowedMethods = map[string]struct{}{
 }
 
 var (
-	errGatewayNotConfigured  = errors.New("Agent Mail gateway is not configured")
-	errBodyTooLarge          = errors.New("body exceeds gateway limit")
-	errLargeRequestSlotWait  = errors.New("timed out waiting for a large request slot")
-	errRequestBodyBudgetWait = errors.New("timed out waiting for request body budget")
+	errGatewayNotConfigured   = errors.New("Agent Mail gateway is not configured")
+	errBodyTooLarge           = errors.New("body exceeds gateway limit")
+	errLargeRequestSlotWait   = errors.New("timed out waiting for a large request slot")
+	errRequestBodyBudgetWait  = errors.New("timed out waiting for request body budget")
+	errResponseBodyBudgetWait = errors.New("timed out waiting for response body budget")
 )
 
 type gatewayConfig struct {
@@ -79,23 +84,29 @@ type Gateway struct {
 	largeRequestSlots    chan struct{}
 	largeRequestSlotWait time.Duration
 	requestBodyBudget    *semaphore.Weighted
-	provisionIdentity    func(context.Context, string, string) error
-	resolveLocalpart     func(context.Context, string) (string, error)
-	provisioned          *lru.Cache[string, struct{}]
-	provisioningFlights  singleflight.Group
+	// responseBodyBudget reserves the worst-case size for each buffered HTTP/2
+	// response and remains held until the buffered body is written downstream.
+	responseBodyBudget     *semaphore.Weighted
+	responseBodyBudgetWait time.Duration
+	provisionIdentity      func(context.Context, string, string) error
+	resolveLocalpart       func(context.Context, string) (string, error)
+	provisioned            *lru.Cache[string, struct{}]
+	provisioningFlights    singleflight.Group
 }
 
 func New(ctx *config.Context) *Gateway {
 	cfg, err := loadGatewayConfig()
 	g := &Gateway{
-		ctx:                  ctx,
-		Log:                  log.NewTLog("AgentMailGateway"),
-		cfg:                  cfg,
-		now:                  time.Now,
-		nonceSource:          randomNonceSource(),
-		largeRequestSlots:    make(chan struct{}, maxConcurrentLargeRequests),
-		largeRequestSlotWait: defaultLargeRequestSlotWait,
-		requestBodyBudget:    semaphore.NewWeighted(maxInFlightRequestBodyBytes),
+		ctx:                    ctx,
+		Log:                    log.NewTLog("AgentMailGateway"),
+		cfg:                    cfg,
+		now:                    time.Now,
+		nonceSource:            randomNonceSource(),
+		largeRequestSlots:      make(chan struct{}, maxConcurrentLargeRequests),
+		largeRequestSlotWait:   defaultLargeRequestSlotWait,
+		requestBodyBudget:      semaphore.NewWeighted(maxInFlightRequestBodyBytes),
+		responseBodyBudget:     semaphore.NewWeighted(maxInFlightResponseBodyBytes),
+		responseBodyBudgetWait: defaultResponseBodyBudgetWait,
 	}
 	if err != nil {
 		if errors.Is(err, errGatewayNotConfigured) {
@@ -358,6 +369,26 @@ func (g *Gateway) proxy(c *wkhttp.Context) {
 		respondGatewayError(c, errcode.ErrAgentMailGatewayBadResponse)
 		return
 	}
+	if unknownLength && c.Request.ProtoMajor >= 2 {
+		releaseResponseBodyBudget, err := g.acquireResponseBodyBudget(c.Request.Context())
+		if err != nil {
+			respondGatewayError(c, errcode.ErrAgentMailGatewayUnavailable)
+			return
+		}
+		defer releaseResponseBodyBudget()
+		// The gateway cannot reliably expose a later upstream truncation after an
+		// HTTP/2 status is committed. Validate the complete bounded body first, then
+		// forward it as a known-length response.
+		bufferedBody, bufferedLength, err := readBoundedResponseBody(response.Body, maxResponseBytes)
+		if err != nil {
+			g.Error("Agent Mail upstream response could not be buffered safely", zap.Error(err))
+			respondGatewayError(c, errcode.ErrAgentMailGatewayBadResponse)
+			return
+		}
+		response.Body = io.NopCloser(bufferedBody)
+		response.ContentLength = bufferedLength
+		unknownLength = false
+	}
 	if unknownLength && !(c.Request.ProtoMajor == 1 && c.Request.ProtoMinor >= 1) {
 		g.Error("Agent Mail response stream cannot expose truncation to a non-HTTP/1.1 client")
 		respondGatewayError(c, errcode.ErrAgentMailGatewayBadResponse)
@@ -456,6 +487,42 @@ func readBoundedBody(reader io.Reader, limit int64) ([]byte, error) {
 		return nil, errBodyTooLarge
 	}
 	return body, nil
+}
+
+// readBoundedResponseBody retains the complete response in fixed-size chunks.
+// Unlike io.ReadAll, this avoids geometrically reallocating and copying a large
+// contiguous slice while preserving the validate-before-commit requirement.
+func readBoundedResponseBody(reader io.Reader, limit int64) (io.Reader, int64, error) {
+	if reader == nil {
+		return bytes.NewReader(nil), 0, nil
+	}
+	var (
+		chunks []io.Reader
+		total  int64
+	)
+	for total <= limit {
+		remaining := limit + 1 - total
+		chunkSize := int64(responseBufferChunkBytes)
+		if remaining < chunkSize {
+			chunkSize = remaining
+		}
+		chunk := make([]byte, int(chunkSize))
+		n, err := io.ReadFull(reader, chunk)
+		if n > 0 {
+			total += int64(n)
+			chunks = append(chunks, bytes.NewReader(chunk[:n]))
+		}
+		if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+			return nil, 0, err
+		}
+		if total > limit {
+			return nil, 0, errBodyTooLarge
+		}
+		if err != nil {
+			return io.MultiReader(chunks...), total, nil
+		}
+	}
+	return nil, 0, errBodyTooLarge
 }
 
 func copyBoundedBody(dst io.Writer, src io.Reader, limit int64) error {
@@ -814,6 +881,31 @@ func (g *Gateway) acquireRequestBodyBudget(request *http.Request) (func(), error
 	var once sync.Once
 	return func() {
 		once.Do(func() { g.requestBodyBudget.Release(reservation) })
+	}, nil
+}
+
+func (g *Gateway) acquireResponseBodyBudget(ctx context.Context) (func(), error) {
+	if g.responseBodyBudget == nil {
+		return func() {}, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	wait := g.responseBodyBudgetWait
+	if wait <= 0 {
+		wait = defaultResponseBodyBudgetWait
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, wait)
+	defer cancel()
+	if err := g.responseBodyBudget.Acquire(waitCtx, maxResponseBytes); err != nil {
+		if ctx.Err() != nil {
+			return func() {}, ctx.Err()
+		}
+		return func() {}, errResponseBodyBudgetWait
+	}
+	var once sync.Once
+	return func() {
+		once.Do(func() { g.responseBodyBudget.Release(maxResponseBytes) })
 	}, nil
 }
 

--- a/modules/agentmailgateway/gateway_test.go
+++ b/modules/agentmailgateway/gateway_test.go
@@ -1,6 +1,7 @@
 package agentmailgateway
 
 import (
+	"bufio"
 	"bytes"
 	"compress/gzip"
 	"context"
@@ -10,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -255,6 +257,12 @@ func TestReadBoundedResponseBodyPreservesChunkedPayloadAndLimit(t *testing.T) {
 	if _, _, err := readBoundedResponseBody(bytes.NewReader(payload), int64(len(payload)-1)); !errors.Is(err, errBodyTooLarge) {
 		t.Fatalf("overflow error=%v", err)
 	}
+	if _, _, err := readBoundedResponseBody(&partialFailingReadCloser{
+		data: []byte("partial"),
+		err:  io.ErrUnexpectedEOF,
+	}, int64(len(payload))); !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("truncation error=%v", err)
+	}
 }
 
 func TestCopyBoundedBodyStreamsWithoutExceedingLimit(t *testing.T) {
@@ -406,6 +414,67 @@ func TestProxyRejectsTruncatedUnknownLengthResponseForRealHTTP2Client(t *testing
 	assertErrorCode(t, body, "err.server.agent_mail_gateway.bad_response")
 	if bytes.Contains(body, []byte("partial upstream body")) {
 		t.Fatalf("partial upstream body leaked in error response: %s", body)
+	}
+}
+
+func TestProxyRejectsTruncatedChunkedUpstreamForRealHTTP2Client(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	upstreamDone := make(chan error, 1)
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			upstreamDone <- acceptErr
+			return
+		}
+		defer connection.Close()
+		reader := bufio.NewReader(connection)
+		for {
+			line, readErr := reader.ReadString('\n')
+			if readErr != nil {
+				upstreamDone <- readErr
+				return
+			}
+			if line == "\r\n" {
+				break
+			}
+		}
+		_, writeErr := io.WriteString(connection,
+			"HTTP/1.1 200 OK\r\n"+
+				"Content-Type: text/plain\r\n"+
+				"Transfer-Encoding: chunked\r\n"+
+				"Connection: close\r\n\r\n"+
+				"10\r\npartial upstream\r\n")
+		upstreamDone <- writeErr
+	}()
+
+	gateway := newTestGateway(t, "http://"+listener.Addr().String(), []byte(strings.Repeat("g", 32)), time.Now())
+	server := httptest.NewUnstartedServer(newProxyRouter(gateway, "user-a", "space-a"))
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	defer server.Close()
+
+	response, err := server.Client().Get(server.URL + "/v1/mail-gateway/webapi/v0/mailboxes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.ProtoMajor != 2 || response.StatusCode != http.StatusBadGateway {
+		t.Fatalf("proto=%s status=%d body=%s", response.Proto, response.StatusCode, body)
+	}
+	assertErrorCode(t, body, "err.server.agent_mail_gateway.bad_response")
+	if bytes.Contains(body, []byte("partial upstream")) {
+		t.Fatalf("partial upstream body leaked in error response: %s", body)
+	}
+	if err := <-upstreamDone; err != nil {
+		t.Fatalf("truncated upstream: %v", err)
 	}
 }
 

--- a/modules/agentmailgateway/gateway_test.go
+++ b/modules/agentmailgateway/gateway_test.go
@@ -239,6 +239,24 @@ func TestReadBoundedBodyRejectsOverflow(t *testing.T) {
 	}
 }
 
+func TestReadBoundedResponseBodyPreservesChunkedPayloadAndLimit(t *testing.T) {
+	payload := bytes.Repeat([]byte("r"), responseBufferChunkBytes+17)
+	buffered, length, err := readBoundedResponseBody(bytes.NewReader(payload), int64(len(payload)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(buffered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if length != int64(len(payload)) || !bytes.Equal(got, payload) {
+		t.Fatalf("length=%d body length=%d", length, len(got))
+	}
+	if _, _, err := readBoundedResponseBody(bytes.NewReader(payload), int64(len(payload)-1)); !errors.Is(err, errBodyTooLarge) {
+		t.Fatalf("overflow error=%v", err)
+	}
+}
+
 func TestCopyBoundedBodyStreamsWithoutExceedingLimit(t *testing.T) {
 	var dst bytes.Buffer
 	if err := copyBoundedBody(&dst, strings.NewReader("123"), 3); err != nil {
@@ -315,8 +333,10 @@ func TestProxyStreamsSelfDelimitedUnknownLengthResponses(t *testing.T) {
 	}
 }
 
-func TestProxyRejectsUnknownLengthResponseForRealHTTP2Client(t *testing.T) {
+func TestProxyBuffersUnknownLengthResponseForRealHTTP2Client(t *testing.T) {
 	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.responseBodyBudget = semaphore.NewWeighted(maxResponseBytes)
+	gateway.responseBodyBudgetWait = 100 * time.Millisecond
 	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode:       http.StatusOK,
@@ -340,10 +360,126 @@ func TestProxyRejectsUnknownLengthResponseForRealHTTP2Client(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if response.ProtoMajor != 2 || response.StatusCode != http.StatusOK || string(body) != "complete" {
+		t.Fatalf("proto=%s status=%d body=%s", response.Proto, response.StatusCode, body)
+	}
+	if got := response.Header.Get("Content-Length"); got != strconv.Itoa(len("complete")) {
+		t.Fatalf("Content-Length=%q", got)
+	}
+	release, err := gateway.acquireResponseBodyBudget(context.Background())
+	if err != nil {
+		t.Fatalf("successful response retained its buffering budget: %v", err)
+	}
+	release()
+}
+
+func TestProxyRejectsTruncatedUnknownLengthResponseForRealHTTP2Client(t *testing.T) {
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			ProtoMajor:    2,
+			ContentLength: -1,
+			Body: &partialFailingReadCloser{
+				data: []byte("partial upstream body"),
+				err:  errors.New("truncated response"),
+			},
+		}, nil
+	})}
+	server := httptest.NewUnstartedServer(newProxyRouter(gateway, "user-a", "space-a"))
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	defer server.Close()
+
+	response, err := server.Client().Get(server.URL + "/v1/mail-gateway/webapi/v0/mailboxes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if response.ProtoMajor != 2 || response.StatusCode != http.StatusBadGateway {
 		t.Fatalf("proto=%s status=%d body=%s", response.Proto, response.StatusCode, body)
 	}
 	assertErrorCode(t, body, "err.server.agent_mail_gateway.bad_response")
+	if bytes.Contains(body, []byte("partial upstream body")) {
+		t.Fatalf("partial upstream body leaked in error response: %s", body)
+	}
+}
+
+func TestProxyRejectsOversizedUnknownLengthResponseForRealHTTP2Client(t *testing.T) {
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.responseBodyBudget = semaphore.NewWeighted(maxResponseBytes)
+	gateway.responseBodyBudgetWait = 100 * time.Millisecond
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			ProtoMajor:    2,
+			ContentLength: -1,
+			Body:          io.NopCloser(io.LimitReader(zeroReader{}, maxResponseBytes+1)),
+		}, nil
+	})}
+	server := httptest.NewUnstartedServer(newProxyRouter(gateway, "user-a", "space-a"))
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	defer server.Close()
+
+	response, err := server.Client().Get(server.URL + "/v1/mail-gateway/webapi/v0/mailboxes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.ProtoMajor != 2 || response.StatusCode != http.StatusBadGateway {
+		t.Fatalf("proto=%s status=%d body=%s", response.Proto, response.StatusCode, body)
+	}
+	assertErrorCode(t, body, "err.server.agent_mail_gateway.bad_response")
+	release, err := gateway.acquireResponseBodyBudget(context.Background())
+	if err != nil {
+		t.Fatalf("failed response retained its buffering budget: %v", err)
+	}
+	release()
+}
+
+func TestProxyRejectsHTTP2BufferingWhenResponseBudgetIsUnavailable(t *testing.T) {
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.responseBodyBudget = semaphore.NewWeighted(maxResponseBytes)
+	gateway.responseBodyBudgetWait = 10 * time.Millisecond
+	if err := gateway.responseBodyBudget.Acquire(context.Background(), maxResponseBytes); err != nil {
+		t.Fatal(err)
+	}
+	defer gateway.responseBodyBudget.Release(maxResponseBytes)
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			ProtoMajor:    2,
+			ContentLength: -1,
+			Body:          failingReadCloser{err: errors.New("body must not be read without a budget")},
+		}, nil
+	})}
+	server := httptest.NewUnstartedServer(newProxyRouter(gateway, "user-a", "space-a"))
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	defer server.Close()
+
+	response, err := server.Client().Get(server.URL + "/v1/mail-gateway/webapi/v0/mailboxes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.ProtoMajor != 2 || response.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("proto=%s status=%d body=%s", response.Proto, response.StatusCode, body)
+	}
+	assertErrorCode(t, body, "err.server.agent_mail_gateway.unavailable")
 }
 
 func TestProxyForwardsGzipResponseToHTTP2WithoutTransparentDecompression(t *testing.T) {
@@ -1142,6 +1278,33 @@ func TestUnknownLengthRequestReservesMaximumBodyBudget(t *testing.T) {
 	}
 }
 
+func TestResponseBufferingHasAggregateBudget(t *testing.T) {
+	gateway := &Gateway{
+		responseBodyBudget:     semaphore.NewWeighted(maxResponseBytes),
+		responseBodyBudgetWait: 10 * time.Millisecond,
+	}
+	release, err := gateway.acquireResponseBodyBudget(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := gateway.acquireResponseBodyBudget(canceled); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled acquire error=%v, want context.Canceled", err)
+	}
+	if _, err := gateway.acquireResponseBodyBudget(context.Background()); !errors.Is(err, errResponseBodyBudgetWait) {
+		t.Fatalf("bounded acquire error=%v, want errResponseBodyBudgetWait", err)
+	}
+
+	release()
+	releaseAfterWait, err := gateway.acquireResponseBodyBudget(context.Background())
+	if err != nil {
+		t.Fatalf("released response budget remained unavailable: %v", err)
+	}
+	releaseAfterWait()
+}
+
 func TestConnectionNominatedHeadersAreNotForwarded(t *testing.T) {
 	requestSource := http.Header{
 		"Connection":        []string{"Content-Type, X-Octo-Mailbox-ID"},
@@ -1176,16 +1339,18 @@ func newTestGateway(t *testing.T, upstreamURL string, secret []byte, now time.Ti
 		t.Fatal(err)
 	}
 	return &Gateway{
-		Log:                  log.NewTLog("AgentMailGatewayTest"),
-		cfg:                  gatewayConfig{upstream: parsed, secret: secret, timeout: 5 * time.Second},
-		client:               newGatewayHTTPClient(5 * time.Second),
-		now:                  func() time.Time { return now },
-		nonceSource:          bytes.NewReader(make([]byte, 16)),
-		largeRequestSlots:    make(chan struct{}, maxConcurrentLargeRequests),
-		largeRequestSlotWait: defaultLargeRequestSlotWait,
-		requestBodyBudget:    semaphore.NewWeighted(maxInFlightRequestBodyBytes),
-		provisionIdentity:    func(context.Context, string, string) error { return nil },
-		resolveLocalpart:     func(context.Context, string) (string, error) { return "test-user", nil },
+		Log:                    log.NewTLog("AgentMailGatewayTest"),
+		cfg:                    gatewayConfig{upstream: parsed, secret: secret, timeout: 5 * time.Second},
+		client:                 newGatewayHTTPClient(5 * time.Second),
+		now:                    func() time.Time { return now },
+		nonceSource:            bytes.NewReader(make([]byte, 16)),
+		largeRequestSlots:      make(chan struct{}, maxConcurrentLargeRequests),
+		largeRequestSlotWait:   defaultLargeRequestSlotWait,
+		requestBodyBudget:      semaphore.NewWeighted(maxInFlightRequestBodyBytes),
+		responseBodyBudget:     semaphore.NewWeighted(maxInFlightResponseBodyBytes),
+		responseBodyBudgetWait: defaultResponseBodyBudgetWait,
+		provisionIdentity:      func(context.Context, string, string) error { return nil },
+		resolveLocalpart:       func(context.Context, string) (string, error) { return "test-user", nil },
 	}
 }
 


### PR DESCRIPTION
## Summary

Buffer and validate unknown-length Agent Mail upstream bodies before forwarding them when the downstream hop terminating at octo-server uses HTTP/2.

Deployments that proxy to octo-server over HTTP/1.1 continue to use the existing HTTP/1.1 streaming path; this change does not alter ingress or proxy configuration.

## Related Issue

Fixes #789

## Linked Spec

`.octospec/tasks/agent-mail-http2-response/brief.md`

## Changes

- Read unknown-length HTTP/2 upstream bodies through the existing 64 MiB bound before committing the downstream response.
- Retain buffered responses in fixed-size chunks to avoid geometric whole-body reallocations.
- Limit aggregate response buffering to four 64 MiB reservations and honor request cancellation while waiting.
- Forward validated bodies with a computed `Content-Length`.
- Preserve the existing gateway error for truncated, unreadable, or oversized bodies.
- Keep HTTP/1.1 streaming behavior unchanged and update the module documentation.
- Add HTTP/2 success, failure, oversize, budget, and release regression tests.

## Testing

- [x] Unit tests added/updated
- `go test ./modules/agentmailgateway/... -count=1` — passed
- `go test -race ./modules/agentmailgateway/... -count=1` — passed
- `go vet ./modules/agentmailgateway/...` — passed
- `go build ./modules/agentmailgateway/...` — passed
- `golangci-lint v2.12.2 run --timeout=5m ./modules/agentmailgateway/...` — 0 issues
- `git diff --check` — passed

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**

   Unknown-length responses on handler-facing HTTP/2 connections are fully read through the existing size bound before the gateway commits a success status, then forwarded as a known-length response.

2. **What could break because of it?**

   Unknown-length HTTP/2 responses use bounded in-memory buffering. At most four full-size reservations are admitted concurrently; a request that cannot obtain a reservation within five seconds receives the existing localized unavailable response. HTTP/1.1 and known-length responses retain their current paths.

3. **How do you know it works?**

   Regression tests cover complete HTTP/2 delivery, upstream truncation, oversize rejection, budget exhaustion and cancellation, release after successful and failed buffering, and unchanged HTTP/1.1 behavior.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated module and task documentation
- [x] Followed Conventional Commits
