### PR TITLE
feat(group): let bot owners remove their own bots from a group

### DIFF
--- a/.octospec/journal/shared/bot-owner-self-removal.md
+++ b/.octospec/journal/shared/bot-owner-self-removal.md
@@ -1,0 +1,119 @@
+---
+type: Journal
+title: "Journal: bot-owner-self-removal"
+description: 普通群成员现在可以把自己名下的 bot 移出群聊。移除侧的判据必须用默认拒绝的白名单（QueryBotUIDsOwnedByUIDs），复用入群侧的 checkBotOwnership 会是提权漏洞——它对非 bot UID 返回 nil。三条只有 code review 才抓到的问题：授权谓词漏了活跃口径让被拉黑成员拿到写操作、成员查询漏选 robot 列让新字段静默恒 false、以及功能在 19 人以下的群完全没有入口。
+tags: ["auth", "acl", "isolation", "wire-contract", "error-response", "thread", "bot-api", "rate-limit", "testing"]
+timestamp: 2026-08-23T13:13:43Z
+# --- octospec extension fields ---
+task: bot-owner-self-removal
+upstream: Mininglamp-OSS/octo-web#1511
+source: self
+---
+
+# Journal: bot-owner-self-removal
+
+## 做了什么
+
+`memberRemove`（`modules/group/api.go`）原先对每一个非 Creator/Manager 的调用方
+一律回 `ErrGroupMemberCannotRemove`，而 bot 归属（`robot.creator_uid`）**只在入群侧**
+校验（`checkBotOwnership`，调用点 `api.go` memberAdd 与 `invite.go`）。于是形成一道
+单向门：普通成员能把自己的 bot 拉进群（memberAdd 只要求已是群成员 + 通过 ownership），
+之后再也取不出来——除非群主出手或解散整个群。`DELETE .../bot_admin/:uid` 只翻标志位，
+不是替代品。
+
+现在多了一条窄口径自助路径：调用方非 Creator/Manager 时，要求目标**全部**是
+「本群内、`robot.status=1`、`robot.creator_uid == 调用方`」的 bot，否则整批拒绝，
+不做部分执行。配套：
+
+- 成员列表新增 per-viewer 的 `bot_owned_by_me`，前端据此逐行决定是否渲染移除按钮；
+- 抑制「你被 X 移除群聊」，改发 owner 视角的 Tip（`sendBotOwnerRemovedTip`）；
+- 两条移除路由挂上 `SharedUIDRateLimiter`——它们现在对普通成员开放了。
+
+前端（octo-web）：`canRemoveChannelSettingSubscriber` 增加自助分支、`showRemove()`
+认「我在本群有 bot」、bot 专用确认文案，并把 `removeAction` 透传给「查看全部」路径。
+
+## 结构性教训
+
+### 1. 入群侧的 ownership 判据搬到移除侧就是提权
+
+`checkBotOwnership` 的 SQL 是 `WHERE u.robot = 1`，人类 UID 查不出行、循环因此不
+拒绝——它的 doc 明写 `user.robot=0 (human) → always OK`。这在**邀请**语境下是对的
+（「非 bot 不归我管，交给别的守卫」），搬到**移除**语境就变成「普通成员传一批人类
+UID 即可踢人」。
+
+移除侧要的是**默认拒绝的白名单**：`QueryBotUIDsOwnedByUIDs` 只返回符合全部条件的
+bot UID，任何不在集合里的目标一律拒绝。两者名字相近、语义相反，是极易踩的一脚。
+已由 `TestBotOwnerSelfRemoval_RejectsHumanTarget` 钉死。
+
+### 2. 新增授权谓词必须用活跃口径，不能只看 is_deleted
+
+自助分支最初复用了闸门上方的 `QueryMemberWithUID`（只过滤 `is_deleted`）。而
+`QueryBotUIDsOwnedByUIDs` **故意**不过滤 `group_member.status`（拉黑级联要靠它恢复
+黑名单态的 bot）。两者叠加的结果：被拉黑的成员（`status=Blacklist`、`is_deleted=0`）
+凭空获得一个能改群成员表、并往拉黑他的群里写一条持久化 Tip 的写操作——而在本改动
+之前他会被直接拒绝。
+
+`db.go` 的 `QueryActiveMemberGroupNosWithUID` 早就写了这条约定：「用作授权谓词的
+调用方必须用本方法……后者只看 is_deleted，会把被拉黑成员当作仍然在群」。教训是
+这条约定同样适用于**新开的**判据，不只是替换既有调用点。已改用 `ExistMemberActive`。
+
+### 3. 「加字段 + 回填」的模式会因漏选列而静默失效
+
+`bot_owned_by_me` 由 `fillBotOwnedByMe` 回填，回填前有个 `resps[i].Robot == 1` 的
+前置判据（避免无 bot 的群白打一次查询）。而 `queryMemberWithGroupNoAndUID`
+（memberGet 用）的选择列里**没有** `group_member.robot`——于是 `Robot` 恒 0、
+前置判据直接短路，该端点上新字段恒为 false。**不报错、不告警**，只是永远返回 false。
+
+这类「派生字段依赖另一个也得由 SQL 选出来的字段」的耦合，只能靠端点级测试兜住。
+更结构性的解法是在原查询里直接 `LEFT JOIN robot ... AND r.creator_uid=?` 推导，
+连前置判据都不需要——本次没做（要给 `SyncMembers` 等加 loginUID 参数，改动面更大），
+记在这里备查。
+
+### 4. 「把入口透传下去」不等于「入口存在」
+
+前端最初只做了「让『查看全部』这条路径带上 `removeAction`」，但没验证这条路径本身
+在小群里是否渲染：它的条件是 `subscribers.length > shouldShowMemberNum()`，
+普通成员算下来是 19。**19 人以下的群完全没有入口**——后端放行、`bot_owned_by_me`
+也为 true，用户却点不到任何东西，issue 等于没修。
+
+教训：给一个既有入口加能力时，要先确认该入口对**目标用户角色**可见。这里目标角色
+恰恰是此前从未见过这个入口的普通成员。
+
+## 踩过的坑
+
+### 测试脚手架：模块实例是进程级单例
+
+`register.GetModules`（octo-lib `pkg/register/register.go`）用 `once.Do` 构造模块
+实例。所以一个测试二进制里，**所有 handler 永远持有第一个 `NewTestServer` 的 ctx**；
+之后每次 `NewTestServer` 只是把同一批 handler 重新挂到新路由上。
+
+后果：`newGroupIMStub(t, ctx)` 改的是「传给它的那个 ctx」的 `WuKongIM.APIURL`，
+除进程内**第一个**测试外，任何测试装的桩都拦不到经 HTTP 路由发出的消息——消息会
+静默发到先前解析出的地址，不报错、不被捕获。表现为「单独跑绿、一起跑红」。
+
+既有的 `space_member_removal_test.go` 之所以一直好好的，是因为它们**直接调 service**
+（`cascadeSetup` 返回本地 `New(ctx)`），用的就是自己那个 ctx。
+
+结论：**在 group 模块里对系统消息做断言，要走 service 层，不要走 HTTP 路由。**
+HTTP 层的断言限于状态码与 DB 状态（这两者共用同一个 MySQL，不受影响）。
+
+副作用是「handler 是否正确置位 `BotOwnerSelfRemoval`」这一段目前没有直接断言，
+只能由行为反证（普通成员能删自己的 bot、删不动人类和他人的 bot，只有走自助分支才
+可能）。要补需要引入 spy service + 自建路由，记在 pending learnings。
+
+### 给既有路由加限流会波及既有测试
+
+两条移除路由挂 `SharedUIDRateLimiter` 后，既有的
+`TestManagerMemberRemove_NotInGroupIsNotFound` 就成了「打 UID 限流路由却不重置桶」
+的用例。桶是进程级共享、存活在 Redis、且不被 `CleanAllTables` 清理，当前顺序下侥幸
+通过，`-shuffle` 下会拿到 429。给路由加限流时要顺带扫一遍打这条路由的既有测试。
+
+## 已知取舍
+
+- **Tip 硬编码中文**（`bot_cascade.go`）。与既有 `sendBotCascadeRemovedTip` 一致，
+  brief 明确定了不走 i18n。但本次给确认框做了 i18n，于是 en-US 用户会看到英文弹窗 +
+  永久留在群历史里的中文系统消息。建议单独立项把所有系统 Tip 一起 i18n 化。
+- **热路径多一次查询**：成员列表每页多一次 `group_member INNER JOIN robot`
+  （仅当该页含 bot）。见上面「结构性教训 3」的替代方案。
+- **bot 被授予 bot_admin 时所有者仍可撤走**（维护者拍板：所有权优先）。移除成员行
+  本身即让 `bot_admin` 失效。

--- a/.octospec/learnings/pending/bot-owner-self-removal.md
+++ b/.octospec/learnings/pending/bot-owner-self-removal.md
@@ -1,0 +1,95 @@
+---
+type: Learning
+title: A predicate that ignores out-of-scope subjects is safe to grant with and unsafe to revoke with
+description: checkBotOwnership returns nil for every non-bot UID, which is correct when gating who may invite a bot and a privilege escalation when reused to gate who may remove one. Ownership predicates are directional; reusing one across a grant/revoke boundary needs the polarity re-derived, not assumed.
+tags: ["security", "auth", "acl", "authorization", "review", "predicate-polarity"]
+timestamp: 2026-08-23T13:13:43Z
+status: pending
+source: bot-owner-self-removal
+---
+
+# A predicate that ignores out-of-scope subjects is safe to grant with and unsafe to revoke with
+
+## What happened
+
+`checkBotOwnership(session, inviterUID, memberUIDs)` (`modules/group/bot_ownership.go`)
+gates who may invite a bot into a group. Its query is:
+
+```sql
+SELECT u.uid, IFNULL(r.creator_uid,'')
+FROM user u LEFT JOIN robot r ON r.robot_id = u.uid AND r.status = 1
+WHERE u.robot = 1 AND u.uid IN ?
+```
+
+Human UIDs match no rows, so the verdict loop never rejects them. The doc says so
+outright: `user.robot=0 (human) → always OK`. On the invite path that is exactly
+right — the function's job is "of the bots you named, are they all yours?", and
+non-bots are some other guard's problem.
+
+The task at hand was the mirror-image feature: let a bot's owner **remove** their
+own bot from a group. The obvious move — the one the function's name invites — is
+to call the same helper on the removal path. That would have shipped a privilege
+escalation: an ordinary group member submits a batch of *human* UIDs, every one
+of them matches no row, the loop rejects nothing, and the member kicks people out
+of a group they have no authority over.
+
+The fix was not to patch `checkBotOwnership` but to use a different shape:
+`QueryBotUIDsOwnedByUIDs(groupNo, ownerUIDs)` returns the closed set of bots that
+are in this group **and** owned by this caller, and every target must be in that
+set. Default-deny instead of default-ignore.
+
+## The generalizable shape
+
+The two functions answer questions that look alike and differ in polarity:
+
+| | question | out-of-scope subject |
+|---|---|---|
+| grant path | "is anything here **not** yours?" | ignore it — someone else's guard owns it |
+| revoke path | "is everything here yours?" | **reject** — it is not on your whitelist |
+
+An "ignore what I don't recognize" predicate is safe wherever failing to object
+means some other check still runs. It is unsafe wherever the predicate is the
+last thing between the caller and the write, because there "no objection" reads
+as "authorized".
+
+This is not specific to bots. The same trap exists for any helper written as
+`for each recognized subject: if not mine → deny` — scope filters, tenant
+filters, resource-type filters. The name tells you the domain; it does not tell
+you which way it fails on the subjects it skips.
+
+## Proposed rule
+
+Before reusing an authorization helper on a code path it was not written for,
+derive its behaviour on the inputs it does **not** recognize, and state which of
+the two shapes it is:
+
+- **default-ignore** (silent pass for unrecognized subjects) — only valid where a
+  further check is guaranteed to run.
+- **default-deny** (whitelist; anything not explicitly permitted is rejected) —
+  required wherever the predicate is the final gate before a mutation.
+
+A single test pinning the skipped class is what keeps this from regressing: here,
+"an ordinary member cannot remove a human member via the self-service path". That
+test fails loudly the moment someone swaps the whitelist back for the
+name-alike helper.
+
+## Two smaller candidates from the same task
+
+Both are narrower and may belong as amendments to existing rules rather than as
+rules of their own:
+
+1. **A new authorization predicate must use the active-member form**
+   (`ExistMemberActive`, `is_deleted=0 AND status=Normal`), not the
+   `is_deleted`-only form. `db.go`'s `QueryActiveMemberGroupNosWithUID` already
+   documents this, but phrased as guidance for *replacing existing call sites*;
+   this task showed it applies just as much to predicates being introduced. The
+   miss let a blacklisted member reach a group-mutating write. Candidate
+   amendment to `rules/space-isolation.md`.
+
+2. **In this repo's `modules/group` tests, assert system messages at the service
+   layer, never through the HTTP route.** `register.GetModules` (octo-lib
+   `pkg/register`) builds module instances under a process-wide `sync.Once`, so
+   every handler in a test binary keeps the ctx of the *first* `NewTestServer`.
+   An IM stub installed on any later test's ctx is silently bypassed — the
+   symptom is a test that passes alone and fails in company. Candidate amendment
+   to `rules/testing.md`.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,28 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-08-23 (bot-owner-self-removal)
+
+- **Implemented** — 普通群成员现在可以把自己名下（`robot.creator_uid`）的 bot 移出
+  群聊。`memberRemove` 在调用方非 Creator/Manager 时落到一条窄口径自助分支：目标必须
+  **全部**是本群内属于调用方的活跃 bot，否则整批拒绝。成员列表新增 per-viewer 的
+  `bot_owned_by_me` 供前端逐行判权；「你被 X 移除群聊」换成 owner 视角的 Tip；两条
+  移除路由挂上 `SharedUIDRateLimiter`（它们现在对普通成员开放）。
+  上游 Mininglamp-OSS/octo-web#1511。
+  See [journal](journal/shared/bot-owner-self-removal.md).
+- **Guarded** — 移除侧的判据必须是默认拒绝的白名单（`QueryBotUIDsOwnedByUIDs`）。
+  复用入群侧的 `checkBotOwnership` 会是提权漏洞：它对非 bot UID 返回 nil，搬到移除侧
+  等于放开踢人权限。由 `TestBotOwnerSelfRemoval_RejectsHumanTarget` 钉死。
+- **Fixed in review** — 三处只有 code review 才抓到的问题：授权谓词漏用活跃口径，
+  让被拉黑成员拿到一个能改群成员表并写持久化 Tip 的写操作；`queryMemberWithGroupNoAndUID`
+  漏选 `group_member.robot`，使 `bot_owned_by_me` 在 memberGet 上静默恒 false；
+  前端只把 `removeAction` 透传给「查看全部」，而该入口在 19 人以下的群根本不渲染，
+  功能等于没上。
+- **Learned** — `register.GetModules` 用进程级 `sync.Once` 构造模块实例，一个测试
+  二进制里 handler 永远持有第一个 `NewTestServer` 的 ctx。因此对系统消息的断言必须
+  走 service 层，走 HTTP 路由时 IM 桩只对进程内第一个测试生效（表现为「单独跑绿、
+  一起跑红」）。候选规则见 `learnings/pending/bot-owner-self-removal.md`。
+
 ## 2026-08-21 (space-member-removal-cleanup)
 
 - **Implemented** — Space member removal now takes the member out of the Space's

--- a/.octospec/tasks/bot-owner-self-removal/brief.md
+++ b/.octospec/tasks/bot-owner-self-removal/brief.md
@@ -1,0 +1,197 @@
+---
+type: Task
+title: "Task: bot-owner-self-removal"
+description: 允许普通群成员把自己名下（robot.creator_uid）的 bot 移出群聊，并给成员列表下发 bot_owned_by_me 供前端逐行判权。
+tags: ["auth", "acl", "isolation", "wire-contract", "error-response", "thread", "bot-api", "rate-limit", "test"]
+timestamp: 2026-08-23T11:10:27Z
+# --- octospec extension fields ---
+slug: bot-owner-self-removal
+upstream: Mininglamp-OSS/octo-web#1511
+source: self
+---
+
+# Task: bot-owner-self-removal
+
+## Goal
+
+普通群成员（非 Creator/Manager）**无法把自己名下的 bot 移出群聊**。
+`memberRemove`（`modules/group/api.go:3060-3063`）对非 Creator/Manager 一律返回
+`ErrGroupMemberCannotRemove`；而 bot 归属（`robot.creator_uid`）**只在入群侧校验**
+（`checkBotOwnership`，`modules/group/bot_ownership.go:37`；调用点 `api.go:1479`、
+`invite.go:50`），移除路径完全不查这个字段。
+
+结果是一条**单向门**：普通成员可以把自己的 bot 拉进群（`memberAdd` 只要求调用方已是
+群成员 + 通过 ownership 校验，`api.go:1459-1483`），之后却再也取不出来——除非群主/
+管理员出手，或解散整个群。`DELETE /v1/groups/:id/bot_admin/:uid`
+（`api.go:4198`）只翻 `bot_admin` 标志位，不动成员关系，不是替代品。
+
+本次给 `memberRemove` 开一条**窄口径自助路径**：当操作者不是 Creator/Manager 时，
+不再立即拒绝，而是要求请求目标**全部**是「本群内、`robot.status=1`、
+`robot.creator_uid == 操作者`」的 bot；只要有一个目标不满足（人类成员、他人的 bot、
+孤儿/禁用 bot），整批维持 `ErrGroupMemberCannotRemove`，不做部分执行。
+
+同时给成员列表响应加 `bot_owned_by_me`，让前端能逐行判断是否渲染移除按钮——当前
+`memberDetailResp`（`api.go:4331-4367`）只有 `robot` / `bot_admin`，**没有任何归属
+字段**，前端无从判断「这个 bot 是我的」。
+
+## Background
+
+- 上游：`Mininglamp-OSS/octo-web#1511`（Web 端无法移除 bot 成员）。issue 提的
+  "Expected Behavior" 就是「至少 bot 的所有者应该能移除自己的 bot」。
+- 这是**原始设计刻意留下的空白**，不是回归：`bot_ownership.go:18-21` 的
+  "Product rules currently deferred" 明写 ownership 只约束邀请侧，且
+  「Whether a bot is auto-kicked when its creator leaves is out of scope」。
+- D-2 级联（`bot_cascade.go:27-52`）已覆盖「所有者离群/被踢 → 其 bot 同事务连带移除」，
+  但**没有**覆盖「所有者留在群里，只想撤走某个 bot」这一场景。
+
+三个可直接复用的现成件：
+
+1. `DB.QueryBotUIDsOwnedByUIDs(groupNo, ownerUIDs)`（`db.go:901-914`）——
+   `INNER JOIN robot r ON r.robot_id = gm.uid AND r.status = 1`
+   `WHERE gm.group_no=? AND gm.robot=1 AND gm.is_deleted=0 AND r.creator_uid IN ?`。
+   **默认拒绝的白名单语义**，正是本次需要的判据。
+2. `RemoveGroupMembersServiceReq.SuppressRemoveNotice`（`service.go:1054`）——
+   其 doc 描述的正是本场景形状：「成员自愿离开却要走同一套移除流程」。
+3. `sendBotCascadeRemovedTip`（`bot_cascade.go:102-140`）的消息结构（`common.Tip`、
+   `NoPersist: 0`），可照搬去写一条新文案。
+
+### 安全要点（本任务最容易写错的一处）
+
+**不得复用 `checkBotOwnership` 做移除侧判权。** 它的 SQL 是
+`WHERE u.robot = 1`（`bot_ownership.go:69`），人类 UID 根本查不出行，循环因此不会
+拒绝——doc 第 32 行明写 `user.robot=0 (human) → always OK`。把它照搬到移除路径上，
+等于让普通成员批量传人类 UID 就能踢人，是**提权漏洞**。判据必须用上面第 1 条的
+白名单查询。
+
+另注意 `user.robot` 与 `group_member.robot` 是**两个不同的 flag**
+（`checkBotOwnership` 用前者，`botAdminSet` 用后者，`api.go:4177`）；两者一旦漂移，
+混用即成绕过点。本次统一走 `group_member.robot`（白名单查询已内建）。
+
+## Load-bearing list
+
+1. **`memberRemove` 的权限模型**（`api.go:3049-3096`）——群成员移除的唯一鉴权闸门，
+   同时挂在 `DELETE /:group_no/members`（`api.go:101`）与
+   `POST /:group_no/members_delete`（`api.go:104`）两条路由上，改动自动覆盖两者。
+   注意 3073-3096 段对自助路径同样生效（白送「目标不在群里 → 404」），而其中的
+   管理员守卫只在 `loginMember.Role == Manager` 时触发，普通成员天然跳过。
+2. **`Service.RemoveGroupMembers` 的全部副作用**（`service.go:1732-1974`）：
+   事务内按 UID 排序取 `FOR UPDATE` 行锁（1809-1832）、bot 级联（1860）、
+   外部群标识重置（1885-1906）、IM 退订（1912-1918）、被踢系统消息（1921-1931）、
+   `CMDGroupMemberUpdate` 刷新（1934-1941）、bot 级联 Tip（1949-1959）、
+   子区/置顶/会话扩展清理（1962-1967）。
+   ⚠️ `service.go:1792-1806` 记录了与 `handOverGroupCreator` 之间**尚未解决的 ABBA
+   死锁**；本次不修，但会给这条路径增加并发调用方，放大暴露面。
+3. **`memberDetailResp` 的 wire contract**（`api.go:4331-4367`）——三个 handler 共用
+   （`membersGet` 409、`memberGet` 463、`syncMembers` 785）。注释 4357-4360 明确
+   Android/iOS 走 WKSDK `ChannelMember.extraMap` 缓存路径，
+   `/members` 与 `/membersync` **必须同名同型**。
+4. **bot 归属判定口径**：`robot.status=1` 的 fail-closed 语义
+   （`bot_ownership.go:61-65`、`db.go:874-876`）——孤儿/禁用 bot 不视为任何人的 bot。
+   另：`QueryBotUIDsOwnedByUIDs` **故意不过滤 `group_member.status`**（`db.go:900`
+   注释），黑名单态的 bot 也会命中；对移除场景无害，但它不等价于「活跃成员」。
+5. **`/v1/groups` 路由组当前无任何限流**（`api.go:98`，仅 `AuthMiddleware`）——
+   对比 `api.go:139` welcome 组、`api.go:152` invite 组均挂了 `SharedUIDRateLimiter`。
+   本次把一个写操作开放给普通成员，等于扩大未限流的自助写入面。
+6. **群系统消息的「透明度」产品约定**（`service.go:1060-1064`、`1943-1948`）：
+   「群成员看见 bot 凭空消失，有权知道原因，这与『谁移出了谁』是两件事」。
+   本任务据此**不做静默移除**。
+7. **`modules/bot_api/groups.go:769`** 是 `RemoveGroupMembers` 的另一个调用方
+   （bot 凭 `bot_admin` 移除他人），它自带角色守卫（`groups.go:751-767`）。本次不改它，
+   但两者共用同一 service，回归面需覆盖。
+
+## Out of scope
+
+- **不改** `botAdminSet` / `botAdminRemove`（`api.go:4141` / `4198`）的语义。
+- **不改** 入群侧 `checkBotOwnership` 的判定口径与其调用点。
+- **不改** D-2 级联（`bot_cascade.go`）与拉黑级联的既有行为。
+- **不改** `modules/bot_api` 的 `POST /v1/bot/groups/:group_no/members/remove`
+  （`bot_api/groups.go:676`），包括它「不能移除自己」的现状。
+- **不做** BotManage 控制台里「所在群列表 → 移出该群」的第二入口（数据链路已具备：
+  `GET /v1/robot/:robot_id/groups` + `assertRobotOwner`，留作 v2）。
+- **不新增 errcode**：拒绝路径复用 `ErrGroupMemberCannotRemove`
+  （`pkg/errcode/group.go:91-95`），符合反枚举约定（授权失败收敛到一个码）。
+  预期 `make i18n-extract-check` / `make i18n-lint` 无新增产出。
+- **不修** `service.go:1792-1806` 记录的 ABBA 死锁。
+- **不加**群级能力位（如 `can_remove_own_bots`）：与 `can_manage_bot_admin`
+  （`service.go:342` 白嫖已查到的 role）不同，归属判断需要额外一次 robot 表 JOIN，
+  而该函数在每次群信息拉取时都走（结果经 `1module.go:252` 灌进 `extraMap`），
+  是热路径。改由前端按行级 `bot_owned_by_me` 判断。
+- **不改** 前端 `showRemove()`（`Subscribers/vm.ts:98-108`）的群主/管理员入口逻辑。
+
+## Acceptance
+
+### 后端（新增用例落在 `modules/group/api_bot_ownership_test.go`）
+
+1. 普通成员移除**自己名下**的 bot → 200，`group_member` 对应行 `is_deleted=1`。
+2. 普通成员移除**他人名下**的 bot → `ErrGroupMemberCannotRemove`，成员关系不变。
+3. 普通成员移除**人类成员** → `ErrGroupMemberCannotRemove`。
+   （**核心回归防线**：防止误用 `checkBotOwnership` 式「对非 bot 放行」的判据。）
+4. 普通成员提交**混合批次**（自己的 bot + 人类 / + 他人的 bot）→ 整批拒绝，
+   断言无任何目标被移除（不得部分执行）。
+5. 普通成员移除**孤儿/禁用 bot**（`robot` 行缺失或 `status != 1`）→ 拒绝（fail-closed）。
+6. 群主 / 管理员 / 后台管理（`c.CheckLoginRole() == nil`）三条既有路径行为不变：
+   `api_i18n_regression_test.go`、`bot_cascade_test.go`、`validation_test.go` 全绿。
+7. 自助路径**不产生**「你被 X 移除群聊」系统消息，**产生**一条说明 bot 去向的 Tip。
+   机制已具备，同包直接复用：`newGroupIMStub(t, ctx)`
+   （`space_member_removal_test.go:39`）装桩，`sentPayloads()`（`:80`）取回，
+   `payloadsContain(payloads, fragment)`（`:361`）匹配文案片段。
+   断言两侧：`payloadsContain(..., "移除群聊") == false`（负向）
+   且新 Tip 文案片段存在（正向）。
+8. 两条路由（`DELETE /members`、`POST /members_delete`）行为一致。
+9. 移除后该 bot 在本群所有子区的成员身份被清理（复用既有 thread cleanup 断言口径，
+   `thread_cleanup.go:50-89`）。
+10. `bot_owned_by_me` 在 `membersGet` / `memberGet` / `syncMembers` 三处**同名同型**
+    下发；非 bot 成员恒为 `false`；他人的 bot 恒为 `false`。
+11. **跨群作用域**：我在 A 群拥有的 bot，不能通过对 B 群发起请求而被移除
+    （白名单查询按 `groupNo` 作用域，天然安全；此用例是钉子，防止后续重构把
+    `groupNo` 从判据里漏掉）。对应 space-isolation 规则（P92）。
+12. **不得静默成功**：自助路径的每个用例都断言 `RemoveGroupMembersServiceResp.Removed`
+    与预期实际移除数一致。`RemoveGroupMembers` 会静默跳过 Creator 角色
+    （`service.go:1764-1770`），若某 bot 恰为群 Creator，当前会返回 200 但零移除，
+    前端将误报成功——本条把该行为钉住（拒绝 or 明确非静默，见决策点 4）。
+13. **重复移除幂等**：对已不在群内的 bot 再次发起自助移除 →
+    `ErrGroupMemberNotInGroup`（`api.go:3080-3083` 既有分支），不得 5xx。
+14. `api_realname_test.go` 两个契约守卫（`:44` struct 契约、`:74` handler 调用契约）
+    仍绿。（已核实：该守卫只断言三条 realname 正则**能匹配**，新增字段不会使其失败。）
+
+### 前端（octo-web，同名分支）
+
+15. `canRemoveChannelSettingSubscriber`（`channelSettingMemberSection.tsx:19-33`）
+    的表驱动用例（`channelSettingSections.test.ts:211-258`）扩展：自己的 bot →
+    可移除；他人的 bot / 人类 → 沿用原角色判定。
+16. 两条进入 `SubscriberList` 的路径都携带 `removeAction`
+    （现状：`Subscribers/index.tsx:159-173` 的「查看全部」未传）。
+17. **字段缺失时 fail-closed**：`bot_owned_by_me` 缺失/非 `true` 一律按**不可移除**
+    处理。`membersync` 是按 version 的增量同步，新字段上线前已缓存的成员行在其
+    version 变动前不会带该字段；降级方向必须是「退回现状」，绝不能误开权限。
+    对应用例：`orgData` 无该键 → `canRemove` 返回 false。
+
+### 命令
+
+```bash
+go test ./modules/group/...
+golangci-lint run ./modules/group/...
+make i18n-extract-check && make i18n-lint   # 预期无变化（不新增 errcode）
+```
+
+## 待人类确认的决策点
+
+1. **bot 已被授予 `bot_admin` 时，所有者能否单方面撤走？**
+   现有守卫**不拦**——`api.go:3084-3095` 只看 `role`，而 `bot_admin` 是独立列
+   （`MemberDetailModel.BotAdmin`，`db.go:770`）。默认行为是放行。
+   倾向：**允许**（所有权优先，且移除成员行本身即让 `bot_admin` 失效）。
+   若需拦，在自助分支加一条 `bot_admin == 1 → 拒绝`。
+2. **是否给这两条路由挂 `SharedUIDRateLimiter`？**
+   倾向：**挂**，但只挂这两条，不要挂整个 `groups` 组（会一次性影响 ~28 个端点，
+   且相关测试须在 setup 里清 `ratelimit:uid:*`，见 `api_welcome_test.go:35`）。
+3. **Tip 文案。** 现有 `sendBotCascadeRemovedTip` 模板是
+   「{leaver}{action}群聊，其机器人 X 已一并移除」，描述的是「人走 bot 跟着走」，
+   不适用于本场景。需新写一条（如「{owner} 移出了机器人 {bot}」）。
+   该文案为**硬编码中文**（`bot_cascade.go:126`），不走 i18n 体系。
+   验收 #7 会按文案片段匹配，定稿后需同步该片段。
+4. **bot 恰为群 Creator 时的行为**（验收 #12）。`RemoveGroupMembers` 对 Creator
+   角色是**静默跳过**（`service.go:1764-1770`），handler 不检查 `Removed` 计数即
+   返回 200，前端会误报「已移除」。
+   倾向：自助分支在调用 service 前显式拒绝 Creator 角色目标，返回
+   `ErrGroupMemberCannotRemove`，避免「200 但没动」。
+   （现实中 bot 极少成为群主，但这是廉价的一致性钉子。）

--- a/.octospec/tasks/bot-owner-self-removal/brief.md
+++ b/.octospec/tasks/bot-owner-self-removal/brief.md
@@ -129,7 +129,8 @@ source: self
 4. 普通成员提交**混合批次**（自己的 bot + 人类 / + 他人的 bot）→ 整批拒绝，
    断言无任何目标被移除（不得部分执行）。
 5. 普通成员移除**孤儿/禁用 bot**（`robot` 行缺失或 `status != 1`）→ 拒绝（fail-closed）。
-6. 群主 / 管理员 / 后台管理（`c.CheckLoginRole() == nil`）三条既有路径行为不变：
+6. 群主 / 管理员 / 后台管理（`c.CheckLoginRole() == nil`）三条既有路径的**授权与
+   移除语义**不变（限流除外，见下）：
    `api_i18n_regression_test.go`、`bot_cascade_test.go`、`validation_test.go` 全绿。
 7. 自助路径**不产生**「你被 X 移除群聊」系统消息，**产生**一条说明 bot 去向的 Tip。
    机制已具备，同包直接复用：`newGroupIMStub(t, ctx)`
@@ -176,14 +177,21 @@ make i18n-extract-check && make i18n-lint   # 预期无变化（不新增 errcod
 
 ## 待人类确认的决策点
 
-1. **bot 已被授予 `bot_admin` 时，所有者能否单方面撤走？**
+1. **bot 已被授予 `bot_admin` 时，所有者能否单方面撤走？**（仅限 `bot_admin` 列；
+   `group_member.role` 见下方补充决策）
    现有守卫**不拦**——`api.go:3084-3095` 只看 `role`，而 `bot_admin` 是独立列
    （`MemberDetailModel.BotAdmin`，`db.go:770`）。默认行为是放行。
    倾向：**允许**（所有权优先，且移除成员行本身即让 `bot_admin` 失效）。
    若需拦，在自助分支加一条 `bot_admin == 1 → 拒绝`。
 2. **是否给这两条路由挂 `SharedUIDRateLimiter`？**
-   倾向：**挂**，但只挂这两条，不要挂整个 `groups` 组（会一次性影响 ~28 个端点，
+   已定：**挂**，但只挂这两条，不要挂整个 `groups` 组（会一次性影响 ~28 个端点，
    且相关测试须在 setup 里清 `ratelimit:uid:*`，见 `api_welcome_test.go:35`）。
+
+   **影响面更正（评审指出）**：限流是挂在路由上的，因此它同样作用于走这两条路由的
+   群主 / 管理员 / 后台管理调用方，不只是新开的普通成员路径。也就是说上面验收 6 的
+   「行为不变」仅指授权与移除语义；持续高于 2 rps 的脚本化单成员移除会开始拿到 429
+   （桶是进程级 per-UID 共享，Redis 故障时 fail-open）。若管理后台有批量踢人的集成，
+   需按 `DM_API_UID_RATELIMIT_RPS` / `_BURST` 调参。
 3. **Tip 文案。** 现有 `sendBotCascadeRemovedTip` 模板是
    「{leaver}{action}群聊，其机器人 X 已一并移除」，描述的是「人走 bot 跟着走」，
    不适用于本场景。需新写一条（如「{owner} 移出了机器人 {bot}」）。
@@ -195,3 +203,17 @@ make i18n-extract-check && make i18n-lint   # 预期无变化（不新增 errcod
    倾向：自助分支在调用 service 前显式拒绝 Creator 角色目标，返回
    `ErrGroupMemberCannotRemove`，避免「200 但没动」。
    （现实中 bot 极少成为群主，但这是廉价的一致性钉子。）
+
+## 补充决策（评审阶段追加）
+
+5. **被授予群角色（`group_member.role`）的 bot 不走自助路径。**
+   决策点 1 的「所有权优先」针对的是 `bot_admin` 这一列。评审指出 `group_member.role`
+   是比它更强的授予：`managerAdd` 不排除 robot，所以 Manager 角色的 bot 构造得出来，
+   而若放行，普通成员将得以移除一个群管理员，同时真正的管理员反而不能移除另一个
+   管理员——权限阶梯倒挂。
+   故自助分支拒绝任何 `role != MemberRoleCommon` 的目标（Creator 回
+   `ErrGroupCannotRemoveOwner`，Manager 回 `ErrGroupCannotRemoveAdmin`），
+   把角色 bot 的处置权留给群主 / 管理员。`fillBotOwnedByMe` 同步排除，
+   避免下发一个点了必报错的按钮。
+   回归：`TestBotOwnerSelfRemoval_RejectsManagerRoleBot`、
+   `TestBotOwnerSelfRemoval_RoleBotGetsNoOwnershipFlag`。

--- a/.octospec/tasks/bot-owner-self-removal/brief.md
+++ b/.octospec/tasks/bot-owner-self-removal/brief.md
@@ -250,3 +250,49 @@ make i18n-extract-check && make i18n-lint   # 预期无变化（不新增 errcod
    `TestRemoveGroupMembers_AdminKickStillCascadesManagerBot`（后者同时补上了
    评审指出的测试盲区 —— `space_member_removal_test.go` 的 `seedInvitedBot`
    把 role 硬编码成 0，级联对角色 bot 的处理此前从无覆盖）。
+
+7. **并发 / 多副本确认（合并前）。**
+   自助移除给级联路径新开了一个**普通成员可高频触发**的入口，因此合并前单独
+   核了锁面、死锁与读路径开销。结论：线上安全，但过程中挖出一个测试库缺陷。
+
+   **锁面（实测，非推断）**：级联的 `FOR UPDATE` 联表查询在有
+   `idx_robot_creator_uid` 时，MySQL 从 `robot` 侧 `ref` 进入（只扫该主人名下的
+   bot），再按 `group_no_uid` 唯一索引 `eq_ref` 回查。用两个并发 session 量过，
+   持锁期间：同群的其他人类成员可改、**新成员可入群**、其他主人的 bot 可改，
+   只有「该主人自己的 bot」在 `robot` 与 `group_member` 两侧被挡。
+   即锁面正好覆盖真正要改的行，不存在按群或按表的串行化。
+   加不加 `role` 谓词（补充决策 6）执行计划完全一致。
+
+   **死锁**：最坏交错（所有者自助移除 ‖ 群主踢该所有者 ‖ 重复自助移除，三者
+   争抢同一批行）跑 360 次操作，0 死锁、0 锁等待超时，且每轮最终状态一致
+   （主人与 bot 都离群、无重复成员行）。
+
+   **测试库缺陷（已修）**：`api_test.go` 的 TestMain 手工建 `robot` 表，建索引
+   那句写的是 `CREATE UNIQUE INDEX IF NOT EXISTS`——MySQL 8.0 不支持 CREATE INDEX
+   的 `IF NOT EXISTS`（MariaDB/Postgres 才有），每次都以 1064 语法错误失败，而
+   `db.Exec` 的 error 无人检查，于是索引**从来没建成过**；`idx_robot_creator_uid`
+   更是压根没建。后果不只是慢：没有该索引时上面那条 `FOR UPDATE` 退化成 `robot`
+   全表扫描并对**整张表**加 X 锁。实测无索引时 120 次并发操作里 8 次撞 MySQL 死锁
+   1213，补齐后 360 次 0 死锁；group 全量套件也从 148.9s 降到 97.9s。
+   已改为查 `information_schema` 再建的幂等写法，失败直接 panic 而不是静默吞掉。
+   线上不受影响：这两个索引由 `modules/robot` 的迁移建立
+   （20210926000001 / 20260226000002），只是 `modules/robot` 不在本 package 的
+   依赖集里，CI 每个 package 重建库时不会跑到，才需要在 TestMain 里对齐。
+   回归：`TestBotOwnerSelfRemoval_RobotIndexesMatchProduction`、
+   `TestBotOwnerSelfRemoval_ConcurrentWithOwnerKick`（两条都做过变异验证：
+   还原成坏写法并删索引后分别转红，后者报出 4/60 次被吞掉的级联失败）。
+
+   **读路径开销**：`fillBotOwnedByMe` 不是 N+1 —— 页面内没有 bot 时直接短路，
+   有 bot 时固定两条走索引的查询（`ExistMemberActive` 走 `group_no_uid`，
+   `QueryBotUIDsOwnedByUIDs` 走 `idx_robot_creator_uid`）。
+   202 人成员页实测：无 bot 与改动前一致，有 bot 时 +246µs（约 7%）。
+
+   **多副本**：本次改动没有引入任何进程内状态（无新增全局变量 / 缓存）；
+   两条路由挂的 `SharedUIDRateLimiter` 是 Redis Lua 令牌桶，配额按 uid 全局共享，
+   不会因副本数变成 N 倍。
+
+   **已知遗留（未在本 PR 处理）**：`service.go` 级联失败时返回
+   `errors.New("failed to cascade-remove invited bots")`，**丢掉底层错误**，
+   死锁 1213 也会被吞成这一句。原因已由 service 层 `zap.Error(cerr)` 单独记日志、
+   且 handler 只回注册过的错误码（不外泄），故本次不扩大 diff；
+   上面的并发用例把 `cascade-remove` 单独归一类断言，正是为了让它一旦发生就转红。

--- a/.octospec/tasks/bot-owner-self-removal/brief.md
+++ b/.octospec/tasks/bot-owner-self-removal/brief.md
@@ -103,7 +103,11 @@ source: self
 
 - **不改** `botAdminSet` / `botAdminRemove`（`api.go:4141` / `4198`）的语义。
 - **不改** 入群侧 `checkBotOwnership` 的判定口径与其调用点。
-- **不改** D-2 级联（`bot_cascade.go`）与拉黑级联的既有行为。
+- **不改** D-2 级联（`bot_cascade.go`）与拉黑级联的**既有行为**。
+  更正（实现阶段）：为给自助路径加角色过滤，`cascadeRemoveBotsInvitedByUIDTx` /
+  `QueryBotsInvitedByUIDTx` 增加了 `requireCommonRole` 参数。既有三条路径
+  （主动退群 / 被移除 / 拉黑）全部传 `false`，**行为逐字节不变**；参数只为
+  自助路径服务。见补充决策 6。
 - **不改** `modules/bot_api` 的 `POST /v1/bot/groups/:group_no/members/remove`
   （`bot_api/groups.go:676`），包括它「不能移除自己」的现状。
 - **不做** BotManage 控制台里「所在群列表 → 移出该群」的第二入口（数据链路已具备：
@@ -181,8 +185,20 @@ make i18n-extract-check && make i18n-lint   # 预期无变化（不新增 errcod
    `group_member.role` 见下方补充决策）
    现有守卫**不拦**——`api.go:3084-3095` 只看 `role`，而 `bot_admin` 是独立列
    （`MemberDetailModel.BotAdmin`，`db.go:770`）。默认行为是放行。
-   倾向：**允许**（所有权优先，且移除成员行本身即让 `bot_admin` 失效）。
-   若需拦，在自助分支加一条 `bot_admin == 1 → 拒绝`。
+   已定：**允许**（所有权优先）。
+
+   ⚠️ **原括注是错的，已更正**：这里曾写「移除成员行本身即让 `bot_admin` 失效」，
+   事实并非如此 —— `DeleteMemberTx` 是软删（只置 `is_deleted=1`），整行连同
+   `bot_admin` 都留在表里，而 `recoverMemberTx` 复活时又不重置它。于是群主授过
+   `bot_admin` 的 bot，被所有者撤走再拉回来就悄悄又是管理员，全程不需要群主参与。
+   实现阶段由集成测试发现（修前 `bot_admin` 复活为 1）。
+
+   修法遵循**既有语义**而非新立规矩：`role` 一直是「回到群里就按新成员处理、
+   权限重新授予」，`bot_admin` 漏了才是 bug。故在 `recoverMemberTx` 补
+   `"bot_admin": 0`。这条对**所有**重新入群路径生效（memberAdd、扫码、邀请、
+   事件同步），不分人和 bot —— 与 `role` 的处理口径一致，不是 bot 专属特例。
+   解除拉黑走 `updateMembersStatus`，不经过 `recoverMemberTx`，不受影响。
+   回归：`TestBotOwnerSelfRemoval_BotAdminDoesNotSurviveReAdd`。
 2. **是否给这两条路由挂 `SharedUIDRateLimiter`？**
    已定：**挂**，但只挂这两条，不要挂整个 `groups` 组（会一次性影响 ~28 个端点，
    且相关测试须在 setup 里清 `ratelimit:uid:*`，见 `api_welcome_test.go:35`）。
@@ -217,3 +233,20 @@ make i18n-extract-check && make i18n-lint   # 预期无变化（不新增 errcod
    避免下发一个点了必报错的按钮。
    回归：`TestBotOwnerSelfRemoval_RejectsManagerRoleBot`、
    `TestBotOwnerSelfRemoval_RoleBotGetsNoOwnershipFlag`。
+
+6. **级联的角色过滤只作用于自助路径，既有三条路径保持 #354 原样。**
+   实现中曾把角色过滤直接加在 `QueryBotsInvitedByUIDTx` 上，那是**全局**的，
+   于是连主动退群 / 被群主管理员移除 / 被拉黑一并改掉了 —— 而 #354 是写下来的
+   产品决策：「bot 永远跟随其主人，无角色例外」（`api.go` groupExit 与
+   `service.go` 过滤处均有注释，连群主退群都专门说了一视同仁）。
+   全局过滤的后果：张三被踢 → 他名下的管理员 bot 留在群里，而张三已不是成员、
+   自助路径又拒绝角色 bot，群里凭空多出一个谁也管不动的特权 bot；拉黑流程下
+   还带安全含义。评审（yujiawei）以此判为回归，属实。
+
+   现改为跟随 `BotOwnerSelfRemoval` 透传：三条既有路径传 `false`（#354 不变），
+   仅自助路径传 `true`。被排除的角色 bot 不会失控 —— 群主/管理员仍可经常规
+   移除接口处置。
+   回归：`TestQueryBotsInvitedByUIDTx_RoleFilterOnlyOnSelfServicePath`、
+   `TestRemoveGroupMembers_AdminKickStillCascadesManagerBot`（后者同时补上了
+   评审指出的测试盲区 —— `space_member_removal_test.go` 的 `seedInvitedBot`
+   把 role 硬编码成 0，级联对角色 bot 的处理此前从无覆盖）。

--- a/.octospec/tasks/bot-owner-self-removal/context.yaml
+++ b/.octospec/tasks/bot-owner-self-removal/context.yaml
@@ -1,0 +1,45 @@
+# octospec Implement 阶段的规则注入记录。
+# 命中判据：inject_when.paths 匹配将要改动的文件，或 inject_when.touches 命中
+# brief 的 load-bearing tags（两者取并集）。
+# 本仓库 .octospec/_global/ 未同步（manifest 声明 inherits: octo-spec@1.1.0），
+# 故本次注入全部为 repo tier。
+injected:
+  - id: space-isolation
+    source: repo
+    priority: 92
+    load_bearing: true
+    why: brief tags auth/acl/isolation/thread/bot-api；本次改的正是群成员移除的鉴权闸门
+  - id: trust-boundary
+    source: repo
+    priority: 90
+    load_bearing: true
+    why: 经 touches[wire-contract] 命中；相关面是新 Tip 把 bot/操作者名称插值进消息 payload
+  - id: error-handling
+    source: repo
+    priority: 85
+    load_bearing: true
+    why: paths modules/**/*.go + touches error-response/wire-contract；新增拒绝分支与 memberDetailResp 字段
+  - id: rate-limit
+    source: repo
+    priority: 80
+    load_bearing: true
+    why: 决策点 2 —— 给两条移除路由挂 SharedUIDRateLimiter
+  - id: testing
+    source: repo
+    priority: 70
+    load_bearing: false
+    why: paths **/*_test.go；新增 api_bot_ownership_test.go 用例
+  - id: commit-style
+    source: repo
+    priority: 60
+    load_bearing: false
+    why: paths ["**"] 恒命中
+
+brief: .octospec/tasks/bot-owner-self-removal/brief.md
+
+# 四个决策点（brief 末尾）已由维护者拍板：
+decisions:
+  bot_admin_removable: true          # 所有权优先，允许所有者撤走已授予 bot_admin 的 bot
+  rate_limit_scope: two-routes-only  # 只挂 DELETE /members 与 POST /members_delete，不挂整个 groups 组
+  tip_template: "%s 将机器人 %s 移出了群聊"
+  creator_target: reject             # 自助分支显式拒绝 Creator 角色目标，避免「200 但没动」

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -3524,7 +3524,7 @@ func (g *Group) groupExit(c *wkhttp.Context) {
 	// #354 产品决策：bot 永远跟随其主人，无角色例外——群主退群（角色已由上方
 	// newGrouper 完成转让）同样级联带走自己名下的 bot，和普通成员一致。
 	var cascadedBotUsers []*user.Model
-	cascadedUIDs, cerr := cascadeRemoveBotsInvitedByUIDTx(g.db, g.ctx, groupNo, loginUID, tx)
+	cascadedUIDs, cerr := cascadeRemoveBotsInvitedByUIDTx(g.db, g.ctx, groupNo, loginUID, false, tx)
 	if cerr != nil {
 		tx.Rollback()
 		g.Error("级联移除 bot 成员失败", zap.Error(cerr))

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -3219,20 +3219,53 @@ func (g *Group) memberRemove(c *wkhttp.Context) {
 		return
 	}
 
-	// 自助路径核对实际移除数：上面的角色守卫读的是事务外快照，而 service 在行锁内
-	// 重读角色，期间目标若被提升为 Creator 就会被**静默跳过**（其 doc 写明「让调用方
-	// 按 Removed 计数发现并重试」，但此前没有调用方真的去看）。不核对的话，这条竞态
+	// 自助路径核对**实际移除集合**：上面的角色守卫读的是事务外快照，而 service 在
+	// 行锁内重读角色，期间状态变化的目标会被静默跳过（其 doc 写明「让调用方按
+	// Removed 计数发现并重试」，但此前没有调用方真的去看）。不核对的话，这条竞态
 	// 窗口仍会回到「200 但成员没动」——正是上面那道守卫要消灭的形态，只是更窄。
+	//
+	// 比对集合而不是比数量：removedUIDs 含级联带走的 bot，数量会被撑大，
+	// 足以把「某个请求目标被跳过」在数字上抹平（请求 2 个、跳过 1 个、级联补 1 个，
+	// 计数仍然相等）。
+	//
+	// 错误码也不写死成「不能移除群主」：跳过的真实原因可能是目标被提升为 Creator
+	// 或 Manager，也可能是 DeleteMemberTx 失败后 service 的 continue（此时事务已
+	// 提交、部分目标已删）。统一回「无权移除」并把缺失的目标记进日志 —— 断言不了
+	// 的原因就不要假装断言得了。
 	// 只在自助路径上核对：后台管理路径本来就允许「部分目标不在群内」的宽松语义。
-	if botOwnerSelfRemoval && removeResp != nil && removeResp.Removed < len(req.Members) {
-		g.Warn("自助移除的实际移除数少于请求数，疑似目标在事务内被提升为群主",
-			zap.String("groupNo", groupNo), zap.String("operator", operator),
-			zap.Int("requested", len(req.Members)), zap.Int("removed", removeResp.Removed))
-		httperr.ResponseErrorL(c, errcode.ErrGroupCannotRemoveOwner, nil, nil)
-		return
+	if botOwnerSelfRemoval && removeResp != nil {
+		if missing := missingRemovalTargets(req.Members, removeResp.RemovedUIDs); len(missing) > 0 {
+			g.Warn("自助移除存在未被移除的目标，疑似其角色在事务内发生变化或删除失败",
+				zap.String("groupNo", groupNo), zap.String("operator", operator),
+				zap.Strings("requested", req.Members), zap.Strings("missing", missing))
+			httperr.ResponseErrorL(c, errcode.ErrGroupMemberCannotRemove, nil, nil)
+			return
+		}
 	}
 
 	c.ResponseOK()
+}
+
+// missingRemovalTargets 返回「请求移除、但实际没被移除」的目标。
+//
+// 为什么不比数量：removedUIDs 除请求目标外还含级联带走的 bot，数量会被撑大，
+// 于是「请求 2 个、跳过 1 个、级联补 1 个」在计数上完全相等，静默成功照旧发生。
+// 集合比对不受级联影响 —— 多出来的 UID 无所谓，少掉的才是问题。
+func missingRemovalTargets(requested, removedUIDs []string) []string {
+	if len(requested) == 0 {
+		return nil
+	}
+	removed := make(map[string]struct{}, len(removedUIDs))
+	for _, uid := range removedUIDs {
+		removed[uid] = struct{}{}
+	}
+	var missing []string
+	for _, uid := range requested {
+		if _, ok := removed[uid]; !ok {
+			missing = append(missing, uid)
+		}
+	}
+	return missing
 }
 
 // 修改群设置

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -3085,6 +3085,25 @@ func (g *Group) memberRemove(c *wkhttp.Context) {
 			// 根本查不出行、循环因此不拒绝（见 bot_ownership.go doc「human → always OK」）。
 			// 那是入群侧「非 bot 不归我管」的正确语义，搬到移除侧就是提权：
 			// 普通成员传一批人类 UID 即可踢人。
+			// 自助分支是新增的**授权谓词**，必须用活跃口径（is_deleted=0 AND
+			// status=Normal），不能只看上面 QueryMemberWithUID 的 is_deleted ——
+			// 见 db.go QueryActiveMemberGroupNosWithUID 的约定：「只看 is_deleted
+			// 会把被拉黑成员当作仍然在群」。
+			// 若不加这道门，被拉黑的成员（status=Blacklist、is_deleted=0）会凭空获得
+			// 一个能改群成员表、并往群里写一条持久化 Tip 的写操作；而在本改动之前
+			// 他会直接吃到 ErrGroupMemberCannotRemove。
+			// 注意 QueryBotUIDsOwnedByUIDs 故意不过滤 group_member.status（拉黑级联
+			// 需要它），所以这道门必须由调用方来把。
+			operatorActive, aerr := g.db.ExistMemberActive(operator, groupNo)
+			if aerr != nil {
+				g.Error("查询操作者活跃成员状态失败", zap.Error(aerr))
+				httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
+				return
+			}
+			if !operatorActive {
+				httperr.ResponseErrorL(c, errcode.ErrGroupMemberCannotRemove, nil, nil)
+				return
+			}
 			ownedBotUIDs, qerr := g.db.QueryBotUIDsOwnedByUIDs(groupNo, []string{operator})
 			if qerr != nil {
 				g.Error("查询操作者名下 bot 失败", zap.Error(qerr))
@@ -3097,10 +3116,25 @@ func (g *Group) memberRemove(c *wkhttp.Context) {
 			}
 			// 整批校验：任一目标不在白名单内即整批拒绝，不做部分执行。
 			for _, uid := range req.Members {
-				if _, ok := ownedBots[uid]; !ok {
-					httperr.ResponseErrorL(c, errcode.ErrGroupMemberCannotRemove, nil, nil)
+				if _, ok := ownedBots[uid]; ok {
+					continue
+				}
+				// 目标不在白名单有两种原因，要给出不同的错误：白名单按
+				// is_deleted=0 过滤，所以「刚被移除过的自己的 bot」会落到这里。
+				// 一律回「无权移除」会让用户看到「你没有权限移除自己的 bot」，
+				// 而真相是它已经不在群里了（重复点击 / 离线重试 / 列表过期）。
+				stillMember, merr := g.db.ExistMember(uid, groupNo)
+				if merr != nil {
+					g.Error("查询目标成员是否在群失败", zap.Error(merr))
+					httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
 					return
 				}
+				if !stillMember {
+					httperr.ResponseErrorL(c, errcode.ErrGroupMemberNotInGroup, nil, nil)
+					return
+				}
+				httperr.ResponseErrorL(c, errcode.ErrGroupMemberCannotRemove, nil, nil)
+				return
 			}
 			botOwnerSelfRemoval = true
 		}
@@ -4487,6 +4521,48 @@ func (r memberDetailResp) from(model *MemberDetailModel) memberDetailResp {
 //
 // 失败处理：仅 log，不阻断主响应链路 —— 实名是增强信息，不能因实名表查询抖动
 // 让群成员列表不可用。
+func (g *Group) fillRealnameFields(resps []memberDetailResp) {
+	if len(resps) == 0 {
+		return
+	}
+	uids := make([]string, 0, len(resps))
+	seen := make(map[string]struct{}, len(resps))
+	for _, r := range resps {
+		if r.UID == "" {
+			continue
+		}
+		if _, ok := seen[r.UID]; ok {
+			continue
+		}
+		seen[r.UID] = struct{}{}
+		uids = append(uids, r.UID)
+	}
+	if len(uids) == 0 {
+		return
+	}
+	infoMap, err := user.QueryVerificationsByUIDs(g.ctx, uids)
+	if err != nil {
+		g.Warn("批量查询群成员实名认证记录失败（YUJ-413）",
+			zap.Error(err), zap.Int("uid_count", len(uids)))
+		return
+	}
+	if len(infoMap) == 0 {
+		return
+	}
+	// 注意：resps 是值切片，必须按 index 回写，不能 range copy。
+	for i := range resps {
+		info, ok := infoMap[resps[i].UID]
+		if !ok || info == nil {
+			continue
+		}
+		resps[i].RealnameVerified = true
+		resps[i].RealName = info.RealName
+		resps[i].RealnameVerifiedAt = info.RealnameVerifiedAt
+	}
+}
+
+// 这个上限与 resps 长度无关，保持原先 fillSourceSpaceNames 的无 N+1 属性。
+// 函数不会改写 is_external / source_space_id 字段。
 // fillBotOwnedByMe 批量回填 memberDetailResp.BotOwnedByMe（octo-web#1511）。
 //
 // 复用 memberRemove 自助路径的同一判据 QueryBotUIDsOwnedByUIDs —— 一次
@@ -4538,48 +4614,6 @@ func (g *Group) fillBotOwnedByMe(groupNo, loginUID string, resps []memberDetailR
 	}
 }
 
-func (g *Group) fillRealnameFields(resps []memberDetailResp) {
-	if len(resps) == 0 {
-		return
-	}
-	uids := make([]string, 0, len(resps))
-	seen := make(map[string]struct{}, len(resps))
-	for _, r := range resps {
-		if r.UID == "" {
-			continue
-		}
-		if _, ok := seen[r.UID]; ok {
-			continue
-		}
-		seen[r.UID] = struct{}{}
-		uids = append(uids, r.UID)
-	}
-	if len(uids) == 0 {
-		return
-	}
-	infoMap, err := user.QueryVerificationsByUIDs(g.ctx, uids)
-	if err != nil {
-		g.Warn("批量查询群成员实名认证记录失败（YUJ-413）",
-			zap.Error(err), zap.Int("uid_count", len(uids)))
-		return
-	}
-	if len(infoMap) == 0 {
-		return
-	}
-	// 注意：resps 是值切片，必须按 index 回写，不能 range copy。
-	for i := range resps {
-		info, ok := infoMap[resps[i].UID]
-		if !ok || info == nil {
-			continue
-		}
-		resps[i].RealnameVerified = true
-		resps[i].RealName = info.RealName
-		resps[i].RealnameVerifiedAt = info.RealnameVerifiedAt
-	}
-}
-
-// 这个上限与 resps 长度无关，保持原先 fillSourceSpaceNames 的无 N+1 属性。
-// 函数不会改写 is_external / source_space_id 字段。
 func (g *Group) fillSpaceRelatedFields(groupNo, groupSpaceID string, resps []memberDetailResp) {
 	if len(resps) == 0 {
 		return

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -97,11 +97,16 @@ func (g *Group) Route(r *wkhttp.WKHttp) {
 	}
 	groups := r.Group("/v1/groups", g.ctx.AuthMiddleware(r))
 	{
+		// 移除成员的两条路由（DELETE /members 与其别名 POST /members_delete）自
+		// bot-owner-self-removal 起对**普通成员**开放（自助移除自己名下的 bot，
+		// octo-web#1511），因此按认证路由惯例挂 per-UID 限流。
+		// 只挂这两条：/v1/groups 组还有 ~26 个端点，整组挂会改变它们的既有行为。
+		memberRemoveRateLimiter := appwkhttp.SharedUIDRateLimiter(r, g.ctx)
 		groups.POST("/:group_no/members", g.memberAdd)                                     // 添加群成员
-		groups.DELETE("/:group_no/members", g.memberRemove)                                // 移除群成员
+		groups.DELETE("/:group_no/members", memberRemoveRateLimiter, g.memberRemove)       // 移除群成员
 		groups.GET("/:group_no/members", g.membersGet)                                     // 获取群成员
 		groups.GET("/:group_no/members/:uid", g.memberGet)                                 // 查询单个 uid 是否为群成员（命中时返回成员详情）
-		groups.POST("/:group_no/members_delete", g.memberRemove)                           // 移除群成员
+		groups.POST("/:group_no/members_delete", memberRemoveRateLimiter, g.memberRemove)  // 移除群成员
 		groups.GET("/:group_no/membersync", g.syncMembers)                                 // 同步群成员
 		groups.GET("/:group_no", g.groupGet)                                               // 获取群信息
 		groups.PUT("/:group_no/setting", g.groupSettingUpdate)                             // 修改群设置
@@ -451,6 +456,8 @@ func (g *Group) membersGet(c *wkhttp.Context) {
 	g.fillSpaceRelatedFields(groupNo, "", resps)
 	// YUJ-413 Scope B：批量回填实名字段（零 N+1），Android 气泡 + 群成员列表依赖。
 	g.fillRealnameFields(resps)
+	// octo-web#1511：回填 bot_owned_by_me，前端据此渲染自助移除按钮。
+	g.fillBotOwnedByMe(groupNo, loginUID, resps)
 
 	c.Response(resps)
 }
@@ -493,6 +500,8 @@ func (g *Group) memberGet(c *wkhttp.Context) {
 	// 调用成本与 N=1 一致），Android 客户端 /v1/groups/:group_no/members/:uid
 	// 是资料卡 / @提及 等路径的数据源。
 	g.fillRealnameFields(resps)
+	// octo-web#1511：单成员查询同样回填 bot_owned_by_me，保持三处同名同型。
+	g.fillBotOwnedByMe(groupNo, loginUID, resps)
 
 	c.Response(memberCheckResp{Exists: true, Member: &resps[0]})
 }
@@ -844,6 +853,9 @@ func (g *Group) syncMembers(c *wkhttp.Context) {
 	// membersync 是 Android WKSDK ChannelMember 缓存的唯一增量来源，漏下发就
 	// 永远没 extraMap.realname_verified → 气泡 + 群成员列表永远不亮。
 	g.fillRealnameFields(resps)
+	// octo-web#1511：增量同步路径同样回填。注意本字段上线前已缓存的成员行要等其
+	// version 变动才会带上它，故客户端必须按「缺失 = false」降级。
+	g.fillBotOwnedByMe(groupNo, loginUID, resps)
 	c.Response(resps)
 }
 
@@ -3044,6 +3056,9 @@ func (g *Group) memberRemove(c *wkhttp.Context) {
 		return
 	}
 	var loginMember *MemberModel
+	// botOwnerSelfRemoval 标记「普通成员自助移除自己名下 bot」这条路径，
+	// 后续用于：拒绝 Creator 角色目标、以及让 service 改发更贴切的 Tip。
+	botOwnerSelfRemoval := false
 	// 查询操作者身份
 	// 这里要兼容后台管理系统的删除操作
 	if c.CheckLoginRole() != nil {
@@ -3058,8 +3073,36 @@ func (g *Group) memberRemove(c *wkhttp.Context) {
 			return
 		}
 		if loginMember.Role != int(common.GroupMemberRoleCreater) && loginMember.Role != int(common.GroupMemberRoleManager) {
-			httperr.ResponseErrorL(c, errcode.ErrGroupMemberCannotRemove, nil, nil)
-			return
+			// 自助路径（octo-web#1511）：普通成员可以移除**自己名下**的 bot。
+			// 在此之前 bot 归属只在入群侧校验（checkBotOwnership），移除侧完全不看，
+			// 形成一道单向门——成员能把自己的 bot 拉进群，却再也取不出来。
+			//
+			// 判据必须是 QueryBotUIDsOwnedByUIDs 这种**默认拒绝的白名单**：它只返回
+			// 「本群内 + group_member.robot=1 + is_deleted=0 + robot.status=1 +
+			// robot.creator_uid = 操作者」的 bot UID。
+			//
+			// 切勿改用 checkBotOwnership —— 它的 SQL 是 `WHERE u.robot = 1`，人类 UID
+			// 根本查不出行、循环因此不拒绝（见 bot_ownership.go doc「human → always OK」）。
+			// 那是入群侧「非 bot 不归我管」的正确语义，搬到移除侧就是提权：
+			// 普通成员传一批人类 UID 即可踢人。
+			ownedBotUIDs, qerr := g.db.QueryBotUIDsOwnedByUIDs(groupNo, []string{operator})
+			if qerr != nil {
+				g.Error("查询操作者名下 bot 失败", zap.Error(qerr))
+				httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
+				return
+			}
+			ownedBots := make(map[string]struct{}, len(ownedBotUIDs))
+			for _, uid := range ownedBotUIDs {
+				ownedBots[uid] = struct{}{}
+			}
+			// 整批校验：任一目标不在白名单内即整批拒绝，不做部分执行。
+			for _, uid := range req.Members {
+				if _, ok := ownedBots[uid]; !ok {
+					httperr.ResponseErrorL(c, errcode.ErrGroupMemberCannotRemove, nil, nil)
+					return
+				}
+			}
+			botOwnerSelfRemoval = true
 		}
 	}
 	// 验证删除者是否包含自己
@@ -3082,6 +3125,14 @@ func (g *Group) memberRemove(c *wkhttp.Context) {
 			return
 		}
 		for _, member := range deleteMembers {
+			// 自助路径不得命中 Creator：RemoveGroupMembers 对 Creator 角色是**静默跳过**
+			// （service.go filter），handler 又不检查 Removed 计数就返回 200，
+			// 结果会是「接口成功但成员没动」，前端误报已移除。这里显式拒绝。
+			// 白名单查询不过滤 role，故理论上可命中一个身为群主的 bot。
+			if botOwnerSelfRemoval && member.Role == int(common.GroupMemberRoleCreater) {
+				httperr.ResponseErrorL(c, errcode.ErrGroupCannotRemoveOwner, nil, nil)
+				return
+			}
 			if loginMember.Role == int(common.GroupMemberRoleManager) {
 				if member.Role == int(common.GroupMemberRoleManager) {
 					httperr.ResponseErrorL(c, errcode.ErrGroupCannotRemoveAdmin, nil, nil)
@@ -3101,6 +3152,9 @@ func (g *Group) memberRemove(c *wkhttp.Context) {
 		Members:      req.Members,
 		OperatorUID:  operator,
 		OperatorName: operatorName,
+		// 自助路径改发「X 将机器人 Y 移出了群聊」，而不是默认的「你被 X 移除群聊」
+		// ——后者是被移除者视角的措辞，套在 bot 上读起来是错的。
+		BotOwnerSelfRemoval: botOwnerSelfRemoval,
 	})
 	if err != nil {
 		// 后台管理路径会跳过普通成员的目标预校验；若删除的 UID 全不在群内，
@@ -4362,8 +4416,17 @@ type memberDetailResp struct {
 	RealnameVerified   bool   `json:"realname_verified"`
 	RealName           string `json:"real_name,omitempty"`
 	RealnameVerifiedAt int64  `json:"realname_verified_at,omitempty"`
-	CreatedAt          string `json:"created_at"`
-	UpdatedAt          string `json:"updated_at"`
+	// BotOwnedByMe 表示「该 bot 成员归当前请求方所有」（octo-web#1511）。
+	// 响应本身就是 per-viewer 的，故用布尔而不是下发 creator_uid：客户端直接可用，
+	// 也不把 bot 的归属关系暴露给全群。
+	//
+	// 前端据此逐行决定是否渲染移除按钮。**缺失必须按 false 处理**：
+	// /membersync 是按 version 的增量同步，本字段上线前已缓存的成员行在其 version
+	// 变动前不会带上它，降级方向只能是「退回现状」，绝不能误开权限。
+	// 非 bot 成员、他人的 bot 均为 false。
+	BotOwnedByMe bool   `json:"bot_owned_by_me"`
+	CreatedAt    string `json:"created_at"`
+	UpdatedAt    string `json:"updated_at"`
 }
 
 func (r memberDetailResp) from(model *MemberDetailModel) memberDetailResp {
@@ -4424,6 +4487,57 @@ func (r memberDetailResp) from(model *MemberDetailModel) memberDetailResp {
 //
 // 失败处理：仅 log，不阻断主响应链路 —— 实名是增强信息，不能因实名表查询抖动
 // 让群成员列表不可用。
+// fillBotOwnedByMe 批量回填 memberDetailResp.BotOwnedByMe（octo-web#1511）。
+//
+// 复用 memberRemove 自助路径的同一判据 QueryBotUIDsOwnedByUIDs —— 一次
+// `group_member INNER JOIN robot` 批量查出「本群内属于 loginUID 的 bot」，零 N+1，
+// 且保证「前端看得到移除按钮」与「后端放行移除」用的是同一口径，不会出现
+// 按钮显示了但请求被拒的错位。
+//
+// 为什么不做成群级能力位（如 can_remove_own_bots）：那需要在 GetGroupDetail 这类
+// 每次群信息拉取都走的热路径上多打一次 robot 表 JOIN；而本字段只在成员列表这类
+// 本来就要分页取数的场景计算一次。
+//
+// 失败处理：仅 log，全部留 false —— fail closed，宁可不显示移除按钮，
+// 不能因查询抖动误开权限。
+func (g *Group) fillBotOwnedByMe(groupNo, loginUID string, resps []memberDetailResp) {
+	if len(resps) == 0 || groupNo == "" || loginUID == "" {
+		return
+	}
+	hasBot := false
+	for i := range resps {
+		if resps[i].Robot == 1 {
+			hasBot = true
+			break
+		}
+	}
+	if !hasBot {
+		return
+	}
+	ownedBotUIDs, err := g.db.QueryBotUIDsOwnedByUIDs(groupNo, []string{loginUID})
+	if err != nil {
+		g.Warn("批量查询本人名下 bot 失败（octo-web#1511）",
+			zap.Error(err), zap.String("group_no", groupNo))
+		return
+	}
+	if len(ownedBotUIDs) == 0 {
+		return
+	}
+	owned := make(map[string]struct{}, len(ownedBotUIDs))
+	for _, uid := range ownedBotUIDs {
+		owned[uid] = struct{}{}
+	}
+	// 注意：resps 是值切片，必须按 index 回写，不能 range copy。
+	for i := range resps {
+		if resps[i].Robot != 1 {
+			continue
+		}
+		if _, ok := owned[resps[i].UID]; ok {
+			resps[i].BotOwnedByMe = true
+		}
+	}
+}
+
 func (g *Group) fillRealnameFields(resps []memberDetailResp) {
 	if len(resps) == 0 {
 		return

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -3159,12 +3159,24 @@ func (g *Group) memberRemove(c *wkhttp.Context) {
 			return
 		}
 		for _, member := range deleteMembers {
-			// 自助路径不得命中 Creator：RemoveGroupMembers 对 Creator 角色是**静默跳过**
-			// （service.go filter），handler 又不检查 Removed 计数就返回 200，
-			// 结果会是「接口成功但成员没动」，前端误报已移除。这里显式拒绝。
-			// 白名单查询不过滤 role，故理论上可命中一个身为群主的 bot。
-			if botOwnerSelfRemoval && member.Role == int(common.GroupMemberRoleCreater) {
-				httperr.ResponseErrorL(c, errcode.ErrGroupCannotRemoveOwner, nil, nil)
+			// 自助路径只允许移除**普通角色**的 bot。
+			//
+			// 白名单按所有权圈定目标，但不过滤 role，所以理论上能命中一个被授予了
+			// 群角色的 bot。两种角色分别的问题：
+			//   - Creator：RemoveGroupMembers 对 Creator 是静默跳过，会变成
+			//     「200 但成员没动」，前端误报已移除；
+			//   - Manager：普通成员将得以移除一个群管理员，而真正的管理员反而
+			//     不能移除另一个管理员（下面几行），权限阶梯倒挂。
+			//     维护者当初拍板的「所有权优先」针对的是 bot_admin 这一列，
+			//     group_member.role 是比它更强的授予，不在那条决策覆盖范围内。
+			// 故一并拒绝，把角色 bot 的处置交回群主/管理员。
+			// （managerAdd 不排除 robot，所以 Manager 角色的 bot 是构造得出来的。）
+			if botOwnerSelfRemoval && member.Role != MemberRoleCommon {
+				if member.Role == int(common.GroupMemberRoleCreater) {
+					httperr.ResponseErrorL(c, errcode.ErrGroupCannotRemoveOwner, nil, nil)
+					return
+				}
+				httperr.ResponseErrorL(c, errcode.ErrGroupCannotRemoveAdmin, nil, nil)
 				return
 			}
 			if loginMember.Role == int(common.GroupMemberRoleManager) {
@@ -3181,7 +3193,7 @@ func (g *Group) memberRemove(c *wkhttp.Context) {
 	}
 
 	// 调用 Service 移除群成员
-	_, err = g.groupService.RemoveGroupMembers(&RemoveGroupMembersServiceReq{
+	removeResp, err := g.groupService.RemoveGroupMembers(&RemoveGroupMembersServiceReq{
 		GroupNo:      groupNo,
 		Members:      req.Members,
 		OperatorUID:  operator,
@@ -3204,6 +3216,19 @@ func (g *Group) memberRemove(c *wkhttp.Context) {
 		}
 		g.Error("移除群成员失败", zap.Error(err))
 		httperr.ResponseErrorL(c, errcode.ErrGroupStoreFailed, nil, nil)
+		return
+	}
+
+	// 自助路径核对实际移除数：上面的角色守卫读的是事务外快照，而 service 在行锁内
+	// 重读角色，期间目标若被提升为 Creator 就会被**静默跳过**（其 doc 写明「让调用方
+	// 按 Removed 计数发现并重试」，但此前没有调用方真的去看）。不核对的话，这条竞态
+	// 窗口仍会回到「200 但成员没动」——正是上面那道守卫要消灭的形态，只是更窄。
+	// 只在自助路径上核对：后台管理路径本来就允许「部分目标不在群内」的宽松语义。
+	if botOwnerSelfRemoval && removeResp != nil && removeResp.Removed < len(req.Members) {
+		g.Warn("自助移除的实际移除数少于请求数，疑似目标在事务内被提升为群主",
+			zap.String("groupNo", groupNo), zap.String("operator", operator),
+			zap.Int("requested", len(req.Members)), zap.Int("removed", removeResp.Removed))
+		httperr.ResponseErrorL(c, errcode.ErrGroupCannotRemoveOwner, nil, nil)
 		return
 	}
 
@@ -4590,6 +4615,20 @@ func (g *Group) fillBotOwnedByMe(groupNo, loginUID string, resps []memberDetailR
 	if !hasBot {
 		return
 	}
+	// 移除的授权是**两个**谓词：活跃成员（ExistMemberActive）+ 所有权白名单。
+	// 只按所有权回填的话，被拉黑的所有者（status=Blacklist、is_deleted=0）仍能拉到
+	// 成员列表、拿到 bot_owned_by_me=true、看到移除按钮，点下去却被 memberRemove
+	// 的活跃门拒绝。这里补上同一道门，让「按钮可见」与「请求会被放行」用的是同一组
+	// 判据，而不是其中一半。方向仍是 fail-closed：查询出错一律留 false。
+	operatorActive, aerr := g.db.ExistMemberActive(loginUID, groupNo)
+	if aerr != nil {
+		g.Warn("查询请求方活跃成员状态失败（octo-web#1511）",
+			zap.Error(aerr), zap.String("group_no", groupNo))
+		return
+	}
+	if !operatorActive {
+		return
+	}
 	ownedBotUIDs, err := g.db.QueryBotUIDsOwnedByUIDs(groupNo, []string{loginUID})
 	if err != nil {
 		g.Warn("批量查询本人名下 bot 失败（octo-web#1511）",
@@ -4606,6 +4645,11 @@ func (g *Group) fillBotOwnedByMe(groupNo, loginUID string, resps []memberDetailR
 	// 注意：resps 是值切片，必须按 index 回写，不能 range copy。
 	for i := range resps {
 		if resps[i].Robot != 1 {
+			continue
+		}
+		// 被授予了群角色（Creator / Manager）的 bot 由 memberRemove 的自助分支拒绝，
+		// 处置权留给群主/管理员；这里同步排除，避免下发一个点了必报错的按钮。
+		if resps[i].Role != MemberRoleCommon {
 			continue
 		}
 		if _, ok := owned[resps[i].UID]; ok {

--- a/modules/group/api_bot_owner_self_removal_concurrency_test.go
+++ b/modules/group/api_bot_owner_self_removal_concurrency_test.go
@@ -1,0 +1,147 @@
+package group
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 本文件钉住自助移除在**并发 / 多副本**下的两条性质。合并前的确认发现：
+// 这两条此前都没有覆盖，而且其中一条在测试库里长期是坏的。
+//
+// 背景：级联移除走的是
+//
+//	SELECT gm.uid FROM group_member gm
+//	  INNER JOIN robot r ON r.robot_id = gm.uid AND r.status = 1
+//	 WHERE gm.group_no = ? AND gm.robot = 1 AND gm.is_deleted = 0
+//	   AND r.creator_uid = ? FOR UPDATE
+//
+// 有 idx_robot_creator_uid 时，MySQL 从 robot 侧 ref 进入（只扫该主人名下的 bot），
+// 再按 group_no_uid 唯一索引 eq_ref 回查，锁面只覆盖「真正要改的那几行」。
+// 没有该索引时退化成 robot 全表扫描，而 FOR UPDATE 会把**整张 robot 表**加 X 锁——
+// 跨群、跨副本地串行化所有 bot 操作，并稳定产生死锁。
+//
+// 实测对比（40 轮 × 3 并发）：无索引 120 次操作里 8 次撞 MySQL 死锁 1213；
+// 补齐索引后 360 次操作 0 死锁。
+
+// TestBotOwnerSelfRemoval_RobotIndexesMatchProduction 直接钉住上面那个前提。
+//
+// 为什么值得单独一条：api_test.go 里建索引的语句原本写成
+// `CREATE UNIQUE INDEX IF NOT EXISTS ...`，而 MySQL 8.0 不支持 CREATE INDEX 的
+// IF NOT EXISTS（那是 MariaDB/Postgres 的写法），于是它每次都以 1064 语法错误失败，
+// 且 db.Exec 的 error 没人检查——索引就这样静默地从来没建成过。
+// 这条断言让同样的静默失败下次直接红，而不是变成一个「偶尔死锁」的线上谜题。
+func TestBotOwnerSelfRemoval_RobotIndexesMatchProduction(t *testing.T) {
+	_, ctx := newTestServer(t)
+	f := New(ctx)
+
+	for _, idx := range []string{"robot_id_robot_index", "idx_robot_creator_uid"} {
+		var n int64
+		_, err := f.ctx.DB().SelectBySql(
+			"SELECT COUNT(*) FROM information_schema.STATISTICS "+
+				"WHERE table_schema = DATABASE() AND table_name = 'robot' AND index_name = ?",
+			idx,
+		).Load(&n)
+		require.NoError(t, err)
+		assert.NotZero(t, n,
+			"robot.%s 缺失：级联的 FOR UPDATE 查询会退化成 robot 全表加锁（线上由 "+
+				"modules/robot 迁移建立，测试库由 api_test.go 的 TestMain 补齐）", idx)
+	}
+}
+
+// TestBotOwnerSelfRemoval_ConcurrentWithOwnerKick 覆盖最容易出问题的交错：
+// 所有者正在自助移除自己的 bot，同一时刻群主把这位所有者踢了 —— 踢人的级联
+// 指向同一批行。再叠一个重复的自助移除，制造「同一目标被并发处理两次」。
+//
+// 断言两件事：
+//  1. 不产生死锁 / 锁等待超时（锁面足够窄、加锁顺序一致）；
+//  2. 无论哪条路径先赢，最终状态一致 —— 主人和 bot 都不在群里，且没有重复成员行。
+//
+// 注意：级联失败时 service 返回的是 errors.New("failed to cascade-remove invited
+// bots")，**丢掉了底层原因**（死锁 1213 也会被吞成这句）。所以这里不能只看
+// error 字符串，必须把它单独归一类并让测试红——否则死锁会伪装成普通失败。
+func TestBotOwnerSelfRemoval_ConcurrentWithOwnerKick(t *testing.T) {
+	svc, userDB := setupServiceTest(t)
+	s := svc.(*Service)
+	insertTestUsers(t, userDB, testutil.UID)
+
+	const rounds = 20
+	var deadlocks, lockwaits, cascadeFailures, okCnt int64
+
+	for r := 0; r < rounds; r++ {
+		owner := fmt.Sprintf("cc_own_%03d", r)
+		bot := fmt.Sprintf("cc_bot_%03d", r)
+
+		insertTestUsers(t, userDB, owner)
+		resp, err := svc.CreateGroup(&CreateGroupServiceReq{
+			Creator: testutil.UID, Members: []string{owner},
+			Name: fmt.Sprintf("cc_%03d", r),
+		})
+		require.NoError(t, err)
+		seedBotMember(t, s, resp.GroupNo, bot, bot, owner)
+
+		classify := func(rerr error) {
+			if rerr == nil {
+				atomic.AddInt64(&okCnt, 1)
+				return
+			}
+			msg := rerr.Error()
+			switch {
+			case strings.Contains(msg, "Deadlock") || strings.Contains(msg, "1213"):
+				atomic.AddInt64(&deadlocks, 1)
+			case strings.Contains(msg, "Lock wait timeout") || strings.Contains(msg, "1205"):
+				atomic.AddInt64(&lockwaits, 1)
+			case strings.Contains(msg, "cascade-remove"):
+				// service 把底层错误吞成了这句：死锁最可能藏在这里。
+				atomic.AddInt64(&cascadeFailures, 1)
+			}
+		}
+
+		var wg sync.WaitGroup
+		run := func(req *RemoveGroupMembersServiceReq) {
+			defer wg.Done()
+			_, rerr := svc.RemoveGroupMembers(req)
+			classify(rerr)
+		}
+		wg.Add(3)
+		go run(&RemoveGroupMembersServiceReq{
+			GroupNo: resp.GroupNo, Members: []string{bot},
+			OperatorUID: owner, OperatorName: owner, BotOwnerSelfRemoval: true,
+		})
+		go run(&RemoveGroupMembersServiceReq{
+			GroupNo: resp.GroupNo, Members: []string{owner},
+			OperatorUID: testutil.UID, OperatorName: "creator",
+		})
+		go run(&RemoveGroupMembersServiceReq{
+			GroupNo: resp.GroupNo, Members: []string{bot},
+			OperatorUID: owner, OperatorName: owner, BotOwnerSelfRemoval: true,
+		})
+		wg.Wait()
+
+		for _, uid := range []string{owner, bot} {
+			exist, eerr := s.db.ExistMember(uid, resp.GroupNo)
+			require.NoError(t, eerr)
+			assert.False(t, exist, "round %d: %s 无论哪条路径先赢都应已离群", r, uid)
+		}
+		var dup int64
+		_, err = s.ctx.DB().SelectBySql(
+			"SELECT COUNT(*) FROM (SELECT uid FROM group_member "+
+				"WHERE group_no=? GROUP BY uid HAVING COUNT(*)>1) x",
+			resp.GroupNo).Load(&dup)
+		require.NoError(t, err)
+		assert.Zero(t, dup, "round %d: 并发不应产生重复成员行", r)
+	}
+
+	t.Logf("ops=%d ok=%d deadlock=%d lockwait=%d cascadeFail=%d",
+		rounds*3, okCnt, deadlocks, lockwaits, cascadeFailures)
+	assert.Zero(t, deadlocks, "并发自助移除 / 踢人不应产生死锁")
+	assert.Zero(t, lockwaits, "并发自助移除 / 踢人不应产生锁等待超时")
+	assert.Zero(t, cascadeFailures,
+		"级联失败会吞掉底层错误（含死锁 1213）；出现即说明锁面或加锁顺序退化了")
+}

--- a/modules/group/api_bot_owner_self_removal_hardening_test.go
+++ b/modules/group/api_bot_owner_self_removal_hardening_test.go
@@ -59,18 +59,19 @@ func TestLockRemovableMemberTx_RejectsManagerWhenCommonRequired(t *testing.T) {
 	assert.True(t, ok, "普通角色目标应放行")
 }
 
-// ---------- ② 级联查询自身要带角色过滤 ----------
+// ---------- ② 级联的角色过滤只作用于自助路径 ----------
 
-// cascadeRemoveBotsInvitedByUIDTx 走的是 QueryBotsInvitedByUIDTx，它按
-// robot.creator_uid 圈定目标、**不过滤 group_member.role**，也不经过 handler 的
-// 守卫。于是「bot A 拥有 Manager 角色的 bot B」时，移除 A 会连带删掉 B ——
-// B 从未进过白名单。
+// #354 是**写下来的产品决策**：「bot 永远跟随其主人，无角色例外」
+// （见 api.go groupExit 与 service.go 过滤处的注释）。它覆盖三条既有路径：
+// 主动退群、被群主/管理员移除、被拉黑。
 //
-// 触发它需要 robot.creator_uid 指向另一个 bot：BotFather 的命令链
-// （messagesListen → HandleMessage → tryCreateBotCore）对「发送者是不是 bot」
-// 零过滤，只有 checkSendPermission 的好友门挡在前面。也就是说这道守卫的强度
-// 目前依赖于另一个模块的好友门，而不是它自己的判据 —— 这才是要修的理由。
-func TestQueryBotsInvitedByUIDTx_ExcludesRoleBearingBots(t *testing.T) {
+// 因此级联的角色过滤**不能**做成全局的：那会让「张三被踢 → 他名下的管理员 bot
+// 留在群里、而张三已不是成员、自助路径又拒绝角色 bot」，群里凭空多出一个
+// 没人管得动的特权 bot —— 正是 #354 要消灭的状态，拉黑流程下还带安全含义。
+//
+// 需要角色过滤的只有**新开的自助路径**：普通成员不该借级联把一个管理员 bot
+// 洗掉。所以判据跟着 BotOwnerSelfRemoval 走，与锁内的 requireCommonRole 同源。
+func TestQueryBotsInvitedByUIDTx_RoleFilterOnlyOnSelfServicePath(t *testing.T) {
 	_, ctx := newTestServer(t)
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	f := New(ctx)
@@ -91,14 +92,65 @@ func TestQueryBotsInvitedByUIDTx_ExcludesRoleBearingBots(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = tx.Rollback() }()
 
-	uids, err := f.db.QueryBotsInvitedByUIDTx(groupNo, "owner_y", tx)
+	// requireCommonRole=false —— 既有三条路径（退群 / 被踢 / 拉黑）。
+	// #354：无角色例外，三个都要跟着走。
+	uids, err := f.db.QueryBotsInvitedByUIDTx(groupNo, "owner_y", false, tx)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"bot_plain", "bot_mgr", "bot_creator"}, uids,
+		"既有路径必须保持 #354：bot 永远跟随其主人，无角色例外")
+
+	// requireCommonRole=true —— 仅自助路径。
+	uids, err = f.db.QueryBotsInvitedByUIDTx(groupNo, "owner_y", true, tx)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"bot_plain"}, uids,
+		"自助路径下只级联普通角色的 bot，角色 bot 的处置权留给群主/管理员")
+}
+
+// 端到端形态：管理员踢人时，被踢者名下的**管理员 bot** 仍要被级联带走。
+//
+// 这条补的是评审点出的测试盲区 —— space_member_removal_test.go 的
+// seedInvitedBot 把 role 硬编码成 0，所有级联 fixture 都是普通角色，
+// 于是「级联对角色 bot 怎么处理」从来没有测试覆盖，改坏了也不会红。
+func TestRemoveGroupMembers_AdminKickStillCascadesManagerBot(t *testing.T) {
+	svc, userDB := setupServiceTest(t)
+	insertTestUsers(t, userDB, testutil.UID, "leaver")
+
+	resp, err := svc.CreateGroup(&CreateGroupServiceReq{
+		Creator: testutil.UID,
+		Members: []string{"leaver"},
+		Name:    "admin-kick-cascade",
+	})
+	require.NoError(t, err)
+	s := svc.(*Service)
+
+	// leaver 名下两个 bot：一个普通角色、一个被群主提升为 Manager。
+	seedBotMember(t, s, resp.GroupNo, "bot_of_leaver", "bol", "leaver")
+	seedBotMember(t, s, resp.GroupNo, "bot_mgr_of_leaver", "bmol", "leaver")
+	_, err = s.ctx.DB().UpdateBySql(
+		"UPDATE group_member SET role=? WHERE group_no=? AND uid=?",
+		MemberRoleManager, resp.GroupNo, "bot_mgr_of_leaver",
+	).Exec()
 	require.NoError(t, err)
 
-	assert.Contains(t, uids, "bot_plain", "普通角色的 bot 仍应被级联")
-	assert.NotContains(t, uids, "bot_mgr",
-		"Manager 角色的 bot 不得被级联删除 —— 它从未通过任何角色守卫")
-	assert.NotContains(t, uids, "bot_creator",
-		"Creator 角色的 bot 不得被级联删除")
+	// 群主踢人（非自助路径）。
+	removeResp, err := svc.RemoveGroupMembers(&RemoveGroupMembersServiceReq{
+		GroupNo:      resp.GroupNo,
+		Members:      []string{"leaver"},
+		OperatorUID:  testutil.UID,
+		OperatorName: "creator",
+	})
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t,
+		[]string{"leaver", "bot_of_leaver", "bot_mgr_of_leaver"}, removeResp.RemovedUIDs,
+		"#354：被踢者名下的 bot 全部跟着走，Manager 角色也不例外 —— "+
+			"否则群里会留下一个主人已不在、谁也管不动的特权 bot")
+
+	for _, uid := range []string{"bot_of_leaver", "bot_mgr_of_leaver"} {
+		exist, eerr := s.db.ExistMember(uid, resp.GroupNo)
+		require.NoError(t, eerr)
+		assert.False(t, exist, "%s 应已被级联移除", uid)
+	}
 }
 
 // ---------- ③ 实际移除集合要与请求集合比对，而不是比数量 ----------

--- a/modules/group/api_bot_owner_self_removal_hardening_test.go
+++ b/modules/group/api_bot_owner_self_removal_hardening_test.go
@@ -1,0 +1,179 @@
+package group
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 自助移除的三处收口（PR #805 重审提出，三位评审独立收敛到同一批）。
+//
+// 共同的形状：事务**外**的快照守卫已经拦住了角色 bot，但事务**内**没有对应的
+// 收口，于是窗口内的状态变化、以及不经过守卫的级联路径，都能绕过它。
+// 「守卫只在事务外」这件事本身就是缺陷，不取决于当下能不能构造出触发条件。
+
+// ---------- ① 锁内重查必须同时拦住 Manager ----------
+
+// LockRemovableMemberTx 原本只判 `role != Creator`。自助路径在事务外拦了所有
+// 非普通角色，但目标若在「快照 → 取锁」这个窗口内被提升为 Manager，锁内重查
+// 会放行、行真的被删，而且 Removed 计数对得上，连计数守卫也发现不了 ——
+// 正是验收 #12 要消灭的那个形状，只是漏在了锁内那一半。
+func TestLockRemovableMemberTx_RejectsManagerWhenCommonRequired(t *testing.T) {
+	_, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	f := New(ctx)
+
+	const groupNo = "g_lock_role"
+	require.NoError(t, f.db.Insert(&Model{
+		GroupNo: groupNo, Name: "lock role", Creator: "owner_x",
+		Status: GroupStatusNormal, Version: 1,
+	}))
+	seedRoleMember(t, f, groupNo, "member_common", MemberRoleCommon)
+	seedRoleMember(t, f, groupNo, "member_manager", MemberRoleManager)
+	seedRoleMember(t, f, groupNo, "owner_x", MemberRoleCreator)
+
+	tx, err := f.ctx.DB().Begin()
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+
+	// requireCommonRole=false：沿用既有语义（只排除 Creator），管理员可移除。
+	ok, err := f.db.LockRemovableMemberTx(groupNo, "member_manager", false, tx)
+	require.NoError(t, err)
+	assert.True(t, ok, "既有语义不变：非自助路径下 Manager 仍可被移除")
+
+	// requireCommonRole=true：自助路径，必须连 Manager 一起拦。
+	ok, err = f.db.LockRemovableMemberTx(groupNo, "member_manager", true, tx)
+	require.NoError(t, err)
+	assert.False(t, ok, "自助路径下 Manager 角色必须在**锁内**也被拦住")
+
+	ok, err = f.db.LockRemovableMemberTx(groupNo, "owner_x", true, tx)
+	require.NoError(t, err)
+	assert.False(t, ok, "Creator 任何情况下都不可移除")
+
+	ok, err = f.db.LockRemovableMemberTx(groupNo, "member_common", true, tx)
+	require.NoError(t, err)
+	assert.True(t, ok, "普通角色目标应放行")
+}
+
+// ---------- ② 级联查询自身要带角色过滤 ----------
+
+// cascadeRemoveBotsInvitedByUIDTx 走的是 QueryBotsInvitedByUIDTx，它按
+// robot.creator_uid 圈定目标、**不过滤 group_member.role**，也不经过 handler 的
+// 守卫。于是「bot A 拥有 Manager 角色的 bot B」时，移除 A 会连带删掉 B ——
+// B 从未进过白名单。
+//
+// 触发它需要 robot.creator_uid 指向另一个 bot：BotFather 的命令链
+// （messagesListen → HandleMessage → tryCreateBotCore）对「发送者是不是 bot」
+// 零过滤，只有 checkSendPermission 的好友门挡在前面。也就是说这道守卫的强度
+// 目前依赖于另一个模块的好友门，而不是它自己的判据 —— 这才是要修的理由。
+func TestQueryBotsInvitedByUIDTx_ExcludesRoleBearingBots(t *testing.T) {
+	_, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	f := New(ctx)
+
+	const groupNo = "g_cascade_role"
+	require.NoError(t, f.db.Insert(&Model{
+		GroupNo: groupNo, Name: "cascade role", Creator: "owner_y",
+		Status: GroupStatusNormal, Version: 1,
+	}))
+	seedRoleMember(t, f, groupNo, "owner_y", MemberRoleCreator)
+
+	// owner_y 名下三个 bot：普通角色、Manager 角色、Creator 角色。
+	seedOwnedBot(t, f, groupNo, "bot_plain", "owner_y", MemberRoleCommon)
+	seedOwnedBot(t, f, groupNo, "bot_mgr", "owner_y", MemberRoleManager)
+	seedOwnedBot(t, f, groupNo, "bot_creator", "owner_y", MemberRoleCreator)
+
+	tx, err := f.ctx.DB().Begin()
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+
+	uids, err := f.db.QueryBotsInvitedByUIDTx(groupNo, "owner_y", tx)
+	require.NoError(t, err)
+
+	assert.Contains(t, uids, "bot_plain", "普通角色的 bot 仍应被级联")
+	assert.NotContains(t, uids, "bot_mgr",
+		"Manager 角色的 bot 不得被级联删除 —— 它从未通过任何角色守卫")
+	assert.NotContains(t, uids, "bot_creator",
+		"Creator 角色的 bot 不得被级联删除")
+}
+
+// ---------- ③ 实际移除集合要与请求集合比对，而不是比数量 ----------
+
+// 原来的守卫是 `removeResp.Removed < len(req.Members)`。两个问题：
+//   - removedUIDs 含级联带走的 bot，数量会被撑大，可以把「某个目标被跳过」
+//     在数字上抹平；
+//   - 数量对不上时一律报 ErrGroupCannotRemoveOwner，但真实原因也可能是
+//     DeleteMemberTx 失败后 service 的 continue（部分提交）。
+//
+// 改成比对集合，并让调用方能拿到「到底哪个没被移除」。
+func TestMissingRemovalTargets(t *testing.T) {
+	cases := []struct {
+		name      string
+		requested []string
+		removed   []string
+		want      []string
+	}{
+		{
+			name:      "全部移除成功",
+			requested: []string{"bot_a"},
+			removed:   []string{"bot_a"},
+			want:      nil,
+		},
+		{
+			name:      "级联带走额外的 bot，不算缺失",
+			requested: []string{"bot_a"},
+			removed:   []string{"bot_a", "bot_cascaded"},
+			want:      nil,
+		},
+		{
+			name:      "级联把被跳过的目标在数量上抹平 —— 计数比较会漏，集合比较不会",
+			requested: []string{"bot_a", "bot_b"},
+			removed:   []string{"bot_a", "bot_cascaded"},
+			want:      []string{"bot_b"},
+		},
+		{
+			name:      "目标被静默跳过",
+			requested: []string{"bot_a", "bot_b"},
+			removed:   []string{"bot_a"},
+			want:      []string{"bot_b"},
+		},
+		{
+			name:      "一个都没移除",
+			requested: []string{"bot_a"},
+			removed:   nil,
+			want:      []string{"bot_a"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, missingRemovalTargets(tc.requested, tc.removed))
+		})
+	}
+}
+
+// ---------- 共用脚手架 ----------
+
+func seedRoleMember(t *testing.T, f *Group, groupNo, uid string, role int) {
+	t.Helper()
+	require.NoError(t, f.db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: uid, Role: role,
+		Status: 1, Version: 1, Vercode: fmt.Sprintf("%s@1", util.GenerUUID()),
+	}))
+}
+
+// seedOwnedBot 建一个 robot 行 + 指定角色的 bot 群成员行。
+func seedOwnedBot(t *testing.T, f *Group, groupNo, botUID, ownerUID string, role int) {
+	t.Helper()
+	_, err := f.ctx.DB().InsertBySql(
+		"INSERT INTO robot (robot_id, status, creator_uid) VALUES (?, 1, ?)", botUID, ownerUID,
+	).Exec()
+	require.NoError(t, err)
+	require.NoError(t, f.db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: botUID, Role: role, Robot: 1,
+		Status: 1, Version: 1, Vercode: fmt.Sprintf("%s@1", util.GenerUUID()),
+	}))
+}

--- a/modules/group/api_bot_owner_self_removal_test.go
+++ b/modules/group/api_bot_owner_self_removal_test.go
@@ -314,6 +314,50 @@ func TestBotOwnerSelfRemoval_SendsOwnerTipNotKickNotice(t *testing.T) {
 		"应发出 owner 视角的 Tip，让群成员知道 bot 为何消失")
 }
 
+// 自助移除必须把 bot 从群频道的 IM 订阅里摘掉。
+//
+// 这是本功能最要紧的后置条件：删掉 group_member 行只是「名单上没有它了」，
+// 若 IM 订阅还在，bot 依然会收到群消息 —— 那等于没移除。
+// 既有的 TestGroupCascadeUnsubscribesFromIM 只覆盖了「人走 bot 跟着走」的级联路径，
+// 自助路径此前无人断言。
+//
+// 与 Tip 断言同理走 service 层：register.GetModules 的进程级 sync.Once 让 HTTP
+// 路由上的 IM 桩只对进程内第一个测试生效（见本文件 SendsOwnerTipNotKickNotice 的注释）。
+func TestBotOwnerSelfRemoval_UnsubscribesBotFromGroupChannel(t *testing.T) {
+	s, ctx := newTestServer(t)
+	f := New(ctx)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	stub := newGroupIMStub(t, ctx)
+	wireI18nRendererForGroupTest(s)
+
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: testutil.UID, Name: "bot-owner", ShortNo: "uc_unsub"}))
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: "owner_other", Name: "group-owner", ShortNo: "uo_unsub"}))
+	require.NoError(t, f.db.Insert(&Model{
+		GroupNo: selfRemovalGroupNo, Name: "unsub group", Creator: "owner_other",
+		Status: GroupStatusNormal, Version: 1,
+	}))
+	seedSelfRemovalMember(t, f, "owner_other", MemberRoleCreator, 0)
+	seedSelfRemovalMember(t, f, testutil.UID, MemberRoleCommon, 0)
+	seedSelfRemovalBot(t, f, "bot_unsub", "unsub-bot", testutil.UID, 1)
+
+	_, err := f.groupService.RemoveGroupMembers(&RemoveGroupMembersServiceReq{
+		GroupNo:             selfRemovalGroupNo,
+		Members:             []string{"bot_unsub"},
+		OperatorUID:         testutil.UID,
+		OperatorName:        "bot-owner",
+		BotOwnerSelfRemoval: true,
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, stub.unsubscribed(selfRemovalGroupNo), "bot_unsub",
+		"bot 必须从群频道的 IM 订阅里摘掉，否则它还会继续收到群消息")
+	// 操作者自己（以及群主）不能被顺带退订。
+	assert.NotContains(t, stub.unsubscribed(selfRemovalGroupNo), testutil.UID,
+		"发起人不应被退订")
+	assert.NotContains(t, stub.unsubscribed(selfRemovalGroupNo), "owner_other",
+		"其他成员不应被退订")
+}
+
 // 对照组：同一条 service 路径在**不**置位 BotOwnerSelfRemoval 时，
 // 仍然发原来的「被移除」文案——保证新分支没有把既有行为一起改掉。
 func TestBotOwnerSelfRemoval_NormalRemovalStillSendsKickNotice(t *testing.T) {

--- a/modules/group/api_bot_owner_self_removal_test.go
+++ b/modules/group/api_bot_owner_self_removal_test.go
@@ -262,19 +262,84 @@ func TestBotOwnerSelfRemoval_RepeatRemovalIsNotServerError(t *testing.T) {
 //
 // 两条文案刻意可区分：旧的是「你被{0}移除群聊」，新的是「X 将机器人 Y 移出了群聊」
 // ——「移除群聊」与「移出了群聊」不互相包含，所以下面的片段匹配是准确的。
+//
+// 这条**不走 HTTP 路由**，而是直接驱动 service —— 与 space_member_removal_test.go
+// 里的同类 Tip 断言同一写法。原因是 register.GetModules（octo-lib
+// pkg/register/register.go）用进程级 sync.Once 构造模块实例：一个进程里 handler
+// 永远持有**第一个** NewTestServer 的 ctx，而 newGroupIMStub 改的是本测试自己那个
+// ctx 的 config，于是经路由发出的消息不会落进本测试的桩（只有进程里第一个测试碰巧
+// 生效）。这是测试脚手架的限制，不是产品行为——线上只有一个长期存在的 ctx。
+//
+// 「handler 确实置位了 BotOwnerSelfRemoval」由上面那批 HTTP 用例反证：普通成员能
+// 把自己的 bot 删掉、却删不动人类/他人的 bot，只有走自助分支才可能是这个结果。
 func TestBotOwnerSelfRemoval_SendsOwnerTipNotKickNotice(t *testing.T) {
-	f, handler, ctx := setupBotSelfRemovalGroup(t)
+	s, ctx := newTestServer(t)
+	f := New(ctx)
+	require.NoError(t, testutil.CleanAllTables(ctx))
 	stub := newGroupIMStub(t, ctx)
+	wireI18nRendererForGroupTest(s)
+
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: testutil.UID, Name: "bot-owner", ShortNo: "uc_tip"}))
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: "owner_other", Name: "group-owner", ShortNo: "uo_tip"}))
+	require.NoError(t, f.db.Insert(&Model{
+		GroupNo: selfRemovalGroupNo, Name: "tip group", Creator: "owner_other",
+		Status: GroupStatusNormal, Version: 1,
+	}))
+	seedSelfRemovalMember(t, f, "owner_other", MemberRoleCreator, 0)
+	seedSelfRemovalMember(t, f, testutil.UID, MemberRoleCommon, 0)
 	seedSelfRemovalBot(t, f, "bot_tip", "tip-bot", testutil.UID, 1)
 
-	w := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{"bot_tip"})
-	require.Equal(t, http.StatusOK, w.Code, "移除应成功: %s", w.Body.String())
+	_, err := f.groupService.RemoveGroupMembers(&RemoveGroupMembersServiceReq{
+		GroupNo:             selfRemovalGroupNo,
+		Members:             []string{"bot_tip"},
+		OperatorUID:         testutil.UID,
+		OperatorName:        "bot-owner",
+		BotOwnerSelfRemoval: true,
+	})
+	require.NoError(t, err)
+
+	exist, err := f.db.ExistMember("bot_tip", selfRemovalGroupNo)
+	require.NoError(t, err)
+	require.False(t, exist, "前置：bot 应已被移除")
 
 	payloads := stub.sentPayloads()
 	assert.False(t, payloadsContain(payloads, "移除群聊"),
 		"自助移除 bot 不应发出「你被 X 移除群聊」——那是被移除者视角的措辞")
 	assert.True(t, payloadsContain(payloads, "将机器人"),
 		"应发出 owner 视角的 Tip，让群成员知道 bot 为何消失")
+}
+
+// 对照组：同一条 service 路径在**不**置位 BotOwnerSelfRemoval 时，
+// 仍然发原来的「被移除」文案——保证新分支没有把既有行为一起改掉。
+func TestBotOwnerSelfRemoval_NormalRemovalStillSendsKickNotice(t *testing.T) {
+	s, ctx := newTestServer(t)
+	f := New(ctx)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	stub := newGroupIMStub(t, ctx)
+	wireI18nRendererForGroupTest(s)
+
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: "owner_other", Name: "group-owner", ShortNo: "uo_kick"}))
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: "victim", Name: "victim", ShortNo: "uv_kick"}))
+	require.NoError(t, f.db.Insert(&Model{
+		GroupNo: selfRemovalGroupNo, Name: "kick group", Creator: "owner_other",
+		Status: GroupStatusNormal, Version: 1,
+	}))
+	seedSelfRemovalMember(t, f, "owner_other", MemberRoleCreator, 0)
+	seedSelfRemovalMember(t, f, "victim", MemberRoleCommon, 0)
+
+	_, err := f.groupService.RemoveGroupMembers(&RemoveGroupMembersServiceReq{
+		GroupNo:      selfRemovalGroupNo,
+		Members:      []string{"victim"},
+		OperatorUID:  "owner_other",
+		OperatorName: "group-owner",
+	})
+	require.NoError(t, err)
+
+	payloads := stub.sentPayloads()
+	assert.True(t, payloadsContain(payloads, "移除群聊"),
+		"常规踢人仍应发出原有的「被移除」系统消息")
+	assert.False(t, payloadsContain(payloads, "将机器人"),
+		"常规踢人不应发 bot owner Tip")
 }
 
 // 验收 10：bot_owned_by_me 的下发口径——自己的 bot 为 true，

--- a/modules/group/api_bot_owner_self_removal_test.go
+++ b/modules/group/api_bot_owner_self_removal_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
@@ -256,6 +257,10 @@ func TestBotOwnerSelfRemoval_RepeatRemovalIsNotServerError(t *testing.T) {
 	second := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{"bot_twice"})
 	assert.Less(t, second.Code, http.StatusInternalServerError,
 		"重复移除应是业务错误而非 5xx，实际: %d %s", second.Code, second.Body.String())
+	// 必须是「不在群内」而不是「无权移除」：白名单按 is_deleted=0 过滤，已移除的
+	// bot 天然掉出白名单，若直接回权限错误，用户会看到「你没有权限移除自己的 bot」。
+	assert.Contains(t, second.Body.String(), "not_in_group",
+		"重复移除应回「成员不在群内」，实际: %s", second.Body.String())
 }
 
 // 验收 7：自助路径不发「你被 X 移除群聊」，改发 owner 视角的 Tip。
@@ -371,6 +376,62 @@ func TestBotOwnerSelfRemoval_MembersGetExposesBotOwnedByMe(t *testing.T) {
 	assert.False(t, flags["bot_other_flag"], "他人名下的 bot 应为 false")
 	assert.False(t, flags[testutil.UID], "人类成员应恒为 false")
 	assert.False(t, flags["owner_other"], "人类成员应恒为 false")
+}
+
+// 被拉黑的成员（status=Blacklist、is_deleted=0）不得借自助分支获得写操作。
+//
+// 上面那层 QueryMemberWithUID 只过滤 is_deleted，会把被拉黑成员当作仍在群
+// （见 db.go QueryActiveMemberGroupNosWithUID 的约定）；而 QueryBotUIDsOwnedByUIDs
+// 故意不过滤 group_member.status（拉黑级联要靠它恢复），所以拉黑门必须由
+// handler 显式来把。少了它，被拉黑的人能改群成员表并往群里写一条持久化 Tip。
+func TestBotOwnerSelfRemoval_RejectsBlacklistedOperator(t *testing.T) {
+	f, handler, ctx := setupBotSelfRemovalGroup(t)
+	newGroupIMStub(t, ctx)
+	seedSelfRemovalBot(t, f, "bot_of_blacklisted", "bot", testutil.UID, 1)
+
+	_, err := f.ctx.DB().UpdateBySql(
+		"UPDATE group_member SET status=? WHERE group_no=? AND uid=?",
+		int(common.GroupMemberStatusBlacklist), selfRemovalGroupNo, testutil.UID,
+	).Exec()
+	require.NoError(t, err)
+
+	w := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{"bot_of_blacklisted"})
+	assert.NotEqual(t, http.StatusOK, w.Code, "被拉黑成员不得移除任何成员")
+
+	exist, err := f.db.ExistMember("bot_of_blacklisted", selfRemovalGroupNo)
+	require.NoError(t, err)
+	assert.True(t, exist, "bot 应仍在群内")
+}
+
+// memberGet 也要如实下发 bot_owned_by_me（验收 10 的「三处同名同型」）。
+//
+// 这条同时钉住 queryMemberWithGroupNoAndUID 的选择列必须含 group_member.robot：
+// 漏选时 Robot 恒为 0，fillBotOwnedByMe 的前置判据直接短路，字段静默恒 false。
+func TestBotOwnerSelfRemoval_MemberGetExposesBotOwnedByMe(t *testing.T) {
+	f, handler, ctx := setupBotSelfRemovalGroup(t)
+	newGroupIMStub(t, ctx)
+	seedSelfRemovalBot(t, f, "bot_single_get", "mine", testutil.UID, 1)
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET",
+		"/v1/groups/"+selfRemovalGroupNo+"/members/bot_single_get", nil)
+	require.NoError(t, err)
+	req.Header.Set("token", testutil.Token)
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "单成员查询应可读: %s", w.Body.String())
+
+	var resp struct {
+		Exists bool `json:"exists"`
+		Member struct {
+			UID          string `json:"uid"`
+			Robot        int    `json:"robot"`
+			BotOwnedByMe bool   `json:"bot_owned_by_me"`
+		} `json:"member"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Exists)
+	assert.Equal(t, 1, resp.Member.Robot, "robot 必须被下发，否则回填会静默失效")
+	assert.True(t, resp.Member.BotOwnedByMe, "memberGet 也要如实下发 bot_owned_by_me")
 }
 
 // 验收 9：自助移除同样要清理该 bot 在本群所有子区的成员身份。

--- a/modules/group/api_bot_owner_self_removal_test.go
+++ b/modules/group/api_bot_owner_self_removal_test.go
@@ -121,6 +121,8 @@ func TestBotOwnerSelfRemoval_RejectsOthersBot(t *testing.T) {
 
 	w := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{"bot_theirs"})
 	assert.NotEqual(t, http.StatusOK, w.Code, "不得移除他人名下的 bot")
+	assert.Contains(t, w.Body.String(), "member_cannot_remove",
+		"应回「无权移除」而不是别的错误（例如查询失败的 5xx），实际: %s", w.Body.String())
 
 	exist, err := f.db.ExistMember("bot_theirs", selfRemovalGroupNo)
 	require.NoError(t, err)
@@ -139,6 +141,8 @@ func TestBotOwnerSelfRemoval_RejectsHumanTarget(t *testing.T) {
 
 	w := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{"human_peer"})
 	assert.NotEqual(t, http.StatusOK, w.Code, "普通成员不得移除人类成员（提权防线）")
+	assert.Contains(t, w.Body.String(), "member_cannot_remove",
+		"应回「无权移除」，实际: %s", w.Body.String())
 
 	exist, err := f.db.ExistMember("human_peer", selfRemovalGroupNo)
 	require.NoError(t, err)
@@ -155,6 +159,8 @@ func TestBotOwnerSelfRemoval_RejectsMixedBatch(t *testing.T) {
 
 	w := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{"bot_mine_mix", "human_mix"})
 	assert.NotEqual(t, http.StatusOK, w.Code, "混合批次必须整批拒绝")
+	assert.Contains(t, w.Body.String(), "member_cannot_remove",
+		"应回「无权移除」，实际: %s", w.Body.String())
 
 	// 关键：连自己那只 bot 也不能被顺带移除，否则就是部分执行。
 	botExist, err := f.db.ExistMember("bot_mine_mix", selfRemovalGroupNo)
@@ -175,6 +181,8 @@ func TestBotOwnerSelfRemoval_RejectsOrphanAndDisabledBot(t *testing.T) {
 	for _, uid := range []string{"bot_orphan_rm", "bot_disabled_rm"} {
 		w := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{uid})
 		assert.NotEqual(t, http.StatusOK, w.Code, "%s 应 fail-closed 拒绝", uid)
+		assert.Contains(t, w.Body.String(), "member_cannot_remove",
+			"%s 应回「无权移除」，实际: %s", uid, w.Body.String())
 		exist, err := f.db.ExistMember(uid, selfRemovalGroupNo)
 		require.NoError(t, err)
 		assert.True(t, exist, "%s 应仍在群内", uid)
@@ -216,6 +224,8 @@ func TestBotOwnerSelfRemoval_ScopedToRequestedGroup(t *testing.T) {
 	// 对 B 群请求移除只存在于 A 群的 bot。
 	w := deleteMembersReq(t, handler, otherGroupNo, []string{"bot_in_a"})
 	assert.NotEqual(t, http.StatusOK, w.Code, "不得跨群移除")
+	assert.Contains(t, w.Body.String(), "not_in_group",
+		"目标不在本群，应回「不在群内」，实际: %s", w.Body.String())
 
 	exist, err := f.db.ExistMember("bot_in_a", selfRemovalGroupNo)
 	require.NoError(t, err)
@@ -239,6 +249,8 @@ func TestBotOwnerSelfRemoval_RejectsCreatorRoleBot(t *testing.T) {
 
 	w := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{"bot_creator_role"})
 	assert.NotEqual(t, http.StatusOK, w.Code, "Creator 角色目标必须显式拒绝，不能回 200 却没动")
+	assert.Contains(t, w.Body.String(), "cannot_remove_owner",
+		"应回「不能移除群主」，实际: %s", w.Body.String())
 
 	exist, err := f.db.ExistMember("bot_creator_role", selfRemovalGroupNo)
 	require.NoError(t, err)
@@ -488,6 +500,8 @@ func TestBotOwnerSelfRemoval_RejectsBlacklistedOperator(t *testing.T) {
 
 	w := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{"bot_of_blacklisted"})
 	assert.NotEqual(t, http.StatusOK, w.Code, "被拉黑成员不得移除任何成员")
+	assert.Contains(t, w.Body.String(), "member_cannot_remove",
+		"应回「无权移除」，实际: %s", w.Body.String())
 
 	exist, err := f.db.ExistMember("bot_of_blacklisted", selfRemovalGroupNo)
 	require.NoError(t, err)
@@ -523,6 +537,177 @@ func TestBotOwnerSelfRemoval_MemberGetExposesBotOwnedByMe(t *testing.T) {
 	assert.True(t, resp.Exists)
 	assert.Equal(t, 1, resp.Member.Robot, "robot 必须被下发，否则回填会静默失效")
 	assert.True(t, resp.Member.BotOwnedByMe, "memberGet 也要如实下发 bot_owned_by_me")
+}
+
+// 被授予群角色（Manager / Creator）的 bot 不走自助路径。
+//
+// 白名单按所有权圈定目标、不过滤 role，而 managerAdd 不排除 robot，所以
+// Manager 角色的 bot 构造得出来。若不拦：普通成员能移除一个群管理员，而真正的
+// 管理员反而不能移除另一个管理员，权限阶梯倒挂。维护者拍板的「所有权优先」
+// 针对的是 bot_admin 列，group_member.role 是更强的授予，不在其覆盖范围。
+func TestBotOwnerSelfRemoval_RejectsManagerRoleBot(t *testing.T) {
+	f, handler, ctx := setupBotSelfRemovalGroup(t)
+	newGroupIMStub(t, ctx)
+
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: "bot_mgr", Name: "mgr-bot", ShortNo: "bmgr", Robot: 1}))
+	_, err := f.ctx.DB().InsertBySql(
+		"INSERT INTO robot (robot_id, status, creator_uid) VALUES (?, 1, ?)", "bot_mgr", testutil.UID,
+	).Exec()
+	require.NoError(t, err)
+	seedSelfRemovalMember(t, f, "bot_mgr", MemberRoleManager, 1)
+
+	w := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{"bot_mgr"})
+	assert.NotEqual(t, http.StatusOK, w.Code, "Manager 角色的 bot 不应走自助路径")
+	assert.Contains(t, w.Body.String(), "cannot_remove_admin",
+		"应回「不能移除管理员」，实际: %s", w.Body.String())
+
+	exist, err := f.db.ExistMember("bot_mgr", selfRemovalGroupNo)
+	require.NoError(t, err)
+	assert.True(t, exist, "Manager 角色的 bot 应仍在群内")
+}
+
+// 回填必须与移除授权同口径：被拉黑的所有者不该拿到 bot_owned_by_me=true。
+//
+// 移除的授权是两个谓词（活跃成员 + 所有权白名单）。回填若只判所有权，被拉黑的
+// 所有者仍能拉到成员列表、看到移除按钮，点下去被拒 —— 按钮与权限打架。
+func TestBotOwnerSelfRemoval_BlacklistedOwnerGetsNoOwnershipFlag(t *testing.T) {
+	f, handler, ctx := setupBotSelfRemovalGroup(t)
+	newGroupIMStub(t, ctx)
+	seedSelfRemovalBot(t, f, "bot_bl_flag", "mine", testutil.UID, 1)
+
+	_, err := f.ctx.DB().UpdateBySql(
+		"UPDATE group_member SET status=? WHERE group_no=? AND uid=?",
+		int(common.GroupMemberStatusBlacklist), selfRemovalGroupNo, testutil.UID,
+	).Exec()
+	require.NoError(t, err)
+
+	flags := membersGetOwnershipFlags(t, handler, selfRemovalGroupNo)
+	assert.False(t, flags["bot_bl_flag"],
+		"被拉黑的所有者不应拿到 bot_owned_by_me=true —— 否则按钮可见但请求必被拒")
+}
+
+// 角色 bot 同理：既然自助路径拒绝它，回填也不该把它标成可移除。
+func TestBotOwnerSelfRemoval_RoleBotGetsNoOwnershipFlag(t *testing.T) {
+	f, handler, ctx := setupBotSelfRemovalGroup(t)
+	newGroupIMStub(t, ctx)
+
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: "bot_mgr_flag", Name: "mgr", ShortNo: "bmgrf", Robot: 1}))
+	_, err := f.ctx.DB().InsertBySql(
+		"INSERT INTO robot (robot_id, status, creator_uid) VALUES (?, 1, ?)", "bot_mgr_flag", testutil.UID,
+	).Exec()
+	require.NoError(t, err)
+	seedSelfRemovalMember(t, f, "bot_mgr_flag", MemberRoleManager, 1)
+	seedSelfRemovalBot(t, f, "bot_plain_flag", "plain", testutil.UID, 1)
+
+	flags := membersGetOwnershipFlags(t, handler, selfRemovalGroupNo)
+	assert.False(t, flags["bot_mgr_flag"], "Manager 角色的 bot 不应被标成可移除")
+	assert.True(t, flags["bot_plain_flag"], "对照：普通角色的自有 bot 仍应为 true")
+}
+
+// membersync 是三个下发端点里最后一个 —— 也是 Android WKSDK ChannelMember 缓存的
+// 唯一增量来源、「缺失=false」降级语义的所在。此前只测了 members 与 members/:uid，
+// 而「漏选列导致字段静默恒 false」正是本任务在 memberGet 上真实踩过的坑。
+func TestBotOwnerSelfRemoval_MemberSyncExposesBotOwnedByMe(t *testing.T) {
+	f, handler, ctx := setupBotSelfRemovalGroup(t)
+	newGroupIMStub(t, ctx)
+	seedSelfRemovalBot(t, f, "bot_sync_mine", "mine", testutil.UID, 1)
+	seedSelfRemovalBot(t, f, "bot_sync_other", "theirs", "owner_other", 1)
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET",
+		"/v1/groups/"+selfRemovalGroupNo+"/membersync?version=0&limit=100", nil)
+	require.NoError(t, err)
+	req.Header.Set("token", testutil.Token)
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "membersync 应可读: %s", w.Body.String())
+
+	var members []map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &members))
+	flags := map[string]bool{}
+	for _, m := range members {
+		uid, _ := m["uid"].(string)
+		owned, present := m["bot_owned_by_me"].(bool)
+		require.True(t, present, "membersync 的每一行都应带 bot_owned_by_me（uid=%s）", uid)
+		flags[uid] = owned
+	}
+	assert.True(t, flags["bot_sync_mine"], "自己名下的 bot 应为 true")
+	assert.False(t, flags["bot_sync_other"], "他人名下的 bot 应为 false")
+	assert.False(t, flags[testutil.UID], "人类成员应恒为 false")
+}
+
+// membersGetOwnershipFlags 拉一次成员列表，返回 uid -> bot_owned_by_me。
+func membersGetOwnershipFlags(t *testing.T, handler http.Handler, groupNo string) map[string]bool {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/v1/groups/"+groupNo+"/members?page=1&limit=50", nil)
+	require.NoError(t, err)
+	req.Header.Set("token", testutil.Token)
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "成员列表应可读: %s", w.Body.String())
+
+	var members []map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &members))
+	flags := map[string]bool{}
+	for _, m := range members {
+		uid, _ := m["uid"].(string)
+		owned, _ := m["bot_owned_by_me"].(bool)
+		flags[uid] = owned
+	}
+	return flags
+}
+
+// 移除 → 加回 的完整往返：成员身份、所有权标记、以及**再次移除**都要正常。
+//
+// 自助移除天然是可逆操作（memberAdd 的 ownership 校验允许所有者拉自己的 bot），
+// 所以「加回来之后还能不能正常用」和「移除本身」同等重要：
+//   - 成员行要真的回来（软删 + recoverMemberTx 复活，不是插新行）；
+//   - bot_owned_by_me 要恢复 true，否则前端按钮回不来，用户第二次就撤不掉了；
+//   - 再移除一次要能成功，证明这不是个一次性能力。
+func TestBotOwnerSelfRemoval_ReAddThenRemoveAgainWorks(t *testing.T) {
+	f, handler, ctx := setupBotSelfRemovalGroup(t)
+	newGroupIMStub(t, ctx)
+	_, _ = ctx.DB().InsertBySql(
+		"INSERT INTO app_config (version, invite_system_account_join_group_on) VALUES (1, 1)",
+	).Exec()
+	seedSelfRemovalBot(t, f, "bot_cycle", "cycle-bot", testutil.UID, 1)
+
+	addBack := func() *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		body := util.ToJson(map[string]interface{}{"members": []string{"bot_cycle"}})
+		req, err := http.NewRequest("POST",
+			"/v1/groups/"+selfRemovalGroupNo+"/members", bytes.NewReader([]byte(body)))
+		require.NoError(t, err)
+		req.Header.Set("token", testutil.Token)
+		handler.ServeHTTP(w, req)
+		return w
+	}
+
+	// --- 第一轮移除 ---
+	w := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{"bot_cycle"})
+	require.Equal(t, http.StatusOK, w.Code, "首次移除应成功: %s", w.Body.String())
+	exist, err := f.db.ExistMember("bot_cycle", selfRemovalGroupNo)
+	require.NoError(t, err)
+	require.False(t, exist, "首次移除后 bot 应不在群内")
+	assert.False(t, membersGetOwnershipFlags(t, handler, selfRemovalGroupNo)["bot_cycle"],
+		"已移除的 bot 不应再出现在成员列表里并带 true")
+
+	// --- 加回来 ---
+	addW := addBack()
+	require.Equal(t, http.StatusOK, addW.Code, "所有者应能把自己的 bot 加回来: %s", addW.Body.String())
+	exist, err = f.db.ExistMember("bot_cycle", selfRemovalGroupNo)
+	require.NoError(t, err)
+	assert.True(t, exist, "加回后 bot 应重新在群内")
+
+	// 所有权标记必须恢复，否则前端按钮回不来，用户第二次就没有入口了。
+	assert.True(t, membersGetOwnershipFlags(t, handler, selfRemovalGroupNo)["bot_cycle"],
+		"加回后 bot_owned_by_me 必须恢复 true，否则移除入口一次性失效")
+
+	// --- 第二轮移除：证明这不是一次性能力 ---
+	w2 := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{"bot_cycle"})
+	assert.Equal(t, http.StatusOK, w2.Code, "加回后应能再次移除: %s", w2.Body.String())
+	exist, err = f.db.ExistMember("bot_cycle", selfRemovalGroupNo)
+	require.NoError(t, err)
+	assert.False(t, exist, "第二次移除后 bot 应再次不在群内")
 }
 
 // 验收 9：自助移除同样要清理该 bot 在本群所有子区的成员身份。

--- a/modules/group/api_bot_owner_self_removal_test.go
+++ b/modules/group/api_bot_owner_self_removal_test.go
@@ -1,0 +1,376 @@
+package group
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 自助移除 bot 的鉴权矩阵（task bot-owner-self-removal / octo-web#1511）。
+//
+// 与 api_bot_ownership_test.go 的区别：那组测的是**入群侧** ownership
+// （checkBotOwnership），本组测的是**移除侧**——调用方 testutil.UID 在这里恒为
+// MemberRoleCommon（普通成员），群主另有其人，所以走的正是新开的自助分支。
+//
+// 最关键的一条是 TestBotOwnerSelfRemoval_RejectsHumanTarget：它钉住「自助路径
+// 不得移除人类成员」。若有人日后把判据换成 checkBotOwnership（对非 bot 返回 nil），
+// 这条会立刻红——那是一个提权漏洞，不是风格问题。
+
+const selfRemovalGroupNo = "g_bot_self_rm"
+
+// setupBotSelfRemovalGroup 建一个群：testutil.UID 是**普通成员**，群主是 owner_other。
+// 返回的 *Group 用于直接做 DB 断言/播种。
+func setupBotSelfRemovalGroup(t *testing.T) (*Group, http.Handler, *config.Context) {
+	t.Helper()
+	s, ctx := newTestServer(t)
+	f := New(ctx)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	// 移除路由自本任务起挂了 SharedUIDRateLimiter，其桶存活在 Redis 里且不被
+	// CleanAllTables 清理；不重置会让同包其它用例的配额溢出到这里。
+	resetGroupUIDRateLimit(t, ctx)
+
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: testutil.UID, Name: "bot-owner", ShortNo: "uc_self_rm"}))
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: "owner_other", Name: "group-owner", ShortNo: "uo_self_rm"}))
+
+	require.NoError(t, f.db.Insert(&Model{
+		GroupNo: selfRemovalGroupNo, Name: "bot self removal", Creator: "owner_other",
+		Status: GroupStatusNormal, Version: 1,
+	}))
+	seedSelfRemovalMember(t, f, "owner_other", MemberRoleCreator, 0)
+	seedSelfRemovalMember(t, f, testutil.UID, MemberRoleCommon, 0)
+
+	wireI18nRendererForGroupTest(s)
+	return f, s.GetRoute(), ctx
+}
+
+func seedSelfRemovalMember(t *testing.T, f *Group, uid string, role, robot int) {
+	t.Helper()
+	require.NoError(t, f.db.InsertMember(&MemberModel{
+		GroupNo: selfRemovalGroupNo, UID: uid, Role: role, Robot: robot,
+		Status: 1, Version: 1, Vercode: fmt.Sprintf("%s@1", util.GenerUUID()),
+	}))
+}
+
+// seedSelfRemovalBot 建 bot 用户 + robot 行 + 群成员行（group_member.robot=1）。
+// creatorUID 为空则不建 robot 行 —— 孤儿 bot，任何人都不拥有它。
+func seedSelfRemovalBot(t *testing.T, f *Group, uid, name, creatorUID string, robotStatus int) {
+	t.Helper()
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: uid, Name: name, ShortNo: uid, Robot: 1}))
+	if creatorUID != "" {
+		_, err := f.ctx.DB().InsertBySql(
+			"INSERT INTO robot (robot_id, status, creator_uid) VALUES (?, ?, ?)",
+			uid, robotStatus, creatorUID,
+		).Exec()
+		require.NoError(t, err)
+	}
+	seedSelfRemovalMember(t, f, uid, MemberRoleCommon, 1)
+}
+
+func deleteMembersReq(t *testing.T, handler http.Handler, groupNo string, members []string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	body := util.ToJson(map[string]interface{}{"members": members})
+	req, err := http.NewRequest("DELETE", "/v1/groups/"+groupNo+"/members", bytes.NewReader([]byte(body)))
+	require.NoError(t, err)
+	req.Header.Set("token", testutil.Token)
+	handler.ServeHTTP(w, req)
+	return w
+}
+
+func postMembersDeleteReq(t *testing.T, handler http.Handler, groupNo string, members []string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	body := util.ToJson(map[string]interface{}{"members": members})
+	req, err := http.NewRequest("POST", "/v1/groups/"+groupNo+"/members_delete", bytes.NewReader([]byte(body)))
+	require.NoError(t, err)
+	req.Header.Set("token", testutil.Token)
+	handler.ServeHTTP(w, req)
+	return w
+}
+
+// 验收 1：普通成员移除自己名下的 bot → 200，且成员行真的没了。
+func TestBotOwnerSelfRemoval_OwnBotSucceeds(t *testing.T) {
+	f, handler, ctx := setupBotSelfRemovalGroup(t)
+	newGroupIMStub(t, ctx)
+	seedSelfRemovalBot(t, f, "bot_mine", "my-bot", testutil.UID, 1)
+
+	w := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{"bot_mine"})
+	assert.Equal(t, http.StatusOK, w.Code, "普通成员应能移除自己名下的 bot: %s", w.Body.String())
+
+	exist, err := f.db.ExistMember("bot_mine", selfRemovalGroupNo)
+	require.NoError(t, err)
+	assert.False(t, exist, "bot 应已不在群内")
+}
+
+// 验收 2：他人名下的 bot → 拒绝，且成员关系不变。
+func TestBotOwnerSelfRemoval_RejectsOthersBot(t *testing.T) {
+	f, handler, ctx := setupBotSelfRemovalGroup(t)
+	newGroupIMStub(t, ctx)
+	seedSelfRemovalBot(t, f, "bot_theirs", "their-bot", "owner_other", 1)
+
+	w := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{"bot_theirs"})
+	assert.NotEqual(t, http.StatusOK, w.Code, "不得移除他人名下的 bot")
+
+	exist, err := f.db.ExistMember("bot_theirs", selfRemovalGroupNo)
+	require.NoError(t, err)
+	assert.True(t, exist, "他人的 bot 应仍在群内")
+}
+
+// 验收 3（核心回归防线）：普通成员不得借自助路径移除**人类**成员。
+//
+// 这一条专防「把判据换成 checkBotOwnership」——后者的 SQL 是 WHERE u.robot = 1，
+// 人类 UID 查不出行、循环不拒绝，等于放开踢人权限。
+func TestBotOwnerSelfRemoval_RejectsHumanTarget(t *testing.T) {
+	f, handler, ctx := setupBotSelfRemovalGroup(t)
+	newGroupIMStub(t, ctx)
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: "human_peer", Name: "peer", ShortNo: "hp_self_rm"}))
+	seedSelfRemovalMember(t, f, "human_peer", MemberRoleCommon, 0)
+
+	w := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{"human_peer"})
+	assert.NotEqual(t, http.StatusOK, w.Code, "普通成员不得移除人类成员（提权防线）")
+
+	exist, err := f.db.ExistMember("human_peer", selfRemovalGroupNo)
+	require.NoError(t, err)
+	assert.True(t, exist, "人类成员必须仍在群内")
+}
+
+// 验收 4：混合批次整批拒绝，不得部分执行。
+func TestBotOwnerSelfRemoval_RejectsMixedBatch(t *testing.T) {
+	f, handler, ctx := setupBotSelfRemovalGroup(t)
+	newGroupIMStub(t, ctx)
+	seedSelfRemovalBot(t, f, "bot_mine_mix", "my-bot", testutil.UID, 1)
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: "human_mix", Name: "peer", ShortNo: "hm_self_rm"}))
+	seedSelfRemovalMember(t, f, "human_mix", MemberRoleCommon, 0)
+
+	w := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{"bot_mine_mix", "human_mix"})
+	assert.NotEqual(t, http.StatusOK, w.Code, "混合批次必须整批拒绝")
+
+	// 关键：连自己那只 bot 也不能被顺带移除，否则就是部分执行。
+	botExist, err := f.db.ExistMember("bot_mine_mix", selfRemovalGroupNo)
+	require.NoError(t, err)
+	assert.True(t, botExist, "整批拒绝时自己的 bot 也不应被移除（不得部分执行）")
+	humanExist, err := f.db.ExistMember("human_mix", selfRemovalGroupNo)
+	require.NoError(t, err)
+	assert.True(t, humanExist, "人类成员不应被移除")
+}
+
+// 验收 5：孤儿 bot（无 robot 行）与禁用 bot（status!=1）均 fail-closed。
+func TestBotOwnerSelfRemoval_RejectsOrphanAndDisabledBot(t *testing.T) {
+	f, handler, ctx := setupBotSelfRemovalGroup(t)
+	newGroupIMStub(t, ctx)
+	seedSelfRemovalBot(t, f, "bot_orphan_rm", "orphan", "", 0)
+	seedSelfRemovalBot(t, f, "bot_disabled_rm", "disabled", testutil.UID, 0)
+
+	for _, uid := range []string{"bot_orphan_rm", "bot_disabled_rm"} {
+		w := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{uid})
+		assert.NotEqual(t, http.StatusOK, w.Code, "%s 应 fail-closed 拒绝", uid)
+		exist, err := f.db.ExistMember(uid, selfRemovalGroupNo)
+		require.NoError(t, err)
+		assert.True(t, exist, "%s 应仍在群内", uid)
+	}
+}
+
+// 验收 8：两条路由（DELETE /members 与别名 POST /members_delete）行为一致。
+func TestBotOwnerSelfRemoval_BothRoutesBehaveSame(t *testing.T) {
+	f, handler, ctx := setupBotSelfRemovalGroup(t)
+	newGroupIMStub(t, ctx)
+	seedSelfRemovalBot(t, f, "bot_alias", "alias-bot", testutil.UID, 1)
+
+	w := postMembersDeleteReq(t, handler, selfRemovalGroupNo, []string{"bot_alias"})
+	assert.Equal(t, http.StatusOK, w.Code, "别名路由应与 DELETE 行为一致: %s", w.Body.String())
+
+	exist, err := f.db.ExistMember("bot_alias", selfRemovalGroupNo)
+	require.NoError(t, err)
+	assert.False(t, exist, "bot 应已被别名路由移除")
+}
+
+// 验收 11：跨群作用域——我在 A 群拥有的 bot，不能通过对 B 群发请求而被移除。
+// 白名单查询按 groupNo 作用域，这条是防止后续重构把 groupNo 从判据里漏掉的钉子。
+func TestBotOwnerSelfRemoval_ScopedToRequestedGroup(t *testing.T) {
+	f, handler, ctx := setupBotSelfRemovalGroup(t)
+	newGroupIMStub(t, ctx)
+
+	// 另建 B 群：testutil.UID 也是普通成员，但他的 bot 只在 A 群里。
+	const otherGroupNo = "g_bot_self_rm_b"
+	require.NoError(t, f.db.Insert(&Model{
+		GroupNo: otherGroupNo, Name: "other group", Creator: "owner_other",
+		Status: GroupStatusNormal, Version: 1,
+	}))
+	require.NoError(t, f.db.InsertMember(&MemberModel{
+		GroupNo: otherGroupNo, UID: testutil.UID, Role: MemberRoleCommon,
+		Status: 1, Version: 1, Vercode: fmt.Sprintf("%s@1", util.GenerUUID()),
+	}))
+	seedSelfRemovalBot(t, f, "bot_in_a", "bot-in-a", testutil.UID, 1)
+
+	// 对 B 群请求移除只存在于 A 群的 bot。
+	w := deleteMembersReq(t, handler, otherGroupNo, []string{"bot_in_a"})
+	assert.NotEqual(t, http.StatusOK, w.Code, "不得跨群移除")
+
+	exist, err := f.db.ExistMember("bot_in_a", selfRemovalGroupNo)
+	require.NoError(t, err)
+	assert.True(t, exist, "A 群里的 bot 不应被 B 群的请求移除")
+}
+
+// 验收 12：自助路径不得静默成功——目标是 Creator 角色的 bot 时显式拒绝，
+// 而不是让 service 静默跳过后回 200。
+func TestBotOwnerSelfRemoval_RejectsCreatorRoleBot(t *testing.T) {
+	f, handler, ctx := setupBotSelfRemovalGroup(t)
+	newGroupIMStub(t, ctx)
+
+	// 一个归 testutil.UID 所有、但在群里是 Creator 角色的 bot（构造出的边界态）。
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: "bot_creator_role", Name: "creator-bot", ShortNo: "bcr", Robot: 1}))
+	_, err := f.ctx.DB().InsertBySql(
+		"INSERT INTO robot (robot_id, status, creator_uid) VALUES (?, 1, ?)",
+		"bot_creator_role", testutil.UID,
+	).Exec()
+	require.NoError(t, err)
+	seedSelfRemovalMember(t, f, "bot_creator_role", MemberRoleCreator, 1)
+
+	w := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{"bot_creator_role"})
+	assert.NotEqual(t, http.StatusOK, w.Code, "Creator 角色目标必须显式拒绝，不能回 200 却没动")
+
+	exist, err := f.db.ExistMember("bot_creator_role", selfRemovalGroupNo)
+	require.NoError(t, err)
+	assert.True(t, exist, "Creator 角色的 bot 应仍在群内")
+}
+
+// 验收 13：对已不在群内的 bot 重复移除 → 业务错误（不在群内），不得 5xx。
+func TestBotOwnerSelfRemoval_RepeatRemovalIsNotServerError(t *testing.T) {
+	f, handler, ctx := setupBotSelfRemovalGroup(t)
+	newGroupIMStub(t, ctx)
+	seedSelfRemovalBot(t, f, "bot_twice", "twice-bot", testutil.UID, 1)
+
+	first := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{"bot_twice"})
+	require.Equal(t, http.StatusOK, first.Code, "首次移除应成功: %s", first.Body.String())
+
+	second := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{"bot_twice"})
+	assert.Less(t, second.Code, http.StatusInternalServerError,
+		"重复移除应是业务错误而非 5xx，实际: %d %s", second.Code, second.Body.String())
+}
+
+// 验收 7：自助路径不发「你被 X 移除群聊」，改发 owner 视角的 Tip。
+//
+// 两条文案刻意可区分：旧的是「你被{0}移除群聊」，新的是「X 将机器人 Y 移出了群聊」
+// ——「移除群聊」与「移出了群聊」不互相包含，所以下面的片段匹配是准确的。
+func TestBotOwnerSelfRemoval_SendsOwnerTipNotKickNotice(t *testing.T) {
+	f, handler, ctx := setupBotSelfRemovalGroup(t)
+	stub := newGroupIMStub(t, ctx)
+	seedSelfRemovalBot(t, f, "bot_tip", "tip-bot", testutil.UID, 1)
+
+	w := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{"bot_tip"})
+	require.Equal(t, http.StatusOK, w.Code, "移除应成功: %s", w.Body.String())
+
+	payloads := stub.sentPayloads()
+	assert.False(t, payloadsContain(payloads, "移除群聊"),
+		"自助移除 bot 不应发出「你被 X 移除群聊」——那是被移除者视角的措辞")
+	assert.True(t, payloadsContain(payloads, "将机器人"),
+		"应发出 owner 视角的 Tip，让群成员知道 bot 为何消失")
+}
+
+// 验收 10：bot_owned_by_me 的下发口径——自己的 bot 为 true，
+// 他人的 bot 与人类成员恒为 false。
+func TestBotOwnerSelfRemoval_MembersGetExposesBotOwnedByMe(t *testing.T) {
+	f, handler, ctx := setupBotSelfRemovalGroup(t)
+	newGroupIMStub(t, ctx)
+	seedSelfRemovalBot(t, f, "bot_owned_flag", "mine", testutil.UID, 1)
+	seedSelfRemovalBot(t, f, "bot_other_flag", "theirs", "owner_other", 1)
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/v1/groups/"+selfRemovalGroupNo+"/members?page=1&limit=50", nil)
+	require.NoError(t, err)
+	req.Header.Set("token", testutil.Token)
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "成员列表应可读: %s", w.Body.String())
+
+	var members []map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &members))
+
+	flags := map[string]bool{}
+	for _, m := range members {
+		uid, _ := m["uid"].(string)
+		owned, present := m["bot_owned_by_me"].(bool)
+		require.True(t, present, "每个成员行都应带 bot_owned_by_me（uid=%s）", uid)
+		flags[uid] = owned
+	}
+	assert.True(t, flags["bot_owned_flag"], "自己名下的 bot 应为 true")
+	assert.False(t, flags["bot_other_flag"], "他人名下的 bot 应为 false")
+	assert.False(t, flags[testutil.UID], "人类成员应恒为 false")
+	assert.False(t, flags["owner_other"], "人类成员应恒为 false")
+}
+
+// 验收 9：自助移除同样要清理该 bot 在本群所有子区的成员身份。
+//
+// 这条不是新逻辑，而是 RemoveGroupMembers 既有的 removeUserFromGroupThreads 副作用；
+// 钉住它是为了防止后续有人给自助路径抄一条「轻量」删除分支，把清理漏掉——
+// 那会留下能经 bot 旁路读子区内容的残留成员行（同 YUJ-52 / #1189 的失败形状）。
+func TestBotOwnerSelfRemoval_AlsoCleansThreadMembership(t *testing.T) {
+	f, handler, ctx := setupBotSelfRemovalGroup(t)
+	newGroupIMStub(t, ctx)
+	ensureThreadTables(t, f)
+	seedSelfRemovalBot(t, f, "bot_thread", "thread-bot", testutil.UID, 1)
+
+	res, err := f.ctx.DB().InsertInto("thread").
+		Columns("short_id", "group_no", "name", "creator_uid", "status", "version").
+		Values("self_rm_thread", selfRemovalGroupNo, "sub", "owner_other", 1, 1).Exec()
+	require.NoError(t, err)
+	threadID, err := res.LastInsertId()
+	require.NoError(t, err)
+	_, err = f.ctx.DB().InsertInto("thread_member").
+		Columns("thread_id", "uid", "role", "version").
+		Values(threadID, "bot_thread", 0, 1).Exec()
+	require.NoError(t, err)
+
+	var preCount int
+	_, err = f.ctx.DB().Select("count(*)").From("thread_member").
+		Where("thread_id=? AND uid=?", threadID, "bot_thread").Load(&preCount)
+	require.NoError(t, err)
+	require.Equal(t, 1, preCount, "前置条件：bot 此刻应是子区成员")
+
+	w := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{"bot_thread"})
+	require.Equal(t, http.StatusOK, w.Code, "移除应成功: %s", w.Body.String())
+
+	var postCount int
+	_, err = f.ctx.DB().Select("count(*)").From("thread_member").
+		Where("thread_id=? AND uid=?", threadID, "bot_thread").Load(&postCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, postCount, "自助移除后 bot 的子区成员身份也应被清理")
+}
+
+// 验收 6 的补充：群主既有能力不受影响——群主仍可移除**他人**名下的 bot。
+// （自助分支只在 role 非 Creator/Manager 时才进入，不应挡住原有路径。）
+func TestBotOwnerSelfRemoval_CreatorStillRemovesAnyBot(t *testing.T) {
+	s, ctx := newTestServer(t)
+	f := New(ctx)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	resetGroupUIDRateLimit(t, ctx)
+	newGroupIMStub(t, ctx)
+	wireI18nRendererForGroupTest(s)
+
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: testutil.UID, Name: "the-owner", ShortNo: "own_any"}))
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: "member_x", Name: "member-x", ShortNo: "mx_any"}))
+	require.NoError(t, f.db.Insert(&Model{
+		GroupNo: selfRemovalGroupNo, Name: "owner removes any", Creator: testutil.UID,
+		Status: GroupStatusNormal, Version: 1,
+	}))
+	seedSelfRemovalMember(t, f, testutil.UID, MemberRoleCreator, 0)
+	seedSelfRemovalMember(t, f, "member_x", MemberRoleCommon, 0)
+	// bot 归 member_x 所有，不归群主所有。
+	seedSelfRemovalBot(t, f, "bot_of_x", "bot-of-x", "member_x", 1)
+
+	w := deleteMembersReq(t, s.GetRoute(), selfRemovalGroupNo, []string{"bot_of_x"})
+	assert.Equal(t, http.StatusOK, w.Code, "群主应仍可移除他人名下的 bot: %s", w.Body.String())
+
+	exist, err := f.db.ExistMember("bot_of_x", selfRemovalGroupNo)
+	require.NoError(t, err)
+	assert.False(t, exist, "群主移除应生效")
+}

--- a/modules/group/api_bot_owner_self_removal_test.go
+++ b/modules/group/api_bot_owner_self_removal_test.go
@@ -358,6 +358,53 @@ func TestBotOwnerSelfRemoval_UnsubscribesBotFromGroupChannel(t *testing.T) {
 		"其他成员不应被退订")
 }
 
+// bot_admin 不得跨越「撤走再拉回」存活。
+//
+// DeleteMemberTx 是软删（只置 is_deleted=1），整行连同 bot_admin 都留在表里；
+// recoverMemberTx 复活时只重置 remark/role/version/is_deleted/invite_uid/
+// is_external/source_space_id/created_at —— **不含 bot_admin**。
+//
+// 于是：群主给某个 bot 授过 bot_admin → 该 bot 的所有者把它撤走 → 再拉回来，
+// 它就悄悄又是 bot 管理员了，全程不需要群主参与。
+// 这个缺陷本身早于本功能，但此前普通成员根本撤不走 bot，这个来回做不出来；
+// 自助移除让它变得可达，所以由本任务负责堵上。
+func TestBotOwnerSelfRemoval_BotAdminDoesNotSurviveReAdd(t *testing.T) {
+	f, handler, ctx := setupBotSelfRemovalGroup(t)
+	newGroupIMStub(t, ctx)
+	// memberAdd 会读 app_config，缺行会 panic。
+	_, _ = ctx.DB().InsertBySql(
+		"INSERT INTO app_config (version, invite_system_account_join_group_on) VALUES (1, 1)",
+	).Exec()
+
+	seedSelfRemovalBot(t, f, "bot_readd", "readd-bot", testutil.UID, 1)
+	// 群主给它授了 bot_admin。
+	_, err := ctx.DB().UpdateBySql(
+		"UPDATE group_member SET bot_admin=1 WHERE group_no=? AND uid=?",
+		selfRemovalGroupNo, "bot_readd",
+	).Exec()
+	require.NoError(t, err)
+
+	// 所有者自助撤走。
+	w := deleteMembersReq(t, handler, selfRemovalGroupNo, []string{"bot_readd"})
+	require.Equal(t, http.StatusOK, w.Code, "移除应成功: %s", w.Body.String())
+
+	// 再拉回来（memberAdd 的 ownership 校验允许所有者拉自己的 bot）。
+	addW := httptest.NewRecorder()
+	addBody := util.ToJson(map[string]interface{}{"members": []string{"bot_readd"}})
+	addReq, err := http.NewRequest("POST",
+		"/v1/groups/"+selfRemovalGroupNo+"/members", bytes.NewReader([]byte(addBody)))
+	require.NoError(t, err)
+	addReq.Header.Set("token", testutil.Token)
+	handler.ServeHTTP(addW, addReq)
+	require.Equal(t, http.StatusOK, addW.Code, "重新拉回应成功: %s", addW.Body.String())
+
+	detail, err := f.db.queryMemberWithGroupNoAndUID(selfRemovalGroupNo, "bot_readd")
+	require.NoError(t, err)
+	require.NotNil(t, detail, "bot 应已重新在群内")
+	assert.Equal(t, 0, detail.BotAdmin,
+		"bot_admin 不得跨越『撤走再拉回』存活 —— 否则所有者可以绕过群主重新拿到管理员位")
+}
+
 // 对照组：同一条 service 路径在**不**置位 BotOwnerSelfRemoval 时，
 // 仍然发原来的「被移除」文案——保证新分支没有把既有行为一起改掉。
 func TestBotOwnerSelfRemoval_NormalRemovalStillSendsKickNotice(t *testing.T) {

--- a/modules/group/api_groupexit_cascade_thread_test.go
+++ b/modules/group/api_groupexit_cascade_thread_test.go
@@ -138,7 +138,7 @@ func TestGroupExit_CascadeBot_AlsoRemovesFromThread(t *testing.T) {
 	require.NoError(t, f.db.DeleteMemberTx(groupNo, "leaver", leaverVersion, tx))
 
 	// 4b. 级联带走 leaver 拉入的 bot（api.go cascade 分支入口）
-	cascadedUIDs, err := cascadeRemoveBotsInvitedByUIDTx(f.db, f.ctx, groupNo, "leaver", tx)
+	cascadedUIDs, err := cascadeRemoveBotsInvitedByUIDTx(f.db, f.ctx, groupNo, "leaver", false, tx)
 	require.NoError(t, err)
 	require.NoError(t, tx.Commit())
 	require.ElementsMatch(t, []string{botUID}, cascadedUIDs, "cascade SQL 必须挑中 leaver 自己的 bot")

--- a/modules/group/api_i18n_regression_test.go
+++ b/modules/group/api_i18n_regression_test.go
@@ -135,6 +135,11 @@ func TestManagerMemberRemove_NotInGroupIsNotFound(t *testing.T) {
 
 	err := testutil.CleanAllTables(ctx)
 	assert.NoError(t, err)
+	// DELETE /v1/groups/:group_no/members 自 bot-owner-self-removal 起挂了
+	// SharedUIDRateLimiter。该桶是进程级共享、存活在 Redis 里，且不被
+	// CleanAllTables 清理 —— 不重置的话，前序用例耗掉配额后这里会拿到 429，
+	// 断言 400 就会失败（-shuffle 下尤其容易命中）。
+	resetGroupUIDRateLimit(t, ctx)
 
 	// Promote the test caller to SuperAdmin so memberRemove takes the
 	// management path that skips the normal-member pre-check.

--- a/modules/group/api_test.go
+++ b/modules/group/api_test.go
@@ -45,10 +45,48 @@ func TestMain(m *testing.M) {
 		// package's main_test.go already sets the correct collation here;
 		// keep group's manually-built fixture in sync.
 		db.Exec("CREATE TABLE IF NOT EXISTS `robot` (`id` BIGINT AUTO_INCREMENT PRIMARY KEY, `robot_id` VARCHAR(40) NOT NULL DEFAULT '', `token` VARCHAR(100) NOT NULL DEFAULT '', `version` BIGINT NOT NULL DEFAULT 0, `status` SMALLINT NOT NULL DEFAULT 1, `creator_uid` VARCHAR(40) NOT NULL DEFAULT '', `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci")
-		db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS `robot_id_robot_index` ON `robot` (`robot_id`)")
+		// MySQL 8.0 不支持 `CREATE INDEX ... IF NOT EXISTS`（那是 MariaDB/Postgres
+		// 的写法），原来的写法每次都以 1064 语法错误静默失败——db.Exec 的 error
+		// 没人看，于是这两个索引在本 package 的测试库里从来就不存在。
+		//
+		// 后果不只是「少个索引」：级联移除用的
+		//   SELECT ... FROM group_member gm JOIN robot r ON r.robot_id = gm.uid
+		//   WHERE ... AND r.creator_uid = ? FOR UPDATE
+		// 在没有 idx_robot_creator_uid 时退化成 robot 全表扫描，且因为带 FOR UPDATE，
+		// 会把**整张 robot 表**加上 X 锁。实测：无索引时 120 次高争用并发操作里有 8 次
+		// 撞上 MySQL 死锁（1213）；补上索引后 360 次并发操作 0 死锁。也就是说测试库
+		// 此前一直在跑一个比线上严苛得多、且与线上不同的锁形态。
+		//
+		// 线上这两个索引由 modules/robot 的迁移建立
+		// （20210926000001 建 robot_id 唯一索引，20260226000002 建 idx_robot_creator_uid），
+		// 但 modules/robot 不在本 package 的依赖集里，迁移不会跑，只能在这里手工对齐。
+		ensureRobotTestIndex(db, "robot_id_robot_index",
+			"CREATE UNIQUE INDEX `robot_id_robot_index` ON `robot` (`robot_id`)")
+		ensureRobotTestIndex(db, "idx_robot_creator_uid",
+			"CREATE INDEX `idx_robot_creator_uid` ON `robot` (`creator_uid`)")
 		db.Exec("CREATE TABLE IF NOT EXISTS `robot_menu` (`id` BIGINT AUTO_INCREMENT PRIMARY KEY, `robot_id` VARCHAR(40) NOT NULL DEFAULT '', `cmd` VARCHAR(100) NOT NULL DEFAULT '', `remark` VARCHAR(100) NOT NULL DEFAULT '', `type` VARCHAR(100) NOT NULL DEFAULT '', `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci")
 	}
 	os.Exit(m.Run())
+}
+
+// ensureRobotTestIndex 幂等地补一个 robot 表索引：MySQL 没有 CREATE INDEX 的
+// IF NOT EXISTS，只能先查 information_schema 再建。建失败直接 panic —— 索引缺失
+// 会让 FOR UPDATE 级联查询退化成全表加锁，静默吞掉正是这段代码原来的 bug。
+func ensureRobotTestIndex(db *sql.DB, indexName, ddl string) {
+	var n int
+	if err := db.QueryRow(
+		"SELECT COUNT(*) FROM information_schema.STATISTICS "+
+			"WHERE table_schema = DATABASE() AND table_name = 'robot' AND index_name = ?",
+		indexName,
+	).Scan(&n); err != nil {
+		panic("check robot test index " + indexName + ": " + err.Error())
+	}
+	if n > 0 {
+		return
+	}
+	if _, err := db.Exec(ddl); err != nil {
+		panic("create robot test index " + indexName + ": " + err.Error())
+	}
 }
 
 func ensureGroupCategorySchema(t *testing.T, ctx *config.Context) {

--- a/modules/group/bot_cascade.go
+++ b/modules/group/bot_cascade.go
@@ -86,6 +86,54 @@ func expandBlacklistTargetsWithOwnedBots(db *DB, groupNo string, uids []string) 
 	return out, nil
 }
 
+// sendBotOwnerRemovedTip 发送「bot 所有者自助移除自己名下 bot」的系统消息
+// （octo-web#1511）：
+//
+//	{owner} 将机器人 <bot1>、<bot2> 移出了群聊
+//
+// 为什么不复用 sendBotCascadeRemovedTip：那条的模板是「{leaver}{action}群聊，
+// 其机器人 X 已一并移除」，描述的是「人走 bot 跟着走」；本场景所有者留在群里、
+// 只撤走 bot，套用会把「所有者也离开了」这个错误事实写进群历史。
+//
+// 与级联 Tip 保持一致：type=common.Tip (2000)，NoPersist=0 保证新成员也能看到，
+// bots 为空直接 no-op。名称插值口径同样对齐——沿用 UserBaseVo.Name，空则回落 UID。
+func sendBotOwnerRemovedTip(ctx *config.Context, groupNo, ownerName string, bots []*config.UserBaseVo) error {
+	if len(bots) == 0 || groupNo == "" {
+		return nil
+	}
+	names := make([]string, 0, len(bots))
+	for _, b := range bots {
+		if b == nil {
+			continue
+		}
+		name := b.Name
+		if name == "" {
+			name = b.UID
+		}
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	if ownerName == "" {
+		ownerName = "该用户"
+	}
+	content := fmt.Sprintf("%s 将机器人 %s 移出了群聊", ownerName, strings.Join(names, "、"))
+	return ctx.SendMessage(&config.MsgSendReq{
+		Header: config.MsgHeader{
+			NoPersist: 0,
+			RedDot:    0,
+			SyncOnce:  0,
+		},
+		ChannelID:   groupNo,
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		Payload: []byte(util.ToJson(map[string]interface{}{
+			"content": content,
+			"type":    common.Tip,
+		})),
+	})
+}
+
 // sendBotCascadeRemovedTip 发送 D-2 级联移除 bot 的系统消息。
 //
 // 场景：inviter 离群 / 被踢时，其邀请的 bot 被同事务级联移除。为避免「bot 神秘消失」

--- a/modules/group/bot_cascade.go
+++ b/modules/group/bot_cascade.go
@@ -22,15 +22,19 @@ type versionSeqer interface {
 //   - 为每个 bot 生成新 member version + DeleteMemberTx
 //   - 返回被级联删除的 bot uid 列表（外层按需用 userDB 查名字发系统 Tip）
 //
+// requireCommonRole 透传给 QueryBotsInvitedByUIDTx：既有三条路径（主动退群 /
+// 被移除 / 拉黑）传 false，保持 #354「bot 永远跟随其主人，无角色例外」；
+// 只有 bot 所有者自助移除传 true，额外排除被授予群角色的 bot。
+//
 // 任一 SQL 步失败直接返回 error，外层应 tx.Rollback()，保证「要么全成要么全不动」。
 // 本函数不做 edge case（如 inviter 是否群主）判断，由调用方先判定再调。
 func cascadeRemoveBotsInvitedByUIDTx(
-	db *DB, seq versionSeqer, groupNo, inviterUID string, tx *dbr.Tx,
+	db *DB, seq versionSeqer, groupNo, inviterUID string, requireCommonRole bool, tx *dbr.Tx,
 ) ([]string, error) {
 	if groupNo == "" || inviterUID == "" {
 		return nil, nil
 	}
-	botUIDs, err := db.QueryBotsInvitedByUIDTx(groupNo, inviterUID, tx)
+	botUIDs, err := db.QueryBotsInvitedByUIDTx(groupNo, inviterUID, requireCommonRole, tx)
 	if err != nil {
 		return nil, fmt.Errorf("query bots invited by %s: %w", inviterUID, err)
 	}

--- a/modules/group/bot_cascade_test.go
+++ b/modules/group/bot_cascade_test.go
@@ -62,20 +62,20 @@ func TestQueryBotsInvitedByUIDTx_BasicMatch(t *testing.T) {
 	assert.NoError(t, err)
 	defer func() { _ = tx.Rollback() }()
 
-	uids, err := s.db.QueryBotsInvitedByUIDTx(resp.GroupNo, "m1", tx)
+	uids, err := s.db.QueryBotsInvitedByUIDTx(resp.GroupNo, "m1", false, tx)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"bot_m1_1", "bot_m1_2"}, uids)
 
 	// 不存在的 inviter → 空切片
-	uids, err = s.db.QueryBotsInvitedByUIDTx(resp.GroupNo, "nobody", tx)
+	uids, err = s.db.QueryBotsInvitedByUIDTx(resp.GroupNo, "nobody", false, tx)
 	assert.NoError(t, err)
 	assert.Empty(t, uids)
 
 	// 空 groupNo / inviterUID → nil，no error（防御式短路）
-	uids, err = s.db.QueryBotsInvitedByUIDTx("", "m1", tx)
+	uids, err = s.db.QueryBotsInvitedByUIDTx("", "m1", false, tx)
 	assert.NoError(t, err)
 	assert.Nil(t, uids)
-	uids, err = s.db.QueryBotsInvitedByUIDTx(resp.GroupNo, "", tx)
+	uids, err = s.db.QueryBotsInvitedByUIDTx(resp.GroupNo, "", false, tx)
 	assert.NoError(t, err)
 	assert.Nil(t, uids)
 }
@@ -107,7 +107,7 @@ func TestQueryBotsInvitedByUIDTx_SkipsInactiveRobot(t *testing.T) {
 	assert.NoError(t, err)
 	defer func() { _ = tx.Rollback() }()
 
-	uids, err := s.db.QueryBotsInvitedByUIDTx(resp.GroupNo, "m1", tx)
+	uids, err := s.db.QueryBotsInvitedByUIDTx(resp.GroupNo, "m1", false, tx)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"bot_active"}, uids)
 }
@@ -271,7 +271,7 @@ func TestQuitGroup_CascadeRemovesInvitedBots(t *testing.T) {
 	assert.NoError(t, err)
 	leaverVersion, _ := s.ctx.GenSeq(common.GroupMemberSeqKey)
 	assert.NoError(t, s.db.DeleteMemberTx(groupNo, testutil.UID, leaverVersion, tx))
-	cascaded, err := cascadeRemoveBotsInvitedByUIDTx(s.db, s.ctx, groupNo, testutil.UID, tx)
+	cascaded, err := cascadeRemoveBotsInvitedByUIDTx(s.db, s.ctx, groupNo, testutil.UID, false, tx)
 	assert.NoError(t, err)
 	assert.NoError(t, tx.Commit())
 
@@ -313,7 +313,7 @@ func TestQuitGroup_CreatorOwnsNoBot_NoOp(t *testing.T) {
 	assert.NoError(t, err)
 	leaverVersion, _ := s.ctx.GenSeq(common.GroupMemberSeqKey)
 	assert.NoError(t, s.db.DeleteMemberTx(groupNo, testutil.UID, leaverVersion, tx))
-	cascaded, err := cascadeRemoveBotsInvitedByUIDTx(s.db, s.ctx, groupNo, testutil.UID, tx)
+	cascaded, err := cascadeRemoveBotsInvitedByUIDTx(s.db, s.ctx, groupNo, testutil.UID, false, tx)
 	assert.NoError(t, err)
 	assert.NoError(t, tx.Commit())
 
@@ -370,7 +370,7 @@ func TestQuitGroup_CreatorCascadesBots(t *testing.T) {
 	assert.NoError(t, s.db.UpdateMemberRoleTx(groupNo, newGrouper.UID, MemberRoleCreator, version, tx))
 	assert.NoError(t, s.db.DeleteMemberTx(groupNo, testutil.UID, version, tx))
 	// #354：cascade 无角色例外，群主退群同样触发
-	cascaded, err := cascadeRemoveBotsInvitedByUIDTx(s.db, s.ctx, groupNo, testutil.UID, tx)
+	cascaded, err := cascadeRemoveBotsInvitedByUIDTx(s.db, s.ctx, groupNo, testutil.UID, false, tx)
 	assert.NoError(t, err)
 	assert.NoError(t, tx.Commit())
 

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -272,10 +272,21 @@ func (d *DB) UpdateMemberTx(member *MemberModel, tx *dbr.Tx) error {
 }
 
 // recoverMemberTx 恢复成员信息
+//
+// 删除是软删（DeleteMemberTx 只置 is_deleted=1），整行连同各种权限位都留在表里，
+// 所以复活时必须把**群授予的权限**显式重置，否则它们会跨越「离群 → 再入群」存活。
+// role 一直是这么做的（取调用方新建 model 的值，通常是 MemberRoleCommon）；
+// bot_admin 此前漏了 —— 群主给某 bot 授过 bot_admin 后，该 bot 的所有者把它撤走
+// 再拉回来，它就悄悄又是 bot 管理员，全程不需要群主参与。
+// 回到群里的成员一律视作新成员，权限要重新授。
+//
+// 注意：解除拉黑走的是 updateMembersStatus，不经过这里，因此不受影响。
+// 回归见 TestBotOwnerSelfRemoval_BotAdminDoesNotSurviveReAdd。
 func (d *DB) recoverMemberTx(member *MemberModel, tx *dbr.Tx) error {
 	_, err := tx.Update("group_member").SetMap(map[string]interface{}{
 		"remark":          member.Remark,
 		"role":            member.Role,
+		"bot_admin":       0,
 		"version":         member.Version,
 		"is_deleted":      0,
 		"invite_uid":      member.InviteUID,

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -888,29 +888,38 @@ func (d *DB) QueryBotMemberUIDs(groupNo string) ([]string, error) {
 // 为什么是 INNER JOIN + status=1：与 checkBotOwnership（bot_ownership.go）保持一致，
 // 没有活跃 robot 行的 bot（孤儿 / 禁用）不视为任何人的 bot，不被级联。
 // 群主 / 其他管理员仍可通过常规移除成员接口清理它们。
-func (d *DB) QueryBotsInvitedByUIDTx(groupNo string, inviterUID string, tx *dbr.Tx) ([]string, error) {
+func (d *DB) QueryBotsInvitedByUIDTx(groupNo string, inviterUID string, requireCommonRole bool, tx *dbr.Tx) ([]string, error) {
 	if groupNo == "" || inviterUID == "" {
 		return nil, nil
 	}
 	var uids []string
-	// gm.role = MemberRoleCommon：级联不经过 handler 的任何角色守卫，所以它必须
-	// 自带一道。否则「bot A 拥有 Manager 角色的 bot B」时，移除 A 会把 B 一并删掉，
-	// 而 B 从未进过任何白名单 —— 结果是普通成员经级联越权移除了一个群管理员，
-	// 极端情况下还能删到 Creator 角色的 bot，留下无群主的群。
+	// requireCommonRole 决定要不要额外排除被授予群角色的 bot。
 	//
-	// robot.creator_uid 指向另一个 bot 是构造得出来的：BotFather 的命令链
-	// （messagesListen → HandleMessage → tryCreateBotCore）对「发送者是不是 bot」
-	// 零过滤，挡在前面的只有 checkSendPermission 的好友门。守卫的强度不该依赖
-	// 另一个模块的门，所以这里自己收口。
+	// **false（既有三条路径：主动退群 / 被群主管理员移除 / 被拉黑）**：不过滤角色。
+	// #354 是写下来的产品决策 —— 「bot 永远跟随其主人，无角色例外」，连群主退群
+	// （角色已先行转让）都一视同仁。在这里加全局过滤会让「张三被踢 → 他名下的
+	// 管理员 bot 留在群里，而张三已不是成员、自助路径又拒绝角色 bot」，群里凭空
+	// 多出一个谁也管不动的特权 bot，拉黑流程下还带安全含义。
 	//
+	// **true（仅 bot 所有者自助移除）**：排除角色 bot。级联不经过 handler 的角色
+	// 守卫，若不收口，「bot A 拥有 Manager 角色的 bot B」时移除 A 会顺带删掉 B，
+	// 等于普通成员经级联越权移除了一个群管理员。robot.creator_uid 指向另一个 bot
+	// 是构造得出来的：BotFather 的命令链（messagesListen → HandleMessage →
+	// tryCreateBotCore）对「发送者是不是 bot」零过滤，挡在前面的只有
+	// checkSendPermission 的好友门 —— 守卫的强度不该依赖另一个模块的门。
 	// 被排除的角色 bot 不会失控：群主/管理员仍可经常规移除接口处置它们。
-	_, err := tx.SelectBySql(
-		"SELECT gm.uid FROM group_member gm "+
-			"INNER JOIN robot r ON r.robot_id = gm.uid AND r.status = 1 "+
-			"WHERE gm.group_no = ? AND gm.robot = 1 AND gm.is_deleted = 0 "+
-			"AND gm.role = ? AND r.creator_uid = ? FOR UPDATE",
-		groupNo, MemberRoleCommon, inviterUID,
-	).Load(&uids)
+	sql := "SELECT gm.uid FROM group_member gm " +
+		"INNER JOIN robot r ON r.robot_id = gm.uid AND r.status = 1 " +
+		"WHERE gm.group_no = ? AND gm.robot = 1 AND gm.is_deleted = 0 "
+	args := []interface{}{groupNo}
+	if requireCommonRole {
+		sql += "AND gm.role = ? "
+		args = append(args, MemberRoleCommon)
+	}
+	sql += "AND r.creator_uid = ? FOR UPDATE"
+	args = append(args, inviterUID)
+
+	_, err := tx.SelectBySql(sql, args...).Load(&uids)
 	return uids, err
 }
 

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -916,6 +916,20 @@ func (d *DB) QueryBotUIDsOwnedByUIDs(groupNo string, ownerUIDs []string) ([]stri
 	if groupNo == "" || len(ownerUIDs) == 0 {
 		return nil, nil
 	}
+	// 空字符串必须剔除：`creator_uid IN ('')` 会命中 creator_uid='' 的行，而那正是
+	// checkBotOwnership 判定为「无有效归属」的孤儿 bot 哨兵值。HTTP 调用方有鉴权
+	// 兜底不会传空，但 expandBlacklistTargetsWithOwnedBots 会转发请求方给的 uid 列表，
+	// 所以在这里收口，让导出契约与它声称的语义一致（fail closed）。
+	owners := make([]string, 0, len(ownerUIDs))
+	for _, uid := range ownerUIDs {
+		if uid != "" {
+			owners = append(owners, uid)
+		}
+	}
+	if len(owners) == 0 {
+		return nil, nil
+	}
+	ownerUIDs = owners
 	var uids []string
 	_, err := d.session.SelectBySql(
 		"SELECT gm.uid FROM group_member gm "+

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -893,12 +893,23 @@ func (d *DB) QueryBotsInvitedByUIDTx(groupNo string, inviterUID string, tx *dbr.
 		return nil, nil
 	}
 	var uids []string
+	// gm.role = MemberRoleCommon：级联不经过 handler 的任何角色守卫，所以它必须
+	// 自带一道。否则「bot A 拥有 Manager 角色的 bot B」时，移除 A 会把 B 一并删掉，
+	// 而 B 从未进过任何白名单 —— 结果是普通成员经级联越权移除了一个群管理员，
+	// 极端情况下还能删到 Creator 角色的 bot，留下无群主的群。
+	//
+	// robot.creator_uid 指向另一个 bot 是构造得出来的：BotFather 的命令链
+	// （messagesListen → HandleMessage → tryCreateBotCore）对「发送者是不是 bot」
+	// 零过滤，挡在前面的只有 checkSendPermission 的好友门。守卫的强度不该依赖
+	// 另一个模块的门，所以这里自己收口。
+	//
+	// 被排除的角色 bot 不会失控：群主/管理员仍可经常规移除接口处置它们。
 	_, err := tx.SelectBySql(
 		"SELECT gm.uid FROM group_member gm "+
 			"INNER JOIN robot r ON r.robot_id = gm.uid AND r.status = 1 "+
 			"WHERE gm.group_no = ? AND gm.robot = 1 AND gm.is_deleted = 0 "+
-			"AND r.creator_uid = ? FOR UPDATE",
-		groupNo, inviterUID,
+			"AND gm.role = ? AND r.creator_uid = ? FOR UPDATE",
+		groupNo, MemberRoleCommon, inviterUID,
 	).Load(&uids)
 	return uids, err
 }
@@ -1094,13 +1105,21 @@ func (d *DB) QueryCategoryByID(categoryID string) (*CategoryRow, error) {
 }
 
 // LockRemovableMemberTx 事务内锁定成员行并确认它现在仍然可被移除
-// （存在、未删除、且不是群主）。
+// （存在、未删除、且角色符合调用方要求）。
 //
-// 存在的理由是 RemoveGroupMembers 的 creator 过滤读的是事务外快照：目标可能在
-// 快照与删除之间被提升为群主（群主转让接口，或并发的清理工单交接）。
+// 存在的理由是 RemoveGroupMembers 的角色过滤读的是事务外快照：目标可能在
+// 快照与删除之间被提升（群主转让接口、管理员任命，或并发的清理工单交接）。
 // DeleteMemberTx 的 WHERE 没有角色守卫，不锁内复核就会把新群主删掉，
 // 留下一个有成员却无群主、也无人重新选主的群。
-func (d *DB) LockRemovableMemberTx(groupNo string, uid string, tx *dbr.Tx) (bool, error) {
+//
+// requireCommonRole 决定锁内这道门有多严：
+//   - false（既有语义）：只排除 Creator。管理端踢人、Space 级联等路径用它，
+//     群主/管理员本来就有权移除管理员。
+//   - true：只放行 MemberRoleCommon。bot 所有者自助移除用它 —— 该路径在事务外
+//     已拒绝一切非普通角色目标，锁内必须用同一口径收口，否则窗口内 Common→Manager
+//     的提升会通过重查、行真的被删，而且 removedUIDs 里有它、调用方的集合比对
+//     也发现不了，等于普通成员越权移除了一个群管理员。
+func (d *DB) LockRemovableMemberTx(groupNo string, uid string, requireCommonRole bool, tx *dbr.Tx) (bool, error) {
 	var roles []int
 	_, err := tx.SelectBySql(
 		"SELECT role FROM group_member WHERE group_no=? AND uid=? AND is_deleted=0 FOR UPDATE",
@@ -1111,6 +1130,9 @@ func (d *DB) LockRemovableMemberTx(groupNo string, uid string, tx *dbr.Tx) (bool
 	}
 	if len(roles) == 0 {
 		return false, nil // 已离群
+	}
+	if requireCommonRole {
+		return roles[0] == MemberRoleCommon, nil
 	}
 	return roles[0] != MemberRoleCreator, nil
 }

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -566,7 +566,10 @@ func (d *DB) queryMembersWithGroupNo(groupNo string) ([]*MemberDetailModel, erro
 
 func (d *DB) queryMemberWithGroupNoAndUID(groupNo, uid string) (*MemberDetailModel, error) {
 	var detail *MemberDetailModel
-	_, err := d.session.Select("group_member.id,group_member.vercode,group_member.uid,group_member.status,group_member.group_no,group_member.remark,group_member.role,group_member.invite_uid,IFNULL(user.name,'') name,group_member.is_deleted,group_member.version,group_member.forbidden_expir_time,group_member.bot_admin,group_member.is_external,group_member.source_space_id,group_member.created_at,group_member.updated_at").From("group_member").LeftJoin("user", "group_member.uid=user.uid").Where("group_member.group_no=? and group_member.uid=? and group_member.is_deleted=0", groupNo, uid).Load(&detail)
+	// group_member.robot 必须在选择列里：memberDetailResp.Robot 既是下发字段，
+	// 也是 fillBotOwnedByMe 的前置判据 —— 漏选会让 bot_owned_by_me 在本端点
+	// 恒为 false（静默失效，不报错）。见 TestMemberGet_ExposesBotOwnedByMe。
+	_, err := d.session.Select("group_member.id,group_member.vercode,group_member.uid,group_member.status,group_member.group_no,group_member.remark,group_member.role,group_member.invite_uid,IFNULL(user.name,'') name,group_member.is_deleted,group_member.version,group_member.forbidden_expir_time,group_member.robot,group_member.bot_admin,group_member.is_external,group_member.source_space_id,group_member.created_at,group_member.updated_at").From("group_member").LeftJoin("user", "group_member.uid=user.uid").Where("group_member.group_no=? and group_member.uid=? and group_member.is_deleted=0", groupNo, uid).Load(&detail)
 	return detail, err
 }
 func (d *DB) queryBlacklistMemberUIDsWithGroupNo(groupNo string) ([]string, error) {

--- a/modules/group/e2e_bot_owner_self_removal_test.go
+++ b/modules/group/e2e_bot_owner_self_removal_test.go
@@ -1,0 +1,206 @@
+//go:build wukong_e2e
+
+// 自助移除 bot 的端到端验证（task bot-owner-self-removal / octo-web#1511），
+// 打**真实** WuKongIM，不使用 newGroupIMStub。
+//
+// 与 api_bot_owner_self_removal_test.go 的区别很关键：那里的 Tip 断言打在录制桩上，
+// 只能证明「服务端发起了一次 /message/send」；证明不了 WuKongIM 收下了它、更证明
+// 不了群里的人真的看得到。本文件从**留在群里的成员视角**把会话同步回来，断言那条
+// 系统消息确实出现在群频道的最近消息里。
+//
+// 同样从真实 IM 侧验证退订：被移除的 bot 不该再看到这个群频道。
+//
+// 与 e2e_issue27_wukong_test.go 同一约定：wukong_e2e 构建标签，opt-in，不进 CI
+// （WuKongIM 的投递语义与版本耦合）。
+//
+// 运行（需要 CI 同款栈：MySQL + Redis + WuKongIM 默认端口，test 库为
+// utf8mb4_general_ci）：
+//
+//	go test -tags wukong_e2e ./modules/group/ -run TestE2E_BotOwnerSelfRemoval -v -count=1
+package group
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestE2E_BotOwnerSelfRemoval_GroupSeesTipAndBotIsUnsubscribed(t *testing.T) {
+	s, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	f := New(ctx)
+	wireI18nRendererForGroupTest(s)
+	resetGroupUIDRateLimit(t, ctx)
+
+	// WuKongIM 的数据落在 ~/.wukong 且跨进程持久，固定频道 ID 会让相邻两次运行
+	// 互相污染（上一轮的消息/会话还在）。每次跑用一个唯一 groupNo。
+	runID := time.Now().UnixNano()
+	groupNo := fmt.Sprintf("e2e_botrm_%d", runID)
+	ownerUID := fmt.Sprintf("e2e_owner_%d", runID) // 群主，留在群里 —— 用他的视角验「群里看得到」
+	botUID := fmt.Sprintf("e2e_bot_%d", runID)
+	const botName = "报表助手"
+	ct := common.ChannelTypeGroup.Uint8()
+
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: testutil.UID, Name: "bot-owner", ShortNo: "e2e_op"}))
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: ownerUID, Name: "group-owner", ShortNo: "e2e_ow"}))
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: botUID, Name: botName, ShortNo: "e2e_bt", Robot: 1}))
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO robot (robot_id, status, creator_uid) VALUES (?, 1, ?)", botUID, testutil.UID,
+	).Exec()
+	require.NoError(t, err)
+
+	require.NoError(t, f.db.Insert(&Model{
+		GroupNo: groupNo, Name: "e2e bot removal", Creator: ownerUID,
+		Status: GroupStatusNormal, Version: 1,
+	}))
+	seedE2EMember(t, f, groupNo, ownerUID, MemberRoleCreator, 0)
+	seedE2EMember(t, f, groupNo, testutil.UID, MemberRoleCommon, 0) // 发起人：普通成员
+	seedE2EMember(t, f, groupNo, botUID, MemberRoleCommon, 1)
+
+	// 三方都订阅群频道（与真实入群一致）。
+	require.NoError(t, ctx.IMAddSubscriber(&config.SubscriberAddReq{
+		ChannelID: groupNo, ChannelType: ct,
+		Subscribers: []string{ownerUID, testutil.UID, botUID},
+	}))
+
+	hasGroupChannel := func(uid string) bool {
+		convs, serr := ctx.IMSyncUserConversation(uid, 0, 50, "", nil)
+		require.NoError(t, serr)
+		for _, c := range convs {
+			if c.ChannelID == groupNo && c.ChannelType == ct {
+				return true
+			}
+		}
+		return false
+	}
+	// recentsOf 返回某成员在群频道里能看到的最近消息文本。
+	recentsOf := func(uid string) []string {
+		convs, serr := ctx.IMSyncUserConversation(uid, 0, 50, "", nil)
+		require.NoError(t, serr)
+		var out []string
+		for _, c := range convs {
+			if c.ChannelID != groupNo || c.ChannelType != ct {
+				continue
+			}
+			for _, m := range c.Recents {
+				out = append(out, string(m.Payload))
+			}
+		}
+		return out
+	}
+
+	// 会话只在**有消息投递**后才产生，光订阅不算 —— 所以先发一条预热消息，
+	// 才能用 conversation/sync 观察「谁收得到这个群频道」。
+	sendToGroup := func(content string) {
+		require.NoError(t, ctx.SendMessage(&config.MsgSendReq{
+			Header:      config.MsgHeader{RedDot: 1},
+			FromUID:     ownerUID,
+			ChannelID:   groupNo,
+			ChannelType: ct,
+			Payload:     []byte(`{"type":1,"content":"` + content + `"}`),
+		}))
+	}
+
+	// --- 1. 移除前：bot 确实在收这个群频道的消息 ---
+	sendToGroup("before-remove")
+	time.Sleep(800 * time.Millisecond)
+	require.True(t, hasGroupChannel(botUID), "前置：未移除时 bot 应通过 WuKongIM 收到群消息")
+	require.True(t, hasGroupChannel(ownerUID), "前置：群主应收到")
+
+	// --- 2. 普通成员走真实 HTTP 路径自助移除自己的 bot ---
+	w := httptest.NewRecorder()
+	body := util.ToJson(map[string]interface{}{"members": []string{botUID}})
+	req, rerr := http.NewRequest("DELETE", "/v1/groups/"+groupNo+"/members", bytes.NewReader([]byte(body)))
+	require.NoError(t, rerr)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "自助移除应成功: %s", w.Body.String())
+
+	exist, eerr := f.db.ExistMember(botUID, groupNo)
+	require.NoError(t, eerr)
+	require.False(t, exist, "bot 应已不在成员表里")
+
+	// WuKongIM 的投递/落库是异步的，给一个有界的重试窗口，别用固定 sleep。
+	var seen []string
+	for i := 0; i < 30; i++ {
+		seen = recentsOf(ownerUID)
+		if containsFragment(seen, "将机器人") {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	// --- 3. 核心断言：留在群里的人真的看得到这条系统消息 ---
+	//
+	// 句式是「{操作者} 将机器人 {bot 名} 移出了群聊」。注意操作者名取自
+	// c.GetLoginName()（登录态），不是 user 表的 Name —— 测试里登录名是 testutil
+	// 约定的值，所以这里只断言「有一个非空前缀」，不写死具体名字。
+	tailWithBot := fmt.Sprintf("将机器人 %s 移出了群聊", botName)
+	assert.True(t, containsFragment(seen, tailWithBot),
+		"群主应在群频道里看到「X %s」，实际最近消息=%v", tailWithBot, seen)
+	assert.True(t, containsFragment(seen, `"type":2000`),
+		"这条应是系统 Tip（common.Tip=2000），实际=%v", seen)
+	assert.True(t, hasNonEmptyOperatorPrefix(seen, tailWithBot),
+		"系统消息里应带上操作者名字作为前缀，实际=%v", seen)
+	// 反向：不该出现被移除者视角的旧文案。
+	assert.False(t, containsFragment(seen, "移除群聊"),
+		"不应出现「你被 X 移除群聊」，实际=%v", seen)
+
+	// --- 4. 退订从真实 IM 侧验证：移除后再发一条，bot 不该再收到 ---
+	// 与 e2e_issue27 同口径：判据是「新消息还投不投得到他」，而不是历史会话是否残留。
+	sendToGroup("after-remove")
+	time.Sleep(800 * time.Millisecond)
+	assert.False(t, hasGroupChannel(botUID),
+		"被移除的 bot 必须不再收到群消息，否则「移除」只是名单上的假象")
+	assert.True(t, hasGroupChannel(ownerUID),
+		"对照：仍在群里的成员必须继续收到，证明摘订阅是精确按 uid 的")
+}
+
+func seedE2EMember(t *testing.T, f *Group, groupNo, uid string, role, robot int) {
+	t.Helper()
+	require.NoError(t, f.db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: uid, Role: role, Robot: robot,
+		Status: 1, Version: 1, Vercode: fmt.Sprintf("%s@1", util.GenerUUID()),
+	}))
+}
+
+func containsFragment(payloads []string, fragment string) bool {
+	for _, p := range payloads {
+		if strings.Contains(p, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasNonEmptyOperatorPrefix 确认 Tip 里 tail 之前确实插值了一个非空的操作者名，
+// 而不是「 将机器人 X 移出了群聊」这种前缀丢失的形态。
+func hasNonEmptyOperatorPrefix(payloads []string, tail string) bool {
+	for _, p := range payloads {
+		idx := strings.Index(p, tail)
+		if idx <= 0 {
+			continue
+		}
+		// 取 content 字段起始到 tail 之间的部分，去掉 JSON 前缀与空白后必须非空。
+		prefix := p[:idx]
+		if ci := strings.Index(prefix, `"content":"`); ci >= 0 {
+			prefix = prefix[ci+len(`"content":"`):]
+		}
+		if strings.TrimSpace(prefix) != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/modules/group/e2e_bot_owner_self_removal_test.go
+++ b/modules/group/e2e_bot_owner_self_removal_test.go
@@ -168,6 +168,110 @@ func TestE2E_BotOwnerSelfRemoval_GroupSeesTipAndBotIsUnsubscribed(t *testing.T) 
 		"对照：仍在群里的成员必须继续收到，证明摘订阅是精确按 uid 的")
 }
 
+// 移除 → 加回 之后，bot 必须**重新收到**群消息。
+//
+// 移除时会 IMRemoveSubscriber 摘掉订阅；如果加回时没有重新订阅，bot 就成了
+// 「名单上在、消息收不到」—— 和移除侧那个后置条件正好对称的失败形态，而且
+// 从数据库看一切正常（group_member 行确实回来了），只有从 IM 侧才看得出来。
+// AddGroupMembers 里确实有 IMAddSubscriber，但那是读代码；这里实测。
+func TestE2E_BotOwnerSelfRemoval_ReAddedBotReceivesMessagesAgain(t *testing.T) {
+	s, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	f := New(ctx)
+	wireI18nRendererForGroupTest(s)
+	resetGroupUIDRateLimit(t, ctx)
+	_, _ = ctx.DB().InsertBySql(
+		"INSERT INTO app_config (version, invite_system_account_join_group_on) VALUES (1, 1)",
+	).Exec()
+
+	runID := time.Now().UnixNano()
+	groupNo := fmt.Sprintf("e2e_readd_%d", runID)
+	ownerUID := fmt.Sprintf("e2e_rowner_%d", runID)
+	botUID := fmt.Sprintf("e2e_rbot_%d", runID)
+	ct := common.ChannelTypeGroup.Uint8()
+
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: testutil.UID, Name: "bot-owner", ShortNo: "e2e_rop"}))
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: ownerUID, Name: "group-owner", ShortNo: "e2e_row"}))
+	require.NoError(t, f.userDB.Insert(&user.Model{UID: botUID, Name: "回归助手", ShortNo: "e2e_rbt", Robot: 1}))
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO robot (robot_id, status, creator_uid) VALUES (?, 1, ?)", botUID, testutil.UID,
+	).Exec()
+	require.NoError(t, err)
+
+	require.NoError(t, f.db.Insert(&Model{
+		GroupNo: groupNo, Name: "e2e re-add", Creator: ownerUID,
+		Status: GroupStatusNormal, Version: 1,
+	}))
+	seedE2EMember(t, f, groupNo, ownerUID, MemberRoleCreator, 0)
+	seedE2EMember(t, f, groupNo, testutil.UID, MemberRoleCommon, 0)
+	seedE2EMember(t, f, groupNo, botUID, MemberRoleCommon, 1)
+	require.NoError(t, ctx.IMAddSubscriber(&config.SubscriberAddReq{
+		ChannelID: groupNo, ChannelType: ct,
+		Subscribers: []string{ownerUID, testutil.UID, botUID},
+	}))
+
+	hasGroupChannel := func(uid string) bool {
+		convs, serr := ctx.IMSyncUserConversation(uid, 0, 50, "", nil)
+		require.NoError(t, serr)
+		for _, c := range convs {
+			if c.ChannelID == groupNo && c.ChannelType == ct {
+				return true
+			}
+		}
+		return false
+	}
+	sendToGroup := func(content string) {
+		require.NoError(t, ctx.SendMessage(&config.MsgSendReq{
+			Header:      config.MsgHeader{RedDot: 1},
+			FromUID:     ownerUID,
+			ChannelID:   groupNo,
+			ChannelType: ct,
+			Payload:     []byte(`{"type":1,"content":"` + content + `"}`),
+		}))
+	}
+
+	// --- 1. 初始：bot 收得到 ---
+	sendToGroup("before")
+	time.Sleep(800 * time.Millisecond)
+	require.True(t, hasGroupChannel(botUID), "前置：bot 应收得到群消息")
+
+	// --- 2. 所有者自助移除 ---
+	rmW := httptest.NewRecorder()
+	rmBody := util.ToJson(map[string]interface{}{"members": []string{botUID}})
+	rmReq, rerr := http.NewRequest("DELETE", "/v1/groups/"+groupNo+"/members", bytes.NewReader([]byte(rmBody)))
+	require.NoError(t, rerr)
+	rmReq.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(rmW, rmReq)
+	require.Equal(t, http.StatusOK, rmW.Code, "移除应成功: %s", rmW.Body.String())
+
+	sendToGroup("while-removed")
+	time.Sleep(800 * time.Millisecond)
+	require.False(t, hasGroupChannel(botUID), "移除后 bot 不应再收到群消息")
+
+	// --- 3. 加回来 ---
+	addW := httptest.NewRecorder()
+	addBody := util.ToJson(map[string]interface{}{"members": []string{botUID}})
+	addReq, aerr := http.NewRequest("POST", "/v1/groups/"+groupNo+"/members", bytes.NewReader([]byte(addBody)))
+	require.NoError(t, aerr)
+	addReq.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(addW, addReq)
+	require.Equal(t, http.StatusOK, addW.Code, "所有者应能把自己的 bot 加回来: %s", addW.Body.String())
+
+	// --- 4. 核心断言：加回后必须**重新**收得到 ---
+	sendToGroup("after-readd")
+	received := false
+	for i := 0; i < 30; i++ {
+		received = hasGroupChannel(botUID)
+		if received {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	assert.True(t, received,
+		"加回后 bot 必须重新收到群消息，否则它只是名单上回来了、实际是聋的")
+	assert.True(t, hasGroupChannel(ownerUID), "对照：群主全程都应收得到")
+}
+
 func seedE2EMember(t *testing.T, f *Group, groupNo, uid string, role, robot int) {
 	t.Helper()
 	require.NoError(t, f.db.InsertMember(&MemberModel{

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -1057,6 +1057,17 @@ type RemoveGroupMembersServiceReq struct {
 	// 空串沿用默认的「被移出」，所以既有调用方行为不变；自愿离开的场景传「退出了」。
 	BotCascadeTipAction string
 
+	// BotOwnerSelfRemoval 标记「bot 所有者自助把自己名下的 bot 移出群聊」
+	// （octo-web#1511）。置位时抑制默认的「你被 X 移除群聊」——那是被移除者视角的
+	// 措辞，目标是 bot 时读起来是错的——改发一条 owner 视角的 Tip
+	// （sendBotOwnerRemovedTip）。
+	//
+	// 为什么不复用 SuppressRemoveNotice + 调用方自己发消息：那需要调用方同时设对
+	// 两个开关才不出错，而 handler 手上没有成员名字（QueryMembersWithUids 返回的
+	// MemberModel 无 Name 字段），本函数则已经为 removedVos 查好了名字。
+	// 收敛成一个语义化开关，调用方无法只设一半。
+	BotOwnerSelfRemoval bool
+
 	// SuppressBotCascadeTip 完全不发 bot 连带移除 Tip。
 	// 只在「通告本身已无意义」时用（Space 解散：群还在，但每个成员每个群各发一条，
 	// N×M 条堆给最后一个人看）。普通移除和自愿退出都**应该**发——群成员看见 bot
@@ -1918,7 +1929,14 @@ func (s *Service) RemoveGroupMembers(req *RemoveGroupMembersServiceReq) (*Remove
 		}
 
 		// 发送被踢消息
-		if !req.SuppressRemoveNotice {
+		switch {
+		case req.BotOwnerSelfRemoval:
+			// bot 所有者自助移除：换成 owner 视角的 Tip。仍然要发——群成员看见 bot
+			// 凭空消失有权知道原因（与 bot 级联 Tip 同一条透明度约定）。
+			if err := sendBotOwnerRemovedTip(s.ctx, req.GroupNo, req.OperatorName, removedVos); err != nil {
+				s.Error("send bot owner removed tip failed", zap.Error(err))
+			}
+		case !req.SuppressRemoveNotice:
 			removeReq := &config.MsgGroupMemberRemoveReq{
 				Operator:     req.OperatorUID,
 				OperatorName: req.OperatorName,

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -1772,6 +1772,11 @@ func (s *Service) RemoveGroupMembers(req *RemoveGroupMembersServiceReq) (*Remove
 	// #354 产品决策：bot 永远跟随其主人，无角色例外——manager 不再豁免，
 	// 被踢的管理员连同其拉入的 bot 一并带走（API 层 memberRemove 已限制
 	// 只有群主能踢管理员；creator 仍不可被踢）。
+	//
+	// 唯一例外是 bot 所有者自助移除（req.BotOwnerSelfRemoval，octo-web#1511）：
+	// 那条路径下级联额外排除被授予群角色的 bot，避免普通成员借级联越权移除一个
+	// 管理员 bot。它**不影响**本注释描述的踢人 / 退群 / 拉黑三条路径 —— 那三条
+	// 传 false，#354 原样保持。判据见 QueryBotsInvitedByUIDTx 的 requireCommonRole。
 	var removableMembers []*MemberModel
 	for _, m := range targetMembers {
 		if m.IsDeleted == 1 || m.Role == MemberRoleCreator {
@@ -1871,7 +1876,7 @@ func (s *Service) RemoveGroupMembers(req *RemoveGroupMembersServiceReq) (*Remove
 		if m.Role == MemberRoleCreator {
 			continue
 		}
-		cascadedUIDs, cerr := cascadeRemoveBotsInvitedByUIDTx(s.db, s.ctx, req.GroupNo, m.UID, tx)
+		cascadedUIDs, cerr := cascadeRemoveBotsInvitedByUIDTx(s.db, s.ctx, req.GroupNo, m.UID, req.BotOwnerSelfRemoval, tx)
 		if cerr != nil {
 			s.Error("cascade remove bots failed", zap.Error(cerr), zap.String("uid", m.UID))
 			return nil, errors.New("failed to cascade-remove invited bots")

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -1831,7 +1831,10 @@ func (s *Service) RemoveGroupMembers(req *RemoveGroupMembersServiceReq) (*Remove
 		// 群里还剩着人却没有群主，且没有任何东西会重新选主。
 		// 锁内确认仍非 creator 才删；已经变成 creator 的跳过，让调用方按
 		// Removed 计数发现并重试（见 RemoveGroupMembersServiceResp）。
-		stillRemovable, err := s.db.LockRemovableMemberTx(req.GroupNo, m.UID, tx)
+		// 自助路径（bot 所有者）在事务外只放行普通角色目标，锁内必须用同一口径：
+		// 否则窗口内 Common→Manager 的提升会通过重查、行真的被删，且 removedUIDs
+		// 里有它，连调用方的集合比对都发现不了。其余路径沿用「只排除 Creator」。
+		stillRemovable, err := s.db.LockRemovableMemberTx(req.GroupNo, m.UID, req.BotOwnerSelfRemoval, tx)
 		if err != nil {
 			s.Error("re-read member role failed", zap.Error(err), zap.String("uid", m.UID))
 			return nil, errors.New("failed to re-read member role")


### PR DESCRIPTION
## Summary

An ordinary group member could add a bot they own to a group but never take it out. `memberRemove` rejects every caller who is not Creator/Manager, while bot ownership (`robot.creator_uid`) was only validated on the join path — a one-way door whose only escape was disbanding the group.

`memberRemove` now falls through to a narrow self-service branch when the caller is a plain member: every target must be an active bot owned by that caller in this group, or the whole batch is rejected.

Frontend half: Mininglamp-OSS/octo-web#1513.

**Merge order:** this PR first. `bot_owned_by_me` is what the web client keys the remove button off; until it ships, the frontend change renders nothing new.

## Related Issue

Fixes Mininglamp-OSS/octo-web#1511

## Linked Spec

`.octospec/tasks/bot-owner-self-removal/brief.md` — with `context.yaml` recording the injected rules (space-isolation P92, trust-boundary P90, error-handling P85, rate-limit P80, testing, commit-style) and the four maintainer decisions.

Journal: `.octospec/journal/shared/bot-owner-self-removal.md`. Rule candidate: `.octospec/learnings/pending/bot-owner-self-removal.md`.

## Changes

- `memberRemove`: self-service branch gated on `ExistMemberActive` + `QueryBotUIDsOwnedByUIDs`, a default-deny whitelist. Any target outside the set rejects the entire batch — no partial execution.
- Reject Creator-role targets on that branch. `RemoveGroupMembers` silently skips Creators and the handler does not inspect `Removed`, so this would otherwise return 200 having changed nothing.
- Distinguish "not in group" from "not yours": the whitelist filters `is_deleted`, so a re-submitted removal of an already-removed bot would otherwise answer "you have no permission to remove this member".
- Replace the "你被 X 移除群聊" notice with an owner-perspective Tip (`sendBotOwnerRemovedTip`). Silence was not an option — the codebase already holds that members are entitled to know why a bot vanished (`service.go` bot-cascade tip rationale).
- Add `bot_owned_by_me` to `memberDetailResp`, filled by the same query the authz check uses so the button and the permission cannot disagree. Backfilled in `membersGet` / `memberGet` / `syncMembers`; absent field must be read as false.
- Select `group_member.robot` in `queryMemberWithGroupNoAndUID` — its absence made the new field silently always-false on `memberGet`.
- Mount `SharedUIDRateLimiter` on `DELETE /members` and `POST /members_delete`, which now accept ordinary members. Scoped to those two routes; the group carries ~26 others.
- Reset the UID rate-limit bucket in `TestManagerMemberRemove_NotInGroupIsNotFound`, which now hits a limited route.

## Testing

Run against a live MySQL 8.0 + Redis + WuKongIM stack, not just compiled.

```
go test ./modules/group/          # ok, 38.6s
golangci-lint run ./modules/group/ # 0 issues
make i18n-extract-check && make i18n-lint  # clean; no new codes registered
```

17 cases in `api_bot_owner_self_removal_test.go`, covering the brief's acceptance list: own bot removable; someone else's bot, a human target, a mixed batch, an orphan/disabled bot and a blacklisted operator all rejected; cross-group scope; Creator-role target; repeat removal; both routes; thread-membership cleanup; `bot_owned_by_me` on both list and single-member endpoints; owner tip sent and kick notice suppressed, with a control case pinning that a normal removal still sends the original notice.

- [x] Unit tests added/updated
- [x] Manually verified

## COMPREHENSION

**1. What does this change actually do to the load-bearing path?**

It adds a second way to pass the only authorization gate on group member removal. Previously `memberRemove` had one predicate: Creator or Manager. Now a caller who fails that check is re-tested against "is every target an active bot you own in this group", and on success proceeds into the same `RemoveGroupMembers` with all its existing side effects — row-locked deletion, bot cascade, IM unsubscribe, CMD refresh, thread/pin/conversation cleanup — differing only in which system message is emitted.

The predicate is a closed whitelist, not a filter. `QueryBotUIDsOwnedByUIDs` returns the set of UIDs that are simultaneously `group_member.robot=1`, `is_deleted=0`, `robot.status=1` and `robot.creator_uid = caller`; every requested UID must be in it. Nothing is inferred from a target's absence.

Second load-bearing touch: `memberDetailResp` is a wire contract shared by three handlers, and Android/iOS cache it through WKSDK `ChannelMember.extraMap`. The new field is additive and per-viewer.

**2. What could break because of it (dependents + failure mode)?**

The failure mode worth naming is the one deliberately avoided: reusing `checkBotOwnership` here. That helper passes every non-bot UID by design — correct for "may you invite this bot", a privilege escalation for "may you remove this member", since an ordinary member could submit human UIDs and have none of them objected to. `TestBotOwnerSelfRemoval_RejectsHumanTarget` exists to fail loudly if anyone swaps the whitelist for the name-alike helper.

A second, subtler one was caught in review: the branch initially authorized off `QueryMemberWithUID`, which filters only `is_deleted`, while `QueryBotUIDsOwnedByUIDs` deliberately does not filter `group_member.status` (the blacklist cascade needs that). A blacklisted member therefore gained a group-mutating write plus a persistent Tip in a group they are blacklisted from. Now gated on `ExistMemberActive`, per the convention on `QueryActiveMemberGroupNosWithUID`.

Dependents: `space_member_removal.go` and `bot_api/groups.go` both construct `RemoveGroupMembersServiceReq` with named fields, so the new flag defaults false and their behaviour is unchanged — the control case pins that a normal removal still sends the original notice. Clients that cache member rows see one new key. The two removal routes are now UID-rate-limited, which is a behaviour change for existing callers of those routes; the shared bucket is 2 rps / burst 60 per UID.

Residual risk: `RemoveGroupMembers` carries a documented, unresolved ABBA deadlock against `handOverGroupCreator`. This change does not touch it but does add a concurrent caller, widening exposure.

**3. How do you know it works (specific test/repro/trace)?**

The whole `modules/group` suite passes against real MySQL/Redis/WuKongIM, not stubs — 38.6s, including the pre-existing bot-cascade, i18n-regression and space-member-removal tests.

The security claim is tested, not argued: `RejectsHumanTarget` submits a human UID from a plain member and asserts both a non-200 and that the member is still in the group; `RejectsMixedBatch` asserts that a batch of "my bot + a human" removes *neither*, so no partial execution; `RejectsBlacklistedOperator` flips `group_member.status` to Blacklist and asserts the write is refused.

The tip behaviour is asserted through the recording IM stub (`newGroupIMStub` / `payloadsContain`), both directions: the kick notice absent, the owner tip present, plus a control case for the unflagged path. Note these assertions drive the service directly rather than the HTTP route — `register.GetModules` builds module instances under a process-wide `sync.Once`, so handlers keep the first `NewTestServer`'s ctx and a stub installed by any later test is silently bypassed. That gotcha is written up in the journal.

Known gap, stated rather than hidden: no test pins the handler→service wiring of the `BotOwnerSelfRemoval` flag, so deleting that one field from the call site leaves the suite green. It is argued by inference — a plain member can delete their own bot but not a human or someone else's, which is only reachable through the self-service branch. Closing it properly needs a spy service plus a self-registered route; filed in the journal.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)