### PR TITLE
feat(app_bot): let the admin listing see every scope

### DIFF
--- a/modules/app_bot/app_bot.go
+++ b/modules/app_bot/app_bot.go
@@ -440,9 +440,29 @@ func (ab *AppBot) createBot(c *wkhttp.Context, scope, spaceID string) {
 }
 
 // listPlatformBots handles GET /v1/admin/app_bot.
+//
+// The optional `scope` query parameter widens the listing for the super admin who owns
+// this route: "platform" (the default, and the historical behaviour) / "space" (further
+// narrowed by an optional space_id) / "all". Without it, a bot that moves into a space
+// drops out of the only list the admin console has, with nothing on screen to say where
+// it went. This widening is deliberately read-only: every mutation still runs through
+// botInRouteScope, so the platform route continues to refuse to touch a space's bot.
 func (ab *AppBot) listPlatformBots(c *wkhttp.Context) {
 	if err := c.CheckLoginRole(); err != nil {
 		respondAppBotForbidden(c)
+		return
+	}
+	scope := c.Query("scope")
+	spaceID := ""
+	switch scope {
+	case "", "platform":
+		scope = "platform"
+	case "all":
+		scope = "" // no scope predicate
+	case "space":
+		spaceID = c.Query("space_id")
+	default:
+		respondAppBotRequestInvalid(c, "scope")
 		return
 	}
 	pageIndex, pageSize := c.GetPage()
@@ -455,13 +475,13 @@ func (ab *AppBot) listPlatformBots(c *wkhttp.Context) {
 			statusFilter = &s
 		}
 	}
-	bots, total, err := ab.db.queryBotsByScope("platform", "", pageIndex, pageSize, keyword, statusFilter)
+	bots, total, err := ab.db.queryBotsByScope(scope, spaceID, pageIndex, pageSize, keyword, statusFilter)
 	if err != nil {
 		ab.Error("query platform bots failed", zap.Error(err))
 		respondAppBotQueryFailed(c)
 		return
 	}
-	c.Response(gin.H{"count": total, "list": ab.toBotListResp(bots)})
+	c.Response(gin.H{"count": total, "list": ab.toBotListRespWithSpaceNames(bots)})
 }
 
 // listSpaceBots handles GET /v1/space/:space_id/app_bot.
@@ -1022,10 +1042,45 @@ func (ab *AppBot) toBotListResp(bots []*appBotModel) []gin.H {
 			"avatar":       ab.ctx.GetConfig().GetAvatarPath(bot.UID),
 			"status":       bot.Status,
 			"scope":        bot.Scope,
+			"space_id":     bot.SpaceID,
 			"created_at":   bot.CreatedAt,
 		})
 	}
 	return result
+}
+
+// toBotListRespWithSpaceNames is toBotListResp plus a `space_name` per row, so a mixed
+// listing can show which space owns a bot instead of a bare id. A lookup failure is not
+// worth failing the listing over — the rows still carry space_id, so the name is dropped
+// and the list renders.
+func (ab *AppBot) toBotListRespWithSpaceNames(bots []*appBotModel) []gin.H {
+	rows := ab.toBotListResp(bots)
+	ids := make([]string, 0, len(bots))
+	seen := make(map[string]struct{}, len(bots))
+	for _, bot := range bots {
+		if bot.SpaceID == "" {
+			continue
+		}
+		if _, ok := seen[bot.SpaceID]; ok {
+			continue
+		}
+		seen[bot.SpaceID] = struct{}{}
+		ids = append(ids, bot.SpaceID)
+	}
+	if len(ids) == 0 {
+		return rows
+	}
+	names, err := ab.db.querySpaceNames(ids)
+	if err != nil {
+		ab.Error("query space names failed", zap.Error(err))
+		return rows
+	}
+	for i, bot := range bots {
+		if name, ok := names[bot.SpaceID]; ok {
+			rows[i]["space_name"] = name
+		}
+	}
+	return rows
 }
 
 // applyBot handles POST /v1/app_bot/apply — user opt-in to establish friend relationship with an App Bot.

--- a/modules/app_bot/app_bot_list_scope_test.go
+++ b/modules/app_bot/app_bot_list_scope_test.go
@@ -1,0 +1,183 @@
+package app_bot
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/gocraft/dbr/v2"
+	"github.com/gocraft/dbr/v2/dialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newScopeListingRoute is newPlatformGateRouteWithMock with one difference: the query
+// matcher accepts everything and records the SQL it saw. dbr interpolates arguments into
+// the statement under the MySQL dialect, so sqlmock never sees bound arguments and the
+// predicates can only be asserted by reading the SQL. Recording also lets a test prove a
+// predicate is *absent*, which is the whole point of scope=all.
+func newScopeListingRoute(t *testing.T) (*wkhttp.WKHttp, sqlmock.Sqlmock, *[]string, func()) {
+	t.Helper()
+	cfg := config.New()
+	cfg.Test = true
+	ctx := config.NewContext(cfg)
+	require.NoError(t, ctx.Cache().Set(cfg.Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.Admin)))
+
+	seen := &[]string{}
+	rawDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(
+		sqlmock.QueryMatcherFunc(func(_, actualSQL string) error {
+			*seen = append(*seen, actualSQL)
+			return nil
+		}),
+	))
+	require.NoError(t, err)
+	conn := &dbr.Connection{DB: rawDB, EventReceiver: &dbr.NullEventReceiver{}, Dialect: dialect.MySQL}
+
+	route := wkhttp.New()
+	ab := &AppBot{
+		ctx: ctx,
+		db:  &appBotDB{ctx: ctx, session: conn.NewSession(nil)},
+		Log: log.NewTLog("AppBotListScopeTest"),
+	}
+	ab.Route(route)
+	return route, mock, seen, func() { _ = rawDB.Close() }
+}
+
+func botRows(scope, spaceID string) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"id", "uid", "display_name", "status", "scope", "space_id"}).
+		AddRow("scout", "app_scout_bot", "Scout", 1, scope, spaceID)
+}
+
+func listScoped(t *testing.T, query string, arrange func(sqlmock.Sqlmock)) (*httptest.ResponseRecorder, []string) {
+	t.Helper()
+	route, mock, seen, cleanup := newScopeListingRoute(t)
+	defer cleanup()
+	if arrange != nil {
+		arrange(mock)
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/admin/app_bot"+query, nil)
+	req.Header.Set("token", testutil.Token)
+	route.ServeHTTP(w, req)
+	return w, *seen
+}
+
+// listingSQL returns the statement that read the page (as opposed to the count, or the
+// space-name lookup), which is where the scope predicate has to be visible.
+func listingSQL(t *testing.T, seen []string) string {
+	t.Helper()
+	for _, sql := range seen {
+		if strings.Contains(sql, "FROM app_bot") && !strings.Contains(sql, "count(") {
+			return sql
+		}
+	}
+	t.Fatalf("no app_bot page query was issued; saw %v", seen)
+	return ""
+}
+
+// The default is unchanged: no scope parameter still means platform-only, so a client
+// written against the old behaviour sees exactly what it saw before.
+func TestListAppBots_DefaultsToPlatformScope(t *testing.T) {
+	w, seen := listScoped(t, "", func(mock sqlmock.Sqlmock) {
+		mock.ExpectQuery("count").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+		mock.ExpectQuery("app_bot").WillReturnRows(botRows("platform", ""))
+	})
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, listingSQL(t, seen), "scope='platform'")
+}
+
+// scope=all drops the scope predicate — that is the entire point. A bot that moved into
+// a space stays visible to the operator responsible for the deployment.
+func TestListAppBots_ScopeAllDropsThePredicate(t *testing.T) {
+	w, seen := listScoped(t, "?scope=all", func(mock sqlmock.Sqlmock) {
+		mock.ExpectQuery("count").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+		mock.ExpectQuery("app_bot").WillReturnRows(botRows("space", "space-x"))
+		mock.ExpectQuery("space").WillReturnRows(
+			sqlmock.NewRows([]string{"space_id", "name"}).AddRow("space-x", "Research"))
+	})
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.NotContains(t, listingSQL(t, seen), "scope=", "scope=all must not filter by scope")
+
+	body := w.Body.String()
+	assert.Contains(t, body, `"space_id":"space-x"`, "rows carry the owning space id")
+	assert.Contains(t, body, `"space_name":"Research"`, "and the space is named, not just id'd")
+}
+
+// scope=space narrows to one space when a space_id comes with it.
+func TestListAppBots_ScopeSpaceNarrowsToOneSpace(t *testing.T) {
+	w, seen := listScoped(t, "?scope=space&space_id=space-x", func(mock sqlmock.Sqlmock) {
+		mock.ExpectQuery("count").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+		mock.ExpectQuery("app_bot").WillReturnRows(botRows("space", "space-x"))
+		mock.ExpectQuery("space").WillReturnRows(
+			sqlmock.NewRows([]string{"space_id", "name"}).AddRow("space-x", "Research"))
+	})
+
+	require.Equal(t, http.StatusOK, w.Code)
+	sql := listingSQL(t, seen)
+	assert.Contains(t, sql, "scope='space'")
+	assert.Contains(t, sql, "space_id='space-x'")
+}
+
+// An unknown scope is rejected rather than quietly treated as one of the valid ones: a
+// typo must not change what an operator believes they are looking at.
+func TestListAppBots_UnknownScopeRejected(t *testing.T) {
+	w, _ := listScoped(t, "?scope=everything", nil)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// A failed space-name lookup degrades to bare ids instead of failing the listing.
+func TestListAppBots_SpaceNameLookupFailureStillLists(t *testing.T) {
+	w, _ := listScoped(t, "?scope=all", func(mock sqlmock.Sqlmock) {
+		mock.ExpectQuery("count").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+		mock.ExpectQuery("app_bot").WillReturnRows(botRows("space", "space-x"))
+		mock.ExpectQuery("space").WillReturnError(assert.AnError)
+	})
+
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `"space_id":"space-x"`)
+	assert.NotContains(t, body, "space_name")
+}
+
+// The widening is read-only. Listing may now cross scopes; mutating must not. This pins
+// the boundary botInRouteScope draws, next to the existing reveal-token regression test —
+// a wider listing must never become a way to reach another tenant's bot.
+func TestScopeWidening_DoesNotOpenMutationsAcrossScopes(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"publish", http.MethodPost, "/v1/admin/app_bot/space-bot-1/publish"},
+		{"unpublish", http.MethodPost, "/v1/admin/app_bot/space-bot-1/unpublish"},
+		{"delete", http.MethodDelete, "/v1/admin/app_bot/space-bot-1"},
+		{"rotate token", http.MethodPost, "/v1/admin/app_bot/space-bot-1/token"},
+		{"reveal token", http.MethodPost, "/v1/admin/app_bot/space-bot-1/token/reveal"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			route, mock, _, cleanup := newScopeListingRoute(t)
+			defer cleanup()
+			mock.ExpectQuery("app_bot").WillReturnRows(
+				sqlmock.NewRows([]string{"id", "scope", "space_id", "status", "token"}).
+					AddRow("space-bot-1", "space", "X", 1, "super-secret-space-token"))
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req.Header.Set("token", testutil.Token)
+			route.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusNotFound, w.Code,
+				"platform route must still refuse to mutate a space bot")
+			assert.NotContains(t, w.Body.String(), "super-secret-space-token")
+		})
+	}
+}

--- a/modules/app_bot/db.go
+++ b/modules/app_bot/db.go
@@ -103,6 +103,10 @@ func (d *appBotDB) queryBotByUID(uid string) (*appBotModel, error) {
 }
 
 // queryBotsByScope queries App Bots by scope (and optional space_id) with pagination.
+// An empty scope means "every scope", which only the platform admin listing uses: it
+// lets a super admin see that a bot still exists after it moved into a space, instead
+// of the bot silently dropping out of the only list the console offers. Mutations are
+// unaffected — they keep going through botInRouteScope.
 func (d *appBotDB) queryBotsByScope(scope, spaceID string, pageIndex, pageSize int64, keyword string, status *int) ([]*appBotModel, int64, error) {
 	var bots []*appBotModel
 	var total int64
@@ -110,10 +114,13 @@ func (d *appBotDB) queryBotsByScope(scope, spaceID string, pageIndex, pageSize i
 	baseQuery := d.session.Select("*").From("app_bot")
 	countQuery := d.session.Select("count(*)").From("app_bot")
 
-	if scope == "space" && spaceID != "" {
+	switch {
+	case scope == "":
+		// no scope predicate
+	case scope == "space" && spaceID != "":
 		baseQuery = baseQuery.Where("scope=? AND space_id=?", scope, spaceID)
 		countQuery = countQuery.Where("scope=? AND space_id=?", scope, spaceID)
-	} else {
+	default:
 		baseQuery = baseQuery.Where("scope=?", scope)
 		countQuery = countQuery.Where("scope=?", scope)
 	}
@@ -148,13 +155,33 @@ func (d *appBotDB) queryBotsByScope(scope, spaceID string, pageIndex, pageSize i
 	return bots, total, err
 }
 
+// querySpaceNames resolves space_id -> name for the given ids, so a listing can name
+// the space a bot belongs to rather than showing a bare id. Unknown ids are simply absent.
+func (d *appBotDB) querySpaceNames(spaceIDs []string) (map[string]string, error) {
+	names := make(map[string]string, len(spaceIDs))
+	if len(spaceIDs) == 0 {
+		return names, nil
+	}
+	var rows []struct {
+		SpaceID string `db:"space_id"`
+		Name    string `db:"name"`
+	}
+	if _, err := d.session.Select("space_id", "name").From("space").
+		Where("space_id IN ?", spaceIDs).Load(&rows); err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		names[row.SpaceID] = row.Name
+	}
+	return names, nil
+}
+
 // queryPublishedBots queries all published App Bots.
 func (d *appBotDB) queryPublishedBots() ([]*appBotModel, error) {
 	var bots []*appBotModel
 	_, err := d.session.Select("*").From("app_bot").Where("status=?", StatusPublished).Load(&bots)
 	return bots, err
 }
-
 
 // queryAvailableBots returns bots available to a given user (each scope capped at 100).
 func (d *appBotDB) queryAvailableBots(loginUID, spaceIDFilter string) ([]*appBotModel, error) {


### PR DESCRIPTION
## The problem

`GET /v1/admin/app_bot` filters to `scope='platform'` server-side. That is correct for mutations — `botInRouteScope` deliberately keeps the platform route away from another tenant's bot — but it also means the admin console has no way to see that a space-scoped bot exists at all.

The console offers exactly one place to create an app bot, and it creates platform-scoped ones. Move a bot into a space afterwards and it drops out of that list with nothing to say where it went. On our deployment the bot was still running, still connected, and the only way to confirm it had not been deleted was to query the database.

## What this changes

`GET /v1/admin/app_bot` takes an optional `scope`:

| value | result |
|---|---|
| absent or `platform` | today's behaviour, unchanged |
| `space` | space-scoped bots, narrowed by an optional `space_id` |
| `all` | every scope |

Rows now carry `space_id`, and a listing that can span scopes resolves the owning space's name into `space_name`.

An unknown value is rejected with a request-invalid response rather than being coerced into one of the valid ones — a typo must not quietly change what an operator believes they are looking at.

## Scope of the widening

Read-only, and deliberately narrow.

Every mutation keeps going through `botInRouteScope`: the platform route still refuses to publish, unpublish, delete, rotate or reveal a space's bot. `TestScopeWidening_DoesNotOpenMutationsAcrossScopes` pins that next to the existing reveal-token regression test, so a future change to the listing cannot quietly turn into a cross-tenant mutation path.

A failed space-name lookup logs and degrades to bare ids rather than failing the listing.

## Tests

`modules/app_bot/app_bot_list_scope_test.go`, six tests: the default still filters to platform, `scope=all` genuinely drops the predicate (asserted against the SQL the handler issues, not against mocked rows), `scope=space` narrows to one space, an unknown scope is refused, a name-lookup failure still lists, and mutations stay scope-bound.

`go test ./modules/app_bot/ -run 'TestListAppBots|TestScopeWidening|TestBotInRouteScope|TestPlatformAppBot'` passes. The remaining failure in that package on my machine is `TestCreatePlatformBot_IncludesConnect_E2E`, which needs MySQL and fails identically on a clean checkout.

## Companion

The admin-side half is [Mininglamp-OSS/octo-admin#144](https://github.com/Mininglamp-OSS/octo-admin/pull/144): an ownership filter and column. It degrades cleanly against a server without this change — the parameter is ignored, every option returns platform bots, which is what its default option shows.

Context: octo-admin#134.
