### PR TITLE
feat(cards): finalize document access requests

### DIFF
--- a/.octospec/tasks/card-action-callback-dispatch/brief.md
+++ b/.octospec/tasks/card-action-callback-dispatch/brief.md
@@ -23,7 +23,8 @@ service via a **signed, config-registered HTTP callback** carrying a typed
 decision request. The consumer service implements **one authenticated HTTP
 endpoint** that returns a decision result; octo-server owns everything else —
 queue consumption, retry/backoff/DLQ, callback signing, and rendering the final
-card state + applicant notification.
+card state. Standard approval routes also send a requester outcome; the Docs
+pilot intentionally uses only the in-place approver-card terminal state.
 
 This replaces the rejected **pull model** (where each new consumer would have to
 implement bot-event polling + ack + cursor + a bot token + card-edit + notify
@@ -51,7 +52,9 @@ unrecognized owner must never run a callback and only then fail finalization.
 **Pilot consumer — docs access-request approve/deny.** The docs
 `access_requested` notification is upgraded from an `octo/v1` display card to an
 `octo/v2` approve/deny card; the click is dispatched to docs-backend's decide
-endpoint; octo-server renders the finalized card + notifies the applicant.
+endpoint; octo-server renders the approver card in place. The Docs pilot does
+not send a second terminal IM card to the applicant; Docs remains the
+authoritative access-status surface.
 
 End-to-end (pilot):
 
@@ -68,8 +71,8 @@ A 申请文档 (docs-backend 创建 pending)
           request_id, inputs, data, channel/message ids, space_id, acted_at}
 → docs-backend 验签 → 幂等(event_id) → 重校验 B 仍为 admin → CAS pending→approved/denied
    返回: {disposition, state, requester_uid, display fields}
-→ octo-server 按返回结果: 编辑 B 的卡为最终态 (走卡片信任边界 + card_seq CAS)
-   + 给 A 发 v1 展示卡通知 (已获权 / 已拒绝)
+→ octo-server 按返回结果编辑 B 的卡为最终态 (走卡片信任边界 + card_seq CAS)
+→ 不给 A 再发第二张终态 IM 卡；申请状态以 Docs 权威状态为准
 → 全部完成后 ack (从分发队列移除)
 ```
 
@@ -264,10 +267,10 @@ injection anchor here:
 - **Custom outcome templates for future owners** — this task ships docs plus a
   generic standard-approval template. New custom visual families remain a code
   review, but standard approval consumers do not.
-- **Exactly-once applicant notification** — business decisions and terminal
-  edits are idempotent, but the applicant notification remains at-least-once.
-  A crash after transport success and before queue ack may produce a rare
-  duplicate, consistent with the existing notify contract; no outbox is added.
+- **Exactly-once requester outcome for standard routes** — business decisions
+  and terminal edits are idempotent, but a generic standard route's requester
+  outcome remains at-least-once. The Docs specialized route sends no second
+  applicant terminal IM card. No outbox is added.
 - **General circuit-breaker framework** — bounded concurrency and scheduled
   retry already protect dependencies in v1.
 
@@ -284,9 +287,10 @@ Machine-checkable on the octo-server side:
   POSTs a signed HTTPS request (valid versioned HMAC over method/path/timestamp/
   event_id/body hash, redirects disabled) to the
   registered URL with the typed-decision fields, then renders the final card
-  (via the carddispatch boundary, `card_seq` incremented) and sends the
-  applicant notification. Test asserts signature validity, request shape, card
-  finalized, notify sent, event ack'd. Oversized or malformed callback
+  (via the carddispatch boundary, `card_seq` incremented). The generic standard
+  route also sends its requester outcome; the Docs route does not. Tests assert
+  signature validity, request shape, finalization, route-specific delivery, and
+  ACK. Oversized or malformed callback
   responses are rejected before rendering.
 - **Retry + DLQ**: consumer 5xx/timeout → dispatcher retries with backoff and
   does NOT ack; after configured attempts → event lands in DLQ + an alert
@@ -298,9 +302,9 @@ Machine-checkable on the octo-server side:
 - **Idempotency / replay**: re-delivering the same `event_id` (dispatcher crash
   before ack) re-calls decide (consumer returns the same stored typed result)
   and re-renders the byte-identical terminal frame (`card_seq=event_id`, CAS
-  no-op). The applicant notification is at-least-once; tests assert no duplicate
-  domain transition or card revision and explicitly allow transport duplication
-  at the crash boundary.
+  no-op). Generic standard requester outcomes are at-least-once; tests assert no
+  duplicate domain transition or card revision and explicitly allow standard-route
+  transport duplication at the crash boundary. Docs sends no requester outcome.
 - **SSRF guard**: non-HTTPS, credential-bearing, fragment-bearing, or
   non-allowlisted exact URLs are rejected at config load; redirects are never
   followed and proxy environment variables are ignored. Cards never carry a
@@ -353,12 +357,13 @@ The **entire** docs-side work is one endpoint:
   and replay the same typed response for one `event_id`:
   - `disposition`: `applied|replayed|forbidden|conflict|not_found`.
   - `state`: `pending|approved|denied|cancelled`.
-  - bounded `requester_uid` is required for `approved` / `denied` (octo must
-    notify the applicant); it may be omitted for other states. Display fields
-    remain optional and are consumed only by reviewed octo templates.
-- No polling, no bot token, no card/IM/notify code. Grant is source-of-truth;
-  the applicant notification is octo's best-effort render (retry independent of
-  the grant).
+  - bounded `requester_uid` remains required by the shared typed response for
+    `approved` / `denied`. Generic standard finalizers consume it to send a
+    requester outcome; the Docs specialized finalizer ignores it and sends no
+    second applicant terminal IM card. Display fields remain optional and are
+    consumed only by reviewed octo templates.
+- No polling, no bot token, and no card/IM construction. The grant and request
+  state are authoritative in Docs; octo only terminalizes the approver card.
 
 ## Locked implementation decisions (maintainer-confirmed 2026-07-15)
 
@@ -373,7 +378,8 @@ The **entire** docs-side work is one endpoint:
 4. **Standard card lifecycle** — octo owns the generic initial approval
    template, final template, requester outcome, and shared mutation primitive.
    A route-bound notify token provides the only generic ingress. Docs binds a
-   specialized template; all other routes use the standard fallback. A new
+   specialized template and intentionally omits the requester outcome; all other
+   routes use the standard fallback. A new
    standard consumer needs only secrets + route + decide endpoint; a genuinely
    new visual template still requires an octo-server code review.
 5. **DLQ** — bounded retries, then DLQ retained 30 days; alert + manual replay
@@ -383,4 +389,5 @@ The **entire** docs-side work is one endpoint:
 7. **Retention** — live queue TTL equals `Robot.MessageExpire` (default 7 days),
    keeping D4 idempotency and actionable event windows aligned.
 8. **Delivery semantics** — callback decision and terminal card mutation are
-   idempotent; applicant notification is explicitly at-least-once.
+   idempotent; generic standard requester outcomes are explicitly at-least-once,
+   while Docs emits no second applicant terminal IM card.

--- a/.octospec/tasks/card-message-internal-dispatch/docs-notify-contract.md
+++ b/.octospec/tasks/card-message-internal-dispatch/docs-notify-contract.md
@@ -50,7 +50,7 @@
    smart-summary 的 dedup / retry / sweep 状态机。
 5. **模板/文案/链接归属 octo-server**:docs-backend **只发原始字段**;卡片布局、
    按钮文案(查看详情)、FactSet 标签(操作人 / 时间)、attribution
-   (「Alice 分享了文档」)、`/d/{doc_id}?sp={space_id}` deep-link、
+   (「Alice 分享了文档」)、`/d/{doc_id}` deep-link、
    `metadata.octo.variant` / `metadata.octo.source` 全部由 octo-server
    `pkg/cardtmpl` + `modules/notify.buildDocsCard` + `i18n.OutboundLanguage`
    生成。docs-backend 不再拼「XX 分享了 <link>」这类降级文本(旧字段作废;
@@ -74,6 +74,9 @@ X-Internal-Token: <OCTO_DOCS_NOTIFY_TOKEN>
     "kind":       "shared",            // "shared" | "commented" | "access_requested"
     "title":      "产品设计方案",         // 原始标题(server 负责转义/截断)
     "actor_name": "Alice",             // 预格式化的操作人显示名;空则用「有人」/「Someone」兜底
+    "requester_space_name": "产品空间",  // access_requested 可选;申请人来源 Space 展示名
+    "requested_bot_names": ["助手 A"],   // access_requested 可选;最多 50 项,每项最多 120 runes
+    "requested_role": "reader",         // access_requested: reader | commenter | writer | admin
     "excerpt":    "Q3 上线计划已确认",    // 可选预览/评论/申请说明;≤ 300 runes 截断
     "updated_at": "2026-07-13 15:04"   // 已格式化的时间字符串;空则省略「时间」行
   }
@@ -85,7 +88,7 @@ X-Internal-Token: <OCTO_DOCS_NOTIFY_TOKEN>
 
 ## 三个约定（对齐 summary-notify）
 
-- **标识 `doc_id`(不是自增 `id`)**:deep-link `/d/{doc_id}?sp={space_id}` 用
+- **标识 `doc_id`(不是自增 `id`)**:deep-link `/d/{doc_id}` 用
   docs-backend 侧不可枚举的文档标识 —— 与 octo-web `/d/:docId` 独立路由
   (已在线;冷加载 + 登录跳转 + XIN-398 多会话 sid 恢复)对齐。**这是 docs-notify
   与 summary-notify 的关键差异:docs 侧「查看详情」按钮开箱可用**,
@@ -108,6 +111,9 @@ X-Internal-Token: <OCTO_DOCS_NOTIFY_TOKEN>
 | `kind` | 触发场景:分享 = `shared`;评论 = `commented`;访问申请 = `access_requested` |
 | `title` | 文档 `title` 字段(空则用「无标题」兜底 —— docs-backend 侧决策) |
 | `actor_name` | 触发者的显示名(docs-backend 已 resolve;匿名场景可留空) |
+| `requester_space_name` | 访问申请人的来源 Space 展示名；可空，octo-server 截断到 200 runes |
+| `requested_bot_names` | 同时申请权限的 AI 助手展示名；可空，最多 50 项，每项截断到 120 runes |
+| `requested_role` | 访问申请角色；允许 `reader | commenter | writer | admin`（大小写不敏感）；空值兼容旧调用并按 `reader` 展示；未知非空值按契约错误拒绝，整次通知零投递 |
 | `excerpt` | 分享:留空 / 简短介绍;评论:评论内容摘要;访问申请:申请理由 |
 | `updated_at` | 触发事件的时间戳格式化字符串(docs-backend 时区) |
 

--- a/docs/card-action-callback-consumer.md
+++ b/docs/card-action-callback-consumer.md
@@ -103,7 +103,9 @@ docs-only `doc_id` and `request_id` top-level conveniences may be absent. For a
 standard approval result, `display.title` is optional but recommended; octo
 uses only that reviewed display field, removes all actions, renders the status,
 and sends a v1 requester outcome. It ignores callback-authored URLs, card JSON,
-reasons, and arbitrary display fields.
+reasons, and arbitrary display fields. The Docs specialized finalizer is the
+exception: it terminalizes approver cards in place and sends no second applicant
+terminal IM card.
 
 Docs uses the same callback transport contract but keeps its existing
 `DocsCard`/`OCTO_DOCS_NOTIFY_TOKEN` ingress and specialized deep-link/template
@@ -457,8 +459,10 @@ states or the standard terminal wording cannot represent the result, the
 consumer needs a separately reviewed finalizer/template rather than inventing
 callback response fields.
 
-`requester_uid` is required whenever `state` is `approved` or `denied`, because
-octo-server must notify the applicant. It must be the consumer-authoritative
+`requester_uid` remains required by the shared typed response whenever `state`
+is `approved` or `denied`. Generic standard approval finalizers consume it to
+send a requester outcome; the Docs specialized finalizer ignores it and sends
+no second applicant terminal IM card. It must be the consumer-authoritative
 request initiator, not the operator or an unverified callback field. Responses
 are limited to 64 KiB and the current decoder rejects unknown top-level fields.
 `display` accepts at most 32 string fields; keys are non-empty and at most 64
@@ -473,7 +477,7 @@ For standard approval routes, the originating card must carry an authoritative
 
 | Consumer response                             | octo-server behavior                               |
 | --------------------------------------------- | -------------------------------------------------- |
-| `2xx` + valid typed body                      | Finalize card; approved/denied also notify requester; then ACK |
+| `2xx` + valid typed body                      | Finalize card; generic standard approved/denied also notify requester; Docs does not; then ACK |
 | `408`, `429`, or `5xx`                        | Retry with bounded exponential backoff             |
 | Other `4xx`                                   | Permanent rejection; move to DLQ                   |
 | `3xx`                                         | Redirect rejected; move to DLQ                     |
@@ -493,5 +497,5 @@ Do not return HTTP 403/404 for normal domain outcomes; use the typed
 - an unknown `decision` is rejected without a domain transition;
 - concurrent decisions produce one domain winner;
 - operator removed from ACL before click returns `forbidden`;
-- terminal `approved`/`denied` always includes `requester_uid`;
+- terminal `approved`/`denied` always includes `requester_uid`; Docs accepts but does not consume it;
 - transient `5xx` can be retried safely.

--- a/docs/card-action-callback-dispatch.md
+++ b/docs/card-action-callback-dispatch.md
@@ -231,11 +231,11 @@ Alert from these bounded-label metrics:
 - `dmwork_card_action_dispatch_leased{owner}`
 - `dmwork_card_action_dispatch_ready_depth`
 - `dmwork_card_action_dispatch_dlq_depth`
-- `dmwork_card_action_dispatch_applicant_notify_failure_total{owner}`
+- `dmwork_card_action_dispatch_applicant_notify_failure_total{owner}` (generic standard routes; Docs emits none)
 
 Deployment-specific thresholds belong in the monitoring repository. At
 minimum, alert on sustained DLQ depth above zero and sustained `consumer_5xx`,
-`invalid_response`, or applicant notification failures.
+`invalid_response`, or generic requester-outcome notification failures.
 
 A `route_missing` at dispatch is treated as transient (a rolling deploy / restart
 that came up before `OCTO_CARD_ACTION_ROUTES` loaded the route): the event is
@@ -264,8 +264,9 @@ go run ./tools/card-action-dlq -config configs/tsdd.yaml -action replay -event-i
 
 Replay resets attempts and returns that one event to ready state. The consumer
 must remain idempotent: its domain decision may already have committed. Terminal
-card mutation is also idempotent (`card_seq=event_id`). Applicant notification
-is at-least-once, so replay may duplicate it at the documented crash boundary.
+card mutation is also idempotent (`card_seq=event_id`). Generic standard-route
+requester outcomes are at-least-once, so replay may duplicate one at the
+documented crash boundary. The Docs specialized route emits no requester outcome.
 Replay is non-destructive: an entry older than the CLI's resolved retention is
 refused (`event_id N was not present in the DLQ`) but left intact for the server to
 prune — it never deletes a server-retained entry. If a replay reports "not present"

--- a/docs/card-protocol.md
+++ b/docs/card-protocol.md
@@ -259,7 +259,7 @@ Bot API 的服务端视觉默认值；错误形状仍是该 API 的单一 conten
 客户端点按钮 → POST /v1/message/card/action     （鉴权/防伪造/幂等,即时 ack）
             → 服务端按 stored sender + data.owner/action_type 分支：
               - 注册的一方 sender/route：内部可靠队列 → HMAC callback
-                → octo-server 写终态卡并通知申请人
+                → octo-server 写终态卡；通用审批再通知申请人，Docs 专用路由不发第二张终态卡
               - 其它 Bot：bot 事件队列 event_type="card_action"
                 （/v1/bot/events 轮询,至少一次）→ Bot 调 /v1/bot/message/edit
             → message_extra + CMD /v1/message/extra/sync

--- a/docs/docs-notify-card.md
+++ b/docs/docs-notify-card.md
@@ -93,7 +93,7 @@ brief），发送方为分享用户本人，与本 producer 无关。docs-notify
   "type": "AdaptiveCard",
   "version": "1.5",
   "metadata": {
-    "webUrl": "https://im.example.com/d/d_20260713_abcd?sp=spc_xxx",
+    "webUrl": "https://im.example.com/d/d_20260713_abcd",
     "octo": {
       "variant": "docs.shared",
       "source": { "label": "文档" }
@@ -111,7 +111,7 @@ brief），发送方为分享用户本人，与本 producer 无关。docs-notify
     ]},
     { "type": "ActionSet", "actions": [
       { "type": "Action.OpenUrl", "title": "查看详情",
-        "url": "https://im.example.com/d/d_20260713_abcd?sp=spc_xxx" }
+        "url": "https://im.example.com/d/d_20260713_abcd" }
     ]}
   ]
 }
@@ -156,8 +156,9 @@ WuKongIM wire 信封（`plain` 由服务端权威派生）：
 - `kind: "access_requested"` + `actor_name: "Bob"` → attribution =
   `"Bob 请求访问文档"`，`metadata.octo.variant = "docs.access_requested"`
 
-`access_requested` 的交互卡、终态和申请人结果通知不在本文重复，统一引用
-[`card-action-callback-dispatch.md`](./card-action-callback-dispatch.md)。
+`access_requested` 的交互卡和终态不在本文重复，统一引用
+[`card-action-callback-dispatch.md`](./card-action-callback-dispatch.md)。Docs 只原地
+终态化审批人卡片，不再给申请人发送第二张终态 IM 卡。
 
 **约定** `docs-backend` 端预格式化 `actor_name`（可含姓+称谓、显示名等，逐字符
 `escapeMarkdown` 后落入 attribution）。octo-server 不做二次身份解析（避免 card 路径
@@ -207,16 +208,16 @@ WuKongIM wire 信封（`plain` 由服务端权威派生）：
 按钮文案由 `pkg/cardtmpl.labelsForLanguage` 提供（同 summary）：
 `viewDetails=查看详情/View details`、`copy=复制/Copy`（docs-notify 未使用后者）。
 
-## 6. Deep-link（`/d/{doc_id}?sp={space_id}`）
+## 6. Deep-link（`/d/{doc_id}`）
 
 `cardtmpl.docsDeepLink`：从 `External.WebLoginURL` 取 origin（`scheme://host`），拼
-`/d/` + `PathEscape(doc_id)` + `?sp=` + `QueryEscape(space_id)`。origin 必须是
-**绝对 https**；否则 `BuildDocsResourceCard` 返回错误 → 请求级降级为纯文本 DM。
+`/d/` + `PathEscape(doc_id)`。origin 必须是**绝对 https**；否则
+`BuildDocsResourceCard` 返回错误 → 请求级降级为纯文本 DM。
 
-**前置**：octo-web `/d/:docId` 路由**已在线**（`packages/dmworkbase` 走的是既有
-standalone doc 通路，含冷加载 → 登录跳转 → 多会话 sid 恢复的 XIN-398 测试套件）。
-这是 docs-notify 与 summary-notify 的关键差异——docs 侧「查看详情」按钮开箱可用；
-summary 侧仍在等 octo-web `/s/:taskId` 上线。
+Docs 链接不携带 `?sp=`。octo-web 的 standalone `/d/:docId` 打开链路从其
+服务端确认的持久化打开上下文恢复 viewer Space；旧 `sp` 查询参数不再是权限或
+路由依据。该路径覆盖冷加载、登录跳转和多会话 sid 恢复。summary 仍使用独立的
+`/s/:taskId?sp=...` 契约，两者不要求保持相同链接形状。
 
 ## 7. 降级与错误分类
 

--- a/internal/cardactiondispatch/orchestration_integration_test.go
+++ b/internal/cardactiondispatch/orchestration_integration_test.go
@@ -139,7 +139,7 @@ func TestCardActionCallbackOrchestrationWithMockDocs(t *testing.T) {
 	require.NoError(t, cardactiondispatch.Install(ctx, service))
 
 	sender := &callbackE2ESender{}
-	docsFinalizer, err := notify.NewDocsActionFinalizer(ctx, carddispatch.NewCardMutator(ctx), sender)
+	docsFinalizer, err := notify.NewDocsActionFinalizer(ctx, carddispatch.NewCardMutator(ctx))
 	require.NoError(t, err)
 	finalizer := &callbackE2EFinalizer{delegate: docsFinalizer}
 	dispatcher, err := cardactiondispatch.NewDispatcher(

--- a/modules/notify/action_finalizer.go
+++ b/modules/notify/action_finalizer.go
@@ -25,7 +25,6 @@ type DocsActionFinalizer struct {
 	ctx     *config.Context
 	mutator cardActionMutator
 	updater cardtmpl.CardUpdater
-	sender  carddispatch.Sender
 }
 
 type actionFinalizeError struct {
@@ -37,31 +36,27 @@ func (e *actionFinalizeError) Error() string    { return "notify: " + e.category
 func (e *actionFinalizeError) Unwrap() error    { return e.err }
 func (e *actionFinalizeError) Category() string { return e.category }
 
-func NewDocsActionFinalizer(ctx *config.Context, mutator cardActionMutator, sender carddispatch.Sender) (*DocsActionFinalizer, error) {
-	if ctx == nil || mutator == nil || sender == nil {
+func NewDocsActionFinalizer(ctx *config.Context, mutator cardActionMutator) (*DocsActionFinalizer, error) {
+	if ctx == nil || mutator == nil {
 		return nil, errors.New("notify: docs action finalizer dependencies are required")
 	}
-	return &DocsActionFinalizer{ctx: ctx, mutator: mutator, sender: sender}, nil
+	return &DocsActionFinalizer{ctx: ctx, mutator: mutator}, nil
 }
 
-func NewDocsActionFinalizerWithUpdater(ctx *config.Context, updater cardtmpl.CardUpdater, mutator cardActionMutator, sender carddispatch.Sender) (*DocsActionFinalizer, error) {
-	if ctx == nil || updater == nil || mutator == nil || sender == nil {
+func NewDocsActionFinalizerWithUpdater(ctx *config.Context, updater cardtmpl.CardUpdater, mutator cardActionMutator) (*DocsActionFinalizer, error) {
+	if ctx == nil || updater == nil || mutator == nil {
 		return nil, errors.New("notify: docs action finalizer dependencies are required")
 	}
-	return &DocsActionFinalizer{ctx: ctx, updater: updater, mutator: mutator, sender: sender}, nil
+	return &DocsActionFinalizer{ctx: ctx, updater: updater, mutator: mutator}, nil
 }
 
 func NewDocsActionFinalizerFromContext(ctx *config.Context) (*DocsActionFinalizer, error) {
-	sender, err := carddispatch.SenderFromContext(ctx, docsNotifyProducerID)
-	if err != nil {
-		return nil, err
-	}
 	mutator := carddispatch.NewCardMutator(ctx)
 	updater, err := cardtmpl.NewCardUpdater(cardtmpl.DefaultCatalog(), mutator)
 	if err != nil {
 		return nil, err
 	}
-	return NewDocsActionFinalizerWithUpdater(ctx, updater, mutator, sender)
+	return NewDocsActionFinalizerWithUpdater(ctx, updater, mutator)
 }
 
 func (f *DocsActionFinalizer) Finalize(ctx context.Context, event cardactiondispatch.Event, result cardactiondispatch.DecisionResult) error {
@@ -71,10 +66,6 @@ func (f *DocsActionFinalizer) Finalize(ctx context.Context, event cardactiondisp
 	docID, _ := event.Data["doc_id"].(string)
 	if strings.TrimSpace(docID) == "" || strings.TrimSpace(event.SpaceID) == "" {
 		return errors.New("notify: docs action result is missing authoritative context")
-	}
-	if (result.State == cardactiondispatch.StateApproved || result.State == cardactiondispatch.StateDenied) &&
-		strings.TrimSpace(result.RequesterUID) == "" {
-		return errors.New("notify: terminal docs decision is missing requester_uid")
 	}
 	// The mutator addresses a DM by the sender's peer. The ingress now stamps that
 	// same peer into event.ChannelID, so for a freshly enqueued event this rewrite
@@ -107,7 +98,6 @@ func (f *DocsActionFinalizer) Finalize(ctx context.Context, event cardactiondisp
 	if v, ok := event.Inputs[cardtmpl.DocsDenyReasonInputID].(string); ok {
 		denyReason = strings.TrimSpace(v)
 	}
-	terminal := result.State == cardactiondispatch.StateApproved || result.State == cardactiondispatch.StateDenied
 	// Every state renders through the Registry when an updater is present, not
 	// just the decided ones. The pending card is a Registry render and so
 	// carries the server-authored catalog markers; the fallback below rebuilds
@@ -126,7 +116,7 @@ func (f *DocsActionFinalizer) Finalize(ctx context.Context, event cardactiondisp
 			return err
 		}
 	} else {
-		terminalDocument, err := f.buildTerminalDocument(ctx, lang, docID, event.SpaceID, title, denyReason, result)
+		terminalDocument, err := f.buildTerminalDocument(ctx, lang, event, title, denyReason, result)
 		if err != nil {
 			return err
 		}
@@ -141,27 +131,16 @@ func (f *DocsActionFinalizer) Finalize(ctx context.Context, event cardactiondisp
 			return err
 		}
 	}
-	if !terminal {
-		return nil
-	}
-	outcomeDocument, err := f.buildOutcomeDocument(ctx, lang, docID, event.SpaceID, title, denyReason, result.State)
-	if err != nil {
-		return err
-	}
-	_, err = f.sender.Send(ctx, carddispatch.Target{
-		SpaceID: event.SpaceID, ChannelID: result.RequesterUID, ChannelType: common.ChannelTypePerson.Uint8(),
-	}, carddispatch.Card{Profile: cardmsg.ProfileV1, Document: outcomeDocument})
-	if err != nil {
-		return &actionFinalizeError{category: "applicant_notify_failed", err: err}
-	}
+	// The original request card is the sole terminal surface. Do not send a
+	// second "access granted/denied" card to the requester.
 	return nil
 }
 
 // 0.3.0 result view schema 的各字段 rune 上限(见
-// handoff/docs.access-request@0.3.0/contract/data.schema.json)。回调 Display 与
-// event.Data 的值合法可达 500 runes(cardactiondispatch 契约),必须在渲染前截断
+// handoff/docs.access-request@0.3.0/contract/data.schema.json)。回调 Display
+// 的值合法可达 500 runes，而 event.Data 只受卡片信封总大小约束；必须在渲染前截断
 // 到各自 schema cap —— 否则 RenderCard 的 InputSchema 校验返回 ErrFieldsInvalid,
-// ReplaceView 确定性失败,审批卡永远停在 pending 且申请人漏通知(PR#641 review P1)。
+// ReplaceView 确定性失败,审批卡永远停在 pending，审批人看不到终态(PR#641 review P1)。
 // 截断而非编造,与 denyReason 既有做法一致。
 const (
 	capResultTitle      = 200                      // document.title / document.sourceName
@@ -194,14 +173,15 @@ func (f *DocsActionFinalizer) replaceWithRegistryResult(ctx context.Context, eve
 	if err != nil {
 		return err
 	}
-	fields, state, err := buildDocsAccessResultFields(lang, docsResultRenderInput{
-		Data:             event.Data,
-		Title:            title,
-		OperatorName:     result.Display["operator_name"],
-		DecidedAtDisplay: result.Display["decided_at"],
-		DenyReason:       denyReason,
-		Denied:           result.State == cardactiondispatch.StateDenied,
-		Cancelled:        result.State == cardactiondispatch.StateCancelled,
+	fields, state, err := buildDocsAccessResultFields(lang, version, docsResultRenderInput{
+		Data:              event.Data,
+		Title:             title,
+		OperatorName:      result.Display["operator_name"],
+		OperatorSpaceName: result.Display["operator_space_name"],
+		DecidedAtDisplay:  result.Display["decided_at"],
+		DenyReason:        denyReason,
+		Denied:            result.State == cardactiondispatch.StateDenied,
+		Cancelled:         result.State == cardactiondispatch.StateCancelled,
 		// Anything that is not a decision and not an explicit cancellation —
 		// `pending` today, whatever a later contract adds — renders as
 		// unavailable, which is what the pre-Registry fallback already showed
@@ -232,17 +212,18 @@ func (f *DocsActionFinalizer) replaceWithRegistryResult(ctx context.Context, eve
 // from the stored server-authored Action.Submit payload, never caller display
 // JSON, so request/document identity cannot be rewritten during a mutation.
 type docsResultRenderInput struct {
-	Data             map[string]interface{}
-	Title            string
-	OperatorName     string
-	DecidedAtDisplay string
-	DenyReason       string
-	Denied           bool
-	Cancelled        bool
-	Unavailable      bool
+	Data              map[string]interface{}
+	Title             string
+	OperatorName      string
+	OperatorSpaceName string
+	DecidedAtDisplay  string
+	DenyReason        string
+	Denied            bool
+	Cancelled         bool
+	Unavailable       bool
 }
 
-func buildDocsAccessResultFields(lang string, input docsResultRenderInput) (json.RawMessage, cardtmpl.State, error) {
+func buildDocsAccessResultFields(lang, version string, input docsResultRenderInput) (json.RawMessage, cardtmpl.State, error) {
 	requestID := strings.TrimSpace(stringEventData(input.Data, "request_id"))
 	docID := strings.TrimSpace(stringEventData(input.Data, "doc_id"))
 	if requestID == "" || docID == "" {
@@ -281,6 +262,11 @@ func buildDocsAccessResultFields(lang string, input docsResultRenderInput) (json
 		"title": truncRunes(strings.TrimSpace(title), capResultTitle),
 	}
 	requester := map[string]any{"name": truncRunes(strings.TrimSpace(actor), capResultName)}
+	if version == docsaccessrequest.TemplateVersionV3 {
+		if value := strings.TrimSpace(stringEventData(input.Data, "requester_space_name")); value != "" {
+			requester["sourceSpaceName"] = truncRunes(value, capResultTitle)
+		}
+	}
 	if value := strings.TrimSpace(stringEventData(input.Data, "source_name")); value != "" {
 		document["sourceName"] = truncRunes(value, capResultTitle)
 	}
@@ -299,10 +285,14 @@ func buildDocsAccessResultFields(lang string, input docsResultRenderInput) (json
 	// approved/rejected; emitting one here would put the generic operator
 	// placeholder on a card nobody acted on.
 	if !input.Cancelled && !input.Unavailable {
-		fields["decision"] = map[string]any{
+		decision := map[string]any{
 			"operatorName":     truncRunes(operatorName, capResultName),
 			"decidedAtDisplay": truncRunes(strings.TrimSpace(input.DecidedAtDisplay), capResultShortLabel),
 		}
+		if version == docsaccessrequest.TemplateVersionV3 {
+			decision["operatorSpaceName"] = truncRunes(strings.TrimSpace(input.OperatorSpaceName), capResultTitle)
+		}
+		fields["decision"] = decision
 	}
 	dataCaps := map[string]int{
 		"requestReason":      capResultReason,
@@ -327,6 +317,19 @@ func buildDocsAccessResultFields(lang string, input docsResultRenderInput) (json
 	if len(permission) > 0 {
 		fields["permission"] = permission
 	}
+	if version == docsaccessrequest.TemplateVersionV3 {
+		if names := stringSliceEventData(input.Data, "requested_bot_names"); len(names) > 0 {
+			bounded := make([]string, 0, len(names))
+			for _, name := range names[:min(len(names), 50)] {
+				if value := strings.TrimSpace(name); value != "" {
+					bounded = append(bounded, truncRunes(value, capResultName))
+				}
+			}
+			if len(bounded) > 0 {
+				fields["requestedBotNames"] = bounded
+			}
+		}
+	}
 	if wireState == "rejected" && denyReason != "" {
 		fields["decision"].(map[string]any)["rejectionReason"] = denyReason
 	}
@@ -342,16 +345,35 @@ func stringEventData(data map[string]interface{}, key string) string {
 	return value
 }
 
-func (f *DocsActionFinalizer) buildTerminalDocument(ctx context.Context, lang, docID, spaceID, title, denyReason string, result cardactiondispatch.DecisionResult) (json.RawMessage, error) {
+func stringSliceEventData(data map[string]interface{}, key string) []string {
+	switch values := data[key].(type) {
+	case []string:
+		return values
+	case []interface{}:
+		out := make([]string, 0, len(values))
+		for _, raw := range values {
+			if value, ok := raw.(string); ok {
+				out = append(out, value)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func (f *DocsActionFinalizer) buildTerminalDocument(ctx context.Context, lang string, event cardactiondispatch.Event, title, denyReason string, result cardactiondispatch.DecisionResult) (json.RawMessage, error) {
 	labels := docsLabelsFor(lang)
+	docID := stringEventData(event.Data, "doc_id")
+	spaceID := event.SpaceID
 	webLoginURL := f.ctx.GetConfig().External.WebLoginURL
 	// The legacy/no-updater fallback still emits the enriched outcome card; the
 	// normal finalizer and sibling mutation paths render V3 through the Registry.
 	switch result.State {
 	case cardactiondispatch.StateApproved:
-		return buildDocsDecisionTerminalDocument(ctx, webLoginURL, lang, docID, spaceID, title, denyReason, false)
+		return buildDocsDecisionTerminalDocument(ctx, webLoginURL, lang, docID, spaceID, title, denyReason, false, event.Data, result.Display)
 	case cardactiondispatch.StateDenied:
-		return buildDocsDecisionTerminalDocument(ctx, webLoginURL, lang, docID, spaceID, title, denyReason, true)
+		return buildDocsDecisionTerminalDocument(ctx, webLoginURL, lang, docID, spaceID, title, denyReason, true, event.Data, result.Display)
 	}
 	// Cancelled / unavailable are transient states without an enriched design —
 	// keep the prior plain resource-card rebuild.
@@ -359,54 +381,34 @@ func (f *DocsActionFinalizer) buildTerminalDocument(ctx context.Context, lang, d
 	if result.State == cardactiondispatch.StateCancelled {
 		attribution, variant = labels.accessCancelledBanner, "docs.access_cancelled"
 	}
-	return cardtmpl.BuildDocsResourceCard(ctx, webLoginURL, docID, spaceID, cardtmpl.ResourceCard{
+	return cardtmpl.BuildDocsResourceCard(ctx, webLoginURL, docID, cardtmpl.ResourceCard{
 		Title: title, Attribution: attribution, Variant: variant, Source: cardtmpl.Source{Label: labels.sourceLabel},
 	})
 }
 
 // buildDocsDecisionTerminalDocument renders the legacy/no-updater fallback for
 // approved/denied outcomes. Production result updates use CardUpdater at the card's stored version.
-func buildDocsDecisionTerminalDocument(ctx context.Context, webLoginURL, lang, docID, spaceID, title, denyReason string, denied bool) (json.RawMessage, error) {
+func buildDocsDecisionTerminalDocument(ctx context.Context, webLoginURL, lang, docID, spaceID, title, denyReason string, denied bool, data map[string]interface{}, display map[string]string) (json.RawMessage, error) {
 	labels := docsLabelsFor(lang)
+	content := cardtmpl.DocsOutcomeContent{
+		Title: title, Source: cardtmpl.Source{Label: labels.sourceLabel},
+		HeaderLabel:               labels.approvalHeader,
+		RequestedAtDisplay:        stringEventData(data, "requested_at_display"),
+		MessageTimeDisplay:        display["decided_at"],
+		DecisionOperatorName:      display["operator_name"],
+		DecisionOperatorSpaceName: display["operator_space_name"],
+	}
 	if denied {
-		return cardtmpl.BuildDocsApprovalOutcomeCard(ctx, webLoginURL, docID, spaceID, cardtmpl.DocsOutcomeContent{
-			Title: title, Variant: "docs.access_denied", Source: cardtmpl.Source{Label: labels.sourceLabel},
-			Denied: true, HeaderLabel: labels.approvalHeader, StatusLabel: labels.deniedStatus,
-			ResultText: labels.deniedResult, ReasonLabel: labels.denyReasonLabel, Reason: denyReason,
-		})
+		content.Variant = "docs.access_denied"
+		content.Denied = true
+		content.StatusLabel = labels.deniedStatus
+		content.ReasonLabel = labels.denyReasonLabel
+		content.Reason = denyReason
+	} else {
+		content.Variant = "docs.access_approved"
+		content.StatusLabel = labels.approvedStatus
 	}
-	return cardtmpl.BuildDocsApprovalOutcomeCard(ctx, webLoginURL, docID, spaceID, cardtmpl.DocsOutcomeContent{
-		Title: title, Variant: "docs.access_approved", Source: cardtmpl.Source{Label: labels.sourceLabel},
-		Denied: false, HeaderLabel: labels.approvalHeader, StatusLabel: labels.approvedStatus,
-		ResultText: labels.approvedResult,
-	})
-}
-
-func (f *DocsActionFinalizer) buildOutcomeDocument(ctx context.Context, lang, docID, spaceID, title, denyReason string, state cardactiondispatch.State) (json.RawMessage, error) {
-	labels := docsLabelsFor(lang)
-	attribution := labels.accessGrantedBanner
-	variant := "docs.access_granted"
-	var facts []cardtmpl.Fact
-	if state == cardactiondispatch.StateDenied {
-		attribution, variant = labels.accessDeniedBanner, "docs.access_denied"
-		// Surface the reviewer's reason to the applicant — a denial is useless to
-		// them without it. Rides as a labeled FactSet row on the same resource
-		// card (no profile/card-type change); omitted when no reason was typed.
-		if reason := strings.TrimSpace(denyReason); reason != "" {
-			// cardtmpl caps FactSet values at maxFactRunes; an over-long reason
-			// fails the whole card build and drops the denial notification
-			// entirely (retries included). Truncate to MaxExcerptRunes — the
-			// same bound the terminal card's reason box uses — so a long reason
-			// is trimmed, never silently lost.
-			if r := []rune(reason); len(r) > cardtmpl.MaxExcerptRunes {
-				reason = string(r[:cardtmpl.MaxExcerptRunes])
-			}
-			facts = append(facts, cardtmpl.Fact{Title: labels.denyReasonLabel, Value: reason})
-		}
-	}
-	return cardtmpl.BuildDocsResourceCard(ctx, f.ctx.GetConfig().External.WebLoginURL, docID, spaceID, cardtmpl.ResourceCard{
-		Title: title, Attribution: attribution, Variant: variant, Facts: facts, Source: cardtmpl.Source{Label: labels.sourceLabel},
-	})
+	return cardtmpl.BuildDocsApprovalOutcomeCard(ctx, webLoginURL, docID, content)
 }
 
 func buildTerminalEnvelope(document json.RawMessage, spaceID string, cardSeq int64) (string, error) {

--- a/modules/notify/action_finalizer_test.go
+++ b/modules/notify/action_finalizer_test.go
@@ -22,14 +22,14 @@ func (m *captureCardMutator) Mutate(_ context.Context, request carddispatch.Card
 	return carddispatch.CardMutationResult{Applied: true}, nil
 }
 
-func TestDocsActionFinalizerUsesEventIDAsCardSeqAndNotifiesRequester(t *testing.T) {
+func TestDocsActionFinalizerUsesEventIDAsCardSeqWithoutSecondOutcomeCard(t *testing.T) {
 	wk := newWuKongServer()
 	defer wk.close()
 	ctx := newTestContext(t, wk)
 	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
 	mutator := &captureCardMutator{}
 	sender := &capturingCardSender{}
-	finalizer, err := NewDocsActionFinalizer(ctx, mutator, sender)
+	finalizer, err := NewDocsActionFinalizer(ctx, mutator)
 	if err != nil {
 		t.Fatalf("NewDocsActionFinalizer() error = %v", err)
 	}
@@ -70,24 +70,20 @@ func TestDocsActionFinalizerUsesEventIDAsCardSeqAndNotifiesRequester(t *testing.
 		t.Fatal("terminal card leaked unreviewed callback display fields")
 	}
 
-	outcome := sender.last()
-	if target := sender.lastTarget(); target.ChannelID != result.RequesterUID || target.SpaceID != event.SpaceID {
-		t.Fatalf("applicant outcome target = %+v, want requester %q in space %q", target, result.RequesterUID, event.SpaceID)
-	}
-	if outcome.Profile != cardmsg.ProfileV1 {
-		t.Fatalf("applicant outcome profile = %q, want octo/v1", outcome.Profile)
-	}
-	if strings.Contains(string(outcome.Document), "must-not-render") {
-		t.Fatal("applicant outcome leaked approver/reason")
+	if len(sender.cards) != 0 {
+		t.Fatalf("second outcome card count = %d, want 0", len(sender.cards))
 	}
 
-	// Replayed callbacks render byte-identical content. The second applicant
-	// notification is explicitly allowed by the at-least-once boundary.
+	// Replayed callbacks render byte-identical content and still do not create
+	// a second outcome card.
 	if err := finalizer.Finalize(context.Background(), event, result); err != nil {
 		t.Fatalf("Finalize(replay) error = %v", err)
 	}
 	if len(mutator.requests) != 2 || mutator.requests[0].ContentEdit != mutator.requests[1].ContentEdit {
 		t.Fatal("replay did not produce a byte-identical deterministic terminal frame")
+	}
+	if len(sender.cards) != 0 {
+		t.Fatalf("replay created second outcome cards: %d", len(sender.cards))
 	}
 }
 
@@ -99,7 +95,7 @@ func TestDocsActionFinalizerEnrichedTerminalAndDenyReason(t *testing.T) {
 
 	build := func(state cardactiondispatch.State, inputs map[string]interface{}) string {
 		mutator := &captureCardMutator{}
-		finalizer, err := NewDocsActionFinalizer(ctx, mutator, &capturingCardSender{})
+		finalizer, err := NewDocsActionFinalizer(ctx, mutator)
 		if err != nil {
 			t.Fatalf("NewDocsActionFinalizer() error = %v", err)
 		}
@@ -124,8 +120,9 @@ func TestDocsActionFinalizerEnrichedTerminalAndDenyReason(t *testing.T) {
 	}
 
 	approved := build(cardactiondispatch.StateApproved, nil)
-	if !strings.Contains(approved, "已允许") || !strings.Contains(approved, "申请人已获得所申请的文档权限。") {
-		t.Fatalf("approved terminal card missing enriched result box: %s", approved)
+	if !strings.Contains(approved, "已允许") || strings.Contains(approved, "申请人已获得所申请的文档权限。") ||
+		strings.Contains(approved, `"style":"good"`) {
+		t.Fatalf("approved terminal card retained duplicate result block: %s", approved)
 	}
 
 	// The reviewer deny reason rides in via event.Inputs and is surfaced on the
@@ -138,17 +135,15 @@ func TestDocsActionFinalizerEnrichedTerminalAndDenyReason(t *testing.T) {
 	}
 }
 
-// The applicant's outcome notification (a fresh resource card sent to the
-// requester, distinct from the reviewer's in-place terminal rewrite) must also
-// carry the deny reason — a denial is useless to the applicant without it.
-func TestDocsActionFinalizerApplicantNotifyCarriesDenyReason(t *testing.T) {
+// Docs terminalization updates only the original request card. It must not send
+// a second approved/denied resource card to the requester.
+func TestDocsActionFinalizerDoesNotSendSecondOutcomeCard(t *testing.T) {
 	wk := newWuKongServer()
 	defer wk.close()
 	ctx := newTestContext(t, wk)
 	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
-
 	sender := &capturingCardSender{}
-	finalizer, err := NewDocsActionFinalizer(ctx, &captureCardMutator{}, sender)
+	finalizer, err := NewDocsActionFinalizer(ctx, &captureCardMutator{})
 	if err != nil {
 		t.Fatalf("NewDocsActionFinalizer() error = %v", err)
 	}
@@ -166,25 +161,24 @@ func TestDocsActionFinalizerApplicantNotifyCarriesDenyReason(t *testing.T) {
 	if err := finalizer.Finalize(context.Background(), event, result); err != nil {
 		t.Fatalf("Finalize() error = %v", err)
 	}
-	outcome := sender.last()
-	if !strings.Contains(string(outcome.Document), "范围不符，请缩小到 Q3") {
-		t.Fatalf("applicant outcome card missing deny reason: %s", outcome.Document)
+	if len(sender.cards) != 0 {
+		t.Fatalf("second outcome card count = %d, want 0", len(sender.cards))
 	}
 }
 
-func TestDocsActionFinalizerRejectsTerminalResultWithoutRequesterBeforeMutation(t *testing.T) {
+func TestDocsActionFinalizerDoesNotRequireRequesterForTerminalMutation(t *testing.T) {
 	wk := newWuKongServer()
 	defer wk.close()
 	ctx := newTestContext(t, wk)
 	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
 	mutator := &captureCardMutator{}
-	finalizer, err := NewDocsActionFinalizer(ctx, mutator, &capturingCardSender{})
+	finalizer, err := NewDocsActionFinalizer(ctx, mutator)
 	if err != nil {
 		t.Fatalf("NewDocsActionFinalizer() error = %v", err)
 	}
 	event := cardactiondispatch.Event{
 		EventID: 42, SenderUID: NotifyBotUIDValue, Owner: "docs", ActionType: "access_request.decision",
-		MessageID: "1001", ChannelID: "user-b", ChannelType: 1, SpaceID: "space-1",
+		MessageID: "1001", ChannelID: "user-b", ChannelType: 1, SpaceID: "space-1", OperatorUID: "user-b",
 		Data: map[string]interface{}{"doc_id": "doc-1", "request_id": "request-1"},
 	}
 	result := cardactiondispatch.DecisionResult{
@@ -192,11 +186,11 @@ func TestDocsActionFinalizerRejectsTerminalResultWithoutRequesterBeforeMutation(
 		State:       cardactiondispatch.StateApproved,
 		Display:     map[string]string{"title": "Roadmap"},
 	}
-	if err := finalizer.Finalize(context.Background(), event, result); err == nil {
-		t.Fatal("Finalize() error = nil for terminal result without requester_uid")
+	if err := finalizer.Finalize(context.Background(), event, result); err != nil {
+		t.Fatalf("Finalize() error = %v", err)
 	}
-	if len(mutator.requests) != 0 {
-		t.Fatalf("mutation count = %d, want 0 before requester validation", len(mutator.requests))
+	if len(mutator.requests) != 1 {
+		t.Fatalf("mutation count = %d, want 1", len(mutator.requests))
 	}
 }
 
@@ -225,7 +219,7 @@ func TestDocsActionFinalizerUsesAuthoritativeMutationChannel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mutator := &captureCardMutator{}
-			finalizer, err := NewDocsActionFinalizer(ctx, mutator, &capturingCardSender{})
+			finalizer, err := NewDocsActionFinalizer(ctx, mutator)
 			if err != nil {
 				t.Fatalf("NewDocsActionFinalizer() error = %v", err)
 			}
@@ -360,18 +354,16 @@ func TestStandardActionFinalizerUsesAuthoritativeGroupChannel(t *testing.T) {
 	}
 }
 
-// A reviewer reason over cardtmpl's per-fact limit (the input allows up to 4 KiB,
-// only byte-capped by ValidateInputs, not maxLength) must be truncated, not
-// dropped — an over-long FactSet value fails the applicant card build and loses
-// the denial notification entirely, retries included.
-func TestDocsActionFinalizerLongDenyReasonTruncatedNotDropped(t *testing.T) {
+// A reviewer reason over the card limit must be truncated on the original
+// terminal card rather than causing terminalization to fail.
+func TestDocsActionFinalizerLongDenyReasonTruncatedInPlace(t *testing.T) {
 	wk := newWuKongServer()
 	defer wk.close()
 	ctx := newTestContext(t, wk)
 	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
-
+	mutator := &captureCardMutator{}
 	sender := &capturingCardSender{}
-	finalizer, err := NewDocsActionFinalizer(ctx, &captureCardMutator{}, sender)
+	finalizer, err := NewDocsActionFinalizer(ctx, mutator)
 	if err != nil {
 		t.Fatalf("NewDocsActionFinalizer() error = %v", err)
 	}
@@ -386,19 +378,21 @@ func TestDocsActionFinalizerLongDenyReasonTruncatedNotDropped(t *testing.T) {
 		Disposition: cardactiondispatch.DispositionApplied, State: cardactiondispatch.StateDenied,
 		RequesterUID: "user-a", Display: map[string]string{"title": "Roadmap"},
 	}
-	// Must NOT error — before the fix a 600-rune reason failed the card build.
 	if err := finalizer.Finalize(context.Background(), event, result); err != nil {
 		t.Fatalf("Finalize() with a 600-rune reason must not fail: %v", err)
 	}
-	doc := string(sender.last().Document)
-	if len(doc) == 0 {
-		t.Fatal("applicant outcome card was dropped for a long deny reason")
+	if len(mutator.requests) != 1 {
+		t.Fatalf("mutation count = %d, want 1", len(mutator.requests))
 	}
-	// Truncated to MaxExcerptRunes(300): 300 consecutive runes survive, 301 do not.
-	if !strings.Contains(doc, strings.Repeat("超", cardtmpl.MaxExcerptRunes)) {
-		t.Fatalf("expected reason truncated to %d runes to appear", cardtmpl.MaxExcerptRunes)
+	doc := mutator.requests[0].ContentEdit
+	// Card text truncation reserves the final rune for an ellipsis.
+	if !strings.Contains(doc, strings.Repeat("超", cardtmpl.MaxExcerptRunes-1)+"…") {
+		t.Fatalf("expected bounded reason with ellipsis: %s", doc)
 	}
-	if strings.Contains(doc, strings.Repeat("超", cardtmpl.MaxExcerptRunes+1)) {
-		t.Fatalf("reason exceeded %d runes — not truncated", cardtmpl.MaxExcerptRunes)
+	if strings.Contains(doc, strings.Repeat("超", cardtmpl.MaxExcerptRunes)) {
+		t.Fatalf("reason exceeded the %d-rune visual bound", cardtmpl.MaxExcerptRunes)
+	}
+	if len(sender.cards) != 0 {
+		t.Fatalf("second outcome card count = %d, want 0", len(sender.cards))
 	}
 }

--- a/modules/notify/action_finalizer_v3_test.go
+++ b/modules/notify/action_finalizer_v3_test.go
@@ -41,13 +41,13 @@ func TestDocsActionFinalizerUsesV3RegistryResultForTerminalStates(t *testing.T) 
 	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
 	updater := &captureViewUpdater{}
 	legacyMutator := &captureCardMutator{}
-	finalizer, err := NewDocsActionFinalizerWithUpdater(ctx, updater, legacyMutator, &capturingCardSender{})
+	finalizer, err := NewDocsActionFinalizerWithUpdater(ctx, updater, legacyMutator)
 	if err != nil {
 		t.Fatalf("NewDocsActionFinalizerWithUpdater: %v", err)
 	}
 	event := cardactiondispatch.Event{
 		EventID: 42, SenderUID: NotifyBotUIDValue, Owner: "docs", ActionType: "access_request.decision",
-		MessageID: "1001", ChannelID: NotifyBotUIDValue, ChannelType: 1, SpaceID: "space-1", OperatorUID: "reviewer-1",
+		MessageID: "1001", ChannelID: NotifyBotUIDValue, ChannelType: 1, SpaceID: "card-space-a", OperatorUID: "reviewer-1",
 		Inputs: map[string]any{cardtmpl.DocsDenyReasonInputID: "scope mismatch"},
 		Data: map[string]any{
 			"doc_id": "doc-1", "request_id": "request-1", "doc_title": "Roadmap", "actor": "Alice",
@@ -58,7 +58,10 @@ func TestDocsActionFinalizerUsesV3RegistryResultForTerminalStates(t *testing.T) 
 	}
 	result := cardactiondispatch.DecisionResult{
 		Disposition: cardactiondispatch.DispositionApplied, State: cardactiondispatch.StateDenied,
-		RequesterUID: "user-a", Display: map[string]string{"title": "Roadmap"},
+		RequesterUID: "user-a", Display: map[string]string{
+			"title": "Roadmap", "operator_name": "林澈", "operator_space_id": "operator-space-b",
+			"operator_space_name": "Operator Space B", "decided_at": "2026-08-20 19:01",
+		},
 	}
 	if err := finalizer.Finalize(context.Background(), event, result); err != nil {
 		t.Fatalf("Finalize: %v", err)
@@ -80,8 +83,24 @@ func TestDocsActionFinalizerUsesV3RegistryResultForTerminalStates(t *testing.T) 
 		t.Fatalf("result fields = %+v", fields)
 	}
 	decision := fields["decision"].(map[string]any)
-	if decision["operatorName"] != "审批人" || decision["rejectionReason"] != "scope mismatch" {
+	if decision["operatorName"] != "林澈" || decision["operatorSpaceName"] != "Operator Space B" ||
+		decision["decidedAtDisplay"] != "2026-08-20 19:01" || decision["rejectionReason"] != "scope mismatch" {
 		t.Fatalf("decision fields = %+v", decision)
+	}
+	r := cardtmpl.NewRegistry()
+	r.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	r.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
+	r.Freeze()
+	rendered, err := r.Render(context.Background(), updater.id, updater.version, updater.state, updater.fields, updater.env)
+	if err != nil {
+		t.Fatalf("render terminal fields: %v", err)
+	}
+	renderedJSON, err := json.Marshal(rendered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(renderedJSON), "Operator Space B") || strings.Contains(string(renderedJSON), "card-space-a") {
+		t.Fatalf("terminal display must identify operator Space B, never card Space A: %s", renderedJSON)
 	}
 	if strings.Contains(string(updater.fields), event.OperatorUID) {
 		t.Fatalf("result fields exposed raw operator uid: %s", updater.fields)
@@ -99,6 +118,40 @@ func TestDocsActionFinalizerUsesV3RegistryResultForTerminalStates(t *testing.T) 
 		t.Fatalf("BuildEnv = %+v", updater.env)
 	}
 	_ = carddispatch.CardMutationResult{}
+}
+
+func TestDocsActionFinalizerUsesConsumerResolvedOperatorDisplay(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	updater := &captureViewUpdater{}
+	finalizer := &DocsActionFinalizer{ctx: ctx, updater: updater}
+	event := cardactiondispatch.Event{
+		EventID: 42, SenderUID: NotifyBotUIDValue, Owner: "docs", ActionType: "access_request.decision",
+		MessageID: "1001", ChannelID: NotifyBotUIDValue, ChannelType: 1, SpaceID: "card-space-a", OperatorUID: "reviewer-1",
+		Data: map[string]any{"doc_id": "doc-1", "request_id": "request-1"},
+	}
+	result := cardactiondispatch.DecisionResult{
+		State: cardactiondispatch.StateApproved,
+		Display: map[string]string{
+			"operator_name": "林澈", "operator_space_name": "产品中心", "operator_space_id": "untrusted-space-id",
+		},
+	}
+	if err := finalizer.replaceWithRegistryResult(context.Background(), event, result,
+		NotifyBotUIDValue, "zh-CN", "Roadmap", ""); err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(updater.fields, &fields); err != nil {
+		t.Fatal(err)
+	}
+	decision := fields["decision"].(map[string]any)
+	if decision["operatorName"] != "林澈" || decision["operatorSpaceName"] != "产品中心" {
+		t.Fatalf("decision display = %+v", decision)
+	}
+	if strings.Contains(string(updater.fields), "untrusted-space-id") {
+		t.Fatalf("operator ids must not enter display fields: %s", updater.fields)
+	}
 }
 
 func TestDocsActionFinalizerV3OmitsUnavailableV2Decoration(t *testing.T) {
@@ -215,7 +268,7 @@ func storedVersionFinalizerFixture(t *testing.T) (*captureViewUpdater, *DocsActi
 	ctx := newTestContext(t, wk)
 	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
 	updater := &captureViewUpdater{}
-	finalizer, err := NewDocsActionFinalizerWithUpdater(ctx, updater, &captureCardMutator{}, &capturingCardSender{})
+	finalizer, err := NewDocsActionFinalizerWithUpdater(ctx, updater, &captureCardMutator{})
 	if err != nil {
 		t.Fatalf("NewDocsActionFinalizerWithUpdater: %v", err)
 	}
@@ -310,7 +363,7 @@ func TestDocsActionFinalizerRoutesEveryStateThroughTheRegistry(t *testing.T) {
 			ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
 			updater := &captureViewUpdater{}
 			legacyMutator := &captureCardMutator{}
-			finalizer, err := NewDocsActionFinalizerWithUpdater(ctx, updater, legacyMutator, &capturingCardSender{})
+			finalizer, err := NewDocsActionFinalizerWithUpdater(ctx, updater, legacyMutator)
 			if err != nil {
 				t.Fatalf("NewDocsActionFinalizerWithUpdater: %v", err)
 			}
@@ -360,6 +413,40 @@ func TestDocsActionFinalizerRoutesEveryStateThroughTheRegistry(t *testing.T) {
 // which would turn the routing fix into a runtime error instead of a card. The
 // finalizer tests above drive a capturing fake and never reach ViewFor, so this
 // is the only thing that witnesses the manifest declaration.
+func TestBuildDocsAccessResultFieldsGatesV3OnlyFieldsByVersion(t *testing.T) {
+	input := docsResultRenderInput{
+		Data: map[string]any{
+			"request_id": "request-1", "doc_id": "doc-1", "requester_space_name": "Space B",
+			"requested_bot_names": []string{"Bot A"},
+		},
+		Title: "Roadmap", OperatorName: "Reviewer", OperatorSpaceName: "Operator Space",
+	}
+	for _, test := range []struct {
+		version string
+		wantV3  bool
+	}{
+		{version: docsaccessrequest.TemplateVersionV3, wantV3: true},
+		{version: "0.4.0", wantV3: false},
+	} {
+		raw, _, err := buildDocsAccessResultFields("en", test.version, input)
+		if err != nil {
+			t.Fatalf("version %s: %v", test.version, err)
+		}
+		var fields map[string]any
+		if err := json.Unmarshal(raw, &fields); err != nil {
+			t.Fatal(err)
+		}
+		requester := fields["requester"].(map[string]any)
+		decision := fields["decision"].(map[string]any)
+		_, hasSpace := requester["sourceSpaceName"]
+		_, hasOperatorSpace := decision["operatorSpaceName"]
+		_, hasBots := fields["requestedBotNames"]
+		if hasSpace != test.wantV3 || hasOperatorSpace != test.wantV3 || hasBots != test.wantV3 {
+			t.Fatalf("version %s fields = %+v", test.version, fields)
+		}
+	}
+}
+
 func TestDocsAccessRequestV3RendersTheNonDecisionStates(t *testing.T) {
 	registry := cardtmpl.NewRegistry()
 	registry.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
@@ -388,7 +475,7 @@ func TestDocsAccessRequestV3RendersTheNonDecisionStates(t *testing.T) {
 			input := test.input
 			input.Data = map[string]any{"request_id": "request-1", "doc_id": "doc-1"}
 			input.Title = "Roadmap"
-			fields, state, err := buildDocsAccessResultFields("zh-CN", input)
+			fields, state, err := buildDocsAccessResultFields("zh-CN", docsaccessrequest.TemplateVersionV3, input)
 			if err != nil {
 				t.Fatalf("buildDocsAccessResultFields: %v", err)
 			}

--- a/modules/notify/card.go
+++ b/modules/notify/card.go
@@ -366,7 +366,7 @@ type summaryLabels struct {
 // deliverDocsCardNotification is the docs-notify card path. Structurally it
 // mirrors deliverCardNotification (dedup -> actor exclusion -> live member
 // verification -> bounded fan-out) but binds to the docs-notify producer and
-// uses BuildDocsResourceCard for the /d/{doc_id}?sp={space_id} deep link. A
+// uses BuildDocsResourceCard for the /d/{doc_id} deep link. A
 // build failure degrades the whole request to a plain-text DM so a docs
 // notification is never silently lost. Runtime-catalog safety rejections are
 // excluded from that fallback and fail closed so an emergency block cannot be
@@ -677,7 +677,7 @@ func (n *Notify) buildDocsCard(ctx context.Context, spaceID string, card *DocsCa
 	attribution, variant := docsAttributionAndVariant(card.Kind, card.ActorName, labels)
 
 	webLoginURL := n.ctx.GetConfig().External.WebLoginURL
-	return cardtmpl.BuildDocsResourceCard(ctx, webLoginURL, card.DocID, spaceID, cardtmpl.ResourceCard{
+	return cardtmpl.BuildDocsResourceCard(ctx, webLoginURL, card.DocID, cardtmpl.ResourceCard{
 		Title:       card.Title,
 		Attribution: attribution,
 		Excerpt:     docsSafeExcerpt(card),
@@ -694,7 +694,7 @@ func (n *Notify) buildDocsCard(ctx context.Context, spaceID string, card *DocsCa
 // 断言与 Registry.Render 字节等价;card_action_test.go 也引用它。请勿把它误当成
 // 第二条活的生产渲染路径;真要改 access-request 卡的生产行为,改 pilot Template
 // (pkg/cardtmpl/docs_access_request) 或 Registry.Render。
-func (n *Notify) buildDocsAccessRequestCard(ctx context.Context, spaceID string, card *DocsCardFields, lang string) (json.RawMessage, error) {
+func (n *Notify) buildDocsAccessRequestCard(ctx context.Context, card *DocsCardFields, lang string) (json.RawMessage, error) {
 	labels := docsLabelsFor(lang)
 	actor := strings.TrimSpace(card.ActorName)
 	bannerSuffix := labels.requestBannerSuffix
@@ -706,7 +706,6 @@ func (n *Notify) buildDocsAccessRequestCard(ctx context.Context, spaceID string,
 		n.ctx.GetConfig().External.WebLoginURL,
 		card.DocID,
 		card.RequestID,
-		spaceID,
 		cardtmpl.DocsApprovalContent{
 			Title:        card.Title,
 			Actor:        actor,
@@ -841,8 +840,6 @@ type docsLabels struct {
 	roleRequester       string // "申请人" / "Requester"
 	reasonLabel         string // "申请原因" / "Reason"
 	denyReasonLabel     string // "拒绝原因" / "Reason for denial"
-	approvedResult      string // result-box copy on approval
-	deniedResult        string // result-box copy on denial
 	decisionActor       string // safe generic when callback omits operator display name
 }
 
@@ -875,8 +872,6 @@ func docsLabelsFor(lang string) docsLabels {
 			roleRequester:             "申请人",
 			reasonLabel:               "申请原因",
 			denyReasonLabel:           "拒绝原因",
-			approvedResult:            "申请人已获得所申请的文档权限。",
-			deniedResult:              "申请已被拒绝。",
 			decisionActor:             "审批人",
 		}
 	}
@@ -907,8 +902,6 @@ func docsLabelsFor(lang string) docsLabels {
 		roleRequester:             "Requester",
 		reasonLabel:               "Reason",
 		denyReasonLabel:           "Reason for denial",
-		approvedResult:            "The requester now has the requested document access.",
-		deniedResult:              "The access request was denied.",
 		decisionActor:             "Reviewer",
 	}
 }

--- a/modules/notify/card_action_test.go
+++ b/modules/notify/card_action_test.go
@@ -62,7 +62,7 @@ func TestBuildDocsAccessRequestCardProducesValidOctoV2(t *testing.T) {
 	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
 	n := newTestNotify(ctx, nil, nil, nil, "legacy-token")
 
-	document, err := n.buildDocsAccessRequestCard(context.Background(), "space-1", validAccessRequestDocsCard(), "zh-CN")
+	document, err := n.buildDocsAccessRequestCard(context.Background(), validAccessRequestDocsCard(), "zh-CN")
 	require.NoError(t, err)
 	var card map[string]interface{}
 	require.NoError(t, json.Unmarshal(document, &card))

--- a/modules/notify/card_mutate_api.go
+++ b/modules/notify/card_mutate_api.go
@@ -85,11 +85,14 @@ type CardMutateReq struct {
 	DocID       string `json:"doc_id"`
 	Title       string `json:"title"`
 	DenyReason  string `json:"deny_reason"` // surfaced on the denied terminal card; empty on approve
-	// OperatorName / DecidedAtDisplay are optional additive display fields.
-	// Older callers omit them and receive localized generic operator copy; raw
-	// UIDs are never derived as display copy by this endpoint.
-	OperatorName     string `json:"operator_name"`
-	DecidedAtDisplay string `json:"decided_at_display"`
+	// Operator display fields are optional and are resolved once by the trusted
+	// Docs decision service. IDs are retained as bounded audit context only;
+	// octo-server never uses unbound caller-supplied IDs for display lookup.
+	OperatorUID       string `json:"operator_uid"`
+	OperatorName      string `json:"operator_name"`
+	OperatorSpaceID   string `json:"operator_space_id"`
+	OperatorSpaceName string `json:"operator_space_name"`
+	DecidedAtDisplay  string `json:"decided_at_display"`
 }
 
 // CardMutateResp reports whether the card is now terminal.
@@ -250,13 +253,14 @@ func replaceSiblingWithRegistryResult(ctx context.Context, updater cardtmpl.Card
 		return fmt.Errorf("%w: %v", errDocsSiblingContextInvalid, err)
 	}
 	denied := req.Kind == DocsCardKindAccessDenied
-	fields, state, err := buildDocsAccessResultFields(env.Lang, docsResultRenderInput{
-		Data:             data,
-		Title:            req.Title,
-		OperatorName:     req.OperatorName,
-		DecidedAtDisplay: req.DecidedAtDisplay,
-		DenyReason:       req.DenyReason,
-		Denied:           denied,
+	fields, state, err := buildDocsAccessResultFields(env.Lang, version, docsResultRenderInput{
+		Data:              data,
+		Title:             req.Title,
+		OperatorName:      req.OperatorName,
+		OperatorSpaceName: req.OperatorSpaceName,
+		DecidedAtDisplay:  req.DecidedAtDisplay,
+		DenyReason:        req.DenyReason,
+		Denied:            denied,
 	})
 	if err != nil {
 		return fmt.Errorf("%w: %v", errDocsSiblingContextInvalid, err)

--- a/modules/notify/card_mutate_api_test.go
+++ b/modules/notify/card_mutate_api_test.go
@@ -17,6 +17,23 @@ func TestDocsCardMutateSeqKeyCompatibility(t *testing.T) {
 	}
 }
 
+func TestCardMutateReqParsesResolvedOperatorDisplay(t *testing.T) {
+	var req CardMutateReq
+	if err := json.Unmarshal([]byte(`{
+		"space_id":"card-space-a",
+		"operator_uid":"reviewer-1",
+		"operator_space_id":"operator-space-b",
+		"operator_name":"Reviewer B",
+		"operator_space_name":"Operator Space B"
+	}`), &req); err != nil {
+		t.Fatal(err)
+	}
+	if req.SpaceID != "card-space-a" || req.OperatorSpaceID != "operator-space-b" ||
+		req.OperatorName != "Reviewer B" || req.OperatorSpaceName != "Operator Space B" {
+		t.Fatalf("parsed request = %+v", req)
+	}
+}
+
 // TestDocsAccessCardVariant is the capability-containment guard for the docs
 // card-mutate endpoint (PR review P0): the shared `notification` bot sends docs,
 // summary, and action-outcome cards, so the mutate endpoint must gate on the

--- a/modules/notify/card_test.go
+++ b/modules/notify/card_test.go
@@ -274,8 +274,8 @@ func TestBuildDocsCard_ProducesValidOctoV1(t *testing.T) {
 				"card":         cardObj,
 			}
 			require.NoError(t, cardmsg.Validate(envelope), "docs template output must pass octo/v1 Validate")
-			// Deep link built from WebLoginURL origin only, /d/{doc_id}?sp={space}.
-			assert.Contains(t, string(doc), "https://im.example.com/d/doc_abcd?sp=spc_1")
+			// Deep link built from WebLoginURL origin only, /d/{doc_id}.
+			assert.Contains(t, string(doc), "https://im.example.com/d/doc_abcd")
 			assert.NotContains(t, string(doc), "/login")
 			// Variant identifier is embedded in metadata.octo.variant.
 			metadata, _ := cardObj["metadata"].(map[string]interface{})

--- a/modules/notify/card_via_registry.go
+++ b/modules/notify/card_via_registry.go
@@ -88,16 +88,22 @@ func templateFallbackText(card *DocsCardFields, lang, spaceID string) (string, b
 	if catalog == nil {
 		return "", false
 	}
-	fields, err := mapDocsCardFieldsToJSON(card, lang)
+	metaCtx, cancelMeta := boundedNotifyCatalogContext(context.Background())
+	access := notifyCatalogAccess(docsNotifyProducerID, spaceID)
+	meta, err := catalog.MetaDefault(metaCtx, cardtmpl.CatalogDefaultRequest{Access: access, ID: docsaccessrequest.TemplateID})
+	cancelMeta()
 	if err != nil {
 		return "", false
 	}
-	ctx, cancel := boundedNotifyCatalogContext(context.Background())
-	defer cancel()
-	text, err := catalog.FallbackText(ctx, cardtmpl.CatalogFallbackRequest{
-		Access: notifyCatalogAccess(docsNotifyProducerID, spaceID),
-		ID:     docsaccessrequest.TemplateID, State: docsaccessrequest.StatePending,
-		Fields: fields, Lang: lang,
+	fields, err := mapDocsCardFieldsToJSON(card, lang, meta.Version)
+	if err != nil {
+		return "", false
+	}
+	fallbackCtx, cancelFallback := boundedNotifyCatalogContext(context.Background())
+	defer cancelFallback()
+	text, err := catalog.FallbackText(fallbackCtx, cardtmpl.CatalogFallbackRequest{
+		Access: access, ID: docsaccessrequest.TemplateID, Version: meta.Version,
+		State: docsaccessrequest.StatePending, Fields: fields, Lang: lang,
 	})
 	if err != nil || strings.TrimSpace(text) == "" {
 		return "", false
@@ -134,7 +140,7 @@ func preflightDocsAccessRequestSchema(parent context.Context, spaceID string, ca
 	if err != nil {
 		return notifyCatalogLookupError(docsaccessrequest.TemplateID, err)
 	}
-	fields, err := mapDocsCardFieldsToJSON(card, "zh-CN") // preflight 只关心 schema shape,lang 无差异
+	fields, err := mapDocsCardFieldsToJSON(card, "zh-CN", meta.Version) // preflight 只关心 schema shape,lang 无差异
 	if err != nil {
 		return fmt.Errorf("%w: map: %v", cardtmpl.ErrFieldsInvalid, err)
 	}
@@ -190,7 +196,14 @@ func (n *Notify) buildDocsAccessRequestCardViaRegistry(
 		return nil, "", fmt.Errorf("%w: default catalog not wired", errCardTmplUnavailable)
 	}
 
-	fields, err := mapDocsCardFieldsToJSON(card, lang)
+	metaCtx, cancelMeta := boundedNotifyCatalogContext(ctx)
+	access := notifyCatalogAccess(docsNotifyProducerID, spaceID)
+	meta, err := catalog.MetaDefault(metaCtx, cardtmpl.CatalogDefaultRequest{Access: access, ID: docsaccessrequest.TemplateID})
+	cancelMeta()
+	if err != nil {
+		return nil, "", notifyCatalogLookupError(docsaccessrequest.TemplateID, err)
+	}
+	fields, err := mapDocsCardFieldsToJSON(card, lang, meta.Version)
 	if err != nil {
 		return nil, "", fmt.Errorf("notify: map DocsCardFields to schema JSON: %w", err)
 	}
@@ -200,11 +213,11 @@ func (n *Notify) buildDocsAccessRequestCardViaRegistry(
 		Lang:        lang,
 		SpaceID:     spaceID,
 	}
-	catalogCtx, cancel := boundedNotifyCatalogContext(ctx)
-	defer cancel()
-	cardDoc, _, renderProfile, err := cardtmpl.RenderCatalogCardWithProfiles(catalogCtx, catalog, cardtmpl.CatalogRenderRequest{
-		Access: notifyCatalogAccess(docsNotifyProducerID, spaceID),
-		ID:     docsaccessrequest.TemplateID, State: docsaccessrequest.StatePending, Fields: fields, Env: env,
+	renderCtx, cancelRender := boundedNotifyCatalogContext(ctx)
+	defer cancelRender()
+	cardDoc, _, renderProfile, err := cardtmpl.RenderCatalogCardWithProfiles(renderCtx, catalog, cardtmpl.CatalogRenderRequest{
+		Access: access, ID: docsaccessrequest.TemplateID, Version: meta.Version,
+		State: docsaccessrequest.StatePending, Fields: fields, Env: env,
 	})
 	if err != nil {
 		return nil, "", err
@@ -332,7 +345,7 @@ func preflightDocsDisplaySchema(
 //
 // state 恒 "pending" (本 PR pilot 只注册 pending view;approved/rejected 由
 // standard_action_finalizer 生成,不走 ingress)。
-func mapDocsCardFieldsToJSON(card *DocsCardFields, lang string) (json.RawMessage, error) {
+func mapDocsCardFieldsToJSON(card *DocsCardFields, lang, version string) (json.RawMessage, error) {
 	if card == nil {
 		return nil, errors.New("mapDocsCardFieldsToJSON: nil card")
 	}
@@ -357,6 +370,25 @@ func mapDocsCardFieldsToJSON(card *DocsCardFields, lang string) (json.RawMessage
 		"requestedAtDisplay": strings.TrimSpace(card.UpdatedAt),
 		"messageTimeDisplay": strings.TrimSpace(card.UpdatedAt),
 	}
+	if version == docsaccessrequest.TemplateVersionV3 {
+		m["requester"].(map[string]any)["sourceSpaceName"] = cardtmpl.TruncateRunes(strings.TrimSpace(card.RequesterSpaceName), 200)
+	}
+	requestedBotNames := make([]string, 0, min(len(card.RequestedBotNames), 50))
+	for _, name := range card.RequestedBotNames[:min(len(card.RequestedBotNames), 50)] {
+		if value := strings.TrimSpace(name); value != "" {
+			requestedBotNames = append(requestedBotNames, cardtmpl.TruncateRunes(value, 120))
+		}
+	}
+	if version == docsaccessrequest.TemplateVersionV3 && len(requestedBotNames) > 0 {
+		m["requestedBotNames"] = requestedBotNames
+	}
+	if version == docsaccessrequest.TemplateVersionV3 {
+		roleLabel, err := docsRequestedRoleLabel(card.RequestedRole, lang)
+		if err != nil {
+			return nil, err
+		}
+		m["permission"] = map[string]any{"roleLabel": roleLabel}
+	}
 	// document.url 由服务端拼接 (docsDeepLink 在 cardtmpl 内做),这里留空,
 	// schema 允许空;pilot Template Build 内部不读它,读的是 requestId + WebLoginURL。
 	raw, err := json.Marshal(m)
@@ -364,6 +396,26 @@ func mapDocsCardFieldsToJSON(card *DocsCardFields, lang string) (json.RawMessage
 		return nil, fmt.Errorf("marshal mapped fields: %w", err)
 	}
 	return json.RawMessage(raw), nil
+}
+
+func docsRequestedRoleLabel(role, lang string) (string, error) {
+	zh := strings.EqualFold(lang, "zh-CN") || strings.HasPrefix(strings.ToLower(lang), "zh")
+	role = strings.ToLower(strings.TrimSpace(role))
+	if role == "" {
+		role = "reader" // legacy callers omitted requested_role and requested viewer access
+	}
+	labels := map[string][2]string{
+		"reader": {"viewer", "只读"}, "commenter": {"commenter", "可评论"},
+		"writer": {"editor", "可编辑"}, "admin": {"administrator", "管理员"},
+	}
+	label, ok := labels[role]
+	if !ok {
+		return "", fmt.Errorf("unsupported requested_role %q", role)
+	}
+	if zh {
+		return label[1], nil
+	}
+	return label[0], nil
 }
 
 // summaryTimeRangeMaxRunes / summaryGeneratedAtMaxRunes mirror the summary card

--- a/modules/notify/card_via_registry_baseline_test.go
+++ b/modules/notify/card_via_registry_baseline_test.go
@@ -42,7 +42,7 @@ func TestBuildDocsAccessRequestCard_MigrationBaseline(t *testing.T) {
 	card := validAccessRequestDocsCard()
 
 	// pre-migration baseline (legacy path)
-	legacyRaw, err := n.buildDocsAccessRequestCard(context.Background(), "space-1", card, "zh-CN")
+	legacyRaw, err := n.buildDocsAccessRequestCard(context.Background(), card, "zh-CN")
 	if err != nil {
 		t.Fatalf("legacy build: %v", err)
 	}

--- a/modules/notify/card_via_registry_test.go
+++ b/modules/notify/card_via_registry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -46,7 +47,7 @@ func TestBuildDocsAccessRequestCardViaRegistry_UnwiredFailsExplicitly(t *testing
 // 的合法 JSON。断言必填字段(requestId/state/document.title)与嵌套结构存在。
 func TestMapDocsCardFieldsToJSON_ShapesToSchema(t *testing.T) {
 	card := validAccessRequestDocsCard()
-	raw, err := mapDocsCardFieldsToJSON(card, "zh-CN")
+	raw, err := mapDocsCardFieldsToJSON(card, "zh-CN", docsaccessrequest.TemplateVersionV3)
 	if err != nil {
 		t.Fatalf("mapDocsCardFieldsToJSON: %v", err)
 	}
@@ -174,9 +175,9 @@ func TestNotifyCatalogOperationsUseBoundedContexts(t *testing.T) {
 	); err != nil {
 		t.Fatalf("build: %v", err)
 	}
-	if !spy.metaDefaultDeadline || !spy.metaDefaultCanceled || !spy.fallbackDeadline || !spy.renderDeadline {
-		t.Fatalf("catalog deadline/cancel meta=%v/%v fallback=%v render=%v, want all true",
-			spy.metaDefaultDeadline, spy.metaDefaultCanceled, spy.fallbackDeadline, spy.renderDeadline)
+	if spy.metaDefaultCalls == 0 || !spy.metaDefaultAllDeadline || !spy.metaDefaultCanceled || !spy.fallbackDeadline || !spy.renderDeadline {
+		t.Fatalf("catalog deadline/cancel meta_calls=%d all_deadlines=%v canceled=%v fallback=%v render=%v, want all true",
+			spy.metaDefaultCalls, spy.metaDefaultAllDeadline, spy.metaDefaultCanceled, spy.fallbackDeadline, spy.renderDeadline)
 	}
 }
 
@@ -268,10 +269,11 @@ func (s *notifyCatalogSpy) Render(ctx context.Context, request cardtmpl.CatalogR
 
 type notifyDeadlineCatalog struct {
 	cardtmpl.Catalog
-	metaDefaultDeadline bool
-	metaDefaultCanceled bool
-	fallbackDeadline    bool
-	renderDeadline      bool
+	metaDefaultCalls       int
+	metaDefaultAllDeadline bool
+	metaDefaultCanceled    bool
+	fallbackDeadline       bool
+	renderDeadline         bool
 }
 
 type notifyFailureCatalog struct {
@@ -304,8 +306,14 @@ func (s *notifyDeadlineCatalog) MetaDefault(
 	ctx context.Context,
 	request cardtmpl.CatalogDefaultRequest,
 ) (cardtmpl.TemplateMeta, error) {
-	_, s.metaDefaultDeadline = ctx.Deadline()
-	s.metaDefaultCanceled = errors.Is(ctx.Err(), context.Canceled)
+	_, hasDeadline := ctx.Deadline()
+	if s.metaDefaultCalls == 0 {
+		s.metaDefaultAllDeadline = hasDeadline
+	} else {
+		s.metaDefaultAllDeadline = s.metaDefaultAllDeadline && hasDeadline
+	}
+	s.metaDefaultCalls++
+	s.metaDefaultCanceled = s.metaDefaultCanceled || errors.Is(ctx.Err(), context.Canceled)
 	return s.Catalog.MetaDefault(ctx, request)
 }
 
@@ -323,4 +331,114 @@ func (s *notifyDeadlineCatalog) Render(
 ) (map[string]any, error) {
 	_, s.renderDeadline = ctx.Deadline()
 	return s.Catalog.Render(ctx, request)
+}
+
+func TestMapDocsAccessRequestContextSeparatesReasonBotsAndSpace(t *testing.T) {
+	card := validAccessRequestDocsCard()
+	card.Excerpt = ""
+	card.RequesterSpaceName = "123"
+	card.RequestedBotNames = []string{"小呆呆", "猪猪侠"}
+	card.RequestedRole = "commenter"
+	raw, err := mapDocsCardFieldsToJSON(card, "zh-CN", docsaccessrequest.TemplateVersionV3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatal(err)
+	}
+	if fields["requestReason"] != "" {
+		t.Fatalf("empty reason was polluted: %+v", fields["requestReason"])
+	}
+	requester := fields["requester"].(map[string]any)
+	if requester["sourceSpaceName"] != "123" {
+		t.Fatalf("requester source Space = %+v", requester)
+	}
+	permission := fields["permission"].(map[string]any)
+	if permission["roleLabel"] != "可评论" {
+		t.Fatalf("requested role label = %+v", permission)
+	}
+	bots := fields["requestedBotNames"].([]any)
+	if len(bots) != 2 || bots[0] != "小呆呆" || bots[1] != "猪猪侠" {
+		t.Fatalf("requested Bot names = %+v", bots)
+	}
+}
+
+func TestMapDocsAccessRequestRoleCompatibilityAndFailClosed(t *testing.T) {
+	for _, tc := range []struct{ role, lang, want string }{
+		{"", "en", "viewer"},
+		{"ReAdEr", "zh-CN", "只读"},
+		{"COMMENTER", "en", "commenter"},
+		{"Writer", "en", "editor"},
+		{"ADMIN", "zh", "管理员"},
+	} {
+		card := validAccessRequestDocsCard()
+		card.RequestedRole = tc.role
+		raw, err := mapDocsCardFieldsToJSON(card, tc.lang, docsaccessrequest.TemplateVersionV3)
+		if err != nil {
+			t.Fatalf("role %q: %v", tc.role, err)
+		}
+		var fields map[string]any
+		if err := json.Unmarshal(raw, &fields); err != nil {
+			t.Fatal(err)
+		}
+		if got := fields["permission"].(map[string]any)["roleLabel"]; got != tc.want {
+			t.Errorf("role %q label = %q, want %q", tc.role, got, tc.want)
+		}
+	}
+	card := validAccessRequestDocsCard()
+	card.RequestedRole = "owner-ish"
+	if _, err := mapDocsCardFieldsToJSON(card, "en", docsaccessrequest.TemplateVersionV3); err == nil {
+		t.Fatal("unknown non-empty role must fail closed")
+	}
+}
+
+func TestMapDocsAccessRequestCapsBotNamesAndSourceSpace(t *testing.T) {
+	for _, count := range []int{50, 51} {
+		card := validAccessRequestDocsCard()
+		card.RequesterSpaceName = strings.Repeat("空", 201)
+		card.RequestedBotNames = make([]string, count)
+		for i := range card.RequestedBotNames {
+			card.RequestedBotNames[i] = fmt.Sprintf("bot-%d", i)
+		}
+		raw, err := mapDocsCardFieldsToJSON(card, "en", docsaccessrequest.TemplateVersionV3)
+		if err != nil {
+			t.Fatalf("count %d: %v", count, err)
+		}
+		var fields map[string]any
+		if err := json.Unmarshal(raw, &fields); err != nil {
+			t.Fatal(err)
+		}
+		if got := len(fields["requestedBotNames"].([]any)); got != min(count, 50) {
+			t.Errorf("count %d mapped to %d", count, got)
+		}
+		if got := []rune(fields["requester"].(map[string]any)["sourceSpaceName"].(string)); len(got) != 200 {
+			t.Errorf("source Space runes = %d", len(got))
+		}
+	}
+}
+
+func TestMapDocsAccessRequestV2KeepsFrozenLegacyShape(t *testing.T) {
+	card := validAccessRequestDocsCard()
+	card.RequesterSpaceName = "new Space"
+	card.RequestedBotNames = []string{"bot-a"}
+	card.RequestedRole = "writer"
+	raw, err := mapDocsCardFieldsToJSON(card, "en", docsaccessrequest.TemplateVersionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := fields["requestedBotNames"]; ok {
+		t.Fatalf("0.2.0 fields leaked requestedBotNames: %s", raw)
+	}
+	if _, ok := fields["permission"]; ok {
+		t.Fatalf("0.2.0 fields leaked requested role: %s", raw)
+	}
+	requester := fields["requester"].(map[string]any)
+	if _, ok := requester["sourceSpaceName"]; ok {
+		t.Fatalf("0.2.0 requester leaked sourceSpaceName: %s", raw)
+	}
 }

--- a/modules/notify/model.go
+++ b/modules/notify/model.go
@@ -66,12 +66,12 @@ const (
 // DocsCardFields is the docs-notify structured card input (cross-repo contract,
 // see .octospec/tasks/card-message-internal-dispatch/docs-notify-contract.md).
 // Fields carry raw values only; attribution/label copy, layout, and the
-// /d/{doc_id}?sp={space_id} deep-link are owned by the server (pkg/cardtmpl +
+// /d/{doc_id} deep-link are owned by the server (pkg/cardtmpl +
 // modules/notify.buildDocsCard + i18n.OutboundLanguage). The docs backend
 // pre-formats display strings it wants surfaced verbatim (ActorName, UpdatedAt)
 // so octo-server does not resolve secondary identities on the card path.
 type DocsCardFields struct {
-	DocID     string `json:"doc_id"`     // maps to /d/{doc_id}?sp={space_id}
+	DocID     string `json:"doc_id"`     // maps to /d/{doc_id}
 	RequestID string `json:"request_id"` // required by access_requested v2; docs domain idempotency/CAS key
 	Kind      string `json:"kind"`       // "shared" | "commented" | "access_requested"
 	Title     string `json:"title"`      // document title
@@ -86,8 +86,13 @@ type DocsCardFields struct {
 	// the card build (same positive allowlist as any rendered image URL). The
 	// docs backend owns population; octo-server does not resolve it.
 	ActorAvatarURL string `json:"actor_avatar_url"`
-	Excerpt        string `json:"excerpt"`    // optional preview / comment / access reason
-	UpdatedAt      string `json:"updated_at"` // pre-formatted timestamp; empty allowed
+	Excerpt        string `json:"excerpt"` // optional preview / comment / access reason
+	// RequesterSpaceName and RequestedBotNames enrich access-request cards only.
+	// They are display values resolved by Docs Backend in the requester's Space.
+	RequesterSpaceName string   `json:"requester_space_name"`
+	RequestedBotNames  []string `json:"requested_bot_names"`
+	RequestedRole      string   `json:"requested_role"` // reader | commenter | writer | admin
+	UpdatedAt          string   `json:"updated_at"`     // pre-formatted timestamp; empty allowed
 }
 
 // Docs card notification kinds.

--- a/modules/notify/platform_card_dispatch_test.go
+++ b/modules/notify/platform_card_dispatch_test.go
@@ -213,18 +213,18 @@ func TestLegacyDocsNotificationsReachTransportWithRenderProfile(t *testing.T) {
 	}
 }
 
-func TestDocsApplicantOutcomesReachTransportWithRenderProfile(t *testing.T) {
+func TestDocsTerminalMutationsDoNotSendApplicantOutcomeToTransport(t *testing.T) {
 	for _, tc := range []struct {
-		name        string
-		state       cardactiondispatch.State
-		inputs      map[string]interface{}
-		wantVariant string
+		name       string
+		state      cardactiondispatch.State
+		inputs     map[string]interface{}
+		wantStatus string
 	}{
-		{name: "approved", state: cardactiondispatch.StateApproved, wantVariant: "docs.access_granted"},
+		{name: "approved", state: cardactiondispatch.StateApproved, wantStatus: "已允许"},
 		{
 			name: "denied", state: cardactiondispatch.StateDenied,
-			inputs:      map[string]interface{}{cardtmpl.DocsDenyReasonInputID: "scope mismatch"},
-			wantVariant: "docs.access_denied",
+			inputs:     map[string]interface{}{cardtmpl.DocsDenyReasonInputID: "scope mismatch"},
+			wantStatus: "已拒绝",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -232,8 +232,9 @@ func TestDocsApplicantOutcomesReachTransportWithRenderProfile(t *testing.T) {
 			defer wk.close()
 			ctx := newTestContext(t, wk)
 			ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
-			sender, transport := newPlatformDispatchSender(t, cardmsg.ProfileV1, "")
-			finalizer, err := NewDocsActionFinalizer(ctx, &captureCardMutator{}, sender)
+			_, transport := newPlatformDispatchSender(t, cardmsg.ProfileV1, "")
+			mutator := &captureCardMutator{}
+			finalizer, err := NewDocsActionFinalizer(ctx, mutator)
 			require.NoError(t, err)
 
 			err = finalizer.Finalize(context.Background(), cardactiondispatch.Event{
@@ -250,11 +251,18 @@ func TestDocsApplicantOutcomesReachTransportWithRenderProfile(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			payload := requirePlatformTransportPayload(t, transport, cardmsg.ProfileV1)
-			card := payload["card"].(map[string]interface{})
-			metadata := card["metadata"].(map[string]interface{})
-			octo := metadata["octo"].(map[string]interface{})
-			assert.Equal(t, tc.wantVariant, octo["variant"])
+			// A Docs decision has one terminal surface: mutate the original request
+			// card. It must not enqueue a separate approved/denied applicant card.
+			require.Len(t, mutator.requests, 1)
+			mutation := mutator.requests[0]
+			assert.Equal(t, "message-1", mutation.MessageID)
+			assert.Equal(t, "reviewer-1", mutation.ChannelID)
+			assert.Contains(t, mutation.ContentEdit, tc.wantStatus)
+			assert.NotContains(t, mutation.ContentEdit, "Action.Submit")
+			if tc.state == cardactiondispatch.StateDenied {
+				assert.Contains(t, mutation.ContentEdit, "scope mismatch")
+			}
+			assert.Empty(t, transport.snapshot(), "must not send a second applicant outcome card")
 		})
 	}
 }

--- a/pilote2e/docs_card_wukongim_test.go
+++ b/pilote2e/docs_card_wukongim_test.go
@@ -2,7 +2,7 @@
 
 // Docs-notify E2E: end-to-end proof that a POST to the real
 // /v1/internal/notify handler with a structured DocsCard field results in a
-// type-17 card persisted in WuKongIM under the /d/{doc_id}?sp={space_id}
+// type-17 card persisted in WuKongIM under the /d/{doc_id}
 // deep link, delivered by the shared notification bot. Mirrors
 // summary_card_wukongim_test.go — same integration stack requirements
 // (MySQL 127.0.0.1:3306 root/demo/test, Redis 127.0.0.1:6379,
@@ -88,7 +88,7 @@ type wkhttpRouter interface {
 // contract body to the real POST /v1/internal/notify handler, has
 // modules/notify build the docs card server-side, and confirms the type-17
 // card persisted in WuKongIM carries the docs-flavoured deep link
-// (/d/{doc_id}?sp={space}) and the reserved metadata.octo.variant identifier.
+// (/d/{doc_id}) and the reserved metadata.octo.variant identifier.
 func TestDocsNotify_HTTPEndpointDeliversCardToWuKongIM(t *testing.T) {
 	t.Setenv(cardmsg.EnvEnabled, "true")
 	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
@@ -163,8 +163,8 @@ func TestDocsNotify_HTTPEndpointDeliversCardToWuKongIM(t *testing.T) {
 
 	payloadJSON := compactJSON(msg)
 	// Deep-link points at octo-web /d/:docId (already live) — not /s/:taskId.
-	assert.Contains(t, payloadJSON, "https://im.example.com/d/d_pilote2e_http?sp="+e2eSpaceID,
-		"docs deep-link must be /d/{doc_id}?sp={space} — that's the whole reason for a separate producer")
+	assert.Contains(t, payloadJSON, "https://im.example.com/d/d_pilote2e_http",
+		"docs deep-link must be /d/{doc_id} — that's the whole reason for a separate producer")
 	// Reserved namespace variant identifier so renderers can style docs cards
 	// distinctly from summary cards later without re-parsing content.
 	assert.Contains(t, payloadJSON, `"variant":"docs.shared"`,
@@ -258,7 +258,7 @@ func TestSummaryAndDocsNotify_NoRegression(t *testing.T) {
 			if bytes.Contains([]byte(pj), []byte("/s/TN_regression_1?sp="+e2eSpaceID)) {
 				sawSummary = true
 			}
-			if bytes.Contains([]byte(pj), []byte("/d/d_regression_1?sp="+e2eSpaceID)) {
+			if bytes.Contains([]byte(pj), []byte("/d/d_regression_1")) {
 				sawDocs = true
 			}
 		}

--- a/pkg/cardtmpl/conformance_test.go
+++ b/pkg/cardtmpl/conformance_test.go
@@ -325,10 +325,19 @@ func assertInteractionLocked(t *testing.T, card map[string]any, ir cardtmpl.Inte
 				id, got, decl.AssociatedInputs)
 		}
 	}
-	// OpenUrl id 集合子集 (视图详情按钮等 optional,不做严格相等)
-	for id := range wantOpenURLIDs {
-		if _, ok := findActionByID(card, id); !ok {
+	// Declared OpenUrl actions must exist and carry no undeclared data payload.
+	for id, decl := range wantOpenURLIDs {
+		action, ok := findActionByID(card, id)
+		if !ok {
 			t.Errorf("A15c OpenUrl action[id=%s] not present in card body/actions", id)
+			continue
+		}
+		data, _ := action["data"].(map[string]any)
+		gotKeys, wantKeys := mapKeys(data), append([]string(nil), decl.DataKeys...)
+		sort.Strings(gotKeys)
+		sort.Strings(wantKeys)
+		if !equalStringSlices(gotKeys, wantKeys) {
+			t.Errorf("A15c Action.OpenUrl[id=%s] data keys drift: got=%v want=%v", id, gotKeys, wantKeys)
 		}
 	}
 }

--- a/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/contract/data.schema.json
+++ b/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/contract/data.schema.json
@@ -3,55 +3,153 @@
   "title": "文档访问申请卡数据契约 0.3.0",
   "type": "object",
   "additionalProperties": false,
-  "required": ["requestId", "state", "document"],
+  "required": [
+    "requestId",
+    "state",
+    "document"
+  ],
   "properties": {
-    "requestId": {"type": "string", "minLength": 1, "maxLength": 200},
-    "state": {"type": "string", "enum": ["pending", "approved", "rejected", "cancelled", "unavailable"]},
+    "requestId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "state": {
+      "type": "string",
+      "enum": [
+        "pending",
+        "approved",
+        "rejected",
+        "cancelled",
+        "unavailable"
+      ]
+    },
     "document": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["title"],
+      "required": [
+        "title"
+      ],
       "properties": {
-        "docId": {"type": "string", "maxLength": 200},
-        "title": {"type": "string", "minLength": 1, "maxLength": 200},
-        "url": {"type": "string", "maxLength": 2048},
-        "sourceName": {"type": "string", "maxLength": 200}
+        "docId": {
+          "type": "string",
+          "maxLength": 200
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "url": {
+          "type": "string",
+          "maxLength": 2048
+        },
+        "sourceName": {
+          "type": "string",
+          "maxLength": 200
+        }
       }
     },
     "requester": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "name": {"type": "string", "maxLength": 120},
-        "avatarUrl": {"type": "string", "maxLength": 2048, "pattern": "^(|https://[^/].*)$"}
+        "name": {
+          "type": "string",
+          "maxLength": 120
+        },
+        "avatarUrl": {
+          "type": "string",
+          "maxLength": 2048,
+          "pattern": "^(|https://[^/].*)$"
+        },
+        "sourceSpaceName": {
+          "type": "string",
+          "maxLength": 200,
+          "description": "申请人的来源 Space 展示名称（可空）"
+        }
       }
     },
     "permission": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {"type": "string", "maxLength": 80},
-        "roleLabel": {"type": "string", "maxLength": 80}
+        "label": {
+          "type": "string",
+          "maxLength": 80
+        },
+        "roleLabel": {
+          "type": "string",
+          "maxLength": 80
+        }
       }
     },
-    "requestReason": {"type": "string", "maxLength": 300},
-    "requestedAtDisplay": {"type": "string", "maxLength": 80},
-    "messageTimeDisplay": {"type": "string", "maxLength": 80},
+    "requestReason": {
+      "type": "string",
+      "maxLength": 300
+    },
+    "requestedAtDisplay": {
+      "type": "string",
+      "maxLength": 80
+    },
+    "messageTimeDisplay": {
+      "type": "string",
+      "maxLength": 80
+    },
     "decision": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["operatorName"],
+      "required": [
+        "operatorName"
+      ],
       "properties": {
-        "operatorName": {"type": "string", "minLength": 1, "maxLength": 120},
-        "decidedAtDisplay": {"type": "string", "maxLength": 80},
-        "rejectionReason": {"type": "string", "maxLength": 300}
+        "operatorName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 120
+        },
+        "decidedAtDisplay": {
+          "type": "string",
+          "maxLength": 80
+        },
+        "rejectionReason": {
+          "type": "string",
+          "maxLength": 300
+        },
+        "operatorSpaceName": {
+          "type": "string",
+          "maxLength": 200
+        }
       }
+    },
+    "requestedBotNames": {
+      "type": "array",
+      "maxItems": 50,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 120
+      },
+      "description": "同时申请权限的 AI 助手展示名称"
     }
   },
   "allOf": [
     {
-      "if": {"properties": {"state": {"enum": ["approved", "rejected"]}}},
-      "then": {"required": ["decision"]}
+      "if": {
+        "properties": {
+          "state": {
+            "enum": [
+              "approved",
+              "rejected"
+            ]
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "decision"
+        ]
+      }
     }
   ]
 }

--- a/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/reports/pending.interaction.json
+++ b/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/reports/pending.interaction.json
@@ -1,19 +1,70 @@
 {
   "actions": [
-    {"id": "view_document", "type": "Action.OpenUrl", "dataKeys": [], "inputIds": []},
     {
-      "id": "docs-access-deny", "type": "Action.Submit", "associatedInputs": "auto",
-      "dataKeys": ["owner", "action_type", "doc_id", "request_id", "doc_title", "actor", "decision", "actor_avatar_url", "request_reason", "requested_at_display", "message_time_display", "permission_label", "permission_role_label", "source_name"],
-      "inputIds": ["deny_reason"]
+      "id": "view_document",
+      "type": "Action.OpenUrl",
+      "dataKeys": [],
+      "inputIds": []
     },
     {
-      "id": "docs-access-approve", "type": "Action.Submit", "associatedInputs": "auto",
-      "dataKeys": ["owner", "action_type", "doc_id", "request_id", "doc_title", "actor", "decision", "actor_avatar_url", "request_reason", "requested_at_display", "message_time_display", "permission_label", "permission_role_label", "source_name"],
+      "id": "docs-access-deny",
+      "type": "Action.Submit",
+      "associatedInputs": "auto",
+      "dataKeys": [
+        "owner",
+        "action_type",
+        "doc_id",
+        "request_id",
+        "doc_title",
+        "actor",
+        "decision",
+        "actor_avatar_url",
+        "request_reason",
+        "requested_at_display",
+        "message_time_display",
+        "permission_label",
+        "permission_role_label",
+        "source_name",
+        "requester_space_name",
+        "requested_bot_names"
+      ],
+      "inputIds": [
+        "deny_reason"
+      ]
+    },
+    {
+      "id": "docs-access-approve",
+      "type": "Action.Submit",
+      "associatedInputs": "auto",
+      "dataKeys": [
+        "owner",
+        "action_type",
+        "doc_id",
+        "request_id",
+        "doc_title",
+        "actor",
+        "decision",
+        "actor_avatar_url",
+        "request_reason",
+        "requested_at_display",
+        "message_time_display",
+        "permission_label",
+        "permission_role_label",
+        "source_name",
+        "requester_space_name",
+        "requested_bot_names"
+      ],
       "inputIds": []
     }
   ],
   "inputs": [
-    {"id": "deny_reason", "type": "Input.Text", "isRequired": false, "isVisible": false, "maxLength": 300}
+    {
+      "id": "deny_reason",
+      "type": "Input.Text",
+      "isRequired": false,
+      "isVisible": false,
+      "maxLength": 300
+    }
   ],
   "toggles": []
 }

--- a/pkg/cardtmpl/docs_access_request/labels.go
+++ b/pkg/cardtmpl/docs_access_request/labels.go
@@ -69,17 +69,19 @@ func pendingLabels(lang string, pf pendingFields) pendingLabelSet {
 // L1 契约里标为 server-filled 的文案(handoff data.schema.json 中同名字段并未 required)。
 func docsApprovalContentFromFields(pf pendingFields, labels pendingLabelSet) cardtmpl.DocsApprovalContent {
 	return cardtmpl.DocsApprovalContent{
-		Title:        pf.Document.Title,
-		Actor:        pf.Requester.Name,
-		ActorAvatar:  pf.Requester.AvatarURL,
-		Timestamp:    pf.RequestedAtDisplay,
-		Reason:       pf.RequestReason,
-		Variant:      Variant,
-		HeaderLabel:  labels.headerLabel,
-		StatusLabel:  labels.statusLabel,
-		BannerSuffix: labels.bannerSuffix,
-		RoleLabel:    labels.roleLabel,
-		ReasonLabel:  labels.reasonLabel,
+		Title:              pf.Document.Title,
+		Actor:              pf.Requester.Name,
+		ActorAvatar:        pf.Requester.AvatarURL,
+		Timestamp:          pf.RequestedAtDisplay,
+		Reason:             pf.RequestReason,
+		RequesterSpaceName: pf.Requester.SourceSpaceName,
+		RequestedBotNames:  pf.RequestedBotNames,
+		Variant:            Variant,
+		HeaderLabel:        labels.headerLabel,
+		StatusLabel:        labels.statusLabel,
+		BannerSuffix:       labels.bannerSuffix,
+		RoleLabel:          labels.roleLabel,
+		ReasonLabel:        labels.reasonLabel,
 		// Source 走 Registry.Render 的 Meta.Source 注入,不在 content 里带
 	}
 }

--- a/pkg/cardtmpl/docs_access_request/template.go
+++ b/pkg/cardtmpl/docs_access_request/template.go
@@ -87,10 +87,12 @@ type pendingFields struct {
 		SourceName string `json:"sourceName"`
 	} `json:"document"`
 	Requester struct {
-		Name      string `json:"name"`
-		AvatarURL string `json:"avatarUrl"`
+		Name            string `json:"name"`
+		AvatarURL       string `json:"avatarUrl"`
+		SourceSpaceName string `json:"sourceSpaceName"`
 	} `json:"requester"`
-	Permission struct {
+	RequestedBotNames []string `json:"requestedBotNames"`
+	Permission        struct {
 		Label     string `json:"label"`
 		RoleLabel string `json:"roleLabel"`
 	} `json:"permission"`
@@ -133,7 +135,7 @@ func (t *Template) Build(
 	actions := cardtmplApprovalActions(labels.approveTitle, labels.denyTitle)
 
 	body, cardActions, deepLink, err := cardtmpl.BuildDocsAccessRequestBodyWithLang(
-		env.Lang, env.WebLoginURL, docID, pf.RequestID, env.SpaceID, content, actions,
+		env.Lang, env.WebLoginURL, docID, pf.RequestID, content, actions,
 	)
 	if err != nil {
 		return cardtmpl.BuildResult{}, err

--- a/pkg/cardtmpl/docs_access_request/v3.go
+++ b/pkg/cardtmpl/docs_access_request/v3.go
@@ -54,10 +54,12 @@ type v3Fields struct {
 		SourceName string `json:"sourceName"`
 	} `json:"document"`
 	Requester struct {
-		Name      string `json:"name"`
-		AvatarURL string `json:"avatarUrl"`
+		Name            string `json:"name"`
+		AvatarURL       string `json:"avatarUrl"`
+		SourceSpaceName string `json:"sourceSpaceName"`
 	} `json:"requester"`
-	Permission struct {
+	RequestedBotNames []string `json:"requestedBotNames"`
+	Permission        struct {
 		Label     string `json:"label"`
 		RoleLabel string `json:"roleLabel"`
 	} `json:"permission"`
@@ -65,9 +67,10 @@ type v3Fields struct {
 	RequestedAtDisplay string `json:"requestedAtDisplay"`
 	MessageTimeDisplay string `json:"messageTimeDisplay"`
 	Decision           struct {
-		OperatorName     string `json:"operatorName"`
-		DecidedAtDisplay string `json:"decidedAtDisplay"`
-		RejectionReason  string `json:"rejectionReason"`
+		OperatorName      string `json:"operatorName"`
+		OperatorSpaceName string `json:"operatorSpaceName"`
+		DecidedAtDisplay  string `json:"decidedAtDisplay"`
+		RejectionReason   string `json:"rejectionReason"`
 	} `json:"decision"`
 }
 
@@ -86,7 +89,7 @@ func (t *TemplateV3) Build(ctx context.Context, state cardtmpl.State, fields jso
 			docID = input.RequestID
 		}
 		body, deepLink, err := cardtmpl.BuildDocsAccessRequestV3BodyWithLang(
-			env.Lang, env.WebLoginURL, docID, input.RequestID, env.SpaceID,
+			env.Lang, env.WebLoginURL, docID, input.RequestID,
 			cardtmpl.DocsAccessRequestV3Content{
 				DocsApprovalContent: docsApprovalContentFromFields(input, labels),
 				SourceName:          input.Document.SourceName,
@@ -117,6 +120,10 @@ func (t *TemplateV3) Build(ctx context.Context, state cardtmpl.State, fields jso
 		docID = input.RequestID
 	}
 	labels := resultLabels(env.Lang, state == StateRejected)
+	decidedAtDisplay := strings.TrimSpace(input.Decision.DecidedAtDisplay)
+	if decidedAtDisplay == "" {
+		decidedAtDisplay = input.MessageTimeDisplay // compatibility for older callers
+	}
 	variant := VariantApproved
 	switch state {
 	case StateRejected:
@@ -126,7 +133,7 @@ func (t *TemplateV3) Build(ctx context.Context, state cardtmpl.State, fields jso
 	case StateUnavailable:
 		labels, variant = unavailableLabels(env.Lang), VariantUnavailable
 	}
-	body, deepLink, err := cardtmpl.BuildDocsApprovalOutcomeV3BodyWithLang(env.Lang, env.WebLoginURL, docID, env.SpaceID, cardtmpl.DocsOutcomeContent{
+	body, deepLink, err := cardtmpl.BuildDocsApprovalOutcomeV3BodyWithLang(env.Lang, env.WebLoginURL, docID, cardtmpl.DocsOutcomeContent{
 		// Denied selects the L0 "not granted" treatment rather than the green
 		// approved one. Cancelled is not a denial, but the outcome builder
 		// carries a two-way flag and the honest half of it is that access was
@@ -135,14 +142,17 @@ func (t *TemplateV3) Build(ctx context.Context, state cardtmpl.State, fields jso
 		// display nuance, which does not belong in this fix.
 		Title: input.Document.Title, Variant: variant, Denied: state != StateApproved,
 		HeaderLabel: labels.header, SourceName: input.Document.SourceName,
-		StatusLabel: labels.status, PermissionLabel: input.Permission.Label, ResultText: labels.result,
-		ReasonLabel: labels.reason, Reason: input.Decision.RejectionReason,
+		StatusLabel: labels.status, PermissionLabel: input.Permission.Label,
+		PermissionRoleLabel: input.Permission.RoleLabel,
+		ReasonLabel:         labels.reason, Reason: input.Decision.RejectionReason,
 		Actor: input.Requester.Name, ActorAvatar: input.Requester.AvatarURL,
+		RequesterSpaceName: input.Requester.SourceSpaceName, RequestedBotNames: input.RequestedBotNames,
 		RequestedAtDisplay: input.RequestedAtDisplay, RequestReason: input.RequestReason,
 		BannerSuffix: labels.banner(input.Permission.RoleLabel), RoleLabel: labels.role,
-		RequestReasonLabel: labels.requestReason, MessageTimeLabel: labels.processedAt,
-		MessageTimeDisplay: input.MessageTimeDisplay,
-		DecisionSummary:    strings.Trim(strings.TrimSpace(input.Decision.OperatorName)+" · "+strings.TrimSpace(input.Decision.DecidedAtDisplay), " ·"),
+		RequestReasonLabel:        labels.requestReason,
+		MessageTimeDisplay:        decidedAtDisplay,
+		DecisionOperatorName:      input.Decision.OperatorName,
+		DecisionOperatorSpaceName: input.Decision.OperatorSpaceName,
 	})
 	if err != nil {
 		return cardtmpl.BuildResult{}, err

--- a/pkg/cardtmpl/docs_access_request/v3_test.go
+++ b/pkg/cardtmpl/docs_access_request/v3_test.go
@@ -64,9 +64,17 @@ func TestV3RegistersPendingAndResultWithoutMutatingV2(t *testing.T) {
 			if !strings.Contains(text, "申请原因") || !strings.Contains(text, "林澈") {
 				t.Errorf("RenderCard(%s) dropped result handoff context: %s", tc.state, text)
 			}
-			if !strings.Contains(text, "Q3 产品规划") || !strings.Contains(text, tc.permission) ||
-				!strings.Contains(text, "处理于 刚刚") {
+			if !strings.Contains(text, "Q3 产品规划") || !strings.Contains(text, tc.permission) {
 				t.Errorf("RenderCard(%s) dropped source/permission context: %s", tc.state, text)
+			}
+			if !strings.Contains(text, "申请于") || !strings.Contains(text, "处理于 刚刚") {
+				t.Errorf("RenderCard(%s) dropped terminal footer times: %s", tc.state, text)
+			}
+			if !strings.Contains(text, `"text":"林澈"`) {
+				t.Errorf("RenderCard(%s) dropped operator below processed time: %s", tc.state, text)
+			}
+			if strings.Contains(text, "申请人已获得") || strings.Contains(text, `"style":"good"`) {
+				t.Errorf("RenderCard(%s) retained duplicate terminal result block: %s", tc.state, text)
 			}
 			if tc.state == docsaccessrequest.StateRejected && !strings.Contains(text, "信息不完整") {
 				t.Errorf("RenderCard(rejected) dropped rejection reason: %s", text)
@@ -293,5 +301,112 @@ func TestV3UsesStableRenderProfileWithoutChangingV2(t *testing.T) {
 	}
 	if _, ok := v2["render_profile"]; ok {
 		t.Error("frozen 0.2.0 must remain on the legacy renderer")
+	}
+}
+
+func TestV3PendingRendersRequestedBotNamesAndSourceSpaceWithoutEmptyReason(t *testing.T) {
+	r := cardtmpl.NewRegistry()
+	r.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	r.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
+	r.Freeze()
+	fields := json.RawMessage(`{
+		"requestId":"r1","state":"pending",
+		"document":{"docId":"d1","title":"测试"},
+		"requester":{"name":"超级管理员","sourceSpaceName":"123"},
+		"permission":{"roleLabel":"可评论"},
+		"requestReason":"",
+		"requestedBotNames":["小呆呆","猪猪侠"]
+	}`)
+	payload, err := r.Render(context.Background(), docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3, docsaccessrequest.StatePending, fields,
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "zh-CN", SpaceID: "space-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(encoded)
+	for _, want := range []string{"申请者：", "超级管理员", "123", "申请权限：", "可评论", "同时申请权限的 AI 助手（2）", "小呆呆、猪猪侠"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("card missing %q: %s", want, text)
+		}
+	}
+	if strings.Contains(text, "申请原因") {
+		t.Fatalf("empty reason section rendered: %s", text)
+	}
+	if strings.Contains(text, "申请成为此文档") {
+		t.Fatalf("duplicate request banner rendered: %s", text)
+	}
+	if strings.Contains(text, "?sp=") {
+		t.Fatalf("Docs deep link retained legacy sp: %s", text)
+	}
+}
+
+func TestV3PendingCapsVisibleBotNames(t *testing.T) {
+	r := cardtmpl.NewRegistry()
+	r.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	r.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
+	r.Freeze()
+	fields := json.RawMessage(`{
+		"requestId":"r-many","state":"pending",
+		"document":{"docId":"d-many","title":"测试"},
+		"requester":{"name":"申请人","sourceSpaceName":"test Space"},
+		"permission":{"roleLabel":"可评论"},
+		"requestedBotNames":["助手1","助手2","助手3","助手4","助手5","助手6","助手7","助手8","助手9","助手10"]
+	}`)
+	payload, err := r.Render(context.Background(), docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3,
+		docsaccessrequest.StatePending, fields,
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "zh-CN", SpaceID: "space-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(encoded)
+	for _, want := range []string{"test Space", "申请权限：", "可评论", "同时申请权限的 AI 助手（10）", "等 3 个"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("card missing %q: %s", want, text)
+		}
+	}
+	// Full names remain in server-authored submit data so terminal cards preserve
+	// context; only the visible TextBlock is capped.
+	if !strings.Contains(text, `"text":"助手1、助手2、助手3、助手4、助手5、助手6、助手7，等 3 个"`) ||
+		!strings.Contains(text, `"maxLines":2`) {
+		t.Fatalf("visible Bot summary was not capped to two lines: %s", text)
+	}
+}
+
+func TestV3PendingTruncatesSingleOversizedBotNameToOneLine(t *testing.T) {
+	r := cardtmpl.NewRegistry()
+	r.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	r.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
+	r.Freeze()
+	const longName = "这是一个非常非常非常非常非常非常非常非常非常非常非常非常非常非常非常非常长的助手名称"
+	fields := json.RawMessage(`{
+		"requestId":"r-long","state":"pending",
+		"document":{"docId":"d-long","title":"测试"},
+		"requester":{"name":"申请人"},
+		"permission":{"roleLabel":"只读"},
+		"requestedBotNames":["` + longName + `"]
+	}`)
+	payload, err := r.Render(context.Background(), docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3,
+		docsaccessrequest.StatePending, fields,
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "zh-CN", SpaceID: "space-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(encoded)
+	if !strings.Contains(text, `非常非常非常非…`) || !strings.Contains(text, `"maxLines":2`) {
+		t.Fatalf("oversized Bot name was not capped to two visible lines: %s", text)
+	}
+	if !strings.Contains(text, `"requested_bot_names":["`+longName+`"]`) {
+		t.Fatalf("full Bot name was not preserved in action data: %s", text)
 	}
 }

--- a/pkg/cardtmpl/docs_action.go
+++ b/pkg/cardtmpl/docs_action.go
@@ -45,13 +45,15 @@ type ApprovalActions struct {
 // localized copy (producer picks them by language). ActorAvatar is optional and
 // must be an absolute https URL when present (empty => no avatar column).
 type DocsApprovalContent struct {
-	Title       string
-	Actor       string
-	ActorAvatar string
-	Timestamp   string
-	Reason      string
-	Variant     string
-	Source      Source
+	Title              string
+	Actor              string
+	ActorAvatar        string
+	Timestamp          string
+	Reason             string
+	RequesterSpaceName string
+	RequestedBotNames  []string
+	Variant            string
+	Source             Source
 
 	HeaderLabel  string // e.g. "文档申请" / "Document access"
 	StatusLabel  string // e.g. "待你处理" / "Pending"
@@ -69,24 +71,26 @@ type DocsOutcomeContent struct {
 	Source  Source
 	Denied  bool // true => denied (attention), false => approved (good)
 
-	HeaderLabel     string // "文档申请"
-	SourceName      string // optional document/source display name
-	StatusLabel     string // "已允许" / "已拒绝"
-	PermissionLabel string // optional permission vocabulary beside status
-	ResultText      string // "申请人已获得所申请的文档权限。" / "申请已被拒绝。"
-	ReasonLabel     string // "拒绝原因"
-	Reason          string // reviewer deny reason (denied only); "" => omit
+	HeaderLabel         string // "文档申请"
+	SourceName          string // optional document/source display name
+	StatusLabel         string // "已允许" / "已拒绝"
+	PermissionLabel     string // optional permission vocabulary beside status
+	PermissionRoleLabel string // requested role display label
+	ReasonLabel         string // "拒绝原因"
+	Reason              string // reviewer deny reason (denied only); "" => omit
 
-	Actor              string
-	ActorAvatar        string
-	RequestedAtDisplay string
-	RequestReason      string
-	BannerSuffix       string
-	RoleLabel          string
-	RequestReasonLabel string
-	DecisionSummary    string
-	MessageTimeLabel   string
-	MessageTimeDisplay string
+	Actor                     string
+	ActorAvatar               string
+	RequesterSpaceName        string
+	RequestedBotNames         []string
+	RequestedAtDisplay        string
+	RequestReason             string
+	BannerSuffix              string
+	RoleLabel                 string
+	RequestReasonLabel        string
+	DecisionOperatorName      string
+	DecisionOperatorSpaceName string
+	MessageTimeDisplay        string
 }
 
 // BuildDocsAccessRequestCard renders the enriched docs access-request approval
@@ -100,13 +104,12 @@ func BuildDocsAccessRequestCard(
 	webLoginURL string,
 	docID string,
 	requestID string,
-	spaceID string,
 	content DocsApprovalContent,
 	actions ApprovalActions,
 ) (json.RawMessage, error) {
 	lang := i18n.OutboundLanguage(ctx)
 	body, cardActions, deepLink, err := BuildDocsAccessRequestBodyWithLang(
-		lang, webLoginURL, docID, requestID, spaceID, content, actions,
+		lang, webLoginURL, docID, requestID, content, actions,
 	)
 	if err != nil {
 		return nil, err
@@ -136,7 +139,6 @@ func BuildDocsAccessRequestBodyWithLang(
 	webLoginURL string,
 	docID string,
 	requestID string,
-	spaceID string,
 	content DocsApprovalContent,
 	actions ApprovalActions,
 ) (body []interface{}, cardActions []interface{}, deepLink string, err error) {
@@ -160,7 +162,7 @@ func BuildDocsAccessRequestBodyWithLang(
 			return nil, nil, "", fmt.Errorf("cardtmpl: source icon URL: %w", err)
 		}
 	}
-	deepLink, err = docsDeepLink(webLoginURL, docID, spaceID)
+	deepLink, err = docsDeepLink(webLoginURL, docID)
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -225,11 +227,10 @@ func BuildDocsApprovalOutcomeCard(
 	ctx context.Context,
 	webLoginURL string,
 	docID string,
-	spaceID string,
 	content DocsOutcomeContent,
 ) (json.RawMessage, error) {
 	body, deepLink, err := BuildDocsApprovalOutcomeBodyWithLang(
-		i18n.OutboundLanguage(ctx), webLoginURL, docID, spaceID, content,
+		i18n.OutboundLanguage(ctx), webLoginURL, docID, content,
 	)
 	if err != nil {
 		return nil, err
@@ -253,7 +254,6 @@ func BuildDocsApprovalOutcomeBodyWithLang(
 	lang string,
 	webLoginURL string,
 	docID string,
-	spaceID string,
 	content DocsOutcomeContent,
 ) ([]interface{}, string, error) {
 	if strings.TrimSpace(content.Title) == "" || utf8.RuneCountInString(content.Title) > maxTitleRunes {
@@ -269,16 +269,15 @@ func BuildDocsApprovalOutcomeBodyWithLang(
 			return nil, "", fmt.Errorf("cardtmpl: actor avatar URL: %w", err)
 		}
 	}
-	deepLink, err := docsDeepLink(webLoginURL, docID, spaceID)
+	deepLink, err := docsDeepLink(webLoginURL, docID)
 	if err != nil {
 		return nil, "", err
 	}
 	labels := labelsForLanguage(lang)
 
 	statusColor := "Good"
-	boxStyle := "good"
 	if content.Denied {
-		statusColor, boxStyle = "Attention", "attention"
+		statusColor = "Attention"
 	}
 	body := []interface{}{
 		docsOutcomeHeader(content.HeaderLabel, content.SourceName, content.StatusLabel, content.PermissionLabel, statusColor),
@@ -293,10 +292,13 @@ func BuildDocsApprovalOutcomeBodyWithLang(
 	if box := docsReasonBox(content.RequestReasonLabel, content.RequestReason); box != nil {
 		body = append(body, box)
 	}
-	body = append(body,
-		docsResultBox(boxStyle, statusColor, content.ResultText, content.DecisionSummary, content.ReasonLabel, content.Reason),
-		docsOutcomeFooter(content.MessageTimeLabel, content.MessageTimeDisplay, labels.viewDetails, deepLink),
-	)
+	if content.Denied {
+		if box := docsReasonBox(content.ReasonLabel, content.Reason); box != nil {
+			body = append(body, box)
+		}
+	}
+	body = append(body, docsOutcomeFooter(lang, content.RequestedAtDisplay, content.MessageTimeDisplay,
+		content.DecisionOperatorName, content.DecisionOperatorSpaceName, labels.viewDetails, deepLink))
 	return body, deepLink, nil
 }
 
@@ -348,30 +350,46 @@ func docsOutcomeHeader(headerLabel, sourceName, statusLabel, permissionLabel, st
 
 // docsOutcomeFooter keeps the terminal card free of submit actions while
 // preserving the handoff's processed-time context and view-details link.
-func docsOutcomeFooter(timeLabel, timeDisplay, viewDetails, deepLink string) map[string]interface{} {
-	actionSet := map[string]interface{}{
-		"type": "ActionSet", "spacing": "None",
-		"actions": []interface{}{
+func docsOutcomeFooter(lang, requestedAt, decidedAt, operatorName, operatorSpaceName, viewDetails, deepLink string) map[string]interface{} {
+	requestedAt = truncateRunes(strings.TrimSpace(requestedAt), maxTimestampRunes)
+	decidedAt = truncateRunes(strings.TrimSpace(decidedAt), maxTimestampRunes)
+	operatorName = truncateRunes(strings.TrimSpace(operatorName), maxActorRunes)
+	operatorSpaceName = truncateRunes(strings.TrimSpace(operatorSpaceName), maxTitleRunes)
+	requestedLabel, decidedLabel := "Requested at", "Processed at"
+	if strings.EqualFold(lang, "zh-CN") || strings.HasPrefix(strings.ToLower(lang), "zh") {
+		requestedLabel, decidedLabel = "申请于", "处理于"
+	}
+	leftItems := []interface{}{}
+	if requestedAt != "" {
+		leftItems = append(leftItems, map[string]interface{}{
+			"type": "TextBlock", "text": escapeMarkdown(requestedLabel + " " + requestedAt),
+			"size": "Small", "isSubtle": true, "spacing": "None", "wrap": false,
+		})
+	}
+	if decidedAt != "" {
+		leftItems = append(leftItems, map[string]interface{}{
+			"type": "TextBlock", "text": escapeMarkdown(decidedLabel + " " + decidedAt),
+			"size": "Small", "isSubtle": true, "spacing": "Small", "wrap": false,
+		})
+	}
+	operatorText := strings.Trim(strings.TrimSpace(operatorName)+" · "+strings.TrimSpace(operatorSpaceName), " ·")
+	if operatorText != "" {
+		leftItems = append(leftItems, map[string]interface{}{
+			"type": "TextBlock", "text": escapeMarkdown(operatorText),
+			"size": "Small", "weight": "Bolder", "spacing": "Small", "wrap": false,
+		})
+	}
+	rightItems := []interface{}{}
+	rightItems = append(rightItems, map[string]interface{}{
+		"type": "ActionSet", "spacing": "Small", "actions": []interface{}{
 			map[string]interface{}{"type": "Action.OpenUrl", "id": "view_document", "title": viewDetails, "url": deepLink},
 		},
-	}
-	timeDisplay = truncateRunes(strings.TrimSpace(timeDisplay), maxTimestampRunes)
-	if timeDisplay == "" {
-		return actionSet
-	}
-	processedAt := strings.TrimSpace(timeLabel + " " + timeDisplay)
+	})
 	return map[string]interface{}{
-		"type": "ColumnSet", "spacing": "Medium", "columns": []interface{}{
-			map[string]interface{}{
-				"type": "Column", "width": "stretch", "verticalContentAlignment": "Center",
-				"items": []interface{}{map[string]interface{}{
-					"type": "TextBlock", "text": escapeMarkdown(processedAt), "size": "Small",
-					"isSubtle": true, "spacing": "None", "wrap": false,
-				}},
-			},
-			map[string]interface{}{
-				"type": "Column", "width": "auto", "items": []interface{}{actionSet},
-			},
+		"type": "ColumnSet", "spacing": "Medium", "verticalContentAlignment": "Center",
+		"columns": []interface{}{
+			map[string]interface{}{"type": "Column", "width": "stretch", "verticalContentAlignment": "Center", "items": leftItems},
+			map[string]interface{}{"type": "Column", "width": "auto", "verticalContentAlignment": "Center", "items": rightItems},
 		},
 	}
 }
@@ -508,36 +526,6 @@ func docsReasonBox(label, reason string) map[string]interface{} {
 		"type": "TextBlock", "text": escapeMarkdown(reason), "size": "Medium", "wrap": true, "spacing": "Small",
 	})
 	return map[string]interface{}{"type": "Container", "style": "emphasis", "spacing": "Medium", "items": items}
-}
-
-// docsResultBox is the terminal good/attention result section. For denials it
-// appends the reviewer reason as a labeled sub-line.
-func docsResultBox(boxStyle, textColor, resultText, decisionSummary, reasonLabel, reason string) map[string]interface{} {
-	items := []interface{}{
-		map[string]interface{}{
-			"type": "TextBlock", "text": escapeMarkdown(strings.TrimSpace(resultText)),
-			"size": "Medium", "weight": "Bolder", "color": textColor, "wrap": true, "spacing": "None",
-		},
-	}
-	if summary := truncateRunes(strings.TrimSpace(decisionSummary), maxTitleRunes); summary != "" {
-		items = append(items, map[string]interface{}{
-			"type": "TextBlock", "text": escapeMarkdown(summary),
-			"size": "Small", "isSubtle": true, "spacing": "Small",
-		})
-	}
-	if r := truncateRunes(strings.TrimSpace(reason), maxReasonRunes); r != "" {
-		label := strings.TrimSpace(reasonLabel)
-		if label != "" {
-			items = append(items, map[string]interface{}{
-				"type": "TextBlock", "text": escapeMarkdown(label),
-				"size": "Small", "weight": "Bolder", "isSubtle": true, "spacing": "Small",
-			})
-		}
-		items = append(items, map[string]interface{}{
-			"type": "TextBlock", "text": escapeMarkdown(r), "size": "Medium", "wrap": true, "spacing": "None",
-		})
-	}
-	return map[string]interface{}{"type": "Container", "style": boxStyle, "spacing": "Medium", "items": items}
 }
 
 func copyActionData(source map[string]interface{}) map[string]interface{} {

--- a/pkg/cardtmpl/docs_action_test.go
+++ b/pkg/cardtmpl/docs_action_test.go
@@ -64,7 +64,6 @@ func TestBuildDocsAccessRequestCardEnrichedLayoutAndActions(t *testing.T) {
 		"https://im.example.com/login",
 		"doc-1",
 		"request-1",
-		"space-1",
 		exampleDocsApprovalContent(),
 		ApprovalActions{ApproveTitle: "允许", DenyTitle: "拒绝"},
 	)
@@ -139,7 +138,7 @@ func cardHasText(nodes []map[string]interface{}, want string) bool {
 // accepts a submitted inputs[deny_reason] and fail-closes on undeclared keys.
 func TestDocsAccessRequestCardDenyReasonSubmitContract(t *testing.T) {
 	document, err := BuildDocsAccessRequestCard(
-		localizedContext("zh-CN"), "https://im.example.com/login", "doc-1", "request-1", "space-1",
+		localizedContext("zh-CN"), "https://im.example.com/login", "doc-1", "request-1",
 		exampleDocsApprovalContent(), ApprovalActions{ApproveTitle: "允许", DenyTitle: "拒绝"},
 	)
 	require.NoError(t, err)
@@ -169,7 +168,6 @@ func TestBuildDocsAccessRequestCardRejectsMissingRequestID(t *testing.T) {
 		"https://im.example.com/login",
 		"doc-1",
 		"",
-		"space-1",
 		exampleDocsApprovalContent(),
 		ApprovalActions{ApproveTitle: "Allow", DenyTitle: "Deny"},
 	)
@@ -182,7 +180,7 @@ func TestBuildDocsAccessRequestCardAvatarHTTPSOnly(t *testing.T) {
 
 	// Empty avatar => no Image element.
 	noAvatar := exampleDocsApprovalContent()
-	doc, err := BuildDocsAccessRequestCard(localizedContext("zh-CN"), base, "d", "r", "s", noAvatar, actions)
+	doc, err := BuildDocsAccessRequestCard(localizedContext("zh-CN"), base, "d", "r", noAvatar, actions)
 	require.NoError(t, err)
 	var card map[string]interface{}
 	require.NoError(t, json.Unmarshal(doc, &card))
@@ -191,7 +189,7 @@ func TestBuildDocsAccessRequestCardAvatarHTTPSOnly(t *testing.T) {
 	// https avatar => one Person Image.
 	withAvatar := exampleDocsApprovalContent()
 	withAvatar.ActorAvatar = "https://cdn.example.com/a/lisi.png"
-	doc, err = BuildDocsAccessRequestCard(localizedContext("zh-CN"), base, "d", "r", "s", withAvatar, actions)
+	doc, err = BuildDocsAccessRequestCard(localizedContext("zh-CN"), base, "d", "r", withAvatar, actions)
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(doc, &card))
 	images := nodesOfType(flattenCardNodes(card["body"]), "Image")
@@ -203,7 +201,7 @@ func TestBuildDocsAccessRequestCardAvatarHTTPSOnly(t *testing.T) {
 	for _, bad := range []string{"http://cdn.example.com/a.png", "data:image/png;base64,AAAA", "//cdn/a.png"} {
 		c := exampleDocsApprovalContent()
 		c.ActorAvatar = bad
-		_, err := BuildDocsAccessRequestCard(localizedContext("zh-CN"), base, "d", "r", "s", c, actions)
+		_, err := BuildDocsAccessRequestCard(localizedContext("zh-CN"), base, "d", "r", c, actions)
 		require.Error(t, err, "avatar %q must be rejected", bad)
 	}
 }
@@ -215,7 +213,7 @@ func TestBuildDocsAccessRequestCardEscapesCallerText(t *testing.T) {
 	c.Title = "Road_map_"
 	doc, err := BuildDocsAccessRequestCard(
 		localizedContext("zh-CN"),
-		"https://im.example.com/login", "d", "r", "s", c,
+		"https://im.example.com/login", "d", "r", c,
 		ApprovalActions{ApproveTitle: "允许", DenyTitle: "拒绝"},
 	)
 	require.NoError(t, err)
@@ -250,7 +248,7 @@ func TestBuildDocsAccessRequestCardBannerTextRunNotEscaped(t *testing.T) {
 	c.Actor = "Wang (FE)_lead"
 	c.BannerSuffix = "requested access."
 	doc, err := BuildDocsAccessRequestCard(
-		localizedContext("en-US"), "https://im.example.com/login", "d", "r", "s", c,
+		localizedContext("en-US"), "https://im.example.com/login", "d", "r", c,
 		ApprovalActions{ApproveTitle: "Allow", DenyTitle: "Deny"},
 	)
 	require.NoError(t, err)
@@ -278,7 +276,7 @@ func TestBuildDocsAccessRequestCardAnonymous(t *testing.T) {
 	c.ActorAvatar = ""
 	c.BannerSuffix = "Someone requested access to this document."
 	doc, err := BuildDocsAccessRequestCard(
-		localizedContext("en-US"), "https://im.example.com/login", "d", "r", "s", c,
+		localizedContext("en-US"), "https://im.example.com/login", "d", "r", c,
 		ApprovalActions{ApproveTitle: "Allow", DenyTitle: "Deny"},
 	)
 	require.NoError(t, err)
@@ -299,7 +297,7 @@ func TestBuildDocsAccessRequestCardBoundsActorInData(t *testing.T) {
 	c := exampleDocsApprovalContent()
 	c.Actor = strings.Repeat("名", maxActorRunes+50)
 	doc, err := BuildDocsAccessRequestCard(
-		localizedContext("zh-CN"), "https://im.example.com/login", "d", "r", "s", c,
+		localizedContext("zh-CN"), "https://im.example.com/login", "d", "r", c,
 		ApprovalActions{ApproveTitle: "允许", DenyTitle: "拒绝"},
 	)
 	require.NoError(t, err)
@@ -319,24 +317,23 @@ func TestBuildDocsAccessRequestCardBoundsActorInData(t *testing.T) {
 func TestBuildDocsApprovalOutcomeCard(t *testing.T) {
 	base := "https://im.example.com/login"
 
-	// Approved: good box, no reason, validates.
-	approved, err := BuildDocsApprovalOutcomeCard(localizedContext("zh-CN"), base, "d", "s", DocsOutcomeContent{
+	// Approved: status appears only in the header; no duplicate result box.
+	approved, err := BuildDocsApprovalOutcomeCard(localizedContext("zh-CN"), base, "d", DocsOutcomeContent{
 		Title: "2026 Q3 产品路线图", Variant: "docs.access_approved", Source: Source{Label: "文档"},
 		Denied: false, HeaderLabel: "文档申请", StatusLabel: "已允许",
-		ResultText: "申请人已获得所申请的文档权限。",
 	})
 	require.NoError(t, err)
 	card := mustCardMap(t, approved)
 	nodes := flattenCardNodes(card["body"])
 	assert.True(t, cardHasText(nodes, "已允许"))
-	assert.True(t, cardHasText(nodes, "申请人已获得所申请的文档权限。"))
+	assert.False(t, cardHasText(nodes, "申请人已获得所申请的文档权限。"))
 	requireOutcomeValidates(t, card)
 
 	// Denied: attention box surfaces the reviewer reason (escaped), validates.
-	denied, err := BuildDocsApprovalOutcomeCard(localizedContext("zh-CN"), base, "d", "s", DocsOutcomeContent{
+	denied, err := BuildDocsApprovalOutcomeCard(localizedContext("zh-CN"), base, "d", DocsOutcomeContent{
 		Title: "2026 Q3 产品路线图", Variant: "docs.access_denied", Source: Source{Label: "文档"},
 		Denied: true, HeaderLabel: "文档申请", StatusLabel: "已拒绝",
-		ResultText: "申请已被拒绝。", ReasonLabel: "拒绝原因", Reason: "权限范围*不符*",
+		ReasonLabel: "拒绝原因", Reason: "权限范围*不符*",
 	})
 	require.NoError(t, err)
 	card = mustCardMap(t, denied)

--- a/pkg/cardtmpl/docs_action_v3.go
+++ b/pkg/cardtmpl/docs_action_v3.go
@@ -1,17 +1,19 @@
 package cardtmpl
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 const (
-	docsV3DocumentIcon      = "https://api.iconify.design/lucide/file-text.svg?color=%236b7075"
-	docsV3ExternalIcon      = "https://api.iconify.design/lucide/external-link.svg?color=%236b7075"
-	docsV3RequesterIcon     = "https://api.iconify.design/lucide/user-round.svg?color=%236b7075"
-	docsV3ClockIcon         = "https://api.iconify.design/lucide/clock-3.svg?color=%236b7075"
-	docsV3MessageIcon       = "https://api.iconify.design/lucide/message-square.svg?color=%23555b61"
-	docsV3ViewIcon          = "https://api.iconify.design/lucide/eye.svg?color=%23555b61"
-	docsV3ApproveIcon       = "https://api.iconify.design/lucide/check.svg?color=%23ffffff"
-	docsV3ApprovedStateIcon = "https://api.iconify.design/lucide/check.svg?color=%2341cd59"
-	docsV3DenyIcon          = "https://api.iconify.design/lucide/x.svg?color=%23f54a45"
+	docsV3DocumentIcon = "https://api.iconify.design/lucide/file-text.svg?color=%236b7075"
+	docsV3ExternalIcon = "https://api.iconify.design/lucide/external-link.svg?color=%236b7075"
+	docsV3BotIcon      = "https://api.iconify.design/lucide/bot.svg?color=%237f3bf5"
+	docsV3ClockIcon    = "https://api.iconify.design/lucide/clock-3.svg?color=%236b7075"
+	docsV3MessageIcon  = "https://api.iconify.design/lucide/message-square.svg?color=%23555b61"
+	docsV3ViewIcon     = "https://api.iconify.design/lucide/eye.svg?color=%23555b61"
+	docsV3ApproveIcon  = "https://api.iconify.design/lucide/check.svg?color=%23ffffff"
+	docsV3DenyIcon     = "https://api.iconify.design/lucide/x.svg?color=%23f54a45"
 )
 
 // DocsAccessRequestV3Content extends the existing production content contract
@@ -53,12 +55,11 @@ func BuildDocsAccessRequestV3BodyWithLang(
 	webLoginURL string,
 	docID string,
 	requestID string,
-	spaceID string,
 	content DocsAccessRequestV3Content,
 	actions ApprovalActions,
 ) ([]interface{}, string, error) {
 	_, cardActions, deepLink, err := BuildDocsAccessRequestBodyWithLang(
-		lang, webLoginURL, docID, requestID, spaceID, content.DocsApprovalContent, actions,
+		lang, webLoginURL, docID, requestID, content.DocsApprovalContent, actions,
 	)
 	if err != nil {
 		return nil, "", err
@@ -83,6 +84,8 @@ func BuildDocsAccessRequestV3BodyWithLang(
 				data["permission_label"] = content.PermissionLabel
 				data["permission_role_label"] = content.PermissionRoleLabel
 				data["source_name"] = content.SourceName
+				data["requester_space_name"] = content.RequesterSpaceName
+				data["requested_bot_names"] = append([]string(nil), content.RequestedBotNames...)
 			}
 			if am["id"] == DocsDenyActionID {
 				am["iconUrl"] = docsV3DenyIcon
@@ -93,12 +96,12 @@ func BuildDocsAccessRequestV3BodyWithLang(
 	}
 
 	labels := docsV3LabelsForLanguage(lang)
-	items := []interface{}{
-		docsV3Title(content.Title, deepLink, labels),
-		docsV3Banner(content.Actor, content.BannerSuffix),
+	items := []interface{}{docsV3Title(content.Title, deepLink, labels)}
+	if summary := docsV3RequestSummary(lang, content.Actor, content.RequesterSpaceName, content.PermissionRoleLabel); summary != nil {
+		items = append(items, summary)
 	}
-	if row := docsV3RequesterRow(content.Actor, content.ActorAvatar, content.RoleLabel, content.Timestamp); row != nil {
-		items = append(items, row)
+	if bots := docsV3BotBox(lang, content.RequestedBotNames); bots != nil {
+		items = append(items, bots)
 	}
 	if reason := docsV3ReasonBox(content.ReasonLabel, content.Reason); reason != nil {
 		items = append(items, reason)
@@ -126,30 +129,35 @@ func BuildDocsApprovalOutcomeV3BodyWithLang(
 	lang string,
 	webLoginURL string,
 	docID string,
-	spaceID string,
 	content DocsOutcomeContent,
 ) ([]interface{}, string, error) {
-	_, deepLink, err := BuildDocsApprovalOutcomeBodyWithLang(lang, webLoginURL, docID, spaceID, content)
+	_, deepLink, err := BuildDocsApprovalOutcomeBodyWithLang(lang, webLoginURL, docID, content)
 	if err != nil {
 		return nil, "", err
 	}
-	statusColor, resultStyle, resultIcon := "Good", "good", docsV3ApprovedStateIcon
+	statusColor := "Good"
 	if content.Denied {
-		statusColor, resultStyle, resultIcon = "Attention", "attention", docsV3DenyIcon
+		statusColor = "Attention"
 	}
 	labels := docsV3LabelsForLanguage(lang)
 	items := []interface{}{docsV3Title(content.Title, deepLink, labels)}
-	if strings.TrimSpace(content.Actor) != "" || strings.TrimSpace(content.BannerSuffix) != "" {
-		items = append(items, docsV3Banner(content.Actor, content.BannerSuffix))
+	if summary := docsV3RequestSummary(lang, content.Actor, content.RequesterSpaceName, content.PermissionRoleLabel); summary != nil {
+		items = append(items, summary)
 	}
-	if row := docsV3RequesterRow(content.Actor, content.ActorAvatar, content.RoleLabel, content.RequestedAtDisplay); row != nil {
-		items = append(items, row)
+	if bots := docsV3BotBox(lang, content.RequestedBotNames); bots != nil {
+		items = append(items, bots)
 	}
 	if reason := docsV3ReasonBox(content.RequestReasonLabel, content.RequestReason); reason != nil {
 		items = append(items, reason)
 	}
-	items = append(items, docsV3ResultBox(resultStyle, resultIcon, content.StatusLabel,
-		content.ResultText, content.DecisionSummary, content.ReasonLabel, content.Reason))
+	// Terminal status already lives in the top-right badge. Do not repeat it in
+	// a large green/red result block. A denial reason remains visible as a compact
+	// neutral detail block.
+	if content.Denied {
+		if reason := docsV3ReasonBox(content.ReasonLabel, content.Reason); reason != nil {
+			items = append(items, reason)
+		}
+	}
 
 	viewAction := map[string]interface{}{
 		"type": "Action.OpenUrl", "id": "view_document", "title": labelsForLanguage(lang).viewDetails,
@@ -159,7 +167,8 @@ func BuildDocsApprovalOutcomeV3BodyWithLang(
 		docsV3Header(content.HeaderLabel, content.SourceName, content.StatusLabel,
 			content.PermissionLabel, statusColor, "octo-badge-result-request-state", labels.document),
 		docsV3Surface(items),
-		docsV3Footer(content.MessageTimeLabel, content.MessageTimeDisplay, "", []interface{}{viewAction}),
+		docsV3TerminalFooter(lang, content.RequestedAtDisplay, content.MessageTimeDisplay,
+			content.DecisionOperatorName, content.DecisionOperatorSpaceName, viewAction),
 	}
 	return body, deepLink, nil
 }
@@ -261,92 +270,174 @@ func docsV3Title(title, deepLink string, labels docsV3Labels) map[string]interfa
 	}
 }
 
-func docsV3Banner(actor, suffix string) map[string]interface{} {
+func docsV3RequestSummary(lang, actor, sourceSpaceName, roleLabel string) map[string]interface{} {
 	actor = truncateRunes(strings.TrimSpace(actor), maxActorRunes)
-	suffix = truncateRunes(strings.TrimSpace(suffix), maxTitleRunes)
-	if actor == "" {
-		return map[string]interface{}{
-			"type": "TextBlock", "text": escapeMarkdown(suffix), "size": "Medium",
-			"isSubtle": true, "wrap": true, "spacing": "Small",
-		}
+	spaceName := truncateRunes(strings.TrimSpace(sourceSpaceName), maxTitleRunes)
+	roleLabel = truncateRunes(strings.TrimSpace(roleLabel), maxTimestampRunes)
+	if actor == "" && spaceName == "" && roleLabel == "" {
+		return nil
 	}
+	applicantLabel, permissionLabel := "Applicant: ", "Permission: "
+	if strings.EqualFold(lang, "zh-CN") || strings.HasPrefix(strings.ToLower(lang), "zh") {
+		applicantLabel, permissionLabel = "申请者：", "申请权限："
+	}
+	inlines := []interface{}{}
+	appendPart := func(label, value string) {
+		if value == "" {
+			return
+		}
+		if len(inlines) > 0 {
+			inlines = append(inlines, map[string]interface{}{
+				"type": "TextRun", "text": "  ·  ", "isSubtle": true, "size": "Small",
+			})
+		}
+		if label != "" {
+			inlines = append(inlines, map[string]interface{}{
+				"type": "TextRun", "text": label, "isSubtle": true, "size": "Small",
+			})
+		}
+		inlines = append(inlines, map[string]interface{}{
+			"type": "TextRun", "text": value, "weight": "Bolder", "size": "Small",
+		})
+	}
+	appendPart(applicantLabel, actor)
+	appendPart("", spaceName)
+	appendPart(permissionLabel, roleLabel)
 	return map[string]interface{}{
-		"type": "RichTextBlock", "spacing": "Small",
-		"inlines": []interface{}{
-			map[string]interface{}{"type": "TextRun", "text": actor + " ", "weight": "Bolder", "size": "Medium"},
-			map[string]interface{}{"type": "TextRun", "text": suffix, "isSubtle": true, "size": "Medium"},
-		},
+		"type": "RichTextBlock", "spacing": "Medium", "inlines": inlines,
 	}
 }
 
-func docsV3RequesterRow(actor, avatar, roleLabel, timestamp string) map[string]interface{} {
-	actor = truncateRunes(strings.TrimSpace(actor), maxActorRunes)
-	timestamp = truncateRunes(strings.TrimSpace(timestamp), maxTimestampRunes)
-	if actor == "" {
+const requestedBotNamesDisplayBudget = 56
+
+func requestedBotNamesForOneLine(names []string, zh bool) []string {
+	if len(names) == 0 {
 		return nil
 	}
-	columns := []interface{}{}
-	if avatar != "" {
-		columns = append(columns, map[string]interface{}{
-			"type": "Column", "width": "auto",
-			"items": []interface{}{map[string]interface{}{
-				"type": "Image", "url": avatar, "altText": actor, "style": "Person",
-				"width": "28px", "height": "28px", "spacing": "None",
-			}},
-		})
+	separator := ", "
+	if zh {
+		separator = "、"
 	}
-	nameItems := []interface{}{map[string]interface{}{
-		"type": "TextBlock", "text": escapeMarkdown(actor), "weight": "Bolder",
-		"size": "Small", "spacing": "None", "wrap": false,
-	}}
-	if role := strings.TrimSpace(roleLabel); role != "" {
-		nameItems = append(nameItems, map[string]interface{}{
+	visible := make([]string, 0, len(names))
+	for _, name := range names {
+		candidate := append(append([]string(nil), visible...), name)
+		hidden := len(names) - len(candidate)
+		text := strings.Join(candidate, separator)
+		if hidden > 0 {
+			if zh {
+				text += fmt.Sprintf("，等 %d 个", hidden)
+			} else {
+				text += fmt.Sprintf(" and %d more", hidden)
+			}
+		}
+		if displayWidth(text) > requestedBotNamesDisplayBudget {
+			break
+		}
+		visible = candidate
+	}
+	if len(visible) == 0 {
+		hidden := len(names) - 1
+		suffix := ""
+		if hidden > 0 {
+			if zh {
+				suffix = fmt.Sprintf("，等 %d 个", hidden)
+			} else {
+				suffix = fmt.Sprintf(" and %d more", hidden)
+			}
+		}
+		visible = append(visible, truncateDisplayWidth(names[0], requestedBotNamesDisplayBudget-displayWidth(suffix)))
+	}
+	return visible
+}
+
+func truncateDisplayWidth(value string, maxWidth int) string {
+	if maxWidth <= 0 || displayWidth(value) <= maxWidth {
+		return value
+	}
+	const ellipsis = "…"
+	target := maxWidth - displayWidth(ellipsis)
+	if target <= 0 {
+		return ellipsis
+	}
+	width := 0
+	runes := make([]rune, 0, len(value))
+	for _, r := range value {
+		runeWidth := 1
+		if r > 0x7f {
+			runeWidth = 2
+		}
+		if width+runeWidth > target {
+			break
+		}
+		runes = append(runes, r)
+		width += runeWidth
+	}
+	return string(runes) + ellipsis
+}
+
+func displayWidth(value string) int {
+	width := 0
+	for _, r := range value {
+		if r > 0x7f {
+			width += 2
+		} else {
+			width++
+		}
+	}
+	return width
+}
+
+func docsV3BotBox(lang string, names []string) map[string]interface{} {
+	clean := make([]string, 0, len(names))
+	for _, name := range names {
+		if value := truncateRunes(strings.TrimSpace(name), maxActorRunes); value != "" {
+			clean = append(clean, value)
+		}
+	}
+	if len(clean) == 0 {
+		return nil
+	}
+	total := len(clean)
+	zh := strings.EqualFold(lang, "zh-CN") || strings.HasPrefix(strings.ToLower(lang), "zh")
+	visible := requestedBotNamesForOneLine(clean, zh)
+	label := fmt.Sprintf("AI assistants requesting access (%d)", total)
+	namesText := strings.Join(visible, ", ")
+	if hidden := total - len(visible); hidden > 0 {
+		namesText += fmt.Sprintf(" and %d more", hidden)
+	}
+	if zh {
+		label = fmt.Sprintf("同时申请权限的 AI 助手（%d）", total)
+		namesText = strings.Join(visible, "、")
+		if hidden := total - len(visible); hidden > 0 {
+			namesText += fmt.Sprintf("，等 %d 个", hidden)
+		}
+	}
+	return map[string]interface{}{
+		"type": "Container", "style": "emphasis", "spacing": "Large",
+		"items": []interface{}{map[string]interface{}{
 			"type": "ColumnSet", "spacing": "None", "columns": []interface{}{
 				map[string]interface{}{
 					"type": "Column", "width": "auto",
 					"items": []interface{}{map[string]interface{}{
-						"type": "Image", "url": docsV3RequesterIcon, "altText": "",
-						"width": "12px", "height": "12px", "spacing": "None",
+						"type": "Image", "url": docsV3BotIcon, "altText": "AI",
+						"width": "18px", "height": "18px", "spacing": "None",
 					}},
 				},
 				map[string]interface{}{
-					"type": "Column", "width": "auto", "spacing": "Small",
-					"items": []interface{}{map[string]interface{}{
-						"type": "TextBlock", "text": escapeMarkdown(role), "size": "Small",
-						"isSubtle": true, "spacing": "None", "wrap": false,
-					}},
+					"type": "Column", "width": "stretch", "spacing": "Default",
+					"items": []interface{}{
+						map[string]interface{}{
+							"type": "TextBlock", "text": escapeMarkdown(label), "size": "Small",
+							"weight": "Bolder", "spacing": "None",
+						},
+						map[string]interface{}{
+							"type": "TextBlock", "text": escapeMarkdown(namesText),
+							"size": "Small", "isSubtle": true, "spacing": "Small", "wrap": true, "maxLines": 2,
+						},
+					},
 				},
 			},
-		})
-	}
-	columns = append(columns, map[string]interface{}{
-		"type": "Column", "width": "stretch", "spacing": "Default", "items": nameItems,
-	})
-	if timestamp != "" {
-		columns = append(columns, map[string]interface{}{
-			"type": "Column", "width": "auto", "verticalContentAlignment": "Bottom",
-			"items": []interface{}{map[string]interface{}{
-				"type": "ColumnSet", "spacing": "None", "columns": []interface{}{
-					map[string]interface{}{
-						"type": "Column", "width": "auto",
-						"items": []interface{}{map[string]interface{}{
-							"type": "Image", "url": docsV3ClockIcon, "altText": "",
-							"width": "13px", "height": "13px", "spacing": "None",
-						}},
-					},
-					map[string]interface{}{
-						"type": "Column", "width": "auto", "spacing": "Small",
-						"items": []interface{}{map[string]interface{}{
-							"type": "TextBlock", "text": escapeMarkdown(timestamp), "size": "Small",
-							"isSubtle": true, "spacing": "None", "wrap": false,
-						}},
-					},
-				},
-			}},
-		})
-	}
-	return map[string]interface{}{
-		"type": "ColumnSet", "spacing": "Medium", "verticalContentAlignment": "Center", "columns": columns,
+		}},
 	}
 }
 
@@ -384,45 +475,50 @@ func docsV3ReasonBox(label, reason string) map[string]interface{} {
 	}
 }
 
-func docsV3ResultBox(style, icon, statusLabel, resultText, decisionSummary, reasonLabel, reason string) map[string]interface{} {
-	items := []interface{}{
-		map[string]interface{}{
-			"type": "TextBlock", "text": escapeMarkdown(strings.TrimSpace(resultText)),
-			"size": "Small", "weight": "Bolder", "spacing": "None", "wrap": true,
-		},
+func docsV3TerminalFooter(lang, requestedAt, decidedAt, operatorName, operatorSpaceName string, viewAction map[string]interface{}) map[string]interface{} {
+	requestedAt = truncateRunes(strings.TrimSpace(requestedAt), maxTimestampRunes)
+	decidedAt = truncateRunes(strings.TrimSpace(decidedAt), maxTimestampRunes)
+	operatorName = truncateRunes(strings.TrimSpace(operatorName), maxActorRunes)
+	operatorSpaceName = truncateRunes(strings.TrimSpace(operatorSpaceName), maxTitleRunes)
+	requestedLabel, decidedLabel := "Requested at", "Processed at"
+	if strings.EqualFold(lang, "zh-CN") || strings.HasPrefix(strings.ToLower(lang), "zh") {
+		requestedLabel, decidedLabel = "申请于", "处理于"
 	}
-	if summary := truncateRunes(strings.TrimSpace(decisionSummary), maxTitleRunes); summary != "" {
-		items = append(items, map[string]interface{}{
-			"type": "TextBlock", "text": escapeMarkdown(summary),
-			"size": "Small", "isSubtle": true, "spacing": "Small",
+	leftItems := []interface{}{}
+	if requestedAt != "" {
+		leftItems = append(leftItems, map[string]interface{}{
+			"type": "TextBlock", "text": escapeMarkdown(requestedLabel + " " + requestedAt),
+			"size": "Small", "isSubtle": true, "spacing": "None", "wrap": false,
 		})
 	}
-	if value := truncateRunes(strings.TrimSpace(reason), maxReasonRunes); value != "" {
-		text := value
-		if label := strings.TrimSpace(reasonLabel); label != "" {
-			text = label + "：" + value
-		}
-		items = append(items, map[string]interface{}{
-			"type": "TextBlock", "text": escapeMarkdown(text),
-			"size": "Small", "isSubtle": true, "spacing": "Small", "wrap": true,
+	if decidedAt != "" {
+		leftItems = append(leftItems, map[string]interface{}{
+			"type": "TextBlock", "text": escapeMarkdown(decidedLabel + " " + decidedAt),
+			"size": "Small", "isSubtle": true, "spacing": "Small", "wrap": false,
 		})
 	}
+	operatorText := strings.Trim(strings.TrimSpace(operatorName)+" · "+strings.TrimSpace(operatorSpaceName), " ·")
+	if operatorText != "" {
+		leftItems = append(leftItems, map[string]interface{}{
+			"type": "TextBlock", "text": escapeMarkdown(operatorText),
+			"size": "Small", "weight": "Bolder", "spacing": "Small", "wrap": false,
+		})
+	}
+	rightItems := []interface{}{}
+	rightItems = append(rightItems, map[string]interface{}{
+		"type": "ActionSet", "spacing": "Small", "actions": []interface{}{viewAction},
+	})
 	return map[string]interface{}{
-		"type": "Container", "style": style, "spacing": "Large",
+		"type": "Container", "style": "emphasis", "bleed": true,
+		"separator": true, "spacing": "None",
 		"items": []interface{}{map[string]interface{}{
-			"type": "ColumnSet", "spacing": "None", "columns": []interface{}{
+			"type": "ColumnSet", "spacing": "None", "verticalContentAlignment": "Center",
+			"columns": []interface{}{
 				map[string]interface{}{
-					"type": "Column", "width": "auto",
-					"items": []interface{}{map[string]interface{}{
-						"type": "Container", "style": "default", "spacing": "None",
-						"items": []interface{}{map[string]interface{}{
-							"type": "Image", "url": icon, "altText": statusLabel,
-							"width": "16px", "height": "16px", "spacing": "None",
-						}},
-					}},
+					"type": "Column", "width": "stretch", "verticalContentAlignment": "Center", "items": leftItems,
 				},
 				map[string]interface{}{
-					"type": "Column", "width": "stretch", "spacing": "Default", "items": items,
+					"type": "Column", "width": "auto", "verticalContentAlignment": "Center", "items": rightItems,
 				},
 			},
 		}},
@@ -438,24 +534,27 @@ func docsV3Footer(timeLabel, timeDisplay, actionSetID string, actions []interfac
 	if actionSetID != "" {
 		actionSet["id"] = actionSetID
 	}
+	columns := []interface{}{}
+	if timeText != "" {
+		columns = append(columns, map[string]interface{}{
+			"type": "Column", "width": "stretch", "verticalContentAlignment": "Center",
+			"items": []interface{}{map[string]interface{}{
+				"type": "TextBlock", "text": escapeMarkdown(timeText), "size": "Small",
+				"isSubtle": true, "spacing": "None", "wrap": false,
+			}},
+		})
+	} else {
+		columns = append(columns, map[string]interface{}{"type": "Column", "width": "stretch", "items": []interface{}{}})
+	}
+	columns = append(columns, map[string]interface{}{
+		"type": "Column", "width": "auto", "verticalContentAlignment": "Center",
+		"items": []interface{}{actionSet},
+	})
 	return map[string]interface{}{
 		"type": "Container", "style": "emphasis", "bleed": true,
 		"separator": true, "spacing": "None",
 		"items": []interface{}{map[string]interface{}{
-			"type": "ColumnSet", "spacing": "None", "verticalContentAlignment": "Center",
-			"columns": []interface{}{
-				map[string]interface{}{
-					"type": "Column", "width": "stretch",
-					"items": []interface{}{map[string]interface{}{
-						"type": "TextBlock", "text": escapeMarkdown(timeText), "size": "Small",
-						"isSubtle": true, "spacing": "None", "wrap": false,
-					}},
-				},
-				map[string]interface{}{
-					"type": "Column", "width": "auto",
-					"items": []interface{}{actionSet},
-				},
-			},
+			"type": "ColumnSet", "spacing": "None", "verticalContentAlignment": "Center", "columns": columns,
 		}},
 	}
 }

--- a/pkg/cardtmpl/docs_commented/template.go
+++ b/pkg/cardtmpl/docs_commented/template.go
@@ -95,7 +95,7 @@ func (t *Template) Build(
 	attribution := attributionFor(strings.TrimSpace(f.ActorName), labels)
 	source := sourceFor(env.Lang)
 	body, deepLink, err := cardtmpl.BuildDocsResourceCardBodyWithLang(
-		env.Lang, env.WebLoginURL, f.DocID, env.SpaceID, cardtmpl.ResourceCard{
+		env.Lang, env.WebLoginURL, f.DocID, cardtmpl.ResourceCard{
 			Title:       f.Title,
 			Attribution: attribution,
 			Excerpt:     strings.TrimSpace(f.Excerpt),

--- a/pkg/cardtmpl/docs_shared/template.go
+++ b/pkg/cardtmpl/docs_shared/template.go
@@ -65,7 +65,7 @@ func (t *Template) Build(
 	attribution := attributionFor(strings.TrimSpace(f.ActorName), labels)
 	source := sourceFor(env.Lang)
 	body, deepLink, err := cardtmpl.BuildDocsResourceCardBodyWithLang(
-		env.Lang, env.WebLoginURL, f.DocID, env.SpaceID, cardtmpl.ResourceCard{
+		env.Lang, env.WebLoginURL, f.DocID, cardtmpl.ResourceCard{
 			Title:       f.Title,
 			Attribution: attribution,
 			Excerpt:     strings.TrimSpace(f.Excerpt),

--- a/pkg/cardtmpl/docs_test.go
+++ b/pkg/cardtmpl/docs_test.go
@@ -24,7 +24,6 @@ func TestBuildDocsResourceCardSnapshotAndValidation(t *testing.T) {
 		localizedContext("en-US"),
 		"https://im.example.com/login?redirect=1",
 		"doc/42",
-		"space a",
 		exampleDocsResourceCard(),
 	)
 	require.NoError(t, err)
@@ -33,7 +32,7 @@ func TestBuildDocsResourceCardSnapshotAndValidation(t *testing.T) {
 	  "type":"AdaptiveCard",
 	  "version":"1.5",
 	  "metadata":{
-	    "webUrl":"https://im.example.com/d/doc%2F42?sp=space+a",
+	    "webUrl":"https://im.example.com/d/doc%2F42",
 	    "octo":{
 	      "variant":"docs.shared",
 	      "source":{"label":"Docs"}
@@ -46,7 +45,7 @@ func TestBuildDocsResourceCardSnapshotAndValidation(t *testing.T) {
 	    ]},
 	    {"type":"TextBlock","text":"Q3 launch plan is finalized.","wrap":true},
 	    {"type":"ActionSet","actions":[
-	      {"type":"Action.OpenUrl","title":"View details","url":"https://im.example.com/d/doc%2F42?sp=space+a"}
+	      {"type":"Action.OpenUrl","title":"View details","url":"https://im.example.com/d/doc%2F42"}
 	    ]}
 	  ]
 	}`
@@ -66,7 +65,6 @@ func TestBuildDocsResourceCardUsesOutboundLanguage(t *testing.T) {
 		localizedContext("zh-CN"),
 		"https://im.example.com/login",
 		"doc-1",
-		"space-1",
 		exampleDocsResourceCard(),
 	)
 	require.NoError(t, err)
@@ -78,7 +76,6 @@ func TestBuildDocsResourceCardDeepLinkShape(t *testing.T) {
 		localizedContext("en-US"),
 		"https://im.example.com/login?redirect=1",
 		"doc-abc",
-		"space-1",
 		exampleDocsResourceCard(),
 	)
 	require.NoError(t, err)
@@ -96,7 +93,7 @@ func TestBuildDocsResourceCardDeepLinkShape(t *testing.T) {
 	first, _ := actions[0].(map[string]interface{})
 	require.NotNil(t, first)
 	assert.Equal(t, "Action.OpenUrl", first["type"])
-	assert.Equal(t, "https://im.example.com/d/doc-abc?sp=space-1", first["url"])
+	assert.Equal(t, "https://im.example.com/d/doc-abc", first["url"])
 }
 
 func TestBuildDocsResourceCardRejectsUnsafeInputs(t *testing.T) {
@@ -104,19 +101,17 @@ func TestBuildDocsResourceCardRejectsUnsafeInputs(t *testing.T) {
 		name       string
 		webBaseURL string
 		docID      string
-		spaceID    string
 		resource   ResourceCard
 	}{
-		{name: "non https web base", webBaseURL: "http://im.example.com/login", docID: "doc-1", spaceID: "space-1", resource: exampleDocsResourceCard()},
-		{name: "unsafe icon", webBaseURL: "https://im.example.com/login", docID: "doc-1", spaceID: "space-1", resource: func() ResourceCard { r := exampleDocsResourceCard(); r.IconURL = "javascript:alert(1)"; return r }()},
-		{name: "missing title", webBaseURL: "https://im.example.com/login", docID: "doc-1", spaceID: "space-1", resource: func() ResourceCard { r := exampleDocsResourceCard(); r.Title = ""; return r }()},
-		{name: "empty doc id", webBaseURL: "https://im.example.com/login", docID: "", spaceID: "space-1", resource: exampleDocsResourceCard()},
-		{name: "empty space id", webBaseURL: "https://im.example.com/login", docID: "doc-1", spaceID: "", resource: exampleDocsResourceCard()},
+		{name: "non https web base", webBaseURL: "http://im.example.com/login", docID: "doc-1", resource: exampleDocsResourceCard()},
+		{name: "unsafe icon", webBaseURL: "https://im.example.com/login", docID: "doc-1", resource: func() ResourceCard { r := exampleDocsResourceCard(); r.IconURL = "javascript:alert(1)"; return r }()},
+		{name: "missing title", webBaseURL: "https://im.example.com/login", docID: "doc-1", resource: func() ResourceCard { r := exampleDocsResourceCard(); r.Title = ""; return r }()},
+		{name: "empty doc id", webBaseURL: "https://im.example.com/login", docID: "", resource: exampleDocsResourceCard()},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			document, err := BuildDocsResourceCard(localizedContext("en-US"), tc.webBaseURL, tc.docID, tc.spaceID, tc.resource)
+			document, err := BuildDocsResourceCard(localizedContext("en-US"), tc.webBaseURL, tc.docID, tc.resource)
 			assert.Nil(t, document)
 			assert.Error(t, err)
 		})

--- a/pkg/cardtmpl/resource.go
+++ b/pkg/cardtmpl/resource.go
@@ -125,13 +125,12 @@ func BuildDocsResourceCard(
 	ctx context.Context,
 	webLoginURL string,
 	docID string,
-	spaceID string,
 	resource ResourceCard,
 ) (json.RawMessage, error) {
-	if strings.TrimSpace(docID) == "" || strings.TrimSpace(spaceID) == "" {
-		return nil, errors.New("cardtmpl: doc ID and space ID are required")
+	if strings.TrimSpace(docID) == "" {
+		return nil, errors.New("cardtmpl: doc ID is required")
 	}
-	deepLink, err := docsDeepLink(webLoginURL, docID, spaceID)
+	deepLink, err := docsDeepLink(webLoginURL, docID)
 	if err != nil {
 		return nil, err
 	}
@@ -180,13 +179,12 @@ func BuildDocsResourceCardBodyWithLang(
 	lang string,
 	webLoginURL string,
 	docID string,
-	spaceID string,
 	resource ResourceCard,
 ) (body []interface{}, deepLink string, err error) {
-	if strings.TrimSpace(docID) == "" || strings.TrimSpace(spaceID) == "" {
-		return nil, "", errors.New("cardtmpl: doc ID and space ID are required")
+	if strings.TrimSpace(docID) == "" {
+		return nil, "", errors.New("cardtmpl: doc ID is required")
 	}
-	deepLink, err = docsDeepLink(webLoginURL, docID, spaceID)
+	deepLink, err = docsDeepLink(webLoginURL, docID)
 	if err != nil {
 		return nil, "", err
 	}
@@ -322,16 +320,16 @@ func summaryDeepLink(webLoginURL, taskID, spaceID string) (string, error) {
 	return origin + "/s/" + url.PathEscape(taskID) + "?sp=" + url.QueryEscape(spaceID), nil
 }
 
-// docsDeepLink mirrors summaryDeepLink but targets octo-web's already-live
-// standalone doc route /d/:docId (cold-load → login bounce → multi-session
-// sid recovery, XIN-398 suite). The origin comes from External.WebLoginURL
-// (positive-allowlisted absolute https).
-func docsDeepLink(webLoginURL, docID, spaceID string) (string, error) {
+// docsDeepLink targets octo-web's standalone /d/:docId route. Unlike summary
+// links, Docs links intentionally carry no Space query: octo-web restores the
+// authoritative viewer Space from its persisted open context. The origin comes
+// from External.WebLoginURL (positive-allowlisted absolute https).
+func docsDeepLink(webLoginURL, docID string) (string, error) {
 	origin, err := webOrigin(webLoginURL)
 	if err != nil {
 		return "", err
 	}
-	return origin + "/d/" + url.PathEscape(docID) + "?sp=" + url.QueryEscape(spaceID), nil
+	return origin + "/d/" + url.PathEscape(docID), nil
 }
 
 // buildMetadata assembles the AdaptiveCard 1.5 `metadata` object. The standard

--- a/scripts/cardpreview/main.go
+++ b/scripts/cardpreview/main.go
@@ -46,7 +46,7 @@ func main() {
 	))
 
 	docsShared := mustCard(cardtmpl.BuildDocsResourceCard(
-		ctx, base, "d_20260713_abcd", "spc_xxx",
+		ctx, base, "d_20260713_abcd",
 		cardtmpl.ResourceCard{
 			Title:       "产品设计方案",
 			Attribution: "Alice 分享了文档",
@@ -61,7 +61,7 @@ func main() {
 	))
 
 	docsAccessRequested := mustCard(cardtmpl.BuildDocsAccessRequestCard(
-		ctx, base, "d_20260716_q3", "DOC-REQ-025", "spc_xxx",
+		ctx, base, "d_20260716_q3", "DOC-REQ-025",
 		cardtmpl.DocsApprovalContent{
 			Title:        "2026 Q3 产品路线图",
 			Actor:        "李四",
@@ -80,20 +80,19 @@ func main() {
 	))
 
 	docsAccessApproved := mustCard(cardtmpl.BuildDocsApprovalOutcomeCard(
-		ctx, base, "d_20260716_q3", "spc_xxx",
+		ctx, base, "d_20260716_q3",
 		cardtmpl.DocsOutcomeContent{
 			Title: "2026 Q3 产品路线图", Variant: "docs.access_approved", Source: cardtmpl.Source{Label: "文档"},
 			Denied: false, HeaderLabel: "文档申请", StatusLabel: "已允许",
-			ResultText: "申请人已获得所申请的文档权限。",
 		},
 	))
 
 	docsAccessDenied := mustCard(cardtmpl.BuildDocsApprovalOutcomeCard(
-		ctx, base, "d_20260716_q3", "spc_xxx",
+		ctx, base, "d_20260716_q3",
 		cardtmpl.DocsOutcomeContent{
 			Title: "2026 Q3 产品路线图", Variant: "docs.access_denied", Source: cardtmpl.Source{Label: "文档"},
 			Denied: true, HeaderLabel: "文档申请", StatusLabel: "已拒绝",
-			ResultText: "申请已被拒绝。", ReasonLabel: "拒绝原因", Reason: "当前版本范围未覆盖该文档，请对齐范围后再申请。",
+			ReasonLabel: "拒绝原因", Reason: "当前版本范围未覆盖该文档，请对齐范围后再申请。",
 		},
 	))
 


### PR DESCRIPTION
## Summary
- Finalizes Docs access-request cards after approve or deny actions.
- Preserves applicant outcome context through the notification dispatch pipeline.
- Keeps legacy and v3 templates aligned with the backend decision callback.

## Linked Issue / Spec
Fixes #792

## What changed
- Before: terminal card mutation could lose applicant outcome/render context or retain stale interaction state. After: finalization carries the authoritative outcome and renders a deterministic terminal card.
- Card contracts, templates, dispatch, mutation, and resource registration are updated together.

## How verified
- Focused notify and card-template suites passed.
- gofmt and `git diff --check` passed.
- Full notify remains environment-blocked by the repository's live MySQL E2E dependency; it is not reported as passing.

## COMPREHENSION
### What does this change actually do?
It converts an actionable Docs access-request card into the correct final approved/denied representation while preserving the applicant outcome needed by the renderer.

### What could break?
A backend payload that violates the versioned card schema, a registry/template version mismatch, or a dispatch path that drops render context. Schema and dispatch regressions cover those boundaries.

### How do we know it works?
Focused finalizer, mutation, registry, platform dispatch, resource, and template tests passed with formatting and diff gates.

## Dependencies / Rollout
Deploy after or alongside the Sharing V3 Docs backend callback contract. The HTML and frontend changes do not directly gate card rendering. Cross-Space PPT is out of scope.

## Accepted product behavior
- Approver cards are terminalized in place as the single IM outcome surface.
- No second terminal IM card is sent to the applicant.
- Canonical Docs links are bare `/d/:docId`; octo-web resolves document provenance through authoritative open-context and ignores/removes legacy `?sp=`.
