### PR TITLE
feat: add OPPO push REST support

### DIFF
--- a/.octospec/tasks/oppo-push-rest-hardening/brief.md
+++ b/.octospec/tasks/oppo-push-rest-hardening/brief.md
@@ -23,8 +23,9 @@ source: self
   文档 11236 为准。
 - `credential` — MasterSecret 和 auth token 不进入日志；token 按 AppKey 隔离并在本地、Redis
   同步提前过期。
-- `retry/idempotency` — 仅在 OPPO 返回 code 11 时刷新 token 并重试一次；两次发送保持同一
-  `app_message_id`，其他业务错误不自动重试。
+- `retry/idempotency` — 仅在 OPPO 返回 code 11 时刷新 token 并重试一次；以设备 token 与
+  WuKongIM 全局 `message_id` 生成稳定 `app_message_id`，不能依赖瞬态消息可能为 0 的
+  `message_seq`；其他业务错误不自动重试。
 - `routing` — 只发送服务端生成的 `space_id/channel_id/channel_type/message_seq`，不接受
   外部任意动作参数。
 - `classification` — `category/notify_level/private_msg_template_id` 由部署配置显式开启；
@@ -44,11 +45,13 @@ source: self
    Redis 故障把 OPPO 推送完全阻断。
 4. code 11 使旧 token 失效，强制重新鉴权后只重试一次。其他 OPPO 错误包装为带 code 和
    retryable 属性的类型，但本任务不新增异步重试队列。
-5. 单推消息开启 `verify_registration_id`，使用稳定 `app_message_id` 去重，不发送会跨会话
-   冲突的 `notify_id`；携带离线 TTL、notification channel、通知级别、私信模板和服务端
-   生成的会话路由参数。未发送 `style` 时使用厂商默认标准样式（`style=1`），标题/正文均按
-   50 Unicode 字符截断，空值使用安全兜底，`action_parameters` 最大 4000 字符；Activity
-   和 URL 配置分别限制为 500/2000 字符。
+5. 单推消息开启 `verify_registration_id`，使用设备 token + 全局 `message_id` 生成稳定
+   `app_message_id`（缺失时回退到发送者/频道作用域内的 `client_msg_no`），不发送会跨会话
+   冲突的 `notify_id`；registration_id 按单值校验，拒绝分隔符、空白、控制字符和超过 256
+   字节的值。携带离线 TTL、notification channel、通知级别、私信模板和服务端生成的会话
+   路由参数。未发送 `style` 时使用厂商默认标准样式（`style=1`），标题/正文均按 50 Unicode
+   字符截断，空值使用安全兜底，`action_parameters` 最大 4000 字符；Activity 和 URL 配置
+   分别限制为 500/2000 字符。
 6. 新分类字段通过 `TS_PUSH_OPPO_*` 环境变量接入，保持未配置时的旧分类语义；配置非法时
    禁用 OPPO pusher 并记录错误，避免静默发送错误分类。
 
@@ -68,10 +71,11 @@ source: self
   SDK 1.1.0 不作为覆盖在线文档的依据。
 - [x] HTTP 总超时为 5 秒，非 2xx、超大/畸形 JSON、缺失或非法 code 均失败。
 - [x] token 按 AppKey 隔离并在本地/Redis 同步 20 小时过期；正常路径不访问 Redis；并发
-  cache miss 只鉴权一次；code 11 刷新并只重试一次，稳定去重 ID 不变。
+  cache miss 和并发 code 11 刷新均只鉴权一次；code 11 只重试一次，稳定去重 ID 不变；
+  Redis 读取失败不会继续删除共享 token。
 - [x] code 41/54/10000 等参数或目标错误不自动重试，错误保留 OPPO code。
-- [x] payload 包含校验 registration_id、去重 ID、离线 TTL、路由参数及已配置的新分类字段，
-  不发送跨会话可能冲突的 `notify_id`，且字段长度符合 SDK 约束。
+- [x] payload 包含校验 registration_id、基于全局消息身份的去重 ID、离线 TTL、路由参数及
+  已配置的新分类字段，不发送跨会话可能冲突的 `notify_id`，且字段长度符合 SDK 约束。
 - [x] 无效 registration_id（code 41）和可自愈的首次 token 失效（code 11）记录 Debug；未恢复
   的 code 11、code 54 等业务拒绝记录 code/retryable 的 Warn；成功响应记录可用于对账的
   messageId；设备 token 只记录脱敏值，日志不包含凭据或完整 registration_id。
@@ -80,5 +84,7 @@ source: self
 - [x] `go test ./modules/webhook -count=1` 已通过：使用临时 octo-lib testutil overlay 指向独立
   临时数据库运行，完成后已删除该数据库。默认共享 `test` 库仍存在 checkout 未知的
   `20260820000001_featuregate_init.sql`；未修改或清理共享测试库。
-- [x] 提供独立 `TestOPPOAuth` 真实鉴权 smoke，仅需 AppKey/MasterSecret；完整单推 smoke 另需
-  同一应用的有效 registration_id，设备到达、展示和点击仍需 Android 端联合验收。
+- [x] 提供独立 `TestOPPOAuth` 真实鉴权 smoke，仅需 AppKey/MasterSecret；完整单推 smoke 需要
+  同一应用的有效 registration_id，接口接受不等同于设备到达、展示或点击成功。
+- [x] 2026-08-24 已使用专用测试应用及设备完成鉴权、单推和通知栏展示验证；默认点击行为只
+  启动应用，直达会话与动作参数消费仍待 Android 端联调。

--- a/.octospec/tasks/oppo-push-rest-hardening/brief.md
+++ b/.octospec/tasks/oppo-push-rest-hardening/brief.md
@@ -1,0 +1,65 @@
+---
+type: Task
+title: "Task: oppo-push-rest-hardening"
+description: Bring the OPPO notification unicast adapter onto the current domestic REST API with bounded I/O, token refresh, classification options, routing metadata, and deterministic tests.
+tags: ["webhook", "push", "oppo", "adapter", "http", "testing"]
+timestamp: 2026-08-24T00:00:00+08:00
+# --- octospec extension fields ---
+slug: oppo-push-rest-hardening
+source: self
+---
+
+# Task: oppo-push-rest-hardening
+
+## Goal
+
+把 OPPO 离线通知单推切到当前国内 REST API，并补齐生产所需的表单编码、HTTP 超时、
+鉴权 token 缓存及失效刷新、严格响应校验、通知去重、会话路由参数和新消息分类字段配置。
+
+## Load-bearing list
+
+- `wire-contract` — 鉴权与单推使用 `api-push-cn.heytapmobi.com`，请求为 UTF-8 form，
+  `message` 为嵌套 JSON。
+- `credential` — MasterSecret 和 auth token 不进入日志；token 按 AppKey 隔离并提前过期。
+- `retry/idempotency` — 仅在 OPPO 返回 code 11 时刷新 token 并重试一次；两次发送保持同一
+  `app_message_id`，其他业务错误不自动重试。
+- `routing` — 只发送服务端生成的 `space_id/channel_id/channel_type/message_seq`，不接受
+  外部任意动作参数。
+- `classification` — `category/notify_level/private_msg_template_id` 由部署配置显式开启；
+  默认不把无法区分的人类、Bot、系统消息全部声明为 `IM`。
+- `availability` — 出站 HTTP 总超时 5 秒，限制响应体大小，HTTP/JSON/协议异常均返回错误。
+- `test` — 使用本地 HTTP server 和内存 token cache 覆盖编码、签名、缓存、刷新、错误码、
+  payload 与超时配置，不依赖真实 OPPO 凭据。
+
+## Design
+
+1. 保留现有 `Push` 接口，在 OPPO adapter 内注入最小 HTTP doer、token cache 和 clock，生产
+   默认使用带 5 秒总超时的 `http.Client` 与 Redis。
+2. 用 `url.Values.Encode()` 生成 form body，严格要求 2xx、合法 JSON 和存在的数值 `code`。
+3. token cache key 包含 AppKey 摘要，缓存 20 小时；缓存故障时仍可直接鉴权，避免 Redis
+   故障把 OPPO 推送完全阻断。
+4. code 11 使旧 token 失效，强制重新鉴权后只重试一次。其他 OPPO 错误包装为带 code 和
+   retryable 属性的类型，但本任务不新增异步重试队列。
+5. 单推消息开启 `verify_registration_id`，使用稳定 `app_message_id` 去重，携带离线 TTL、
+   notification channel、通知级别、私信模板和服务端生成的会话路由参数。
+6. 新分类字段通过 `TS_PUSH_OPPO_*` 环境变量接入，保持未配置时的旧分类语义；配置非法时
+   禁用 OPPO pusher 并记录错误，避免静默发送错误分类。
+
+## Out of scope
+
+- Android SDK 初始化、registration_id 上报和通知点击消费。
+- 多设备 token 存储模型改造。
+- 广播、批量单推、透传消息和回执回调消费。
+- 为所有厂商推送统一重试队列或统一客户端抽象。
+- 在没有测试凭据和测试设备时宣称真实设备已送达。
+
+## Acceptance
+
+- [ ] 鉴权、单推均命中最新国内 host，form 特殊字符和中文可无损解析。
+- [ ] HTTP 总超时为 5 秒，非 2xx、超大/畸形 JSON、缺失或非法 code 均失败。
+- [ ] token 按 AppKey 隔离缓存；code 11 刷新并只重试一次，稳定去重 ID 不变。
+- [ ] code 41/54/10000 等参数或目标错误不自动重试，错误保留 OPPO code。
+- [ ] payload 包含校验 registration_id、去重 ID、离线 TTL、路由参数及已配置的新分类字段。
+- [ ] 聚焦测试、race、coverage、`go vet ./modules/webhook` 与 `git diff --check` 通过。
+- [ ] 尝试模块级回归；若共享基础设施阻塞，保留完整错误证据且不误报为通过。
+

--- a/.octospec/tasks/oppo-push-rest-hardening/brief.md
+++ b/.octospec/tasks/oppo-push-rest-hardening/brief.md
@@ -71,6 +71,6 @@ source: self
   不包含凭据或 registration_id。
 - [x] 聚焦测试、race、10 次重复运行、OPPO adapter coverage 83.0%、`go vet ./modules/webhook`、
   `golangci-lint run ./modules/webhook/...` 与 `git diff --check` 通过。
-- [x] 已尝试模块级回归；共享测试库存在 checkout 未知的
-  `20260820000001_featuregate_init.sql`，在 `testutil.NewTestServer` 创建 migration plan 时阻塞。
-  未修改或清理共享测试库。
+- [x] `go test ./modules/webhook -count=1` 已通过：使用临时 octo-lib testutil overlay 指向独立的
+  `test_oppo_santiago` 数据库运行，完成后已删除该临时库。默认共享 `test` 库仍存在 checkout
+  未知的 `20260820000001_featuregate_init.sql`；未修改或清理共享测试库。

--- a/.octospec/tasks/oppo-push-rest-hardening/brief.md
+++ b/.octospec/tasks/oppo-push-rest-hardening/brief.md
@@ -20,14 +20,16 @@ source: self
 
 - `wire-contract` — 鉴权与单推使用 `api-push-cn.heytapmobi.com`，请求为 UTF-8 form，
   `message` 为嵌套 JSON。
-- `credential` — MasterSecret 和 auth token 不进入日志；token 按 AppKey 隔离并提前过期。
+- `credential` — MasterSecret 和 auth token 不进入日志；token 按 AppKey 隔离并在本地、Redis
+  同步提前过期。
 - `retry/idempotency` — 仅在 OPPO 返回 code 11 时刷新 token 并重试一次；两次发送保持同一
   `app_message_id`，其他业务错误不自动重试。
 - `routing` — 只发送服务端生成的 `space_id/channel_id/channel_type/message_seq`，不接受
   外部任意动作参数。
 - `classification` — `category/notify_level/private_msg_template_id` 由部署配置显式开启；
   默认不把无法区分的人类、Bot、系统消息全部声明为 `IM`。
-- `availability` — 出站 HTTP 总超时 5 秒，限制响应体大小，HTTP/JSON/协议异常均返回错误。
+- `availability` — 出站 HTTP 总超时 5 秒，限制响应体大小，HTTP/JSON/协议异常均返回错误；
+  正常推送使用进程内 token 快路径，不因 Redis RTT 串行化。
 - `test` — 使用本地 HTTP server 和内存 token cache 覆盖编码、签名、缓存、刷新、错误码、
   payload 与超时配置，不依赖真实 OPPO 凭据。
 
@@ -36,12 +38,15 @@ source: self
 1. 保留现有 `Push` 接口，在 OPPO adapter 内注入最小 HTTP doer、token cache 和 clock，生产
    默认使用带 5 秒总超时的 `http.Client` 与 Redis。
 2. 用 `url.Values.Encode()` 生成 form body，严格要求 2xx、合法 JSON 和存在的数值 `code`。
-3. token cache key 包含 AppKey 摘要，缓存 20 小时；缓存故障时仍可直接鉴权，避免 Redis
-   故障把 OPPO 推送完全阻断。
+3. token cache key 包含 AppKey 摘要，缓存值携带绝对过期时间并缓存 20 小时；正常路径无锁读取
+   进程内 token，只有缓存 miss、过期或 code 11 才串行刷新。缓存故障时仍可直接鉴权，避免
+   Redis 故障把 OPPO 推送完全阻断。
 4. code 11 使旧 token 失效，强制重新鉴权后只重试一次。其他 OPPO 错误包装为带 code 和
    retryable 属性的类型，但本任务不新增异步重试队列。
-5. 单推消息开启 `verify_registration_id`，使用稳定 `app_message_id` 去重，携带离线 TTL、
-   notification channel、通知级别、私信模板和服务端生成的会话路由参数。
+5. 单推消息开启 `verify_registration_id`，使用稳定 `app_message_id` 去重，不发送会跨会话
+   冲突的 `notify_id`；携带离线 TTL、notification channel、通知级别、私信模板和服务端
+   生成的会话路由参数。标题/正文分别按 50/200 Unicode 字符截断，空值使用安全兜底，
+   `action_parameters` 最大 4 KiB。
 6. 新分类字段通过 `TS_PUSH_OPPO_*` 环境变量接入，保持未配置时的旧分类语义；配置非法时
    禁用 OPPO pusher 并记录错误，避免静默发送错误分类。
 
@@ -57,10 +62,14 @@ source: self
 
 - [x] 鉴权、单推均命中最新国内 host，form 特殊字符和中文可无损解析。
 - [x] HTTP 总超时为 5 秒，非 2xx、超大/畸形 JSON、缺失或非法 code 均失败。
-- [x] token 按 AppKey 隔离缓存；code 11 刷新并只重试一次，稳定去重 ID 不变。
+- [x] token 按 AppKey 隔离并在本地/Redis 同步 20 小时过期；正常路径不访问 Redis；并发
+  cache miss 只鉴权一次；code 11 刷新并只重试一次，稳定去重 ID 不变。
 - [x] code 41/54/10000 等参数或目标错误不自动重试，错误保留 OPPO code。
-- [x] payload 包含校验 registration_id、去重 ID、离线 TTL、路由参数及已配置的新分类字段。
-- [x] 聚焦测试、race、OPPO adapter coverage 82.5%、`go vet ./modules/webhook`、
+- [x] payload 包含校验 registration_id、去重 ID、离线 TTL、路由参数及已配置的新分类字段，
+  不发送跨会话可能冲突的 `notify_id`，且字段长度符合 SDK 约束。
+- [x] OPPO 业务拒绝记录 code/retryable 的 Warn；成功响应记录可用于对账的 messageId，日志
+  不包含凭据或 registration_id。
+- [x] 聚焦测试、race、10 次重复运行、OPPO adapter coverage 83.0%、`go vet ./modules/webhook`、
   `golangci-lint run ./modules/webhook/...` 与 `git diff --check` 通过。
 - [x] 已尝试模块级回归；共享测试库存在 checkout 未知的
   `20260820000001_featuregate_init.sql`，在 `testutil.NewTestServer` 创建 migration plan 时阻塞。

--- a/.octospec/tasks/oppo-push-rest-hardening/brief.md
+++ b/.octospec/tasks/oppo-push-rest-hardening/brief.md
@@ -18,8 +18,9 @@ source: self
 
 ## Load-bearing list
 
-- `wire-contract` — 鉴权与单推使用 `api-push-cn.heytapmobi.com`，请求为 UTF-8 form，
-  `message` 为嵌套 JSON。
+- `wire-contract` — 鉴权与单推使用 OPPO 在线文档 11235 指定的
+  `api-push-cn.heytapmobi.com`，请求为 UTF-8 form，`message` 为嵌套 JSON；字段限制以在线
+  文档 11236 为准。
 - `credential` — MasterSecret 和 auth token 不进入日志；token 按 AppKey 隔离并在本地、Redis
   同步提前过期。
 - `retry/idempotency` — 仅在 OPPO 返回 code 11 时刷新 token 并重试一次；两次发送保持同一
@@ -45,8 +46,9 @@ source: self
    retryable 属性的类型，但本任务不新增异步重试队列。
 5. 单推消息开启 `verify_registration_id`，使用稳定 `app_message_id` 去重，不发送会跨会话
    冲突的 `notify_id`；携带离线 TTL、notification channel、通知级别、私信模板和服务端
-   生成的会话路由参数。标题/正文分别按 50/200 Unicode 字符截断，空值使用安全兜底，
-   `action_parameters` 最大 4 KiB。
+   生成的会话路由参数。未发送 `style` 时使用厂商默认标准样式（`style=1`），标题/正文均按
+   50 Unicode 字符截断，空值使用安全兜底，`action_parameters` 最大 4000 字符；Activity
+   和 URL 配置分别限制为 500/2000 字符。
 6. 新分类字段通过 `TS_PUSH_OPPO_*` 环境变量接入，保持未配置时的旧分类语义；配置非法时
    禁用 OPPO pusher 并记录错误，避免静默发送错误分类。
 
@@ -61,16 +63,22 @@ source: self
 ## Acceptance
 
 - [x] 鉴权、单推均命中最新国内 host，form 特殊字符和中文可无损解析。
+- [x] 2026-08-24 已核对 OPPO 官方在线文档 11235/11236：国内 host、标题 50 字符、默认
+  `style=1` 正文 50 字符、Activity 500 字符、URL 2000 字符、动作参数 4000 字符；旧 Java
+  SDK 1.1.0 不作为覆盖在线文档的依据。
 - [x] HTTP 总超时为 5 秒，非 2xx、超大/畸形 JSON、缺失或非法 code 均失败。
 - [x] token 按 AppKey 隔离并在本地/Redis 同步 20 小时过期；正常路径不访问 Redis；并发
   cache miss 只鉴权一次；code 11 刷新并只重试一次，稳定去重 ID 不变。
 - [x] code 41/54/10000 等参数或目标错误不自动重试，错误保留 OPPO code。
 - [x] payload 包含校验 registration_id、去重 ID、离线 TTL、路由参数及已配置的新分类字段，
   不发送跨会话可能冲突的 `notify_id`，且字段长度符合 SDK 约束。
-- [x] OPPO 业务拒绝记录 code/retryable 的 Warn；成功响应记录可用于对账的 messageId，日志
-  不包含凭据或 registration_id。
-- [x] 聚焦测试、race、10 次重复运行、OPPO adapter coverage 83.0%、`go vet ./modules/webhook`、
+- [x] 无效 registration_id（code 41）和可自愈的首次 token 失效（code 11）记录 Debug；未恢复
+  的 code 11、code 54 等业务拒绝记录 code/retryable 的 Warn；成功响应记录可用于对账的
+  messageId；设备 token 只记录脱敏值，日志不包含凭据或完整 registration_id。
+- [x] 聚焦测试、race、10 次重复运行、OPPO adapter coverage 83.6%、`go vet ./modules/webhook`、
   `golangci-lint run ./modules/webhook/...` 与 `git diff --check` 通过。
-- [x] `go test ./modules/webhook -count=1` 已通过：使用临时 octo-lib testutil overlay 指向独立的
-  `test_oppo_santiago` 数据库运行，完成后已删除该临时库。默认共享 `test` 库仍存在 checkout
-  未知的 `20260820000001_featuregate_init.sql`；未修改或清理共享测试库。
+- [x] `go test ./modules/webhook -count=1` 已通过：使用临时 octo-lib testutil overlay 指向独立
+  临时数据库运行，完成后已删除该数据库。默认共享 `test` 库仍存在 checkout 未知的
+  `20260820000001_featuregate_init.sql`；未修改或清理共享测试库。
+- [x] 提供独立 `TestOPPOAuth` 真实鉴权 smoke，仅需 AppKey/MasterSecret；完整单推 smoke 另需
+  同一应用的有效 registration_id，设备到达、展示和点击仍需 Android 端联合验收。

--- a/.octospec/tasks/oppo-push-rest-hardening/brief.md
+++ b/.octospec/tasks/oppo-push-rest-hardening/brief.md
@@ -55,11 +55,13 @@ source: self
 
 ## Acceptance
 
-- [ ] 鉴权、单推均命中最新国内 host，form 特殊字符和中文可无损解析。
-- [ ] HTTP 总超时为 5 秒，非 2xx、超大/畸形 JSON、缺失或非法 code 均失败。
-- [ ] token 按 AppKey 隔离缓存；code 11 刷新并只重试一次，稳定去重 ID 不变。
-- [ ] code 41/54/10000 等参数或目标错误不自动重试，错误保留 OPPO code。
-- [ ] payload 包含校验 registration_id、去重 ID、离线 TTL、路由参数及已配置的新分类字段。
-- [ ] 聚焦测试、race、coverage、`go vet ./modules/webhook` 与 `git diff --check` 通过。
-- [ ] 尝试模块级回归；若共享基础设施阻塞，保留完整错误证据且不误报为通过。
-
+- [x] 鉴权、单推均命中最新国内 host，form 特殊字符和中文可无损解析。
+- [x] HTTP 总超时为 5 秒，非 2xx、超大/畸形 JSON、缺失或非法 code 均失败。
+- [x] token 按 AppKey 隔离缓存；code 11 刷新并只重试一次，稳定去重 ID 不变。
+- [x] code 41/54/10000 等参数或目标错误不自动重试，错误保留 OPPO code。
+- [x] payload 包含校验 registration_id、去重 ID、离线 TTL、路由参数及已配置的新分类字段。
+- [x] 聚焦测试、race、OPPO adapter coverage 82.5%、`go vet ./modules/webhook`、
+  `golangci-lint run ./modules/webhook/...` 与 `git diff --check` 通过。
+- [x] 已尝试模块级回归；共享测试库存在 checkout 未知的
+  `20260820000001_featuregate_init.sql`，在 `testutil.NewTestServer` 创建 migration plan 时阻塞。
+  未修改或清理共享测试库。

--- a/docs/oppo-push-server.md
+++ b/docs/oppo-push-server.md
@@ -11,7 +11,10 @@
 - auth token：按 AppKey 隔离，本地和 Redis 均按绝对时间提前 20 小时过期；正常发送不访问
   Redis，Redis 故障时使用进程内缓存降级
 - token 失效：仅对 OPPO code `11` 强制鉴权并重试一次
-- 去重：重试沿用同一个 `app_message_id`
+- 去重：按设备 token 与 WuKongIM 全局 `message_id` 生成稳定 `app_message_id`；仅当上游异常缺失
+  `message_id` 时，使用发送者/频道作用域内的 `client_msg_no` 回退；同一次重试沿用同一 ID
+- 目标校验：registration_id 必须是单值，拒绝分号、逗号、空白、控制字符以及超过 256 字节的值；
+  256 字节是服务端防御上限，不宣称为 OPPO 官方格式上限
 - 可观测性：无效 registration_id（code `41`）和可自愈的首次 token 失效（code `11`）以
   Debug 记录；未恢复的 code `11`、code `54` 等业务拒绝以 Warn 记录
   `oppo_code/retryable`；成功响应以 Debug 记录 `oppo_message_id`
@@ -124,3 +127,6 @@ unset OPPO_APP_KEY OPPO_MASTER_SECRET OPPO_DEVICE_TOKEN
 
 该烟测只证明 OPPO 接口接受请求。到达、展示和点击跳转还必须结合测试设备与 Android 客户端
 日志验收。
+
+2026-08-24 已使用专用测试应用及设备完成鉴权、单推和通知栏展示验证；默认
+`click_action_type=0` 仅验证启动应用，直达会话与 `action_parameters` 消费仍需 Android 端联调。

--- a/docs/oppo-push-server.md
+++ b/docs/oppo-push-server.md
@@ -12,8 +12,10 @@
   Redis，Redis 故障时使用进程内缓存降级
 - token 失效：仅对 OPPO code `11` 强制鉴权并重试一次
 - 去重：重试沿用同一个 `app_message_id`
-- 可观测性：厂商业务拒绝以 Warn 记录 `oppo_code/retryable`，成功响应以 Debug 记录
-  `oppo_message_id`；日志不包含 MasterSecret、auth token 或 registration_id
+- 可观测性：无效 registration_id（code `41`）和可自愈的首次 token 失效（code `11`）以
+  Debug 记录；未恢复的 code `11`、code `54` 等业务拒绝以 Warn 记录
+  `oppo_code/retryable`；成功响应以 Debug 记录 `oppo_message_id`
+- 日志不包含 MasterSecret、auth token 或完整 registration_id，仅记录脱敏后的设备 token
 
 服务端会发送 `verify_registration_id=true`、24 小时离线 TTL，但不发送 `notify_id`（避免
 不同会话中相同 `message_seq` 的通知互相覆盖），并把以下会话路由字段编码进
@@ -28,9 +30,22 @@
 }
 ```
 
-通知标题和正文是 OPPO 必填字段。服务端对空值使用“您有一条新的消息”兜底，并分别按
-50/200 个 Unicode 字符截断；`action_parameters` 编码后不得超过 4 KiB，超限时拒绝发送并
-返回错误。
+通知标题和正文是 OPPO 必填字段。当前 payload 不发送 `style`，厂商按默认标准样式
+`style=1` 处理。服务端对空值使用“您有一条新的消息”兜底，标题和正文均按 50 个 Unicode
+字符截断；`action_parameters` 编码后不得超过 4000 个字符，超限时拒绝发送并返回错误。
+
+### 官方契约依据
+
+以下结论于 2026-08-24 按 OPPO 开放平台在线文档核对，附件中的 Java SDK 1.1.0 仅作为旧版
+参考，不覆盖在线文档：
+
+- [服务端接口说明（文档 11235）](https://open.oppomobile.com/documentation/page/info?id=11235)：
+  国内服务地址为 `https://api-push-cn.heytapmobi.com/`
+- [消息体说明（文档 11236）](https://open.oppomobile.com/documentation/page/info?id=11236)：
+  `title` 最多 50 字符；默认 `style=1` 时 `content` 最多 50 字符；Activity 最多 500 字符；
+  URL 最多 2000 字符；`action_parameters` 最多 4000 字符
+- [鉴权说明（文档 11234）](https://open.oppomobile.com/documentation/page/info?id=11234)：
+  以 AppKey、13 位毫秒时间戳和 MasterSecret 拼接后计算 SHA-256，auth token 默认有效 24 小时
 
 ## 配置
 
@@ -81,13 +96,30 @@ go test -race ./modules/webhook -run '^Test(OPPO|ParseOPPO|LoadOPPO|NewOPPO)' -c
 go vet ./modules/webhook
 ```
 
+拿到 AppKey 和 MasterSecret 后可直接在本地验证鉴权，无需部署，也不需要包名或
+registration_id。不要把密钥粘贴到聊天、日志、命令历史或仓库文件中；以下 zsh 示例通过
+隐藏输入设置当前 shell 的临时环境变量：
+
+```bash
+read -rs "OPPO_APP_KEY?OPPO AppKey: "; echo
+read -rs "OPPO_MASTER_SECRET?OPPO MasterSecret: "; echo
+export OPPO_APP_KEY OPPO_MASTER_SECRET
+go test ./modules/webhook -run '^TestOPPOAuth$' -count=1 -v
+unset OPPO_APP_KEY OPPO_MASTER_SECRET
+```
+
+该测试只校验最新 host、签名和凭据能够换取非空 auth token，不会打印 token，也不代表消息已
+送达设备。
+
 真实设备烟测需要专用测试应用、测试设备和有效 registration_id：
 
 ```bash
-OPPO_APP_KEY='...' \
-OPPO_MASTER_SECRET='...' \
-OPPO_DEVICE_TOKEN='...' \
+read -rs "OPPO_APP_KEY?OPPO AppKey: "; echo
+read -rs "OPPO_MASTER_SECRET?OPPO MasterSecret: "; echo
+read -rs "OPPO_DEVICE_TOKEN?OPPO registration_id: "; echo
+export OPPO_APP_KEY OPPO_MASTER_SECRET OPPO_DEVICE_TOKEN
 go test ./modules/webhook -run '^TestOPPOPush$' -count=1 -v
+unset OPPO_APP_KEY OPPO_MASTER_SECRET OPPO_DEVICE_TOKEN
 ```
 
 该烟测只证明 OPPO 接口接受请求。到达、展示和点击跳转还必须结合测试设备与 Android 客户端

--- a/docs/oppo-push-server.md
+++ b/docs/oppo-push-server.md
@@ -8,12 +8,16 @@
 - 单推：`POST https://api-push-cn.heytapmobi.com/server/v1/message/notification/unicast`
 - 编码：UTF-8 `application/x-www-form-urlencoded`
 - HTTP 总超时：5 秒
-- auth token：按 AppKey 隔离，Redis 缓存 20 小时；Redis 故障时使用进程内缓存降级
+- auth token：按 AppKey 隔离，本地和 Redis 均按绝对时间提前 20 小时过期；正常发送不访问
+  Redis，Redis 故障时使用进程内缓存降级
 - token 失效：仅对 OPPO code `11` 强制鉴权并重试一次
 - 去重：重试沿用同一个 `app_message_id`
+- 可观测性：厂商业务拒绝以 Warn 记录 `oppo_code/retryable`，成功响应以 Debug 记录
+  `oppo_message_id`；日志不包含 MasterSecret、auth token 或 registration_id
 
-服务端会发送 `verify_registration_id=true`、24 小时离线 TTL、`notify_id`，并把以下
-会话路由字段编码进 `action_parameters`：
+服务端会发送 `verify_registration_id=true`、24 小时离线 TTL，但不发送 `notify_id`（避免
+不同会话中相同 `message_seq` 的通知互相覆盖），并把以下会话路由字段编码进
+`action_parameters`：
 
 ```json
 {
@@ -23,6 +27,10 @@
   "message_seq": 42
 }
 ```
+
+通知标题和正文是 OPPO 必填字段。服务端对空值使用“您有一条新的消息”兜底，并分别按
+50/200 个 Unicode 字符截断；`action_parameters` 编码后不得超过 4 KiB，超限时拒绝发送并
+返回错误。
 
 ## 配置
 
@@ -34,7 +42,7 @@
 | `TS_PUSH_OPPO_APPKEY` | 是 | OPPO PUSH AppKey |
 | `TS_PUSH_OPPO_MASTERSECRET` | 是 | OPPO PUSH 服务端密钥；不得写入日志或仓库 |
 
-以下为 octo-server 本地扩展配置：
+以下为 octo-server 本地扩展配置，当前版本**仅从环境变量读取**，写入 `tsdd.yaml` 不会生效：
 
 | 环境变量 | 默认 | 说明 |
 | --- | --- | --- |

--- a/docs/oppo-push-server.md
+++ b/docs/oppo-push-server.md
@@ -1,0 +1,86 @@
+# OPPO PUSH 服务端接入
+
+## 当前实现
+
+服务端通过 OPPO 国内 REST API 发送通知栏单推：
+
+- 鉴权：`POST https://api-push-cn.heytapmobi.com/server/v1/auth`
+- 单推：`POST https://api-push-cn.heytapmobi.com/server/v1/message/notification/unicast`
+- 编码：UTF-8 `application/x-www-form-urlencoded`
+- HTTP 总超时：5 秒
+- auth token：按 AppKey 隔离，Redis 缓存 20 小时；Redis 故障时使用进程内缓存降级
+- token 失效：仅对 OPPO code `11` 强制鉴权并重试一次
+- 去重：重试沿用同一个 `app_message_id`
+
+服务端会发送 `verify_registration_id=true`、24 小时离线 TTL、`notify_id`，并把以下
+会话路由字段编码进 `action_parameters`：
+
+```json
+{
+  "space_id": "space-id",
+  "channel_id": "channel-id",
+  "channel_type": 2,
+  "message_seq": 42
+}
+```
+
+## 配置
+
+基础配置由 octo-lib 加载。启用 OPPO pusher 至少需要：
+
+| 环境变量 | 必需 | 说明 |
+| --- | --- | --- |
+| `TS_PUSH_OPPO_PACKAGENAME` | 是 | Android 包名，同时作为厂商 pusher 路由键 |
+| `TS_PUSH_OPPO_APPKEY` | 是 | OPPO PUSH AppKey |
+| `TS_PUSH_OPPO_MASTERSECRET` | 是 | OPPO PUSH 服务端密钥；不得写入日志或仓库 |
+
+以下为 octo-server 本地扩展配置：
+
+| 环境变量 | 默认 | 说明 |
+| --- | --- | --- |
+| `TS_PUSH_OPPO_CATEGORY` | 空 | 新消息分类，例如 `IM`；仅在流量确实符合已获批分类时设置 |
+| `TS_PUSH_OPPO_NOTIFY_LEVEL` | 分类为空时不发送；分类非空时为 `2` | 允许 `1`、`2`、`16`；`16` 需要 OPPO 强提醒权益 |
+| `TS_PUSH_OPPO_CHANNEL_ID` | 空 | Android `NotificationChannel` ID，不是 IM 会话 ID |
+| `TS_PUSH_OPPO_PRIVATE_MSG_TEMPLATE_ID` | 空 | OPPO 审核通过的私信模板 ID；平台要求时必须配置 |
+| `TS_PUSH_OPPO_CLICK_ACTION_TYPE` | `0` | `0` 启动应用，`1/4` 打开 Activity，`2/5` 使用 URL/Intent URI |
+| `TS_PUSH_OPPO_CLICK_ACTION_ACTIVITY` | 空 | action type 为 `1/4` 时必需 |
+| `TS_PUSH_OPPO_CLICK_ACTION_URL` | 空 | action type 为 `2/5` 时必需 |
+
+配置值不合法时，OPPO pusher 在启动构造阶段会被禁用并记录错误。不会回退为带错误分类的
+请求。
+
+### 分类边界
+
+`TS_PUSH_OPPO_CATEGORY` 是当前应用级配置。octo-server 同一推送流里可能同时存在真人会话、
+Bot 和系统消息，因此不能在所有环境中无条件默认 `IM`。只有确认该部署送往 OPPO 的消息都
+符合 OPPO 已批准的 `IM` 分类时才设置；否则保持为空，或后续增加经过评审的逐消息分类器。
+
+已配置 `category` 后不要在同一设备上混用旧分类和新分类 payload。若 OPPO 控制台要求
+私信模板，同时配置 `TS_PUSH_OPPO_PRIVATE_MSG_TEMPLATE_ID`，避免 code `54`。
+
+### 点击路由
+
+服务端只负责生成可信 `action_parameters`。若需要点击后直达会话，应配置 Android Activity
+或 Intent URI，并由客户端校验、解析上述四个字段。未配置时 `click_action_type=0`，只保证
+启动应用，不宣称能够直达会话。
+
+## 验证
+
+无需真实凭据的契约测试：
+
+```bash
+go test -race ./modules/webhook -run '^Test(OPPO|ParseOPPO|LoadOPPO|NewOPPO)' -count=1
+go vet ./modules/webhook
+```
+
+真实设备烟测需要专用测试应用、测试设备和有效 registration_id：
+
+```bash
+OPPO_APP_KEY='...' \
+OPPO_MASTER_SECRET='...' \
+OPPO_DEVICE_TOKEN='...' \
+go test ./modules/webhook -run '^TestOPPOPush$' -count=1 -v
+```
+
+该烟测只证明 OPPO 接口接受请求。到达、展示和点击跳转还必须结合测试设备与 Android 客户端
+日志验收。

--- a/modules/webhook/api.go
+++ b/modules/webhook/api.go
@@ -105,8 +105,13 @@ func New(ctx *config.Context) *Webhook {
 		}
 	}
 	if oppo.PackageName != "" {
-		pushMap[common.DeviceTypeOPPO] = map[string]Push{
-			ctx.GetConfig().Push.OPPO.PackageName: NewOPPOPush(oppo.AppID, oppo.AppKey, oppo.AppSecret, oppo.MasterSecret, ctx),
+		oppoPusher := NewOPPOPush(oppo.AppID, oppo.AppKey, oppo.AppSecret, oppo.MasterSecret, ctx)
+		if oppoPusher.configErr != nil {
+			log.Error("OPPO push configuration is invalid; pusher disabled", zap.Error(oppoPusher.configErr))
+		} else {
+			pushMap[common.DeviceTypeOPPO] = map[string]Push{
+				oppo.PackageName: oppoPusher,
+			}
 		}
 	}
 	if vivo.PackageName != "" {

--- a/modules/webhook/push_oppo.go
+++ b/modules/webhook/push_oppo.go
@@ -8,11 +8,17 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/network"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"go.uber.org/zap"
+)
+
+const (
+	oppoAPIBaseURL             = "https://api-push-cn.heytapmobi.com"
+	oppoAuthURL                = oppoAPIBaseURL + "/server/v1/auth"
+	oppoNotificationUnicastURL = oppoAPIBaseURL + "/server/v1/message/notification/unicast"
 )
 
 // OPPO 推送
@@ -77,7 +83,7 @@ func (o *OPPOPush) Push(deviceToken string, payload Payload) error {
 	}
 	dataType, _ := json.Marshal(message)
 	dataString := string(dataType)
-	resp, err := network.PostForWWWForm("https://api.push.oppomobile.com/server/v1/message/notification/unicast", map[string]string{
+	resp, err := network.PostForWWWForm(oppoNotificationUnicastURL, map[string]string{
 		"auth_token": authToken,
 		"message":    dataString,
 	}, nil)
@@ -108,7 +114,7 @@ func (o *OPPOPush) getAuthToken() string {
 	}
 	timestamp := time.Now().Local().UnixNano() / 1e6
 	sign := o.SHA256(fmt.Sprintf("%s%d%s", o.appKey, timestamp, o.masterSecret))
-	resp, err := network.PostForWWWForm("https://api.push.oppomobile.com/server/v1/auth", map[string]string{
+	resp, err := network.PostForWWWForm(oppoAuthURL, map[string]string{
 		"app_key":   o.appKey,
 		"sign":      sign,
 		"timestamp": fmt.Sprintf("%d", timestamp),

--- a/modules/webhook/push_oppo.go
+++ b/modules/webhook/push_oppo.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -32,6 +33,11 @@ const (
 	oppoAuthTokenTTL      = 20 * time.Hour
 	oppoMaxResponseBytes  = 1 << 20
 	oppoDefaultOfflineTTL = 24 * 60 * 60
+
+	oppoMaxTitleRunes            = 50
+	oppoMaxContentRunes          = 200
+	oppoMaxActionParametersBytes = 4 * 1024
+	oppoDefaultNotificationText  = "您有一条新的消息"
 )
 
 type oppoHTTPDoer interface {
@@ -173,8 +179,18 @@ type OPPOPush struct {
 	configErr              error
 
 	authMu         sync.Mutex
-	localAuthToken string
+	localAuthToken atomic.Pointer[oppoAuthToken]
 	log.Log
+}
+
+type oppoAuthToken struct {
+	value     string
+	expiresAt time.Time
+}
+
+type oppoCachedAuthToken struct {
+	AuthToken string `json:"auth_token"`
+	ExpiresAt int64  `json:"expires_at"`
 }
 
 // NewOPPOPush creates a production OPPO REST pusher. Redis is used as a shared
@@ -267,7 +283,6 @@ type oppoNotification struct {
 	OffLine                  bool   `json:"off_line"`
 	OffLineTTL               int    `json:"off_line_ttl"`
 	ChannelID                string `json:"channel_id,omitempty"`
-	NotifyID                 uint32 `json:"notify_id"`
 	Category                 string `json:"category,omitempty"`
 	NotifyLevel              int    `json:"notify_level,omitempty"`
 	PrivateMessageTemplateID string `json:"private_msg_template_id,omitempty"`
@@ -285,10 +300,6 @@ func (o *OPPOPush) buildUnicastMessage(deviceToken string, payload *OPPOPayload)
 		return nil, errors.New("OPPO push: empty registration ID")
 	}
 
-	notifyID, err := strconv.ParseUint(payload.notifyID, 10, 32)
-	if err != nil {
-		return nil, fmt.Errorf("OPPO push: invalid notify ID %q: %w", payload.notifyID, err)
-	}
 	routing, err := json.Marshal(oppoRoutingParameters{
 		SpaceID:     payload.spaceID,
 		ChannelID:   payload.channelID,
@@ -297,6 +308,9 @@ func (o *OPPOPush) buildUnicastMessage(deviceToken string, payload *OPPOPayload)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("OPPO push: encode action parameters: %w", err)
+	}
+	if len(routing) > oppoMaxActionParametersBytes {
+		return nil, fmt.Errorf("OPPO push: action parameters exceed %d bytes", oppoMaxActionParametersBytes)
 	}
 
 	dedupeSource := strings.Join([]string{
@@ -315,8 +329,8 @@ func (o *OPPOPush) buildUnicastMessage(deviceToken string, payload *OPPOPayload)
 		VerifyRegistrationID: true,
 		Notification: oppoNotification{
 			AppMessageID:             "octo-" + hex.EncodeToString(dedupeDigest[:16]),
-			Title:                    payload.GetTitle(),
-			Content:                  payload.GetContent(),
+			Title:                    normalizeOPPONotificationText(payload.GetTitle(), oppoMaxTitleRunes),
+			Content:                  normalizeOPPONotificationText(payload.GetContent(), oppoMaxContentRunes),
 			ClickActionType:          o.options.clickActionType,
 			ClickActionActivity:      o.options.clickActionActivity,
 			ClickActionURL:           o.options.clickActionURL,
@@ -324,7 +338,6 @@ func (o *OPPOPush) buildUnicastMessage(deviceToken string, payload *OPPOPayload)
 			OffLine:                  true,
 			OffLineTTL:               o.options.offlineTTLSeconds,
 			ChannelID:                o.options.channelID,
-			NotifyID:                 uint32(notifyID),
 			Category:                 o.options.category,
 			NotifyLevel:              o.options.notifyLevel,
 			PrivateMessageTemplateID: o.options.privateMessageTemplateID,
@@ -336,6 +349,17 @@ func (o *OPPOPush) buildUnicastMessage(deviceToken string, payload *OPPOPayload)
 		return nil, fmt.Errorf("OPPO push: encode message: %w", err)
 	}
 	return encoded, nil
+}
+
+func normalizeOPPONotificationText(value string, maxRunes int) string {
+	if strings.TrimSpace(value) == "" {
+		value = oppoDefaultNotificationText
+	}
+	runes := []rune(value)
+	if len(runes) > maxRunes {
+		return string(runes[:maxRunes])
+	}
+	return value
 }
 
 // Push sends one notification. OPPO code 11 is the only response retried here:
@@ -381,24 +405,43 @@ func (o *OPPOPush) sendUnicast(authToken string, message []byte) error {
 		o.Warn("OPPO push request failed", zap.Error(err))
 		return err
 	}
-	return response.apiError("push")
+	if err := response.apiError("push"); err != nil {
+		var apiErr *oppoAPIError
+		if errors.As(err, &apiErr) {
+			o.Warn("OPPO push rejected", zap.Int("oppo_code", apiErr.Code), zap.Bool("retryable", apiErr.Retryable))
+		}
+		return err
+	}
+	if messageID := response.messageID(); messageID != "" {
+		o.Debug("OPPO push accepted", zap.String("oppo_message_id", messageID))
+	}
+	return nil
 }
 
 func (o *OPPOPush) getAuthToken() (string, error) {
+	if token, ok := o.processLocalAuthToken(); ok {
+		return token, nil
+	}
+
 	o.authMu.Lock()
 	defer o.authMu.Unlock()
 
+	if token, ok := o.processLocalAuthToken(); ok {
+		return token, nil
+	}
 	if o.tokenCache != nil {
-		token, err := o.tokenCache.GetString(o.authTokenCacheKey)
+		cached, err := o.tokenCache.GetString(o.authTokenCacheKey)
 		if err != nil {
 			o.Warn("read OPPO auth token cache failed; falling back to direct authentication", zap.Error(err))
-		} else if token != "" {
-			o.localAuthToken = token
-			return token, nil
+		} else if cached != "" {
+			token, parseErr := parseOPPOCachedAuthToken(cached, o.now())
+			if parseErr == nil {
+				o.localAuthToken.Store(token)
+				return token.value, nil
+			}
+			o.Warn("discard invalid OPPO auth token cache", zap.Error(parseErr))
+			o.deleteCachedAuthToken()
 		}
-	}
-	if o.localAuthToken != "" {
-		return o.localAuthToken, nil
 	}
 	return o.authenticateLocked()
 }
@@ -407,24 +450,65 @@ func (o *OPPOPush) refreshAuthToken(rejectedToken string) (string, error) {
 	o.authMu.Lock()
 	defer o.authMu.Unlock()
 
+	if token, ok := o.processLocalAuthToken(); ok && token != rejectedToken {
+		return token, nil
+	}
 	if o.tokenCache != nil {
-		cachedToken, err := o.tokenCache.GetString(o.authTokenCacheKey)
+		cached, err := o.tokenCache.GetString(o.authTokenCacheKey)
 		if err != nil {
 			o.Warn("read OPPO auth token cache during refresh failed", zap.Error(err))
-		} else if cachedToken != "" && cachedToken != rejectedToken {
-			o.localAuthToken = cachedToken
-			return cachedToken, nil
+		} else if cached != "" {
+			cachedToken, parseErr := parseOPPOCachedAuthToken(cached, o.now())
+			if parseErr == nil && cachedToken.value != rejectedToken {
+				o.localAuthToken.Store(cachedToken)
+				return cachedToken.value, nil
+			}
 		}
-		if err := o.tokenCache.Del(o.authTokenCacheKey); err != nil {
-			o.Warn("invalidate OPPO auth token cache failed", zap.Error(err))
-		}
+		o.deleteCachedAuthToken()
 	}
-	o.localAuthToken = ""
+	o.localAuthToken.Store(nil)
 	return o.authenticateLocked()
 }
 
+func (o *OPPOPush) processLocalAuthToken() (string, bool) {
+	token := o.localAuthToken.Load()
+	if token == nil || token.value == "" || !o.now().Before(token.expiresAt) {
+		return "", false
+	}
+	return token.value, true
+}
+
+func parseOPPOCachedAuthToken(value string, now time.Time) (*oppoAuthToken, error) {
+	var cached oppoCachedAuthToken
+	if err := json.Unmarshal([]byte(value), &cached); err != nil {
+		return nil, fmt.Errorf("decode cached token: %w", err)
+	}
+	cached.AuthToken = strings.TrimSpace(cached.AuthToken)
+	if cached.AuthToken == "" || cached.ExpiresAt <= 0 {
+		return nil, errors.New("cached token is missing auth_token or expires_at")
+	}
+	token := &oppoAuthToken{
+		value:     cached.AuthToken,
+		expiresAt: time.UnixMilli(cached.ExpiresAt),
+	}
+	if !now.Before(token.expiresAt) {
+		return nil, errors.New("cached token has expired")
+	}
+	return token, nil
+}
+
+func (o *OPPOPush) deleteCachedAuthToken() {
+	if o.tokenCache == nil {
+		return
+	}
+	if err := o.tokenCache.Del(o.authTokenCacheKey); err != nil {
+		o.Warn("invalidate OPPO auth token cache failed", zap.Error(err))
+	}
+}
+
 func (o *OPPOPush) authenticateLocked() (string, error) {
-	timestamp := o.now().UnixMilli()
+	issuedAt := o.now()
+	timestamp := issuedAt.UnixMilli()
 	sign := o.SHA256(fmt.Sprintf("%s%d%s", o.appKey, timestamp, o.masterSecret))
 	response, err := o.postForm(o.authURL, url.Values{
 		"app_key":   {o.appKey},
@@ -435,6 +519,10 @@ func (o *OPPOPush) authenticateLocked() (string, error) {
 		return "", fmt.Errorf("OPPO auth request: %w", err)
 	}
 	if err := response.apiError("auth"); err != nil {
+		var apiErr *oppoAPIError
+		if errors.As(err, &apiErr) {
+			o.Warn("OPPO auth rejected", zap.Int("oppo_code", apiErr.Code), zap.Bool("retryable", apiErr.Retryable))
+		}
 		return "", err
 	}
 
@@ -451,13 +539,24 @@ func (o *OPPOPush) authenticateLocked() (string, error) {
 		return "", errors.New("OPPO auth: missing auth_token")
 	}
 
-	o.localAuthToken = data.AuthToken
+	token := &oppoAuthToken{
+		value:     data.AuthToken,
+		expiresAt: issuedAt.Add(oppoAuthTokenTTL),
+	}
+	o.localAuthToken.Store(token)
 	if o.tokenCache != nil {
-		if err := o.tokenCache.SetAndExpire(o.authTokenCacheKey, data.AuthToken, oppoAuthTokenTTL); err != nil {
+		cached, err := json.Marshal(oppoCachedAuthToken{
+			AuthToken: token.value,
+			ExpiresAt: token.expiresAt.UnixMilli(),
+		})
+		if err != nil {
+			return "", fmt.Errorf("OPPO auth: encode token cache: %w", err)
+		}
+		if err := o.tokenCache.SetAndExpire(o.authTokenCacheKey, string(cached), oppoAuthTokenTTL); err != nil {
 			o.Warn("cache OPPO auth token failed; using process-local token", zap.Error(err))
 		}
 	}
-	return data.AuthToken, nil
+	return token.value, nil
 }
 
 type oppoAPIResponse struct {
@@ -479,6 +578,19 @@ func (r *oppoAPIResponse) apiError(operation string) error {
 		Message:   r.Message,
 		Retryable: isRetryableOPPOCode(*r.Code),
 	}
+}
+
+func (r *oppoAPIResponse) messageID() string {
+	if r == nil || len(r.Data) == 0 || string(r.Data) == "null" {
+		return ""
+	}
+	var data struct {
+		MessageID string `json:"messageId"`
+	}
+	if err := json.Unmarshal(r.Data, &data); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(data.MessageID)
 }
 
 type oppoAPIError struct {

--- a/modules/webhook/push_oppo.go
+++ b/modules/webhook/push_oppo.go
@@ -271,7 +271,13 @@ func newOPPOPayloadForMessage(payloadInfo *PayloadInfo, msg msgOfflineNotify) (*
 	if msg.MessageID != 0 {
 		dedupeID = "message:" + strconv.FormatInt(msg.MessageID, 10)
 	} else if clientMsgNo := strings.TrimSpace(msg.ClientMsgNo); clientMsgNo != "" {
-		dedupeID = "client:" + clientMsgNo
+		dedupeID = strings.Join([]string{
+			"client",
+			msg.FromUID,
+			msg.ChannelID,
+			strconv.Itoa(int(msg.ChannelType)),
+			clientMsgNo,
+		}, "\x00")
 	} else {
 		return nil, errors.New("OPPO push: missing message identity")
 	}

--- a/modules/webhook/push_oppo.go
+++ b/modules/webhook/push_oppo.go
@@ -25,6 +25,7 @@ import (
 )
 
 const (
+	// OPPO domestic service endpoint: https://open.oppomobile.com/documentation/page/info?id=11235
 	oppoAPIBaseURL             = "https://api-push-cn.heytapmobi.com"
 	oppoAuthURL                = oppoAPIBaseURL + "/server/v1/auth"
 	oppoNotificationUnicastURL = oppoAPIBaseURL + "/server/v1/message/notification/unicast"

--- a/modules/webhook/push_oppo.go
+++ b/modules/webhook/push_oppo.go
@@ -236,7 +236,7 @@ func NewOPPOPush(appID, appKey, appSecret, masterSecret string, ctx *config.Cont
 // OPPOPayload is the server-owned input for an OPPO notification.
 type OPPOPayload struct {
 	Payload
-	notifyID    string
+	dedupeID    string
 	spaceID     string
 	channelID   string
 	channelType uint8
@@ -245,10 +245,10 @@ type OPPOPayload struct {
 
 // NewOPPOPayload creates an OPPO payload and preserves the authoritative
 // routing fields used by the Android client after a notification click.
-func NewOPPOPayload(payloadInfo *PayloadInfo, notifyID string) *OPPOPayload {
+func NewOPPOPayload(payloadInfo *PayloadInfo, dedupeID string) *OPPOPayload {
 	return &OPPOPayload{
 		Payload:     payloadInfo.toPayload(),
-		notifyID:    notifyID,
+		dedupeID:    dedupeID,
 		spaceID:     payloadInfo.SpaceID,
 		channelID:   payloadInfo.ChannelID,
 		channelType: payloadInfo.ChannelType,
@@ -319,7 +319,7 @@ func (o *OPPOPush) buildUnicastMessage(deviceToken string, payload *OPPOPayload)
 		payload.channelID,
 		strconv.Itoa(int(payload.channelType)),
 		strconv.FormatUint(uint64(payload.messageSeq), 10),
-		payload.notifyID,
+		payload.dedupeID,
 	}, "\x00")
 	dedupeDigest := sha256.Sum256([]byte(dedupeSource))
 

--- a/modules/webhook/push_oppo.go
+++ b/modules/webhook/push_oppo.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -40,6 +41,7 @@ const (
 	oppoMaxTitleRunes            = 50
 	oppoMaxContentRunes          = 50
 	oppoMaxActionParametersRunes = 4000
+	oppoMaxRegistrationIDBytes   = 256
 	oppoDefaultNotificationText  = "您有一条新的消息"
 )
 
@@ -220,12 +222,17 @@ func NewOPPOPush(appID, appKey, appSecret, masterSecret string, ctx *config.Cont
 
 	keyDigest := sha256.Sum256([]byte(appKey))
 	return &OPPOPush{
-		appID:                  appID,
-		appKey:                 appKey,
-		appSecret:              appSecret,
-		masterSecret:           masterSecret,
-		authTokenCacheKey:      "oppo_auth_token:" + hex.EncodeToString(keyDigest[:8]),
-		httpClient:             &http.Client{Timeout: oppoHTTPTimeout},
+		appID:             appID,
+		appKey:            appKey,
+		appSecret:         appSecret,
+		masterSecret:      masterSecret,
+		authTokenCacheKey: "oppo_auth_token:" + hex.EncodeToString(keyDigest[:8]),
+		httpClient: &http.Client{
+			Timeout: oppoHTTPTimeout,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
 		tokenCache:             tokenCache,
 		authURL:                oppoAuthURL,
 		notificationUnicastURL: oppoNotificationUnicastURL,
@@ -259,13 +266,25 @@ func NewOPPOPayload(payloadInfo *PayloadInfo, dedupeID string) *OPPOPayload {
 	}
 }
 
+func newOPPOPayloadForMessage(payloadInfo *PayloadInfo, msg msgOfflineNotify) (*OPPOPayload, error) {
+	var dedupeID string
+	if msg.MessageID != 0 {
+		dedupeID = "message:" + strconv.FormatInt(msg.MessageID, 10)
+	} else if clientMsgNo := strings.TrimSpace(msg.ClientMsgNo); clientMsgNo != "" {
+		dedupeID = "client:" + clientMsgNo
+	} else {
+		return nil, errors.New("OPPO push: missing message identity")
+	}
+	return NewOPPOPayload(payloadInfo, dedupeID), nil
+}
+
 // GetPayload builds the OPPO payload from the canonical offline-message data.
 func (o *OPPOPush) GetPayload(msg msgOfflineNotify, ctx *config.Context, toUser *user.Resp) (Payload, error) {
 	payloadInfo, err := ParsePushInfo(msg, ctx, toUser)
 	if err != nil {
 		return nil, err
 	}
-	return NewOPPOPayload(payloadInfo, fmt.Sprintf("%d", msg.MessageSeq)), nil
+	return newOPPOPayloadForMessage(payloadInfo, msg)
 }
 
 type oppoRoutingParameters struct {
@@ -299,8 +318,8 @@ type oppoUnicastMessage struct {
 }
 
 func (o *OPPOPush) buildUnicastMessage(deviceToken string, payload *OPPOPayload) ([]byte, error) {
-	if strings.TrimSpace(deviceToken) == "" {
-		return nil, errors.New("OPPO push: empty registration ID")
+	if err := validateOPPORegistrationID(deviceToken); err != nil {
+		return nil, err
 	}
 
 	routing, err := json.Marshal(oppoRoutingParameters{
@@ -318,10 +337,6 @@ func (o *OPPOPush) buildUnicastMessage(deviceToken string, payload *OPPOPayload)
 
 	dedupeSource := strings.Join([]string{
 		deviceToken,
-		payload.spaceID,
-		payload.channelID,
-		strconv.Itoa(int(payload.channelType)),
-		strconv.FormatUint(uint64(payload.messageSeq), 10),
 		payload.dedupeID,
 	}, "\x00")
 	dedupeDigest := sha256.Sum256([]byte(dedupeSource))
@@ -352,6 +367,24 @@ func (o *OPPOPush) buildUnicastMessage(deviceToken string, payload *OPPOPayload)
 		return nil, fmt.Errorf("OPPO push: encode message: %w", err)
 	}
 	return encoded, nil
+}
+
+func validateOPPORegistrationID(deviceToken string) error {
+	if deviceToken == "" {
+		return errors.New("OPPO push: empty registration ID")
+	}
+	if len(deviceToken) > oppoMaxRegistrationIDBytes {
+		return fmt.Errorf("OPPO push: registration ID exceeds %d bytes", oppoMaxRegistrationIDBytes)
+	}
+	if !utf8.ValidString(deviceToken) {
+		return errors.New("OPPO push: registration ID is not valid UTF-8")
+	}
+	for _, character := range deviceToken {
+		if character == ';' || character == ',' || unicode.IsSpace(character) || unicode.IsControl(character) {
+			return errors.New("OPPO push: malformed registration ID")
+		}
+	}
+	return nil
 }
 
 func normalizeOPPONotificationText(value string, maxRunes int) string {
@@ -487,8 +520,8 @@ func (o *OPPOPush) refreshAuthToken(rejectedToken string) (string, error) {
 				o.localAuthToken.Store(cachedToken)
 				return cachedToken.value, nil
 			}
+			o.deleteCachedAuthToken()
 		}
-		o.deleteCachedAuthToken()
 	}
 	o.localAuthToken.Store(nil)
 	return o.authenticateLocked()
@@ -625,10 +658,7 @@ type oppoAPIError struct {
 }
 
 func (e *oppoAPIError) Error() string {
-	if e.Message == "" {
-		return fmt.Sprintf("OPPO %s failed with code %d", e.Operation, e.Code)
-	}
-	return fmt.Sprintf("OPPO %s failed with code %d: %s", e.Operation, e.Code, e.Message)
+	return fmt.Sprintf("OPPO %s failed with code %d", e.Operation, e.Code)
 }
 
 func isRetryableOPPOCode(code int) bool {

--- a/modules/webhook/push_oppo.go
+++ b/modules/webhook/push_oppo.go
@@ -34,9 +34,11 @@ const (
 	oppoMaxResponseBytes  = 1 << 20
 	oppoDefaultOfflineTTL = 24 * 60 * 60
 
+	// OPPO notification limits: https://open.oppomobile.com/documentation/page/info?id=11236
+	// The adapter omits style, so OPPO applies standard style (1) and its 50-character content limit.
 	oppoMaxTitleRunes            = 50
-	oppoMaxContentRunes          = 200
-	oppoMaxActionParametersBytes = 4 * 1024
+	oppoMaxContentRunes          = 50
+	oppoMaxActionParametersRunes = 4000
 	oppoDefaultNotificationText  = "您有一条新的消息"
 )
 
@@ -309,8 +311,8 @@ func (o *OPPOPush) buildUnicastMessage(deviceToken string, payload *OPPOPayload)
 	if err != nil {
 		return nil, fmt.Errorf("OPPO push: encode action parameters: %w", err)
 	}
-	if len(routing) > oppoMaxActionParametersBytes {
-		return nil, fmt.Errorf("OPPO push: action parameters exceed %d bytes", oppoMaxActionParametersBytes)
+	if utf8.RuneCount(routing) > oppoMaxActionParametersRunes {
+		return nil, fmt.Errorf("OPPO push: action parameters exceed %d characters", oppoMaxActionParametersRunes)
 	}
 
 	dedupeSource := strings.Join([]string{
@@ -386,14 +388,22 @@ func (o *OPPOPush) Push(deviceToken string, payload Payload) error {
 	err = o.sendUnicast(authToken, message)
 	var apiErr *oppoAPIError
 	if !errors.As(err, &apiErr) || apiErr.Code != 11 {
+		o.logPushFailure(deviceToken, err)
 		return err
 	}
+	o.Debug("OPPO auth token rejected; refreshing",
+		zap.Int("oppo_code", apiErr.Code),
+		zap.Bool("retryable", true),
+		zap.String("device_token", maskToken(deviceToken)),
+	)
 
 	refreshedToken, refreshErr := o.refreshAuthToken(authToken)
 	if refreshErr != nil {
 		return refreshErr
 	}
-	return o.sendUnicast(refreshedToken, message)
+	err = o.sendUnicast(refreshedToken, message)
+	o.logPushFailure(deviceToken, err)
+	return err
 }
 
 func (o *OPPOPush) sendUnicast(authToken string, message []byte) error {
@@ -402,20 +412,33 @@ func (o *OPPOPush) sendUnicast(authToken string, message []byte) error {
 		"message":    {string(message)},
 	})
 	if err != nil {
-		o.Warn("OPPO push request failed", zap.Error(err))
 		return err
 	}
 	if err := response.apiError("push"); err != nil {
-		var apiErr *oppoAPIError
-		if errors.As(err, &apiErr) {
-			o.Warn("OPPO push rejected", zap.Int("oppo_code", apiErr.Code), zap.Bool("retryable", apiErr.Retryable))
-		}
 		return err
 	}
 	if messageID := response.messageID(); messageID != "" {
 		o.Debug("OPPO push accepted", zap.String("oppo_message_id", messageID))
 	}
 	return nil
+}
+
+func (o *OPPOPush) logPushFailure(deviceToken string, err error) {
+	if err == nil {
+		return
+	}
+	fields := []zap.Field{zap.String("device_token", maskToken(deviceToken))}
+	var apiErr *oppoAPIError
+	if errors.As(err, &apiErr) {
+		fields = append(fields, zap.Int("oppo_code", apiErr.Code), zap.Bool("retryable", apiErr.Retryable))
+		if apiErr.Code == 41 {
+			o.Debug("OPPO push rejected", fields...)
+			return
+		}
+	} else {
+		fields = append(fields, zap.Error(err))
+	}
+	o.Warn("OPPO push rejected", fields...)
 }
 
 func (o *OPPOPush) getAuthToken() (string, error) {
@@ -608,7 +631,7 @@ func (e *oppoAPIError) Error() string {
 }
 
 func isRetryableOPPOCode(code int) bool {
-	return code == -1 || code == -2 || code == 55 || (code >= 500 && code < 600)
+	return code == -1 || code == -2 || code == 11 || code == 55 || (code >= 500 && code < 600)
 }
 
 func (o *OPPOPush) postForm(endpoint string, values url.Values) (*oppoAPIResponse, error) {

--- a/modules/webhook/push_oppo.go
+++ b/modules/webhook/push_oppo.go
@@ -305,6 +305,7 @@ func (o *OPPOPush) buildUnicastMessage(deviceToken string, payload *OPPOPayload)
 		payload.channelID,
 		strconv.Itoa(int(payload.channelType)),
 		strconv.FormatUint(uint64(payload.messageSeq), 10),
+		payload.notifyID,
 	}, "\x00")
 	dedupeDigest := sha256.Sum256([]byte(dedupeSource))
 

--- a/modules/webhook/push_oppo.go
+++ b/modules/webhook/push_oppo.go
@@ -1,16 +1,24 @@
 package webhook
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
-	"github.com/Mininglamp-OSS/octo-lib/pkg/network"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"go.uber.org/zap"
 )
@@ -19,47 +27,220 @@ const (
 	oppoAPIBaseURL             = "https://api-push-cn.heytapmobi.com"
 	oppoAuthURL                = oppoAPIBaseURL + "/server/v1/auth"
 	oppoNotificationUnicastURL = oppoAPIBaseURL + "/server/v1/message/notification/unicast"
+
+	oppoHTTPTimeout       = 5 * time.Second
+	oppoAuthTokenTTL      = 20 * time.Hour
+	oppoMaxResponseBytes  = 1 << 20
+	oppoDefaultOfflineTTL = 24 * 60 * 60
 )
 
-// OPPO 推送
-type OPPOPush struct {
-	appID                string
-	appKey               string
-	appSecret            string
-	masterSecret         string // 服务端密钥
-	authTokenCachePrefix string
-	log.Log
+type oppoHTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type oppoTokenCache interface {
+	GetString(key string) (string, error)
+	SetAndExpire(key string, value interface{}, expire time.Duration) error
+	Del(key string) error
+}
+
+type oppoContextTokenCache struct {
 	ctx *config.Context
 }
 
-// NewOPPOPush NewOPPOPush
-func NewOPPOPush(appID, appKey, appSecret, masterSecret string, ctx *config.Context) *OPPOPush {
-	return &OPPOPush{
-		appID:                appID,
-		appKey:               appKey,
-		appSecret:            appSecret,
-		masterSecret:         masterSecret,
-		authTokenCachePrefix: "oppo_auth_token",
-		Log:                  log.NewTLog("oppopush"),
-		ctx:                  ctx,
+func (c *oppoContextTokenCache) GetString(key string) (string, error) {
+	return c.ctx.GetRedisConn().GetString(key)
+}
+
+func (c *oppoContextTokenCache) SetAndExpire(key string, value interface{}, expire time.Duration) error {
+	return c.ctx.GetRedisConn().SetAndExpire(key, value, expire)
+}
+
+func (c *oppoContextTokenCache) Del(key string) error {
+	return c.ctx.GetRedisConn().Del(key)
+}
+
+type oppoPushOptions struct {
+	category                 string
+	notifyLevel              int
+	channelID                string
+	privateMessageTemplateID string
+	clickActionType          int
+	clickActionActivity      string
+	clickActionURL           string
+	offlineTTLSeconds        int
+}
+
+func defaultOPPOPushOptions() oppoPushOptions {
+	return oppoPushOptions{
+		clickActionType:   0,
+		offlineTTLSeconds: oppoDefaultOfflineTTL,
 	}
 }
 
-// OPPOPayload oppo负载
+func loadOPPOPushOptionsFromEnv() (oppoPushOptions, error) {
+	options := defaultOPPOPushOptions()
+	options.category = strings.TrimSpace(os.Getenv("TS_PUSH_OPPO_CATEGORY"))
+	options.channelID = strings.TrimSpace(os.Getenv("TS_PUSH_OPPO_CHANNEL_ID"))
+	options.privateMessageTemplateID = strings.TrimSpace(os.Getenv("TS_PUSH_OPPO_PRIVATE_MSG_TEMPLATE_ID"))
+	options.clickActionActivity = strings.TrimSpace(os.Getenv("TS_PUSH_OPPO_CLICK_ACTION_ACTIVITY"))
+	options.clickActionURL = strings.TrimSpace(os.Getenv("TS_PUSH_OPPO_CLICK_ACTION_URL"))
+
+	if err := validateOPPOOptionLength("category", options.category, 32); err != nil {
+		return oppoPushOptions{}, err
+	}
+	if err := validateOPPOOptionLength("channel ID", options.channelID, 64); err != nil {
+		return oppoPushOptions{}, err
+	}
+	if err := validateOPPOOptionLength("private message template ID", options.privateMessageTemplateID, 128); err != nil {
+		return oppoPushOptions{}, err
+	}
+	if err := validateOPPOOptionLength("click action activity", options.clickActionActivity, 500); err != nil {
+		return oppoPushOptions{}, err
+	}
+	if err := validateOPPOOptionLength("click action URL", options.clickActionURL, 2000); err != nil {
+		return oppoPushOptions{}, err
+	}
+
+	if raw := strings.TrimSpace(os.Getenv("TS_PUSH_OPPO_NOTIFY_LEVEL")); raw != "" {
+		level, err := strconv.Atoi(raw)
+		if err != nil || (level != 1 && level != 2 && level != 16) {
+			return oppoPushOptions{}, fmt.Errorf("invalid TS_PUSH_OPPO_NOTIFY_LEVEL %q: allowed values are 1, 2, and 16", raw)
+		}
+		if options.category == "" {
+			return oppoPushOptions{}, errors.New("TS_PUSH_OPPO_CATEGORY is required when TS_PUSH_OPPO_NOTIFY_LEVEL is set")
+		}
+		options.notifyLevel = level
+	} else if options.category != "" {
+		options.notifyLevel = 2
+	}
+
+	if raw := strings.TrimSpace(os.Getenv("TS_PUSH_OPPO_CLICK_ACTION_TYPE")); raw != "" {
+		clickType, err := strconv.Atoi(raw)
+		if err != nil {
+			return oppoPushOptions{}, fmt.Errorf("invalid TS_PUSH_OPPO_CLICK_ACTION_TYPE %q", raw)
+		}
+		options.clickActionType = clickType
+	}
+
+	switch options.clickActionType {
+	case 0:
+		if options.clickActionActivity != "" || options.clickActionURL != "" {
+			return oppoPushOptions{}, errors.New("OPPO click action activity or URL requires a non-zero click action type")
+		}
+	case 1, 4:
+		if options.clickActionActivity == "" {
+			return oppoPushOptions{}, fmt.Errorf("TS_PUSH_OPPO_CLICK_ACTION_ACTIVITY is required for click action type %d", options.clickActionType)
+		}
+		if options.clickActionURL != "" {
+			return oppoPushOptions{}, fmt.Errorf("TS_PUSH_OPPO_CLICK_ACTION_URL is not valid for click action type %d", options.clickActionType)
+		}
+	case 2, 5:
+		if options.clickActionURL == "" {
+			return oppoPushOptions{}, fmt.Errorf("TS_PUSH_OPPO_CLICK_ACTION_URL is required for click action type %d", options.clickActionType)
+		}
+		if options.clickActionActivity != "" {
+			return oppoPushOptions{}, fmt.Errorf("TS_PUSH_OPPO_CLICK_ACTION_ACTIVITY is not valid for click action type %d", options.clickActionType)
+		}
+	default:
+		return oppoPushOptions{}, fmt.Errorf("invalid TS_PUSH_OPPO_CLICK_ACTION_TYPE %d: allowed values are 0, 1, 2, 4, and 5", options.clickActionType)
+	}
+
+	return options, nil
+}
+
+func validateOPPOOptionLength(name, value string, maxRunes int) error {
+	if utf8.RuneCountInString(value) > maxRunes {
+		return fmt.Errorf("OPPO %s exceeds %d characters", name, maxRunes)
+	}
+	return nil
+}
+
+// OPPOPush implements OPPO notification unicast over the current REST API.
+type OPPOPush struct {
+	appID        string
+	appKey       string
+	appSecret    string
+	masterSecret string
+
+	authTokenCacheKey      string
+	httpClient             oppoHTTPDoer
+	tokenCache             oppoTokenCache
+	authURL                string
+	notificationUnicastURL string
+	now                    func() time.Time
+	options                oppoPushOptions
+	configErr              error
+
+	authMu         sync.Mutex
+	localAuthToken string
+	log.Log
+}
+
+// NewOPPOPush creates a production OPPO REST pusher. Redis is used as a shared
+// token cache when a config context is supplied; a local token remains available
+// as a bounded fallback when Redis is temporarily unavailable.
+func NewOPPOPush(appID, appKey, appSecret, masterSecret string, ctx *config.Context) *OPPOPush {
+	options, configErr := loadOPPOPushOptionsFromEnv()
+	if configErr != nil {
+		options = defaultOPPOPushOptions()
+	}
+	if strings.TrimSpace(appKey) == "" || strings.TrimSpace(masterSecret) == "" {
+		credentialErr := errors.New("OPPO appKey and masterSecret are required")
+		if configErr == nil {
+			configErr = credentialErr
+		} else {
+			configErr = errors.Join(configErr, credentialErr)
+		}
+	}
+
+	var tokenCache oppoTokenCache
+	if ctx != nil {
+		tokenCache = &oppoContextTokenCache{ctx: ctx}
+	}
+
+	keyDigest := sha256.Sum256([]byte(appKey))
+	return &OPPOPush{
+		appID:                  appID,
+		appKey:                 appKey,
+		appSecret:              appSecret,
+		masterSecret:           masterSecret,
+		authTokenCacheKey:      "oppo_auth_token:" + hex.EncodeToString(keyDigest[:8]),
+		httpClient:             &http.Client{Timeout: oppoHTTPTimeout},
+		tokenCache:             tokenCache,
+		authURL:                oppoAuthURL,
+		notificationUnicastURL: oppoNotificationUnicastURL,
+		now:                    time.Now,
+		options:                options,
+		configErr:              configErr,
+		Log:                    log.NewTLog("oppopush"),
+	}
+}
+
+// OPPOPayload is the server-owned input for an OPPO notification.
 type OPPOPayload struct {
 	Payload
-	notifyID string
+	notifyID    string
+	spaceID     string
+	channelID   string
+	channelType uint8
+	messageSeq  uint32
 }
 
-// NewOPPOPayload NewOPPOPayload
+// NewOPPOPayload creates an OPPO payload and preserves the authoritative
+// routing fields used by the Android client after a notification click.
 func NewOPPOPayload(payloadInfo *PayloadInfo, notifyID string) *OPPOPayload {
 	return &OPPOPayload{
-		Payload:  payloadInfo.toPayload(),
-		notifyID: notifyID,
+		Payload:     payloadInfo.toPayload(),
+		notifyID:    notifyID,
+		spaceID:     payloadInfo.SpaceID,
+		channelID:   payloadInfo.ChannelID,
+		channelType: payloadInfo.ChannelType,
+		messageSeq:  payloadInfo.MessageSeq,
 	}
 }
 
-// GetPayload GetPayload
+// GetPayload builds the OPPO payload from the canonical offline-message data.
 func (o *OPPOPush) GetPayload(msg msgOfflineNotify, ctx *config.Context, toUser *user.Resp) (Payload, error) {
 	payloadInfo, err := ParsePushInfo(msg, ctx, toUser)
 	if err != nil {
@@ -68,100 +249,323 @@ func (o *OPPOPush) GetPayload(msg msgOfflineNotify, ctx *config.Context, toUser 
 	return NewOPPOPayload(payloadInfo, fmt.Sprintf("%d", msg.MessageSeq)), nil
 }
 
-// Push Push
-func (o *OPPOPush) Push(deviceToken string, payload Payload) error {
-	// 推送文档 https://open.oppomobile.com/new/developmentDoc/info?id=11238
-	authToken := o.getAuthToken()
-	oppoPayload := payload.(*OPPOPayload)
-	message := map[string]interface{}{
-		"target_type":  2,
-		"target_value": deviceToken,
-		"notification": map[string]string{
-			"title":   oppoPayload.GetTitle(),
-			"content": oppoPayload.GetContent(),
+type oppoRoutingParameters struct {
+	SpaceID     string `json:"space_id,omitempty"`
+	ChannelID   string `json:"channel_id,omitempty"`
+	ChannelType uint8  `json:"channel_type"`
+	MessageSeq  uint32 `json:"message_seq"`
+}
+
+type oppoNotification struct {
+	AppMessageID             string `json:"app_message_id"`
+	Title                    string `json:"title"`
+	Content                  string `json:"content"`
+	ClickActionType          int    `json:"click_action_type"`
+	ClickActionActivity      string `json:"click_action_activity,omitempty"`
+	ClickActionURL           string `json:"click_action_url,omitempty"`
+	ActionParameters         string `json:"action_parameters"`
+	OffLine                  bool   `json:"off_line"`
+	OffLineTTL               int    `json:"off_line_ttl"`
+	ChannelID                string `json:"channel_id,omitempty"`
+	NotifyID                 uint32 `json:"notify_id"`
+	Category                 string `json:"category,omitempty"`
+	NotifyLevel              int    `json:"notify_level,omitempty"`
+	PrivateMessageTemplateID string `json:"private_msg_template_id,omitempty"`
+}
+
+type oppoUnicastMessage struct {
+	TargetType           int              `json:"target_type"`
+	TargetValue          string           `json:"target_value"`
+	VerifyRegistrationID bool             `json:"verify_registration_id"`
+	Notification         oppoNotification `json:"notification"`
+}
+
+func (o *OPPOPush) buildUnicastMessage(deviceToken string, payload *OPPOPayload) ([]byte, error) {
+	if strings.TrimSpace(deviceToken) == "" {
+		return nil, errors.New("OPPO push: empty registration ID")
+	}
+
+	notifyID, err := strconv.ParseUint(payload.notifyID, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("OPPO push: invalid notify ID %q: %w", payload.notifyID, err)
+	}
+	routing, err := json.Marshal(oppoRoutingParameters{
+		SpaceID:     payload.spaceID,
+		ChannelID:   payload.channelID,
+		ChannelType: payload.channelType,
+		MessageSeq:  payload.messageSeq,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("OPPO push: encode action parameters: %w", err)
+	}
+
+	dedupeSource := strings.Join([]string{
+		deviceToken,
+		payload.spaceID,
+		payload.channelID,
+		strconv.Itoa(int(payload.channelType)),
+		strconv.FormatUint(uint64(payload.messageSeq), 10),
+	}, "\x00")
+	dedupeDigest := sha256.Sum256([]byte(dedupeSource))
+
+	message := oppoUnicastMessage{
+		TargetType:           2,
+		TargetValue:          deviceToken,
+		VerifyRegistrationID: true,
+		Notification: oppoNotification{
+			AppMessageID:             "octo-" + hex.EncodeToString(dedupeDigest[:16]),
+			Title:                    payload.GetTitle(),
+			Content:                  payload.GetContent(),
+			ClickActionType:          o.options.clickActionType,
+			ClickActionActivity:      o.options.clickActionActivity,
+			ClickActionURL:           o.options.clickActionURL,
+			ActionParameters:         string(routing),
+			OffLine:                  true,
+			OffLineTTL:               o.options.offlineTTLSeconds,
+			ChannelID:                o.options.channelID,
+			NotifyID:                 uint32(notifyID),
+			Category:                 o.options.category,
+			NotifyLevel:              o.options.notifyLevel,
+			PrivateMessageTemplateID: o.options.privateMessageTemplateID,
 		},
 	}
-	dataType, _ := json.Marshal(message)
-	dataString := string(dataType)
-	resp, err := network.PostForWWWForm(oppoNotificationUnicastURL, map[string]string{
-		"auth_token": authToken,
-		"message":    dataString,
-	}, nil)
 
+	encoded, err := json.Marshal(message)
 	if err != nil {
-		o.Warn("OPPO推送错误", zap.Error(err))
+		return nil, fmt.Errorf("OPPO push: encode message: %w", err)
+	}
+	return encoded, nil
+}
+
+// Push sends one notification. OPPO code 11 is the only response retried here:
+// it means the cached auth token is invalid, so the adapter refreshes it and
+// repeats the same idempotent message once.
+func (o *OPPOPush) Push(deviceToken string, payload Payload) error {
+	if o.configErr != nil {
+		return fmt.Errorf("OPPO push configuration: %w", o.configErr)
+	}
+
+	oppoPayload, ok := payload.(*OPPOPayload)
+	if !ok || oppoPayload == nil {
+		return fmt.Errorf("OPPO push: unexpected payload type %T", payload)
+	}
+	message, err := o.buildUnicastMessage(deviceToken, oppoPayload)
+	if err != nil {
 		return err
 	}
-	if resp != nil && resp["code"] != nil {
-		if codeNum, ok := resp["code"].(json.Number); ok {
-			code, _ := codeNum.Int64()
-			if code != 0 {
-				if msg, ok := resp["message"].(string); ok {
-					return errors.New(msg)
-				}
-				return fmt.Errorf("OPPO push failed with code %d", code)
-			}
-		}
-	}
-	return nil
-}
 
-// getAuthToken 获取推送鉴权令牌
-func (o *OPPOPush) getAuthToken() string {
-	authToken, _ := o.ctx.GetRedisConn().GetString(o.authTokenCachePrefix)
-	if authToken != "" {
-		return authToken
-	}
-	timestamp := time.Now().Local().UnixNano() / 1e6
-	sign := o.SHA256(fmt.Sprintf("%s%d%s", o.appKey, timestamp, o.masterSecret))
-	resp, err := network.PostForWWWForm(oppoAuthURL, map[string]string{
-		"app_key":   o.appKey,
-		"sign":      sign,
-		"timestamp": fmt.Sprintf("%d", timestamp),
-	}, nil)
+	authToken, err := o.getAuthToken()
 	if err != nil {
-		o.Error("获取OPPO推送鉴权错误", zap.Error(err))
-		return ""
+		return err
+	}
+	err = o.sendUnicast(authToken, message)
+	var apiErr *oppoAPIError
+	if !errors.As(err, &apiErr) || apiErr.Code != 11 {
+		return err
 	}
 
-	if resp != nil && resp["code"] != nil {
-		if codeNum, ok := resp["code"].(json.Number); ok {
-			code, _ := codeNum.Int64()
-			message, _ := resp["message"].(string)
-			if code != 0 {
-				o.Error("OPPO鉴权返回错误数据", zap.String("错误信息", message))
-			} else {
-				if data, ok := resp["data"].(map[string]interface{}); ok {
-					if token, ok := data["auth_token"].(string); ok {
-						authToken = token
-					}
-				}
-			}
+	refreshedToken, refreshErr := o.refreshAuthToken(authToken)
+	if refreshErr != nil {
+		return refreshErr
+	}
+	return o.sendUnicast(refreshedToken, message)
+}
+
+func (o *OPPOPush) sendUnicast(authToken string, message []byte) error {
+	response, err := o.postForm(o.notificationUnicastURL, url.Values{
+		"auth_token": {authToken},
+		"message":    {string(message)},
+	})
+	if err != nil {
+		o.Warn("OPPO push request failed", zap.Error(err))
+		return err
+	}
+	return response.apiError("push")
+}
+
+func (o *OPPOPush) getAuthToken() (string, error) {
+	o.authMu.Lock()
+	defer o.authMu.Unlock()
+
+	if o.tokenCache != nil {
+		token, err := o.tokenCache.GetString(o.authTokenCacheKey)
+		if err != nil {
+			o.Warn("read OPPO auth token cache failed; falling back to direct authentication", zap.Error(err))
+		} else if token != "" {
+			o.localAuthToken = token
+			return token, nil
 		}
 	}
-	if authToken != "" {
-		_ = o.ctx.GetRedisConn().SetAndExpire(o.authTokenCachePrefix, authToken, time.Hour*20)
+	if o.localAuthToken != "" {
+		return o.localAuthToken, nil
 	}
-	return authToken
+	return o.authenticateLocked()
 }
 
-func (o *OPPOPush) SHA256(password string) string {
-	hash := sha256.New()
-	hash.Write([]byte(password))
-	return hex.EncodeToString(hash.Sum(nil))
+func (o *OPPOPush) refreshAuthToken(rejectedToken string) (string, error) {
+	o.authMu.Lock()
+	defer o.authMu.Unlock()
+
+	if o.tokenCache != nil {
+		cachedToken, err := o.tokenCache.GetString(o.authTokenCacheKey)
+		if err != nil {
+			o.Warn("read OPPO auth token cache during refresh failed", zap.Error(err))
+		} else if cachedToken != "" && cachedToken != rejectedToken {
+			o.localAuthToken = cachedToken
+			return cachedToken, nil
+		}
+		if err := o.tokenCache.Del(o.authTokenCacheKey); err != nil {
+			o.Warn("invalidate OPPO auth token cache failed", zap.Error(err))
+		}
+	}
+	o.localAuthToken = ""
+	return o.authenticateLocked()
 }
 
-// parseOPPOAuthResponse 解析 OPPO 认证响应，返回 authToken
-// 如果响应格式错误或认证失败，返回空字符串和错误信息
+func (o *OPPOPush) authenticateLocked() (string, error) {
+	timestamp := o.now().UnixMilli()
+	sign := o.SHA256(fmt.Sprintf("%s%d%s", o.appKey, timestamp, o.masterSecret))
+	response, err := o.postForm(o.authURL, url.Values{
+		"app_key":   {o.appKey},
+		"sign":      {sign},
+		"timestamp": {strconv.FormatInt(timestamp, 10)},
+	})
+	if err != nil {
+		return "", fmt.Errorf("OPPO auth request: %w", err)
+	}
+	if err := response.apiError("auth"); err != nil {
+		return "", err
+	}
+
+	var data struct {
+		AuthToken string `json:"auth_token"`
+	}
+	if len(response.Data) == 0 || string(response.Data) == "null" {
+		return "", errors.New("OPPO auth: missing data")
+	}
+	if err := json.Unmarshal(response.Data, &data); err != nil {
+		return "", fmt.Errorf("OPPO auth: decode data: %w", err)
+	}
+	if strings.TrimSpace(data.AuthToken) == "" {
+		return "", errors.New("OPPO auth: missing auth_token")
+	}
+
+	o.localAuthToken = data.AuthToken
+	if o.tokenCache != nil {
+		if err := o.tokenCache.SetAndExpire(o.authTokenCacheKey, data.AuthToken, oppoAuthTokenTTL); err != nil {
+			o.Warn("cache OPPO auth token failed; using process-local token", zap.Error(err))
+		}
+	}
+	return data.AuthToken, nil
+}
+
+type oppoAPIResponse struct {
+	Code    *int            `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data"`
+}
+
+func (r *oppoAPIResponse) apiError(operation string) error {
+	if r == nil || r.Code == nil {
+		return fmt.Errorf("OPPO %s: response missing code", operation)
+	}
+	if *r.Code == 0 {
+		return nil
+	}
+	return &oppoAPIError{
+		Operation: operation,
+		Code:      *r.Code,
+		Message:   r.Message,
+		Retryable: isRetryableOPPOCode(*r.Code),
+	}
+}
+
+type oppoAPIError struct {
+	Operation string
+	Code      int
+	Message   string
+	Retryable bool
+}
+
+func (e *oppoAPIError) Error() string {
+	if e.Message == "" {
+		return fmt.Sprintf("OPPO %s failed with code %d", e.Operation, e.Code)
+	}
+	return fmt.Sprintf("OPPO %s failed with code %d: %s", e.Operation, e.Code, e.Message)
+}
+
+func isRetryableOPPOCode(code int) bool {
+	return code == -1 || code == -2 || code == 55 || (code >= 500 && code < 600)
+}
+
+func (o *OPPOPush) postForm(endpoint string, values url.Values) (*oppoAPIResponse, error) {
+	body := values.Encode()
+	request, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create OPPO request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
+	request.Header.Set("Accept", "application/json")
+
+	response, err := o.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("execute OPPO request: %w", err)
+	}
+	defer func() {
+		if closeErr := response.Body.Close(); closeErr != nil {
+			o.Warn("close OPPO response body failed", zap.Error(closeErr))
+		}
+	}()
+
+	limitedBody, err := io.ReadAll(io.LimitReader(response.Body, oppoMaxResponseBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read OPPO response: %w", err)
+	}
+	if len(limitedBody) > oppoMaxResponseBytes {
+		return nil, fmt.Errorf("OPPO response exceeds %d bytes", oppoMaxResponseBytes)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("OPPO HTTP request failed with status %d", response.StatusCode)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(limitedBody))
+	var decoded oppoAPIResponse
+	if err := decoder.Decode(&decoded); err != nil {
+		return nil, fmt.Errorf("decode OPPO response: %w", err)
+	}
+	var trailing interface{}
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return nil, errors.New("decode OPPO response: multiple JSON values")
+		}
+		return nil, fmt.Errorf("decode OPPO response trailing data: %w", err)
+	}
+	if decoded.Code == nil {
+		return nil, errors.New("decode OPPO response: missing code")
+	}
+	return &decoded, nil
+}
+
+// SHA256 returns the lowercase hex digest required by the OPPO auth API.
+func (o *OPPOPush) SHA256(value string) string {
+	digest := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(digest[:])
+}
+
+// parseOPPOAuthResponse is kept as a compatibility seam for existing unit
+// tests and callers that decode through octo-lib's generic response map.
 func parseOPPOAuthResponse(resp map[string]interface{}) (string, error) {
 	if resp == nil || resp["code"] == nil {
 		return "", errors.New("OPPO auth: empty response")
 	}
-	codeNum, ok := resp["code"].(json.Number)
+	codeNumber, ok := resp["code"].(json.Number)
 	if !ok {
 		return "", fmt.Errorf("OPPO auth: unexpected code type %T", resp["code"])
 	}
-	code, _ := codeNum.Int64()
+	code, err := codeNumber.Int64()
+	if err != nil {
+		return "", fmt.Errorf("OPPO auth: invalid code: %w", err)
+	}
 	if code != 0 {
 		message, _ := resp["message"].(string)
 		return "", fmt.Errorf("OPPO auth failed: code=%d, message=%s", code, message)
@@ -171,7 +575,7 @@ func parseOPPOAuthResponse(resp map[string]interface{}) (string, error) {
 		return "", fmt.Errorf("OPPO auth: unexpected data type %T", resp["data"])
 	}
 	token, ok := data["auth_token"].(string)
-	if !ok {
+	if !ok || strings.TrimSpace(token) == "" {
 		return "", fmt.Errorf("OPPO auth: unexpected auth_token type %T", data["auth_token"])
 	}
 	return token, nil

--- a/modules/webhook/push_oppo_rest_test.go
+++ b/modules/webhook/push_oppo_rest_test.go
@@ -465,6 +465,56 @@ func TestOPPOPushRejectsOversizedActionParameters(t *testing.T) {
 	require.ErrorContains(t, err, "action parameters exceed 4000 characters")
 }
 
+func TestOPPOPushDedupeUsesGlobalMessageIdentity(t *testing.T) {
+	pusher := NewOPPOPush("app-id", "app-key", "app-secret", "master-secret", nil)
+	pusher.configErr = nil
+	payloadInfo := &PayloadInfo{
+		Title:       "title",
+		Content:     "content",
+		SpaceID:     "space",
+		ChannelID:   "channel",
+		ChannelType: 1,
+		MessageSeq:  0,
+	}
+
+	firstPayload, err := newOPPOPayloadForMessage(payloadInfo, msgOfflineNotify{MsgResp: MsgResp{
+		MessageID:   1001,
+		MessageSeq:  0,
+		ClientMsgNo: "same-client-message-number",
+	}})
+	require.NoError(t, err)
+	secondPayload, err := newOPPOPayloadForMessage(payloadInfo, msgOfflineNotify{MsgResp: MsgResp{
+		MessageID:   1002,
+		MessageSeq:  0,
+		ClientMsgNo: "same-client-message-number",
+	}})
+	require.NoError(t, err)
+
+	firstEncoded, err := pusher.buildUnicastMessage("registration-id", firstPayload)
+	require.NoError(t, err)
+	secondEncoded, err := pusher.buildUnicastMessage("registration-id", secondPayload)
+	require.NoError(t, err)
+
+	var firstMessage, secondMessage oppoUnicastMessage
+	require.NoError(t, json.Unmarshal(firstEncoded, &firstMessage))
+	require.NoError(t, json.Unmarshal(secondEncoded, &secondMessage))
+	assert.NotEqual(t, firstMessage.Notification.AppMessageID, secondMessage.Notification.AppMessageID,
+		"different global message IDs must not be collapsed when message_seq is zero")
+}
+
+func TestOPPOPushDedupeFallsBackToClientMessageNumber(t *testing.T) {
+	payloadInfo := &PayloadInfo{Title: "title", Content: "content", MessageSeq: 0}
+
+	first, err := newOPPOPayloadForMessage(payloadInfo, msgOfflineNotify{MsgResp: MsgResp{ClientMsgNo: "client-1"}})
+	require.NoError(t, err)
+	second, err := newOPPOPayloadForMessage(payloadInfo, msgOfflineNotify{MsgResp: MsgResp{ClientMsgNo: "client-2"}})
+	require.NoError(t, err)
+	assert.NotEqual(t, first.dedupeID, second.dedupeID)
+
+	_, err = newOPPOPayloadForMessage(payloadInfo, msgOfflineNotify{})
+	require.ErrorContains(t, err, "missing message identity")
+}
+
 func TestOPPOPushRefreshesInvalidTokenOnceWithStableDedupeID(t *testing.T) {
 	cache := &memoryOPPOTokenCache{token: cachedOPPOAuthToken(t, "stale-token", oppoTestNow.Add(oppoAuthTokenTTL))}
 	authCalls := 0

--- a/modules/webhook/push_oppo_rest_test.go
+++ b/modules/webhook/push_oppo_rest_test.go
@@ -17,7 +17,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
+
+var oppoTestNow = time.UnixMilli(1_700_000_000_123)
 
 type memoryOPPOTokenCache struct {
 	mu        sync.Mutex
@@ -34,8 +38,70 @@ type memoryOPPOTokenCache struct {
 
 type oppoDoerFunc func(*http.Request) (*http.Response, error)
 
+type recordedOPPOLogEntry struct {
+	message string
+	fields  map[string]interface{}
+}
+
+type recordingOPPOLogger struct {
+	mu       sync.Mutex
+	warnings []recordedOPPOLogEntry
+	debugs   []recordedOPPOLogEntry
+}
+
 func (f oppoDoerFunc) Do(request *http.Request) (*http.Response, error) {
 	return f(request)
+}
+
+func (l *recordingOPPOLogger) Info(string, ...zap.Field)  {}
+func (l *recordingOPPOLogger) Error(string, ...zap.Field) {}
+
+func (l *recordingOPPOLogger) Debug(message string, fields ...zap.Field) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.debugs = append(l.debugs, recordedOPPOLogEntry{message: message, fields: encodeOPPOLogFields(fields)})
+}
+
+func (l *recordingOPPOLogger) Warn(message string, fields ...zap.Field) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warnings = append(l.warnings, recordedOPPOLogEntry{message: message, fields: encodeOPPOLogFields(fields)})
+}
+
+func encodeOPPOLogFields(fields []zap.Field) map[string]interface{} {
+	encoder := zapcore.NewMapObjectEncoder()
+	for _, field := range fields {
+		field.AddTo(encoder)
+	}
+	return encoder.Fields
+}
+
+func cachedOPPOAuthToken(t *testing.T, token string, expiresAt time.Time) string {
+	t.Helper()
+	encoded, err := json.Marshal(map[string]interface{}{
+		"auth_token": token,
+		"expires_at": expiresAt.UnixMilli(),
+	})
+	require.NoError(t, err)
+	return string(encoded)
+}
+
+func (c *memoryOPPOTokenCache) getCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.getKeys)
+}
+
+func (c *memoryOPPOTokenCache) clearToken() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.token = ""
+}
+
+func (l *recordingOPPOLogger) snapshot() (warnings, debugs []recordedOPPOLogEntry) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]recordedOPPOLogEntry(nil), l.warnings...), append([]recordedOPPOLogEntry(nil), l.debugs...)
 }
 
 func (c *memoryOPPOTokenCache) GetString(key string) (string, error) {
@@ -80,7 +146,7 @@ func newOPPOPushForTest(t *testing.T, handler http.Handler, cache *memoryOPPOTok
 	pusher.tokenCache = cache
 	pusher.options = options
 	pusher.configErr = nil
-	pusher.now = func() time.Time { return time.UnixMilli(1_700_000_000_123) }
+	pusher.now = func() time.Time { return oppoTestNow }
 	return pusher
 }
 
@@ -107,7 +173,7 @@ func decodeOPPOMessage(t *testing.T, r *http.Request) map[string]interface{} {
 }
 
 func TestOPPOPushUsesEncodedFormAndCurrentNotificationPayload(t *testing.T) {
-	cache := &memoryOPPOTokenCache{token: "cached&token+%"}
+	cache := &memoryOPPOTokenCache{token: cachedOPPOAuthToken(t, "cached&token+%", oppoTestNow.Add(oppoAuthTokenTTL))}
 	var gotMessage map[string]interface{}
 	var requestCount int
 	pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -154,7 +220,7 @@ func TestOPPOPushUsesEncodedFormAndCurrentNotificationPayload(t *testing.T) {
 	assert.Equal(t, "com.example.chat.MainActivity", notification["click_action_activity"])
 	assert.Equal(t, true, notification["off_line"])
 	assert.Equal(t, float64(86400), notification["off_line_ttl"])
-	assert.Equal(t, float64(42), notification["notify_id"])
+	assert.NotContains(t, notification, "notify_id")
 	assert.NotEmpty(t, notification["app_message_id"])
 
 	var actionParameters map[string]interface{}
@@ -193,7 +259,14 @@ func TestOPPOPushAuthenticatesWithDocumentedSignatureAndCachesToken(t *testing.T
 	require.NoError(t, pusher.Push("registration-id", payload))
 	require.Equal(t, 1, authCalls)
 	require.Equal(t, 1, unicastCalls)
-	require.Equal(t, []string{"fresh-token"}, cache.setValues)
+	require.Len(t, cache.setValues, 1)
+	var cachedToken struct {
+		AuthToken string `json:"auth_token"`
+		ExpiresAt int64  `json:"expires_at"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(cache.setValues[0]), &cachedToken))
+	assert.Equal(t, "fresh-token", cachedToken.AuthToken)
+	assert.Equal(t, oppoTestNow.Add(oppoAuthTokenTTL).UnixMilli(), cachedToken.ExpiresAt)
 	require.Equal(t, []time.Duration{20 * time.Hour}, cache.setTTLs)
 	require.Len(t, cache.setKeys, 1)
 	assert.Contains(t, cache.setKeys[0], "oppo_auth_token:")
@@ -204,8 +277,176 @@ func TestOPPOPushAuthenticatesWithDocumentedSignatureAndCachesToken(t *testing.T
 	require.Equal(t, 2, unicastCalls)
 }
 
+func TestOPPOPushUsesProcessLocalTokenOnConcurrentNormalPath(t *testing.T) {
+	cache := &memoryOPPOTokenCache{}
+	pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/server/v1/auth":
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":0,"data":{"auth_token":"fresh-token"}}`)
+		case "/server/v1/message/notification/unicast":
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":0}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}), cache, defaultOPPOPushOptions())
+	payload := NewOPPOPayload(&PayloadInfo{Title: "title", Content: "content", MessageSeq: 7}, "7")
+
+	require.NoError(t, pusher.Push("registration-id", payload))
+	require.Equal(t, 1, cache.getCount())
+
+	const pushes = 16
+	errs := make(chan error, pushes)
+	var wg sync.WaitGroup
+	for range pushes {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- pusher.Push("registration-id", payload)
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 1, cache.getCount(), "a valid process-local token must avoid Redis and the refresh mutex")
+}
+
+func TestOPPOPushConcurrentCacheMissAuthenticatesOnce(t *testing.T) {
+	cache := &memoryOPPOTokenCache{}
+	var mu sync.Mutex
+	authCalls := 0
+	unicastCalls := 0
+	pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch r.URL.Path {
+		case "/server/v1/auth":
+			authCalls++
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":0,"data":{"auth_token":"fresh-token"}}`)
+		case "/server/v1/message/notification/unicast":
+			unicastCalls++
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":0}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}), cache, defaultOPPOPushOptions())
+	payload := NewOPPOPayload(&PayloadInfo{Title: "title", Content: "content", MessageSeq: 7}, "7")
+
+	const pushes = 16
+	errs := make(chan error, pushes)
+	var wg sync.WaitGroup
+	for range pushes {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- pusher.Push("registration-id", payload)
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, authCalls)
+	assert.Equal(t, pushes, unicastCalls)
+}
+
+func TestOPPOPushRefreshesExpiredProcessLocalToken(t *testing.T) {
+	cache := &memoryOPPOTokenCache{}
+	now := oppoTestNow
+	authCalls := 0
+	var sentTokens []string
+	pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/server/v1/auth":
+			authCalls++
+			writeOPPOJSON(t, w, http.StatusOK, fmt.Sprintf(`{"code":0,"data":{"auth_token":"token-%d"}}`, authCalls))
+		case "/server/v1/message/notification/unicast":
+			require.NoError(t, r.ParseForm())
+			sentTokens = append(sentTokens, r.PostForm.Get("auth_token"))
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":0}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}), cache, defaultOPPOPushOptions())
+	pusher.now = func() time.Time { return now }
+	payload := NewOPPOPayload(&PayloadInfo{Title: "title", Content: "content", MessageSeq: 7}, "7")
+
+	require.NoError(t, pusher.Push("registration-id", payload))
+	now = now.Add(oppoAuthTokenTTL)
+	cache.clearToken() // Simulate the Redis TTL expiring at the same instant.
+	require.NoError(t, pusher.Push("registration-id", payload))
+
+	assert.Equal(t, 2, authCalls)
+	assert.Equal(t, []string{"token-1", "token-2"}, sentTokens)
+}
+
+func TestOPPOPushSanitizesRequiredNotificationText(t *testing.T) {
+	pusher := NewOPPOPush("app-id", "app-key", "app-secret", "master-secret", nil)
+	pusher.configErr = nil
+
+	tests := []struct {
+		name        string
+		title       string
+		content     string
+		wantTitle   string
+		wantContent string
+	}{
+		{
+			name:        "blank values use safe fallback",
+			title:       " \t\n",
+			content:     "",
+			wantTitle:   "您有一条新的消息",
+			wantContent: "您有一条新的消息",
+		},
+		{
+			name:        "multibyte values are truncated by rune",
+			title:       strings.Repeat("题", 51),
+			content:     strings.Repeat("文", 201),
+			wantTitle:   strings.Repeat("题", 50),
+			wantContent: strings.Repeat("文", 200),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded, err := pusher.buildUnicastMessage("registration-id", NewOPPOPayload(&PayloadInfo{
+				Title:      tt.title,
+				Content:    tt.content,
+				MessageSeq: 1,
+			}, "1"))
+			require.NoError(t, err)
+
+			var message oppoUnicastMessage
+			require.NoError(t, json.Unmarshal(encoded, &message))
+			assert.Equal(t, tt.wantTitle, message.Notification.Title)
+			assert.Equal(t, tt.wantContent, message.Notification.Content)
+			assert.LessOrEqual(t, len([]rune(message.Notification.Title)), 50)
+			assert.LessOrEqual(t, len([]rune(message.Notification.Content)), 200)
+		})
+	}
+}
+
+func TestOPPOPushRejectsOversizedActionParameters(t *testing.T) {
+	pusher := NewOPPOPush("app-id", "app-key", "app-secret", "master-secret", nil)
+	pusher.configErr = nil
+	payload := NewOPPOPayload(&PayloadInfo{
+		Title:      "title",
+		Content:    "content",
+		ChannelID:  strings.Repeat("界", 1400),
+		MessageSeq: 1,
+	}, "1")
+
+	_, err := pusher.buildUnicastMessage("registration-id", payload)
+	require.ErrorContains(t, err, "action parameters exceed 4096 bytes")
+}
+
 func TestOPPOPushRefreshesInvalidTokenOnceWithStableDedupeID(t *testing.T) {
-	cache := &memoryOPPOTokenCache{token: "stale-token"}
+	cache := &memoryOPPOTokenCache{token: cachedOPPOAuthToken(t, "stale-token", oppoTestNow.Add(oppoAuthTokenTTL))}
 	authCalls := 0
 	var sentTokens []string
 	var appMessageIDs []string
@@ -251,7 +492,7 @@ func TestOPPOPushDoesNotRetryBusinessErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(strconv.Itoa(tt.code), func(t *testing.T) {
-			cache := &memoryOPPOTokenCache{token: "cached-token"}
+			cache := &memoryOPPOTokenCache{token: cachedOPPOAuthToken(t, "cached-token", oppoTestNow.Add(oppoAuthTokenTTL))}
 			requestCount := 0
 			pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				requestCount++
@@ -287,7 +528,7 @@ func TestOPPOPushRejectsMalformedResponsesAndWrongPayload(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				writeOPPOJSON(t, w, tt.statusCode, tt.body)
-			}), &memoryOPPOTokenCache{token: "cached-token"}, defaultOPPOPushOptions())
+			}), &memoryOPPOTokenCache{token: cachedOPPOAuthToken(t, "cached-token", oppoTestNow.Add(oppoAuthTokenTTL))}, defaultOPPOPushOptions())
 			err := pusher.Push("registration-id", NewOPPOPayload(&PayloadInfo{Title: "t", Content: "c"}, "1"))
 			require.Error(t, err)
 		})
@@ -382,7 +623,7 @@ func TestOPPOPushDefaultPayloadKeepsClassificationOptIn(t *testing.T) {
 		message := decodeOPPOMessage(t, r)
 		notification = message["notification"].(map[string]interface{})
 		writeOPPOJSON(t, w, http.StatusOK, `{"code":0}`)
-	}), &memoryOPPOTokenCache{token: "cached-token"}, defaultOPPOPushOptions())
+	}), &memoryOPPOTokenCache{token: cachedOPPOAuthToken(t, "cached-token", oppoTestNow.Add(oppoAuthTokenTTL))}, defaultOPPOPushOptions())
 
 	require.NoError(t, pusher.Push("registration-id", NewOPPOPayload(&PayloadInfo{
 		Title:      "title",
@@ -400,7 +641,7 @@ func TestOPPOPushDefaultPayloadKeepsClassificationOptIn(t *testing.T) {
 func TestOPPOPushValidatesInputBeforeNetwork(t *testing.T) {
 	pusher := NewOPPOPush("app-id", "app-key", "app-secret", "master-secret", nil)
 	pusher.configErr = nil
-	pusher.tokenCache = &memoryOPPOTokenCache{token: "cached-token"}
+	pusher.tokenCache = &memoryOPPOTokenCache{token: cachedOPPOAuthToken(t, "cached-token", time.Now().Add(oppoAuthTokenTTL))}
 	pusher.httpClient = oppoDoerFunc(func(*http.Request) (*http.Response, error) {
 		t.Fatal("invalid input must not reach the network")
 		return nil, nil
@@ -413,7 +654,7 @@ func TestOPPOPushValidatesInputBeforeNetwork(t *testing.T) {
 	}{
 		{name: "wrong payload type", deviceToken: "registration-id", payload: &BasePayload{}},
 		{name: "empty registration ID", payload: NewOPPOPayload(&PayloadInfo{MessageSeq: 1}, "1")},
-		{name: "invalid notify ID", deviceToken: "registration-id", payload: NewOPPOPayload(&PayloadInfo{MessageSeq: 1}, "not-a-number")},
+		{name: "oversized action parameters", deviceToken: "registration-id", payload: NewOPPOPayload(&PayloadInfo{ChannelID: strings.Repeat("界", 1400), MessageSeq: 1}, "1")},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -458,7 +699,7 @@ func TestOPPOPushRejectsAuthFailures(t *testing.T) {
 }
 
 func TestOPPOPushRetriesInvalidTokenOnlyOnce(t *testing.T) {
-	cache := &memoryOPPOTokenCache{token: "stale-token"}
+	cache := &memoryOPPOTokenCache{token: cachedOPPOAuthToken(t, "stale-token", oppoTestNow.Add(oppoAuthTokenTTL))}
 	authCalls := 0
 	unicastCalls := 0
 	pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -482,7 +723,7 @@ func TestOPPOPushRetriesInvalidTokenOnlyOnce(t *testing.T) {
 }
 
 func TestOPPOPushUsesTokenAlreadyRefreshedByPeer(t *testing.T) {
-	cache := &memoryOPPOTokenCache{token: "stale-token"}
+	cache := &memoryOPPOTokenCache{token: cachedOPPOAuthToken(t, "stale-token", oppoTestNow.Add(oppoAuthTokenTTL))}
 	var sentTokens []string
 	authCalls := 0
 	pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -495,7 +736,7 @@ func TestOPPOPushUsesTokenAlreadyRefreshedByPeer(t *testing.T) {
 			sentTokens = append(sentTokens, r.PostForm.Get("auth_token"))
 			if len(sentTokens) == 1 {
 				cache.mu.Lock()
-				cache.token = "peer-refreshed-token"
+				cache.token = cachedOPPOAuthToken(t, "peer-refreshed-token", oppoTestNow.Add(oppoAuthTokenTTL))
 				cache.mu.Unlock()
 				writeOPPOJSON(t, w, http.StatusOK, `{"code":11}`)
 				return
@@ -514,7 +755,7 @@ func TestOPPOPushReturnsTransportAndRequestConstructionErrors(t *testing.T) {
 	t.Run("transport", func(t *testing.T) {
 		pusher := NewOPPOPush("app-id", "app-key", "app-secret", "master-secret", nil)
 		pusher.configErr = nil
-		pusher.tokenCache = &memoryOPPOTokenCache{token: "cached-token"}
+		pusher.tokenCache = &memoryOPPOTokenCache{token: cachedOPPOAuthToken(t, "cached-token", time.Now().Add(oppoAuthTokenTTL))}
 		pusher.httpClient = oppoDoerFunc(func(*http.Request) (*http.Response, error) {
 			return nil, errors.New("network unavailable")
 		})
@@ -525,10 +766,44 @@ func TestOPPOPushReturnsTransportAndRequestConstructionErrors(t *testing.T) {
 	t.Run("invalid URL", func(t *testing.T) {
 		pusher := NewOPPOPush("app-id", "app-key", "app-secret", "master-secret", nil)
 		pusher.configErr = nil
-		pusher.tokenCache = &memoryOPPOTokenCache{token: "cached-token"}
+		pusher.tokenCache = &memoryOPPOTokenCache{token: cachedOPPOAuthToken(t, "cached-token", time.Now().Add(oppoAuthTokenTTL))}
 		pusher.notificationUnicastURL = "://invalid"
 		err := pusher.Push("registration-id", NewOPPOPayload(&PayloadInfo{MessageSeq: 1}, "1"))
 		require.ErrorContains(t, err, "create OPPO request")
+	})
+}
+
+func TestOPPOPushLogsProviderBusinessResult(t *testing.T) {
+	t.Run("rejection", func(t *testing.T) {
+		logger := &recordingOPPOLogger{}
+		pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":54,"message":"template rejected"}`)
+		}), &memoryOPPOTokenCache{token: cachedOPPOAuthToken(t, "cached-token", oppoTestNow.Add(oppoAuthTokenTTL))}, defaultOPPOPushOptions())
+		pusher.Log = logger
+
+		err := pusher.Push("registration-id", NewOPPOPayload(&PayloadInfo{Title: "t", Content: "c", MessageSeq: 1}, "1"))
+		require.Error(t, err)
+		warnings, _ := logger.snapshot()
+		require.Len(t, warnings, 1)
+		assert.Equal(t, "OPPO push rejected", warnings[0].message)
+		assert.Equal(t, int64(54), warnings[0].fields["oppo_code"])
+		assert.Equal(t, false, warnings[0].fields["retryable"])
+		assert.NotContains(t, warnings[0].fields, "auth_token")
+		assert.NotContains(t, warnings[0].fields, "registration_id")
+	})
+
+	t.Run("accepted message ID", func(t *testing.T) {
+		logger := &recordingOPPOLogger{}
+		pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":0,"data":{"messageId":"provider-message-id"}}`)
+		}), &memoryOPPOTokenCache{token: cachedOPPOAuthToken(t, "cached-token", oppoTestNow.Add(oppoAuthTokenTTL))}, defaultOPPOPushOptions())
+		pusher.Log = logger
+
+		require.NoError(t, pusher.Push("registration-id", NewOPPOPayload(&PayloadInfo{Title: "t", Content: "c", MessageSeq: 1}, "1")))
+		_, debugs := logger.snapshot()
+		require.Len(t, debugs, 1)
+		assert.Equal(t, "OPPO push accepted", debugs[0].message)
+		assert.Equal(t, "provider-message-id", debugs[0].fields["oppo_message_id"])
 	})
 }
 

--- a/modules/webhook/push_oppo_rest_test.go
+++ b/modules/webhook/push_oppo_rest_test.go
@@ -674,7 +674,7 @@ func TestOPPOPushValidatesInputBeforeNetwork(t *testing.T) {
 	}{
 		{name: "wrong payload type", deviceToken: "registration-id", payload: &BasePayload{}},
 		{name: "empty registration ID", payload: NewOPPOPayload(&PayloadInfo{MessageSeq: 1}, "1")},
-		{name: "oversized action parameters", deviceToken: "registration-id", payload: NewOPPOPayload(&PayloadInfo{ChannelID: strings.Repeat("界", 1400), MessageSeq: 1}, "1")},
+		{name: "oversized action parameters", deviceToken: "registration-id", payload: NewOPPOPayload(&PayloadInfo{ChannelID: strings.Repeat("界", oppoMaxActionParametersRunes+1), MessageSeq: 1}, "1")},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/modules/webhook/push_oppo_rest_test.go
+++ b/modules/webhook/push_oppo_rest_test.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -406,9 +407,9 @@ func TestOPPOPushSanitizesRequiredNotificationText(t *testing.T) {
 		{
 			name:        "multibyte values are truncated by rune",
 			title:       strings.Repeat("题", 51),
-			content:     strings.Repeat("文", 201),
+			content:     strings.Repeat("文", 51),
 			wantTitle:   strings.Repeat("题", 50),
-			wantContent: strings.Repeat("文", 200),
+			wantContent: strings.Repeat("文", 50),
 		},
 	}
 
@@ -426,7 +427,7 @@ func TestOPPOPushSanitizesRequiredNotificationText(t *testing.T) {
 			assert.Equal(t, tt.wantTitle, message.Notification.Title)
 			assert.Equal(t, tt.wantContent, message.Notification.Content)
 			assert.LessOrEqual(t, len([]rune(message.Notification.Title)), 50)
-			assert.LessOrEqual(t, len([]rune(message.Notification.Content)), 200)
+			assert.LessOrEqual(t, len([]rune(message.Notification.Content)), 50)
 		})
 	}
 }
@@ -434,15 +435,34 @@ func TestOPPOPushSanitizesRequiredNotificationText(t *testing.T) {
 func TestOPPOPushRejectsOversizedActionParameters(t *testing.T) {
 	pusher := NewOPPOPush("app-id", "app-key", "app-secret", "master-secret", nil)
 	pusher.configErr = nil
-	payload := NewOPPOPayload(&PayloadInfo{
-		Title:      "title",
-		Content:    "content",
-		ChannelID:  strings.Repeat("界", 1400),
-		MessageSeq: 1,
+	baseRouting, err := json.Marshal(oppoRoutingParameters{
+		ChannelID:   "a",
+		ChannelType: 1,
+		MessageSeq:  1,
+	})
+	require.NoError(t, err)
+	overhead := utf8.RuneCount(baseRouting) - 1
+
+	atLimit := NewOPPOPayload(&PayloadInfo{
+		Title:       "title",
+		Content:     "content",
+		ChannelID:   strings.Repeat("a", 4000-overhead),
+		ChannelType: 1,
+		MessageSeq:  1,
+	}, "1")
+	_, err = pusher.buildUnicastMessage("registration-id", atLimit)
+	require.NoError(t, err)
+
+	overLimit := NewOPPOPayload(&PayloadInfo{
+		Title:       "title",
+		Content:     "content",
+		ChannelID:   strings.Repeat("a", 4001-overhead),
+		ChannelType: 1,
+		MessageSeq:  1,
 	}, "1")
 
-	_, err := pusher.buildUnicastMessage("registration-id", payload)
-	require.ErrorContains(t, err, "action parameters exceed 4096 bytes")
+	_, err = pusher.buildUnicastMessage("registration-id", overLimit)
+	require.ErrorContains(t, err, "action parameters exceed 4000 characters")
 }
 
 func TestOPPOPushRefreshesInvalidTokenOnceWithStableDedupeID(t *testing.T) {
@@ -788,8 +808,56 @@ func TestOPPOPushLogsProviderBusinessResult(t *testing.T) {
 		assert.Equal(t, "OPPO push rejected", warnings[0].message)
 		assert.Equal(t, int64(54), warnings[0].fields["oppo_code"])
 		assert.Equal(t, false, warnings[0].fields["retryable"])
+		assert.Equal(t, "registra***", warnings[0].fields["device_token"])
 		assert.NotContains(t, warnings[0].fields, "auth_token")
 		assert.NotContains(t, warnings[0].fields, "registration_id")
+	})
+
+	t.Run("invalid registration ID is debug noise", func(t *testing.T) {
+		logger := &recordingOPPOLogger{}
+		pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":41,"message":"invalid registration id"}`)
+		}), &memoryOPPOTokenCache{token: cachedOPPOAuthToken(t, "cached-token", oppoTestNow.Add(oppoAuthTokenTTL))}, defaultOPPOPushOptions())
+		pusher.Log = logger
+
+		err := pusher.Push("registration-id", NewOPPOPayload(&PayloadInfo{Title: "t", Content: "c", MessageSeq: 1}, "1"))
+		require.Error(t, err)
+		warnings, debugs := logger.snapshot()
+		assert.Empty(t, warnings)
+		require.Len(t, debugs, 1)
+		assert.Equal(t, "OPPO push rejected", debugs[0].message)
+		assert.Equal(t, int64(41), debugs[0].fields["oppo_code"])
+		assert.Equal(t, "registra***", debugs[0].fields["device_token"])
+	})
+
+	t.Run("recovered auth token rejection is debug noise", func(t *testing.T) {
+		logger := &recordingOPPOLogger{}
+		unicastCalls := 0
+		pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/server/v1/auth":
+				writeOPPOJSON(t, w, http.StatusOK, `{"code":0,"data":{"auth_token":"fresh-token"}}`)
+			case "/server/v1/message/notification/unicast":
+				unicastCalls++
+				if unicastCalls == 1 {
+					writeOPPOJSON(t, w, http.StatusOK, `{"code":11,"message":"invalid auth token"}`)
+					return
+				}
+				writeOPPOJSON(t, w, http.StatusOK, `{"code":0}`)
+			default:
+				http.NotFound(w, r)
+			}
+		}), &memoryOPPOTokenCache{token: cachedOPPOAuthToken(t, "stale-token", oppoTestNow.Add(oppoAuthTokenTTL))}, defaultOPPOPushOptions())
+		pusher.Log = logger
+
+		require.NoError(t, pusher.Push("registration-id", NewOPPOPayload(&PayloadInfo{Title: "t", Content: "c", MessageSeq: 1}, "1")))
+		warnings, debugs := logger.snapshot()
+		assert.Empty(t, warnings)
+		require.Len(t, debugs, 1)
+		assert.Equal(t, "OPPO auth token rejected; refreshing", debugs[0].message)
+		assert.Equal(t, int64(11), debugs[0].fields["oppo_code"])
+		assert.Equal(t, true, debugs[0].fields["retryable"])
+		assert.Equal(t, "registra***", debugs[0].fields["device_token"])
 	})
 
 	t.Run("accepted message ID", func(t *testing.T) {

--- a/modules/webhook/push_oppo_rest_test.go
+++ b/modules/webhook/push_oppo_rest_test.go
@@ -565,8 +565,33 @@ func TestOPPOPushHTTPClientHasBoundedTimeoutAndNamespacedCacheKey(t *testing.T) 
 	client, ok := first.httpClient.(*http.Client)
 	require.True(t, ok)
 	assert.Equal(t, 5*time.Second, client.Timeout)
+	require.NotNil(t, client.CheckRedirect)
+	assert.ErrorIs(t, client.CheckRedirect(nil, nil), http.ErrUseLastResponse)
 	assert.NotEqual(t, first.authTokenCacheKey, second.authTokenCacheKey)
 	assert.True(t, strings.HasPrefix(first.authTokenCacheKey, "oppo_auth_token:"))
+}
+
+func TestOPPOPushDoesNotFollowRedirects(t *testing.T) {
+	redirectTargetCalls := 0
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		redirectTargetCalls++
+		writeOPPOJSON(t, w, http.StatusOK, `{"code":0}`)
+	}))
+	t.Cleanup(redirectTarget.Close)
+
+	redirectSource := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectTarget.URL, http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(redirectSource.Close)
+
+	pusher := NewOPPOPush("app-id", "app-key", "app-secret", "master-secret", nil)
+	pusher.configErr = nil
+	pusher.notificationUnicastURL = redirectSource.URL
+	pusher.tokenCache = &memoryOPPOTokenCache{token: cachedOPPOAuthToken(t, "cached-token", time.Now().Add(oppoAuthTokenTTL))}
+
+	err := pusher.Push("registration-id", NewOPPOPayload(&PayloadInfo{Title: "t", Content: "c", MessageSeq: 1}, "1"))
+	require.ErrorContains(t, err, "status 307")
+	assert.Zero(t, redirectTargetCalls, "credential-bearing form body must not be replayed to a redirect target")
 }
 
 func TestLoadOPPOPushOptionsFromEnv(t *testing.T) {
@@ -674,6 +699,12 @@ func TestOPPOPushValidatesInputBeforeNetwork(t *testing.T) {
 	}{
 		{name: "wrong payload type", deviceToken: "registration-id", payload: &BasePayload{}},
 		{name: "empty registration ID", payload: NewOPPOPayload(&PayloadInfo{MessageSeq: 1}, "1")},
+		{name: "leading whitespace in registration ID", deviceToken: " registration-id", payload: NewOPPOPayload(&PayloadInfo{MessageSeq: 1}, "1")},
+		{name: "embedded whitespace in registration ID", deviceToken: "registration id", payload: NewOPPOPayload(&PayloadInfo{MessageSeq: 1}, "1")},
+		{name: "control character in registration ID", deviceToken: "registration-id\x00", payload: NewOPPOPayload(&PayloadInfo{MessageSeq: 1}, "1")},
+		{name: "semicolon separator in registration ID", deviceToken: "registration-id;other-id", payload: NewOPPOPayload(&PayloadInfo{MessageSeq: 1}, "1")},
+		{name: "comma separator in registration ID", deviceToken: "registration-id,other-id", payload: NewOPPOPayload(&PayloadInfo{MessageSeq: 1}, "1")},
+		{name: "oversized registration ID", deviceToken: strings.Repeat("a", 257), payload: NewOPPOPayload(&PayloadInfo{MessageSeq: 1}, "1")},
 		{name: "oversized action parameters", deviceToken: "registration-id", payload: NewOPPOPayload(&PayloadInfo{ChannelID: strings.Repeat("界", oppoMaxActionParametersRunes+1), MessageSeq: 1}, "1")},
 	}
 	for _, tt := range tests {
@@ -681,6 +712,35 @@ func TestOPPOPushValidatesInputBeforeNetwork(t *testing.T) {
 			require.Error(t, pusher.Push(tt.deviceToken, tt.payload))
 		})
 	}
+}
+
+func TestOPPOPushRefreshCacheReadFailureDoesNotDeleteSharedToken(t *testing.T) {
+	cache := &memoryOPPOTokenCache{getErr: errors.New("redis unavailable")}
+	authCalls := 0
+	unicastCalls := 0
+	pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/server/v1/auth":
+			authCalls++
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":0,"data":{"auth_token":"fresh-token"}}`)
+		case "/server/v1/message/notification/unicast":
+			unicastCalls++
+			require.NoError(t, r.ParseForm())
+			if r.PostForm.Get("auth_token") == "stale-token" {
+				writeOPPOJSON(t, w, http.StatusOK, `{"code":11,"message":"Invalid AuthToken"}`)
+				return
+			}
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":0}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}), cache, defaultOPPOPushOptions())
+	pusher.localAuthToken.Store(&oppoAuthToken{value: "stale-token", expiresAt: oppoTestNow.Add(oppoAuthTokenTTL)})
+
+	require.NoError(t, pusher.Push("registration-id", NewOPPOPayload(&PayloadInfo{Title: "t", Content: "c", MessageSeq: 1}, "1")))
+	assert.Equal(t, 1, authCalls)
+	assert.Equal(t, 2, unicastCalls)
+	assert.Empty(t, cache.delKeys, "a failed Redis read must not be followed by a destructive delete")
 }
 
 func TestOPPOPushRejectsAuthFailures(t *testing.T) {
@@ -876,11 +936,13 @@ func TestOPPOPushLogsProviderBusinessResult(t *testing.T) {
 }
 
 func TestOPPOAPIErrorFormatting(t *testing.T) {
-	assert.Equal(t, "OPPO push failed with code 54: template rejected", (&oppoAPIError{
+	errText := (&oppoAPIError{
 		Operation: "push",
 		Code:      54,
-		Message:   "template rejected",
-	}).Error())
+		Message:   "rejected registration-id-sensitive-value",
+	}).Error()
+	assert.Equal(t, "OPPO push failed with code 54", errText)
+	assert.NotContains(t, errText, "registration-id-sensitive-value")
 	assert.Equal(t, "OPPO auth failed with code -1", (&oppoAPIError{
 		Operation: "auth",
 		Code:      -1,

--- a/modules/webhook/push_oppo_rest_test.go
+++ b/modules/webhook/push_oppo_rest_test.go
@@ -506,11 +506,22 @@ func TestOPPOPushDedupeUsesGlobalMessageIdentity(t *testing.T) {
 func TestOPPOPushDedupeFallsBackToClientMessageNumber(t *testing.T) {
 	payloadInfo := &PayloadInfo{Title: "title", Content: "content", MessageSeq: 0}
 
-	first, err := newOPPOPayloadForMessage(payloadInfo, msgOfflineNotify{MsgResp: MsgResp{ClientMsgNo: "client-1"}})
+	first, err := newOPPOPayloadForMessage(payloadInfo, msgOfflineNotify{MsgResp: MsgResp{
+		ClientMsgNo: "same-client-message-number",
+		FromUID:     "sender-1",
+		ChannelID:   "channel",
+		ChannelType: 1,
+	}})
 	require.NoError(t, err)
-	second, err := newOPPOPayloadForMessage(payloadInfo, msgOfflineNotify{MsgResp: MsgResp{ClientMsgNo: "client-2"}})
+	second, err := newOPPOPayloadForMessage(payloadInfo, msgOfflineNotify{MsgResp: MsgResp{
+		ClientMsgNo: "same-client-message-number",
+		FromUID:     "sender-2",
+		ChannelID:   "channel",
+		ChannelType: 1,
+	}})
 	require.NoError(t, err)
-	assert.NotEqual(t, first.dedupeID, second.dedupeID)
+	assert.NotEqual(t, first.dedupeID, second.dedupeID,
+		"fallback identity must remain scoped when different senders reuse a client message number")
 
 	_, err = newOPPOPayloadForMessage(payloadInfo, msgOfflineNotify{})
 	require.ErrorContains(t, err, "missing message identity")

--- a/modules/webhook/push_oppo_rest_test.go
+++ b/modules/webhook/push_oppo_rest_test.go
@@ -1,0 +1,370 @@
+package webhook
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"mime"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type memoryOPPOTokenCache struct {
+	mu        sync.Mutex
+	token     string
+	getErr    error
+	setErr    error
+	delErr    error
+	getKeys   []string
+	setKeys   []string
+	delKeys   []string
+	setTTLs   []time.Duration
+	setValues []string
+}
+
+func (c *memoryOPPOTokenCache) GetString(key string) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.getKeys = append(c.getKeys, key)
+	return c.token, c.getErr
+}
+
+func (c *memoryOPPOTokenCache) SetAndExpire(key string, value interface{}, ttl time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.setKeys = append(c.setKeys, key)
+	c.setTTLs = append(c.setTTLs, ttl)
+	c.setValues = append(c.setValues, fmt.Sprint(value))
+	if c.setErr == nil {
+		c.token = fmt.Sprint(value)
+	}
+	return c.setErr
+}
+
+func (c *memoryOPPOTokenCache) Del(key string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.delKeys = append(c.delKeys, key)
+	if c.delErr == nil {
+		c.token = ""
+	}
+	return c.delErr
+}
+
+func newOPPOPushForTest(t *testing.T, handler http.Handler, cache *memoryOPPOTokenCache, options oppoPushOptions) *OPPOPush {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	pusher := NewOPPOPush("app-id", "app-key", "app-secret", "master-secret", nil)
+	pusher.httpClient = server.Client()
+	pusher.authURL = server.URL + "/server/v1/auth"
+	pusher.notificationUnicastURL = server.URL + "/server/v1/message/notification/unicast"
+	pusher.tokenCache = cache
+	pusher.options = options
+	pusher.now = func() time.Time { return time.UnixMilli(1_700_000_000_123) }
+	return pusher
+}
+
+func writeOPPOJSON(t *testing.T, w http.ResponseWriter, status int, body string) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, err := w.Write([]byte(body))
+	require.NoError(t, err)
+}
+
+func decodeOPPOMessage(t *testing.T, r *http.Request) map[string]interface{} {
+	t.Helper()
+
+	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	require.NoError(t, err)
+	require.Equal(t, "application/x-www-form-urlencoded", mediaType)
+	require.NoError(t, r.ParseForm())
+	require.Len(t, r.PostForm, 2)
+
+	var message map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(r.PostForm.Get("message")), &message))
+	return message
+}
+
+func TestOPPOPushUsesEncodedFormAndCurrentNotificationPayload(t *testing.T) {
+	cache := &memoryOPPOTokenCache{token: "cached&token+%"}
+	var gotMessage map[string]interface{}
+	var requestCount int
+	pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		require.Equal(t, "/server/v1/message/notification/unicast", r.URL.Path)
+		gotMessage = decodeOPPOMessage(t, r)
+		require.Equal(t, "cached&token+%", r.PostForm.Get("auth_token"))
+		writeOPPOJSON(t, w, http.StatusOK, `{"code":0,"message":"","data":{"messageId":"oppo-message-id"}}`)
+	}), cache, oppoPushOptions{
+		category:                 "IM",
+		notifyLevel:              2,
+		channelID:                "messages",
+		privateMessageTemplateID: "private-template-1",
+		clickActionType:          4,
+		clickActionActivity:      "com.example.chat.MainActivity",
+		offlineTTLSeconds:        86400,
+	})
+
+	payload := NewOPPOPayload(&PayloadInfo{
+		Title:       "标题 & + %",
+		Content:     "内容=甲&乙+丙%",
+		Badge:       3,
+		SpaceID:     "space-A",
+		ChannelID:   "group&+%",
+		ChannelType: 2,
+		MessageSeq:  42,
+	}, "42")
+
+	require.NoError(t, pusher.Push("CN_token&+%", payload))
+	require.Equal(t, 1, requestCount)
+	require.Equal(t, float64(2), gotMessage["target_type"])
+	require.Equal(t, "CN_token&+%", gotMessage["target_value"])
+	require.Equal(t, true, gotMessage["verify_registration_id"])
+
+	notification, ok := gotMessage["notification"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "标题 & + %", notification["title"])
+	assert.Equal(t, "内容=甲&乙+丙%", notification["content"])
+	assert.Equal(t, "IM", notification["category"])
+	assert.Equal(t, float64(2), notification["notify_level"])
+	assert.Equal(t, "messages", notification["channel_id"])
+	assert.Equal(t, "private-template-1", notification["private_msg_template_id"])
+	assert.Equal(t, float64(4), notification["click_action_type"])
+	assert.Equal(t, "com.example.chat.MainActivity", notification["click_action_activity"])
+	assert.Equal(t, true, notification["off_line"])
+	assert.Equal(t, float64(86400), notification["off_line_ttl"])
+	assert.Equal(t, float64(42), notification["notify_id"])
+	assert.NotEmpty(t, notification["app_message_id"])
+
+	var actionParameters map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(notification["action_parameters"].(string)), &actionParameters))
+	assert.Equal(t, "space-A", actionParameters["space_id"])
+	assert.Equal(t, "group&+%", actionParameters["channel_id"])
+	assert.Equal(t, float64(2), actionParameters["channel_type"])
+	assert.Equal(t, float64(42), actionParameters["message_seq"])
+}
+
+func TestOPPOPushAuthenticatesWithDocumentedSignatureAndCachesToken(t *testing.T) {
+	cache := &memoryOPPOTokenCache{}
+	authCalls := 0
+	unicastCalls := 0
+	pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/server/v1/auth":
+			authCalls++
+			require.NoError(t, r.ParseForm())
+			require.Equal(t, "app-key", r.PostForm.Get("app_key"))
+			require.Equal(t, "1700000000123", r.PostForm.Get("timestamp"))
+			digest := sha256.Sum256([]byte("app-key1700000000123master-secret"))
+			require.Equal(t, hex.EncodeToString(digest[:]), r.PostForm.Get("sign"))
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":0,"message":"success","data":{"auth_token":"fresh-token"}}`)
+		case "/server/v1/message/notification/unicast":
+			unicastCalls++
+			require.NoError(t, r.ParseForm())
+			require.Equal(t, "fresh-token", r.PostForm.Get("auth_token"))
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":0}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}), cache, defaultOPPOPushOptions())
+
+	payload := NewOPPOPayload(&PayloadInfo{Title: "title", Content: "content", MessageSeq: 7}, "7")
+	require.NoError(t, pusher.Push("registration-id", payload))
+	require.Equal(t, 1, authCalls)
+	require.Equal(t, 1, unicastCalls)
+	require.Equal(t, []string{"fresh-token"}, cache.setValues)
+	require.Equal(t, []time.Duration{20 * time.Hour}, cache.setTTLs)
+	require.Len(t, cache.setKeys, 1)
+	assert.Contains(t, cache.setKeys[0], "oppo_auth_token:")
+	assert.NotContains(t, cache.setKeys[0], "master-secret")
+
+	require.NoError(t, pusher.Push("registration-id", payload))
+	require.Equal(t, 1, authCalls, "second push must reuse the cached token")
+	require.Equal(t, 2, unicastCalls)
+}
+
+func TestOPPOPushRefreshesInvalidTokenOnceWithStableDedupeID(t *testing.T) {
+	cache := &memoryOPPOTokenCache{token: "stale-token"}
+	authCalls := 0
+	var sentTokens []string
+	var appMessageIDs []string
+	pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/server/v1/auth":
+			authCalls++
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":0,"data":{"auth_token":"fresh-token"}}`)
+		case "/server/v1/message/notification/unicast":
+			message := decodeOPPOMessage(t, r)
+			sentTokens = append(sentTokens, r.PostForm.Get("auth_token"))
+			notification := message["notification"].(map[string]interface{})
+			appMessageIDs = append(appMessageIDs, notification["app_message_id"].(string))
+			if len(sentTokens) == 1 {
+				writeOPPOJSON(t, w, http.StatusOK, `{"code":11,"message":"Invalid AuthToken"}`)
+				return
+			}
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":0}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}), cache, defaultOPPOPushOptions())
+
+	payload := NewOPPOPayload(&PayloadInfo{Title: "title", Content: "content", ChannelID: "channel", MessageSeq: 8}, "8")
+	require.NoError(t, pusher.Push("registration-id", payload))
+	assert.Equal(t, []string{"stale-token", "fresh-token"}, sentTokens)
+	assert.Equal(t, 1, authCalls)
+	assert.Len(t, cache.delKeys, 1)
+	require.Len(t, appMessageIDs, 2)
+	assert.Equal(t, appMessageIDs[0], appMessageIDs[1], "auth retry must not create a second logical notification")
+}
+
+func TestOPPOPushDoesNotRetryBusinessErrors(t *testing.T) {
+	tests := []struct {
+		code      int
+		retryable bool
+	}{
+		{code: 41, retryable: false},
+		{code: 54, retryable: false},
+		{code: 55, retryable: true},
+		{code: 10000, retryable: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(strconv.Itoa(tt.code), func(t *testing.T) {
+			cache := &memoryOPPOTokenCache{token: "cached-token"}
+			requestCount := 0
+			pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+				writeOPPOJSON(t, w, http.StatusOK, fmt.Sprintf(`{"code":%d,"message":"rejected"}`, tt.code))
+			}), cache, defaultOPPOPushOptions())
+
+			err := pusher.Push("registration-id", NewOPPOPayload(&PayloadInfo{Title: "t", Content: "c"}, "1"))
+			require.Error(t, err)
+			var apiErr *oppoAPIError
+			require.ErrorAs(t, err, &apiErr)
+			assert.Equal(t, tt.code, apiErr.Code)
+			assert.Equal(t, tt.retryable, apiErr.Retryable)
+			assert.Equal(t, 1, requestCount)
+			assert.Empty(t, cache.delKeys)
+		})
+	}
+}
+
+func TestOPPOPushRejectsMalformedResponsesAndWrongPayload(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+	}{
+		{name: "non 2xx", statusCode: http.StatusBadGateway, body: `{"code":0}`},
+		{name: "malformed JSON", statusCode: http.StatusOK, body: `{`},
+		{name: "missing code", statusCode: http.StatusOK, body: `{"message":"missing"}`},
+		{name: "invalid code type", statusCode: http.StatusOK, body: `{"code":"0"}`},
+		{name: "oversized body", statusCode: http.StatusOK, body: `{"code":0,"padding":"` + strings.Repeat("x", oppoMaxResponseBytes) + `"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				writeOPPOJSON(t, w, tt.statusCode, tt.body)
+			}), &memoryOPPOTokenCache{token: "cached-token"}, defaultOPPOPushOptions())
+			err := pusher.Push("registration-id", NewOPPOPayload(&PayloadInfo{Title: "t", Content: "c"}, "1"))
+			require.Error(t, err)
+		})
+	}
+
+	pusher := NewOPPOPush("app-id", "app-key", "app-secret", "master-secret", nil)
+	require.Error(t, pusher.Push("registration-id", &BasePayload{}))
+}
+
+func TestOPPOPushHTTPClientHasBoundedTimeoutAndNamespacedCacheKey(t *testing.T) {
+	first := NewOPPOPush("app-id", "app-key-1", "app-secret", "master-secret", nil)
+	second := NewOPPOPush("app-id", "app-key-2", "app-secret", "master-secret", nil)
+
+	client, ok := first.httpClient.(*http.Client)
+	require.True(t, ok)
+	assert.Equal(t, 5*time.Second, client.Timeout)
+	assert.NotEqual(t, first.authTokenCacheKey, second.authTokenCacheKey)
+	assert.True(t, strings.HasPrefix(first.authTokenCacheKey, "oppo_auth_token:"))
+}
+
+func TestLoadOPPOPushOptionsFromEnv(t *testing.T) {
+	t.Setenv("TS_PUSH_OPPO_CATEGORY", "IM")
+	t.Setenv("TS_PUSH_OPPO_NOTIFY_LEVEL", "2")
+	t.Setenv("TS_PUSH_OPPO_CHANNEL_ID", "messages")
+	t.Setenv("TS_PUSH_OPPO_PRIVATE_MSG_TEMPLATE_ID", "private-template")
+	t.Setenv("TS_PUSH_OPPO_CLICK_ACTION_TYPE", "4")
+	t.Setenv("TS_PUSH_OPPO_CLICK_ACTION_ACTIVITY", "com.example.chat.MainActivity")
+	t.Setenv("TS_PUSH_OPPO_CLICK_ACTION_URL", "")
+
+	options, err := loadOPPOPushOptionsFromEnv()
+	require.NoError(t, err)
+	assert.Equal(t, "IM", options.category)
+	assert.Equal(t, 2, options.notifyLevel)
+	assert.Equal(t, "messages", options.channelID)
+	assert.Equal(t, "private-template", options.privateMessageTemplateID)
+	assert.Equal(t, 4, options.clickActionType)
+	assert.Equal(t, "com.example.chat.MainActivity", options.clickActionActivity)
+	assert.Equal(t, 86400, options.offlineTTLSeconds)
+}
+
+func TestLoadOPPOPushOptionsRejectsInvalidValues(t *testing.T) {
+	tests := []struct {
+		name      string
+		notify    string
+		clickType string
+		activity  string
+		url       string
+	}{
+		{name: "invalid notify level", notify: "99"},
+		{name: "invalid click action", clickType: "3"},
+		{name: "activity required", clickType: "4"},
+		{name: "URL required", clickType: "2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("TS_PUSH_OPPO_CATEGORY", "IM")
+			t.Setenv("TS_PUSH_OPPO_NOTIFY_LEVEL", tt.notify)
+			t.Setenv("TS_PUSH_OPPO_CLICK_ACTION_TYPE", tt.clickType)
+			t.Setenv("TS_PUSH_OPPO_CLICK_ACTION_ACTIVITY", tt.activity)
+			t.Setenv("TS_PUSH_OPPO_CLICK_ACTION_URL", tt.url)
+			_, err := loadOPPOPushOptionsFromEnv()
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestOPPOPushCacheFailureFallsBackToAuthentication(t *testing.T) {
+	cache := &memoryOPPOTokenCache{getErr: errors.New("redis unavailable"), setErr: errors.New("redis unavailable")}
+	authCalls := 0
+	pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/server/v1/auth":
+			authCalls++
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":0,"data":{"auth_token":"fresh-token"}}`)
+		case "/server/v1/message/notification/unicast":
+			require.NoError(t, r.ParseForm())
+			require.Equal(t, "fresh-token", r.PostForm.Get("auth_token"))
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":0}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}), cache, defaultOPPOPushOptions())
+
+	require.NoError(t, pusher.Push("registration-id", NewOPPOPayload(&PayloadInfo{Title: "t", Content: "c"}, "1")))
+	assert.Equal(t, 1, authCalls)
+}

--- a/modules/webhook/push_oppo_rest_test.go
+++ b/modules/webhook/push_oppo_rest_test.go
@@ -32,6 +32,12 @@ type memoryOPPOTokenCache struct {
 	setValues []string
 }
 
+type oppoDoerFunc func(*http.Request) (*http.Response, error)
+
+func (f oppoDoerFunc) Do(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
 func (c *memoryOPPOTokenCache) GetString(key string) (string, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -73,6 +79,7 @@ func newOPPOPushForTest(t *testing.T, handler http.Handler, cache *memoryOPPOTok
 	pusher.notificationUnicastURL = server.URL + "/server/v1/message/notification/unicast"
 	pusher.tokenCache = cache
 	pusher.options = options
+	pusher.configErr = nil
 	pusher.now = func() time.Time { return time.UnixMilli(1_700_000_000_123) }
 	return pusher
 }
@@ -367,4 +374,177 @@ func TestOPPOPushCacheFailureFallsBackToAuthentication(t *testing.T) {
 
 	require.NoError(t, pusher.Push("registration-id", NewOPPOPayload(&PayloadInfo{Title: "t", Content: "c"}, "1")))
 	assert.Equal(t, 1, authCalls)
+}
+
+func TestOPPOPushDefaultPayloadKeepsClassificationOptIn(t *testing.T) {
+	var notification map[string]interface{}
+	pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		message := decodeOPPOMessage(t, r)
+		notification = message["notification"].(map[string]interface{})
+		writeOPPOJSON(t, w, http.StatusOK, `{"code":0}`)
+	}), &memoryOPPOTokenCache{token: "cached-token"}, defaultOPPOPushOptions())
+
+	require.NoError(t, pusher.Push("registration-id", NewOPPOPayload(&PayloadInfo{
+		Title:      "title",
+		Content:    "content",
+		MessageSeq: 9,
+	}, "9")))
+	assert.NotContains(t, notification, "category")
+	assert.NotContains(t, notification, "notify_level")
+	assert.NotContains(t, notification, "private_msg_template_id")
+	assert.NotContains(t, notification, "channel_id")
+	assert.Equal(t, float64(0), notification["click_action_type"])
+	assert.Equal(t, float64(oppoDefaultOfflineTTL), notification["off_line_ttl"])
+}
+
+func TestOPPOPushValidatesInputBeforeNetwork(t *testing.T) {
+	pusher := NewOPPOPush("app-id", "app-key", "app-secret", "master-secret", nil)
+	pusher.configErr = nil
+	pusher.tokenCache = &memoryOPPOTokenCache{token: "cached-token"}
+	pusher.httpClient = oppoDoerFunc(func(*http.Request) (*http.Response, error) {
+		t.Fatal("invalid input must not reach the network")
+		return nil, nil
+	})
+
+	tests := []struct {
+		name        string
+		deviceToken string
+		payload     Payload
+	}{
+		{name: "wrong payload type", deviceToken: "registration-id", payload: &BasePayload{}},
+		{name: "empty registration ID", payload: NewOPPOPayload(&PayloadInfo{MessageSeq: 1}, "1")},
+		{name: "invalid notify ID", deviceToken: "registration-id", payload: NewOPPOPayload(&PayloadInfo{MessageSeq: 1}, "not-a-number")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Error(t, pusher.Push(tt.deviceToken, tt.payload))
+		})
+	}
+}
+
+func TestOPPOPushRejectsAuthFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantAPIErr bool
+	}{
+		{name: "OPPO rejection", body: `{"code":41,"message":"bad credentials"}`, wantAPIErr: true},
+		{name: "missing data", body: `{"code":0}`},
+		{name: "invalid data", body: `{"code":0,"data":"invalid"}`},
+		{name: "missing token", body: `{"code":0,"data":{}}`},
+		{name: "empty token", body: `{"code":0,"data":{"auth_token":"  "}}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unicastCalls := 0
+			pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/server/v1/message/notification/unicast" {
+					unicastCalls++
+				}
+				writeOPPOJSON(t, w, http.StatusOK, tt.body)
+			}), &memoryOPPOTokenCache{}, defaultOPPOPushOptions())
+
+			err := pusher.Push("registration-id", NewOPPOPayload(&PayloadInfo{Title: "t", Content: "c", MessageSeq: 1}, "1"))
+			require.Error(t, err)
+			assert.Zero(t, unicastCalls)
+			if tt.wantAPIErr {
+				var apiErr *oppoAPIError
+				require.ErrorAs(t, err, &apiErr)
+				assert.Equal(t, 41, apiErr.Code)
+			}
+		})
+	}
+}
+
+func TestOPPOPushRetriesInvalidTokenOnlyOnce(t *testing.T) {
+	cache := &memoryOPPOTokenCache{token: "stale-token"}
+	authCalls := 0
+	unicastCalls := 0
+	pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/server/v1/auth":
+			authCalls++
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":0,"data":{"auth_token":"fresh-token"}}`)
+		case "/server/v1/message/notification/unicast":
+			unicastCalls++
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":11,"message":"Invalid AuthToken"}`)
+		}
+	}), cache, defaultOPPOPushOptions())
+
+	err := pusher.Push("registration-id", NewOPPOPayload(&PayloadInfo{Title: "t", Content: "c", MessageSeq: 1}, "1"))
+	require.Error(t, err)
+	var apiErr *oppoAPIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, 11, apiErr.Code)
+	assert.Equal(t, 1, authCalls)
+	assert.Equal(t, 2, unicastCalls)
+}
+
+func TestOPPOPushUsesTokenAlreadyRefreshedByPeer(t *testing.T) {
+	cache := &memoryOPPOTokenCache{token: "stale-token"}
+	var sentTokens []string
+	authCalls := 0
+	pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/server/v1/auth":
+			authCalls++
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":0,"data":{"auth_token":"unexpected"}}`)
+		case "/server/v1/message/notification/unicast":
+			require.NoError(t, r.ParseForm())
+			sentTokens = append(sentTokens, r.PostForm.Get("auth_token"))
+			if len(sentTokens) == 1 {
+				cache.mu.Lock()
+				cache.token = "peer-refreshed-token"
+				cache.mu.Unlock()
+				writeOPPOJSON(t, w, http.StatusOK, `{"code":11}`)
+				return
+			}
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":0}`)
+		}
+	}), cache, defaultOPPOPushOptions())
+
+	require.NoError(t, pusher.Push("registration-id", NewOPPOPayload(&PayloadInfo{Title: "t", Content: "c", MessageSeq: 1}, "1")))
+	assert.Equal(t, []string{"stale-token", "peer-refreshed-token"}, sentTokens)
+	assert.Zero(t, authCalls)
+	assert.Empty(t, cache.delKeys)
+}
+
+func TestOPPOPushReturnsTransportAndRequestConstructionErrors(t *testing.T) {
+	t.Run("transport", func(t *testing.T) {
+		pusher := NewOPPOPush("app-id", "app-key", "app-secret", "master-secret", nil)
+		pusher.configErr = nil
+		pusher.tokenCache = &memoryOPPOTokenCache{token: "cached-token"}
+		pusher.httpClient = oppoDoerFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("network unavailable")
+		})
+		err := pusher.Push("registration-id", NewOPPOPayload(&PayloadInfo{MessageSeq: 1}, "1"))
+		require.ErrorContains(t, err, "network unavailable")
+	})
+
+	t.Run("invalid URL", func(t *testing.T) {
+		pusher := NewOPPOPush("app-id", "app-key", "app-secret", "master-secret", nil)
+		pusher.configErr = nil
+		pusher.tokenCache = &memoryOPPOTokenCache{token: "cached-token"}
+		pusher.notificationUnicastURL = "://invalid"
+		err := pusher.Push("registration-id", NewOPPOPayload(&PayloadInfo{MessageSeq: 1}, "1"))
+		require.ErrorContains(t, err, "create OPPO request")
+	})
+}
+
+func TestOPPOAPIErrorFormatting(t *testing.T) {
+	assert.Equal(t, "OPPO push failed with code 54: template rejected", (&oppoAPIError{
+		Operation: "push",
+		Code:      54,
+		Message:   "template rejected",
+	}).Error())
+	assert.Equal(t, "OPPO auth failed with code -1", (&oppoAPIError{
+		Operation: "auth",
+		Code:      -1,
+	}).Error())
+}
+
+func TestNewOPPOPushRejectsMissingCredentials(t *testing.T) {
+	pusher := NewOPPOPush("", "", "", "", nil)
+	require.Error(t, pusher.configErr)
 }

--- a/modules/webhook/push_oppo_rest_test.go
+++ b/modules/webhook/push_oppo_rest_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 	"unicode/utf8"
@@ -547,6 +548,64 @@ func TestOPPOPushRefreshesInvalidTokenOnceWithStableDedupeID(t *testing.T) {
 	assert.Len(t, cache.delKeys, 1)
 	require.Len(t, appMessageIDs, 2)
 	assert.Equal(t, appMessageIDs[0], appMessageIDs[1], "auth retry must not create a second logical notification")
+}
+
+func TestOPPOPushConcurrentInvalidTokenAuthenticatesOnce(t *testing.T) {
+	const pushes = 8
+	cache := &memoryOPPOTokenCache{token: cachedOPPOAuthToken(t, "stale-token", oppoTestNow.Add(oppoAuthTokenTTL))}
+	staleRequests := make(chan struct{}, pushes)
+	releaseStaleRequests := make(chan struct{})
+	var authCalls atomic.Int32
+	var freshRequests atomic.Int32
+
+	pusher := newOPPOPushForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/server/v1/auth":
+			authCalls.Add(1)
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":0,"data":{"auth_token":"fresh-token"}}`)
+		case "/server/v1/message/notification/unicast":
+			require.NoError(t, r.ParseForm())
+			if r.PostForm.Get("auth_token") == "stale-token" {
+				staleRequests <- struct{}{}
+				<-releaseStaleRequests
+				writeOPPOJSON(t, w, http.StatusOK, `{"code":11,"message":"Invalid AuthToken"}`)
+				return
+			}
+			freshRequests.Add(1)
+			writeOPPOJSON(t, w, http.StatusOK, `{"code":0}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}), cache, defaultOPPOPushOptions())
+	pusher.localAuthToken.Store(&oppoAuthToken{value: "stale-token", expiresAt: oppoTestNow.Add(oppoAuthTokenTTL)})
+	payload := NewOPPOPayload(&PayloadInfo{Title: "title", Content: "content", MessageSeq: 1}, "message:1")
+
+	errs := make(chan error, pushes)
+	var wg sync.WaitGroup
+	for range pushes {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- pusher.Push("registration-id", payload)
+		}()
+	}
+	for range pushes {
+		select {
+		case <-staleRequests:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for concurrent stale-token requests")
+		}
+	}
+	close(releaseStaleRequests)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, int32(1), authCalls.Load())
+	assert.Equal(t, int32(pushes), freshRequests.Load())
+	assert.Len(t, cache.delKeys, 1)
 }
 
 func TestOPPOPushDoesNotRetryBusinessErrors(t *testing.T) {

--- a/modules/webhook/push_test.go
+++ b/modules/webhook/push_test.go
@@ -90,6 +90,20 @@ func TestOPPOPush(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestOPPOAuth(t *testing.T) {
+	appKey := os.Getenv("OPPO_APP_KEY")
+	masterSecret := os.Getenv("OPPO_MASTER_SECRET")
+	if appKey == "" || masterSecret == "" {
+		t.Skip("OPPO credentials not configured (set OPPO_APP_KEY and OPPO_MASTER_SECRET)")
+	}
+
+	oppo := NewOPPOPush("", appKey, "", masterSecret, nil)
+	assert.NoError(t, oppo.configErr)
+	token, err := oppo.getAuthToken()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, token)
+}
+
 func TestVIVOPush(t *testing.T) {
 	appID := os.Getenv("VIVO_APP_ID")
 	appKey := os.Getenv("VIVO_APP_KEY")

--- a/modules/webhook/push_test.go
+++ b/modules/webhook/push_test.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"encoding/json"
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -9,6 +10,27 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestOPPOAPIEndpointsUseDocumentedDomesticHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		path     string
+	}{
+		{name: "auth", endpoint: oppoAuthURL, path: "/server/v1/auth"},
+		{name: "notification unicast", endpoint: oppoNotificationUnicastURL, path: "/server/v1/message/notification/unicast"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.endpoint)
+			assert.NoError(t, err)
+			assert.Equal(t, "https", u.Scheme)
+			assert.Equal(t, "api-push-cn.heytapmobi.com", u.Host)
+			assert.Equal(t, tt.path, u.Path)
+		})
+	}
+}
 
 func TestHMSPush(t *testing.T) {
 	appID := os.Getenv("HMS_APP_ID")

--- a/modules/webhook/push_test.go
+++ b/modules/webhook/push_test.go
@@ -74,15 +74,13 @@ func TestMIPush(t *testing.T) {
 }
 
 func TestOPPOPush(t *testing.T) {
-	appID := os.Getenv("OPPO_APP_ID")
 	appKey := os.Getenv("OPPO_APP_KEY")
-	appSecret := os.Getenv("OPPO_APP_SECRET")
 	masterSecret := os.Getenv("OPPO_MASTER_SECRET")
 	deviceToken := os.Getenv("OPPO_DEVICE_TOKEN")
-	if appID == "" || appKey == "" || appSecret == "" || masterSecret == "" || deviceToken == "" {
-		t.Skip("OPPO push credentials not configured (set OPPO_APP_ID, OPPO_APP_KEY, OPPO_APP_SECRET, OPPO_MASTER_SECRET, OPPO_DEVICE_TOKEN)")
+	if appKey == "" || masterSecret == "" || deviceToken == "" {
+		t.Skip("OPPO push credentials not configured (set OPPO_APP_KEY, OPPO_MASTER_SECRET, OPPO_DEVICE_TOKEN)")
 	}
-	oppo := NewOPPOPush(appID, appKey, appSecret, masterSecret, &config.Context{})
+	oppo := NewOPPOPush("", appKey, "", masterSecret, nil)
 	payloadInfo := &PayloadInfo{
 		Title:   "标题",
 		Content: "内容",

--- a/modules/webhook/push_test.go
+++ b/modules/webhook/push_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOPPOAPIEndpointsUseDocumentedDomesticHost(t *testing.T) {
@@ -98,10 +99,10 @@ func TestOPPOAuth(t *testing.T) {
 	}
 
 	oppo := NewOPPOPush("", appKey, "", masterSecret, nil)
-	assert.NoError(t, oppo.configErr)
+	require.NoError(t, oppo.configErr)
 	token, err := oppo.getAuthToken()
-	assert.NoError(t, err)
-	assert.NotEmpty(t, token)
+	require.NoError(t, err)
+	require.NotEmpty(t, token)
 }
 
 func TestVIVOPush(t *testing.T) {


### PR DESCRIPTION
## Summary

Replace the legacy OPPO push integration with the current domestic REST API and harden the adapter for production use.

## Related Issue

N/A — no linked issue was provided.

## Linked Spec

`.octospec/tasks/oppo-push-rest-hardening/brief.md`

## Changes

- Send UTF-8 form requests to the current OPPO domestic auth and notification-unicast endpoints with a five-second HTTP timeout, redirects disabled, and strict response validation.
- Cache auth tokens per AppKey in process and Redis, serialize concurrent refreshes, avoid deleting shared state after Redis read failures, and retry exactly once on OPPO code 11.
- Derive `app_message_id` from the device token and WuKongIM's globally unique `message_id`; use a sender/channel-scoped `client_msg_no` fallback only when the upstream message ID is absent.
- Validate OPPO registration IDs as one bounded value before network I/O, rejecting separators, whitespace, control characters, invalid UTF-8, and values over the internal 256-byte safety limit.
- Enforce current notification limits, omit cross-conversation `notify_id`, include server-owned routing metadata, and support opt-in classification/channel/click-action settings.
- Keep provider response text out of propagated error strings while retaining structured OPPO codes and masked device identifiers in logs.
- Add deterministic adapter tests, credential-gated auth/unicast smoke tests, and deployment documentation.

## Testing

- [x] `go test -race ./modules/webhook -run '^Test(OPPO|ParseOPPO|LoadOPPO|NewOPPO)' -count=10`
- [x] Focused `push_oppo.go` statement coverage: 84.9% (247/291)
- [x] `go test ./modules/webhook -count=1` using an isolated temporary MySQL schema; the schema was removed after the run and the shared `test` database was not modified
- [x] `go build ./modules/webhook`
- [x] `go vet ./modules/webhook`
- [x] `golangci-lint run ./modules/webhook/...`
- [x] `git diff --check origin/main...HEAD`
- [x] Official OPPO online API contract manually verified
- [x] Real-credential authentication and unicast smoke tests passed on 2026-08-24
- [x] Notification arrival and display confirmed on the dedicated OPPO test device
- [ ] Deep-link routing and `action_parameters` consumption still require Android-side verification; the current default `click_action_type=0` only launches the app

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   OPPO offline notifications now authenticate and send through the documented domestic REST endpoints. The adapter owns credential handling, bounded HTTP I/O, token caching and refresh, message-identity-based idempotency, target validation, classification settings, and safe observability.

2. **What could break** because of it (dependents + failure mode)?

   Incorrect OPPO credentials, package registration, classification settings, or client click-routing support can reject or misroute notifications. Provider contract drift could also reject bounded fields. Failures surface provider codes and masked device identifiers without propagating provider-controlled text.

3. **How do you know it works** (specific test/repro/trace)?

   Local HTTP-server tests cover signatures, form encoding, malformed targets, redirect refusal, concurrent cache misses, token expiry, concurrent code-11 refresh, stable per-message deduplication including `message_seq=0`, payload boundaries, provider errors, malformed responses, logging, and timeouts. Race, repeat, isolated-database package, build, vet, lint, and diff checks pass. Real credentials and a dedicated OPPO device verified authentication, provider acceptance, arrival, and display.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
