### PR TITLE
fix(group): make the member self-exit notice visible to everyone

### DIFF
--- a/.octospec/journal/shared/group-exit-notice-visibility.md
+++ b/.octospec/journal/shared/group-exit-notice-visibility.md
@@ -1,0 +1,161 @@
+---
+type: Journal
+title: "Journal: group-exit-notice-visibility"
+description: 「某成员退出群聊」的系统提示改为全员可见 + RedDot:0。根因不是红点字段——IM 的未读是纯游标减法（latest_msg_seq − read_seq），与 red_dot、visibles 都无关；payload 里的 visibles 挡得住内容却挡不住 seq，于是非管理员看不到气泡、也永远推不动 read 游标，红点永久卡死。只改 red_dot 是无效修复，必须让消息可读。附带发现：可见性白名单还藏着一条早退，群里没有其他管理员时提示被整条静默吞掉。
+tags: ["acl", "isolation", "wire-contract", "testing"]
+timestamp: 2026-08-24T12:45:00Z
+# --- octospec extension fields ---
+task: group-exit-notice-visibility
+upstream: Mininglamp-OSS/octo-server#group-member-exit-message-visibility
+source: self
+---
+
+# Journal: group-exit-notice-visibility
+
+## 做了什么
+
+群成员自助退群时发的系统提示（`type=1021` GroupMemberQuit），原先带一个 `visibles`
+白名单只给**一位**管理员可见，且 `RedDot:1`。改成**全员可见 + RedDot:0**，与既有的
+bot 级联移除 Tip（`sendBotCascadeRemovedTip`）同一套语义。
+
+实现放在 octo-server 侧：新增 `modules/group/group_exit_notice.go` 的
+`sendGroupExitNotice`，经 `ctx.SendMessage` 直接发，**不动 octo-lib 的
+`SendGroupExit`**（该函数原样保留，只是这两处不再调它）。两处调用点
+（`api.go` 的 `groupExit`、`space_member_removal.go` 的 `sendGroupExitTip`）
+同步去掉了那次只为挑 `visibles` 目标而存在的管理员查询。
+
+渲染契约逐字节保持：`type=1021`、同一条 content 模板、退群者姓名仍放结构化 `extra`。
+
+## 结构性认知：`visibles` 挡内容，挡不住 seq
+
+这是本次最值得记住的一条，因为它让「改红点字段」这个直觉修复**完全无效**。
+
+WuKongIM（octo-im）的未读是**纯游标减法**：
+
+- `internal/app/build.go` `loadLatestConversationMessage` 直接取频道 `CommittedSeq`
+  那一条，**不看 `red_dot`、不看 `visibles`**；
+- `internal/usecase/conversation/sync.go` `unread = latest.MessageSeq − max(read_seq, delete_seq)`；
+- 全仓 conversation/unread 逻辑里**没有任何一处分支于 `RedDot`**（唯一的分支是
+  `SyncOnce`，且只在会话活跃度投影里，不在未读计算里）；
+- octo-server `api_conversation.go` 只是 `Unread: resp.Unread` **原样透传**；
+  `from()` 的 `visibles` 过滤只把 recents 的**内容**置 `is_deleted=1`，**不改未读数**。
+
+于是这条持久频道消息推高了群的共享 committed seq → 所有还没读到它的成员 unread +1；
+但内容被 `visibles` 锁给管理员 → 非管理员永远看不到这个气泡 → read 游标永远追不过
+这条 seq → **未读卡死、红点消不掉**。
+
+**推论（对以后所有系统消息都成立）**：在单条共享 channel log 里，
+「只给部分人看的持久气泡」和「不给其他人产生未读」**不可兼得**。要安静就别持久
+（`SyncOnce` 会被改写进 command channel，不参与未读），要持久就得人人可读。
+本次选了后者——`RedDot:0` 只是顺带的「不打扰」，**真正修好未读的是去掉 `visibles`**。
+
+## Gotcha 1：可见性白名单里藏着一条静默早退
+
+`sendGroupExitTip` 原先在挑不到管理员（群里没有其他 creator/manager）时直接
+`return`，`groupExit` 那侧则是 `len(visiblesUids) > 0` 的发送门槛。两处都是
+「白名单为空 ⇒ 整条提示不发」——**不是**有意的产品规则，只是可见性实现的副作用。
+白名单去掉后这两个门槛失去意义，现在只剩「群没解散」这一个条件，无管理员时同样照发。
+
+`groupExit` 那侧还连带去掉了一个**失败即 500 中断整个退群**的错误分支
+（`QueryGroupManagerOrCreatorUIDS` 查询失败）——它唯一的用途就是挑一个可见性目标。
+
+## Gotcha 2：差分证据只回退一半 = 没证明
+
+第一轮做「改动前必红」时，只把 helper 的 payload 回退成 `RedDot:1` + `visibles`，
+两条新测确实红了——看起来证据齐了。**但那次回退没有还原 `sendGroupExitTip` 的早退
+门槛**，所以 `require.Len(notices, 1)` 那条根本没红，等于「无管理员仍照发」这条
+门槛**从未被真正钉住**。
+
+补做第二段（把早退门槛整段还原）才跑出 `"[]" should have 1 item(s), but has 0`。
+
+> 教训：一次改动若移除了 **N 个**行为门槛，差分验证就得**逐个**还原。
+> 只回退最显眼的那个（payload 形状），会让另外几条断言在"看起来红了"的掩护下
+> 从未被验证过。这与 `learnings/pending/mutation-testing-must-be-adversarial.md`
+> 是同一族问题的另一个面：那条讲「变异由作者自选会失真」，这条讲
+> **「变异只覆盖了改动面的一部分，也同样失真」**。
+
+同时核实了该用例真的走「无管理员」路径：`seedGroupInSpace` 只插 `group` 表，而
+`QueryGroupManagerOrCreatorUIDS` 查的是 `group_member` 的 creator/manager 行——
+用例只种了两个 `MemberRoleCommon`，查询返回空。
+
+## Gotcha 3：octo-lib 的文案里有个笔误，必须原样抄
+
+content 模板是 `“{0}“退出群聊` —— `{0}` 两侧的引号**都是** U+201C（`0x201c`），
+第二个并不是 U+201D。这是 octo-lib `config/msg_group.go` 里的既有笔误。
+
+helper 里刻意逐字节保留，并写了注释挡住"顺手修正"的冲动：三端已经在渲染这个字符串，
+改它属于范围外的可见变化，要改得另开任务并同步 octo-lib。Finish 前用脚本做了
+字节比对确认两边一致（`0x201c 0x7b 0x30 0x7d 0x201c`）。
+
+## 判断：i18n 源码守卫**不**登记新文件
+
+CLAUDE.md 说新 handler 文件要加进 `TestGroupNoLegacyResponseError` 的文件列表。
+查证后判定本次**不该加**：
+
+- 该守卫是显式列表 `{api.go, api_manager.go, invite.go, api_welcome.go}`；
+- 直系先例 `bot_cascade.go`（同样 `ctx.SendMessage` 发系统消息、同样非 handler）
+  **不在**列表里；
+- `group_exit_notice.go` 不接 `wkhttp.Context`，**结构上发不出** HTTP 响应。
+
+按仓内先例不登记才是一致做法。
+
+## 已知覆盖缺口（未解决）
+
+`groupExit` handler 那处**发送门槛**的改动（`!disband && len(visiblesUids)>0`
+→ `!disband`）**没有运行中的测试**。payload 与另一调用点共用同一 helper 故已覆盖，
+缺的是门槛本身。原因：`api_test.go` 整片 HTTP handler 测试（19 处 `t.Skip`）卡在
+issue #17 的路由重复注册——实测解除 skip 会
+`panic: handlers are already registered for path '/v1/group/create'`。
+
+补齐前置是先修 issue #17，独立任务。当前只有编译期保证 + grep 确认被删的
+`QueryGroupManagerOrCreatorUIDS`/`visiblesUids` 计算确实只服务于 `visibles`
+（该 DB 方法本身仍有 6 个其它调用者，未变死代码）。
+
+## 范围外（同源但独立）
+
+排查中确认了**第二个**问题，本任务未动：**跨端已读不同步**（web 读过 app 仍未读，
+反之亦然）。根因是另外三处——`unreadClear` CMD 是 `NoPersist:true`（离线端永久丢失）、
+`readed_to_msg_seq` 被 octo-lib 的 `SyncUserConversationResp` 丢弃（IM 明明回传了）、
+iOS `WKUnreadStore.reconcileServerSnapshot` 默认走 `MAX(local, server)` 本地优先
+（结构上不可能接受别端的已读）。独立任务。
+
+## Review 后补的四件事（PR #807）
+
+1. **存量通知不被本次修复补救。** 改的只是此后的发送。已经发出去的那些仍带
+   `visibles`，而所有读门禁（`from()`、`visiblesAllows`、全局搜索门）会继续挡住它们
+   —— 按本任务自己的根因分析，**那些会话在部署后依然卡着**。受影响用户仍可通过
+   既有会话端点手动清除。别把绿部署读成"事故已关闭"，补救（回填 或 明示让用户清）
+   要另行立项。
+
+2. **可见性论证补上了"未来加入者"这一层。** 原论证只说"CMDGroupMemberUpdate 已广播
+   给全群"，那只覆盖当时在群的人。消息是持久的、入群即得完整历史，所以后来加入的人
+   会读到一条他从没收到过 CMD 的退群记录 —— `visibles` 此前是永久挡住这层的。结论
+   仍然接受（bot 级联 Tip 已是同样的先例，Slack/Discord 亦然），但代价是展示名永久
+   留在群历史里，因此展示名口径收紧（见下）。
+
+3. **展示名统一，且绝不落到裸 UID。** 两个调用点此前一个用 `group_member.Remark`、
+   另一个用全局 `user.Name`，同一个产品事件写出不同的名字；而后者在 `QueryByUID`
+   失败或名字为空时会兜底成**裸 uid**，等于把内部标识符永久写进全群可读的历史。
+   现在共用 `resolveExitShowName`：群内备注 → 全局名 → 中性兜底"该成员"。
+   注意 `sendGroupExitTip` 跑在 `RemoveGroupMembers` **之后**，那时
+   `QueryMemberWithUID`（`where is_deleted=0`）已经查不到人，所以备注必须由调用方
+   在移除前读到的那一行传进来。
+
+4. **"不可兼得"那条规律经实测核验成立。** Review 指出 octo-lib
+   `SendGroupMemberBeRemove` 像是反例（持久 + `Subscribers` + `visibles`）。拿实际
+   部署的 broker 二进制（`wukongim v2.2.4-20260313`）实测：该形状
+   （`channel_id` + `subscribers` + `sync_once:0`）返回 **HTTP 400**，而本任务的形状
+   （无 `subscribers`）返回 200。源码侧对得上 —— broker 在 `subscribers` 非空时清空
+   `channel_id` 走 request-scoped 路径，而该路径头一句就要求 `SyncOnce`。
+   **`Subscribers` 这条路对持久消息根本不可用**，故不构成反例。
+
+   顺带两个超范围发现，应另行立项：
+   - `SendGroupMemberBeRemove` 在这个 broker 上**发不出去**（400），「你被 X 移除群聊」
+     实际从未投递。仓内 `TestGroupCascadeKickStillNotifies` 是绿的，因为它打的是返回
+     `{}` 的 stub，不校验 broker 真实响应 —— 又一个"stub 让真实故障隐身"的例子。
+   - broker 请求体**没有 `setting` 字段**，octo-lib 传的
+     `Setting{NoUpdateConversation:true}` 被静默丢弃。
+
+5. **测试不再拿生产常量自比。** 原来 `assert.Equal(t, groupExitNoticeContent, ...)`
+   是用产物跟同一个常量比，常量被改照样绿。现在钉独立字面量
+   `"\u201c{0}\u201c退出群聊"`，并额外断言生产常量本身没漂移。

--- a/.octospec/learnings/pending/group-exit-notice-visibility.md
+++ b/.octospec/learnings/pending/group-exit-notice-visibility.md
@@ -1,0 +1,95 @@
+---
+type: Learning
+title: "Learning: 差分验证必须覆盖改动面的每一个门槛，不只是最显眼的那个"
+description: 一次改动移除了两个行为门槛（payload 里的可见性白名单、以及白名单为空时的静默早退）。做「改动前必红」时只回退了 payload，两条测试确实红了——但另一条断言从未被验证过。回退整段早退门槛后才发现它本来就没被钉住。
+tags: ["testing", "verification", "review"]
+timestamp: 2026-08-24T12:45:00Z
+# --- octospec extension fields ---
+status: pending
+source: self
+upstream: Mininglamp-OSS/octo-server#group-member-exit-message-visibility
+candidate_rule_id: differential-must-cover-every-gate
+---
+
+# 差分验证必须覆盖改动面的每一个门槛，不只是最显眼的那个
+
+## 观察到的事
+
+一个改动同时移除了**两个**行为门槛：
+
+1. 消息 payload 里的 `visibles` 可见性白名单（显眼：wire 形状变了）；
+2. 「白名单为空就直接 `return`」的静默早退（不显眼：藏在可见性实现里，
+   删掉后行为从"有时不发"变成"总是发"）。
+
+新增了两条测试，然后按惯例做「改动前必红」：把 helper 回退成改动前的 payload
+语义（`RedDot:1` + `visibles`），跑测试——**两条都红了**。证据看起来齐了。
+
+但那次回退**只动了 payload**，没有还原早退门槛。于是：
+
+- 断言 `不得带 visibles` / `不应点亮红点` → 红了 ✅
+- 断言 `require.Len(notices, 1)`（无管理员时提示仍须发出）→ **没红**
+
+因为提示照发（早退门槛还没被还原回去），Len 自然是 1。**那条断言在"整体看起来
+红了"的掩护下，从未被验证过。**
+
+补做第二段回退（把查管理员 + 早退整段还原）后才跑出：
+
+```
+Error: "[]" should have 1 item(s), but has 0
+Messages: 群里没有其他管理员时，退群提示同样要发（改动前会被静默吞掉）
+```
+
+## 为什么会漏
+
+「改动前必红」在心里被当成一个**布尔**：跑一次、看到红、打勾。
+但改动面不是布尔——它是**一组**被移除/修改的门槛。红色只证明
+「至少有一条断言咬住了你回退的那一部分」，不证明每条断言都有对应的保护对象。
+
+而且越是不显眼的门槛越危险：显眼的（wire 形状）改错了 code review 一眼能看出来；
+静默早退这种"删掉后只是变得更常发生"的行为，除了测试没有第二道防线。
+
+## 候选规则
+
+做差分/变异验证时，先**列出这次改动移除或改写的每一个行为门槛**，再逐个还原、
+逐个确认有断言变红。
+
+- 一次回退只还原一个门槛，确认**具体是哪条断言**红了；
+- 若某个门槛还原后没有任何断言变红 → 该门槛**缺测试**，不是"顺带就覆盖了"；
+- 尤其针对「删掉后行为只是变得更宽松」的门槛（早退、`if len(x) > 0` 发送条件、
+  静默 `return`）——它们不改 wire 形状，review 看不出来。
+
+与既有的 `mutation-testing-must-be-adversarial` 是同一族问题的另一个面：
+那条讲**变异由作者自选会失真**，这条讲**变异只覆盖改动面的一部分也会失真**。
+
+## 附：一条相关规律的反例核验（PR #807 review 要求）
+
+Review 指出本任务顺带记下的另一条规律 ——「单条共享 channel log 里，『只给部分人
+看的持久气泡』与『不给其他人产生未读』不可兼得」—— 在仓内似乎有反例：
+octo-lib `SendGroupMemberBeRemove`（`config/msg_group.go:203-238`）正是
+`NoPersist:0` + `SyncOnce:0` + `Subscribers` + `Setting{NoUpdateConversation:true}`
++ `visibles` 的组合。
+
+**已用实际部署的 broker 二进制实测（`wukongim v2.2.4-20260313`），规律成立、反例不成立：**
+
+| 请求形状 | 结果 |
+|---|---|
+| `channel_id` + `subscribers` + `sync_once:0`（`SendGroupMemberBeRemove` 的形状） | **HTTP 400** `无法处理发送消息请求！` |
+| `channel_id`，无 `subscribers`（本任务退群提示的形状） | HTTP 200，正常投递 |
+
+源码侧对得上（octo-im）：`internal/access/api/message_send.go` 在
+`len(subscribers) > 0` 时把 `channel_id` 清空并走 request-scoped 路径，而
+`internal/usecase/message/send.go` 的 `sendRequestScoped` 头一句就是
+`if !cmd.Framer.SyncOnce { return ErrRequestSubscribersRequireSyncOnce }`。
+也就是说 **`Subscribers` 这条路对持久消息根本不可用**，不构成反例。
+
+顺带两个发现（均超出本任务范围，应另行立项）：
+
+1. `SendGroupMemberBeRemove` 在这个 broker 上**发不出去**（400）——「你被 X 移除群聊」
+   实际从未投递。仓内 `TestGroupCascadeKickStillNotifies` 之所以是绿的，是因为它打的是
+   返回 `{}` 的 HTTP stub，不校验 broker 的真实响应。
+2. broker 的 `sendMessageRequest` **没有 `setting` 字段**，octo-lib 传的
+   `Setting{NoUpdateConversation:true}` 被静默丢弃。
+
+**对本 learning 的影响**：主规律（差分验证要覆盖每个门槛）与此无关，不受影响；
+上面这条附带规律经此核验可以照写，但必须带上「`Subscribers` 路线对持久消息不可用」
+这个前提，否则读者会以为 `SendGroupMemberBeRemove` 是可行的反例做法。

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,33 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-08-24 (group-exit-notice-visibility)
+
+- **Fixed** — 「某成员退出群聊」系统提示（`type=1021`）改为**全员可见 + RedDot:0**，
+  与 bot 级联移除 Tip 同一套语义。此前它带 `visibles` 白名单只给一位管理员可见，
+  非管理员看不到气泡却被计一格未读、且永远消不掉。实现走 octo-server 侧新增的
+  `modules/group/group_exit_notice.go`，**不动 octo-lib 的 `SendGroupExit`**。
+  See [journal](journal/shared/group-exit-notice-visibility.md).
+- **Learned** — `visibles` 挡的是**内容**，挡不住 **seq**。IM 的未读是纯游标减法
+  （`unread = latest_msg_seq − read_seq`），与 `red_dot`、`visibles` **都无关**
+  （octo-im `build.go` / `sync.go`，octo-server 只原样透传）。所以「改红点字段」
+  这个直觉修复**完全无效** —— 真正修好未读的是让消息可读。推论：单条共享 channel log
+  里，「只给部分人看的持久气泡」与「不给其他人产生未读」不可兼得。
+- **Guarded** — 可见性白名单里藏着一条**静默早退**：白名单为空（群里没有其他
+  管理员）时整条提示不发。那不是产品规则，只是可见性实现的副作用。现已由
+  `TestGroupExitTipSentWhenNoOtherAdmin` 钉死。`groupExit` 侧还连带去掉了一个
+  查询失败即 500 中断整个退群的错误分支。
+- **Learned** — 差分验证若只回退**改动面的一部分**，同样失真。第一轮只回退了 helper
+  的 payload，两条测试确实红了，但那条早退门槛的断言从未被验证过；补做整段还原才
+  跑出 `"[]" should have 1 item(s), but has 0`。移除了 N 个行为门槛，就得逐个还原。
+  See [learning](learnings/pending/group-exit-notice-visibility.md).
+- **Known gap** — `groupExit` handler 那处发送门槛的改动**无运行中的测试**：
+  `api_test.go` 整片 HTTP handler 测试（19 处 skip）卡在 issue #17 的路由重复注册
+  （解除 skip 会 `panic: handlers are already registered`）。补齐前置是先修 #17。
+- **Out of scope** — 排查中确认的第二个问题（跨端已读不同步：`unreadClear` CMD
+  `NoPersist:true` 离线丢失、`readed_to_msg_seq` 被 octo-lib 丢弃、iOS
+  `reconcileServerSnapshot` 走 `MAX` 本地优先）未动，独立任务。
+
 ## 2026-08-23 (bot-owner-self-removal)
 
 - **Implemented** — 普通群成员现在可以把自己名下（`robot.creator_uid`）的 bot 移出

--- a/.octospec/tasks/group-exit-notice-visibility/brief.md
+++ b/.octospec/tasks/group-exit-notice-visibility/brief.md
@@ -1,0 +1,181 @@
+---
+type: Task
+title: "Task: group-exit-notice-visibility"
+description: 群成员自助退出的系统消息改为「全员可见 + RedDot:0」（对齐 bot 级联 Tip），修复非管理员被 visibles 白名单挡住内容却仍被推高未读、红点消不掉的幽灵未读。改动全部落在 octo-server 侧，不改 octo-lib 的 SendGroupExit——两处调用点改为调用 octo-server 本地 helper 直接经 ctx.SendMessage 发送。不含跨端已读同步（问题二，独立任务）。
+tags: ["wire-contract", "acl", "test", "commit"]
+timestamp: 2026-08-24T06:10:36Z
+# --- octospec extension fields ---
+slug: group-exit-notice-visibility
+upstream: Mininglamp-OSS/octo-server#group-member-exit-message-visibility
+source: self
+---
+
+# Task: group-exit-notice-visibility
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+## Goal
+
+把**群成员自助退出**的系统消息，从当前的「`visibles` 白名单只给一位管理员看 +
+`RedDot:1`」，改成「**全员可见 + `RedDot:0`**」，与已有的 bot 级联移除 Tip
+（`modules/group/bot_cascade.go:179-191`，`RedDot:0`、无 `visibles`、人人可见）
+**同一套语义**。
+
+**要修的现象**：普通成员看不到「X 退出群聊」这条消息（`visibles` 把内容挡在
+管理员之外），但这条消息仍然给每个成员**推高了一格未读 / 红点，且消不掉**。
+
+**根因（已核到底，纯读代码）**：`visibles` 挡的是**内容**，挡不住 channel 的
+**seq**。octo-im 的未读是纯游标减法，与 `red_dot`、`visibles` **都无关**：
+
+- `octo-im internal/app/build.go:1544-1577` — `loadLatestConversationMessage`
+  直接取 `CommittedSeq` 那条，不看 `red_dot`、不看 `visibles`。
+- `octo-im internal/usecase/conversation/sync.go:155-158` — `unread =
+  latest.MessageSeq − max(read_seq, delete_seq)`。
+- `octo-im` 全仓 conversation/unread 逻辑**没有任何一处分支于 `RedDot`**。
+- `octo-server modules/message/api_conversation.go:1602` — `Unread: resp.Unread`
+  **原样透传** IM 的未读数；`from()` 的 `visibles` 过滤（`api.go:3839-3846`）只把
+  recents 的**内容**置 `is_deleted=1`，**不改未读数**。
+
+于是：这条退群消息作为**持久频道消息**推高了群的共享 `committed seq` → 所有还没
+读到它的成员 `unread = latest − read = 1`；但内容被 `visibles` 锁给管理员 → 非管理员
+永远看不到这个气泡 → read 游标永远追不到这条 seq → 未读卡死。
+
+**为什么改 `RedDot` 一个字段不够、必须同时去掉 `visibles`**：单把 `RedDot:1→0`
+是无效的（未读与 red_dot 无关，见上）。要真正消除幽灵未读，就必须让这条消息**可读**
+——即去掉 `visibles`，让全员能看到、能读、能正常清掉。`RedDot:0` 是附带项：让它
+不再实时点亮红点，与 bot 级联 Tip 一致。两者一起改，才等价于「一条人人可见、不打扰
+badge、可被正常已读」的系统提示。
+
+**为什么落在 octo-server 侧**：真正发消息的 `SendGroupExit` 在
+`octo-lib config/msg_group.go:348`（当前仓库只读，不改）。octo-server 有两处调用它
+（见 Load-bearing）。本任务在 `modules/group` 内新增一个本地 helper，直接经
+`ctx.SendMessage`（与 `bot_cascade.go` 同一路径）构造并发送退群提示，两处调用点改为
+调用该 helper，`octo-lib.SendGroupExit` 保持原样、只是不再被这两处调用。
+
+## Background
+
+- 复现自生产（截图）：某群聊对普通成员显示一条「"{退群者}"退出群聊」的未读，
+  `payload` 里 `type:1021`、`red_dot:1`、`visibles:["…"]`、`is_deleted:1`，未读无法消除。
+  （群名与退群者姓名此处脱敏 —— 本仓库是公开仓，生产复现细节不落公开产物。）
+- 三家 IM（Slack `last_read` / Discord `read_state` / Feishu 已读游标）的通行做法是
+  「服务端只存单调已读游标、未读客户端 derive」。本任务不动这套架构，只消除
+  「不可见却计未读」这一具体缺陷（最小改动，对齐仓内既有的 bot 级联 Tip 先例）。
+- 跨端已读同步（`unreadClear` CMD 的 `NoPersist:true` 离线丢失、`readed_to_msg_seq`
+  中间层丢弃、iOS `MAX` 本地优先）是**另一个独立问题**，见 Out of scope。
+
+## Load-bearing list
+
+- **调用点 1 — 主动退群 handler**：`modules/group/api.go:3608-3614`。当前
+  `if groupInfo.Status != GroupStatusDisband && len(visiblesUids) > 0 { SendGroupExit(...) }`。
+  其中 `visiblesUids`（`api.go:3445-3453`）挑一位「非退群者的管理员/群主」。改为全员
+  可见后，`len(visiblesUids) > 0` 这个**发送门槛作废** —— 需改成仅按解散态判定，否则
+  「群里已无其他管理员」时不再发提示（行为回退）。`visiblesUids` 的计算若不再被别处
+  使用则一并移除。`acl`/`wire-contract`
+- **调用点 2 — Space 清理路径的自助退群 Tip**：`modules/group/space_member_removal.go:198-221`
+  `sendGroupExitTip`。当前查管理员、`visibles` 只给一位、无管理员则 `return` 不发。
+  改为全员可见后：不再需要 `QueryGroupManagerOrCreatorUIDS` 挑 `visibles`，且**无管理员
+  时也应照发**。`acl`/`wire-contract`
+- **消息 payload 契约（客户端渲染依赖）**：三端按 `type == GroupMemberQuit(1021)`
+  （octo-lib `common/msg.go:80`）渲染「"{0}"退出群聊」系统气泡，`extra:[{uid,name}]`
+  提供占位名。**必须保持** `type=1021`、`content="“{0}“退出群聊"`、
+  `extra` 结构不变，只去掉 payload 里的 `visibles` 字段、并把 header `RedDot` 置 0。
+  `wire-contract`
+- **发送路径**：新 helper 经 `ctx.SendMessage(&config.MsgSendReq{...})`，与
+  `bot_cascade.go:179` 同一路径与 header 形状（`NoPersist:0, RedDot:0, SyncOnce:0`），
+  `ChannelID=groupNo`、`ChannelType=ChannelTypeGroup`。`wire-contract`
+- **`visibles` 作为读 ACL 的移除**：`visibles` 非空时 octo-server 的 `from()` /
+  `visiblesAllows`（`modules/message/api.go:3839-3846`、`api_message_get.go:41`）把它
+  当读白名单强制执行。去掉后退群提示对全体群成员可读。**需论证无信息泄漏**：内容仅
+  含退群者名 +「退出群聊」，而成员变更本就通过 `CMDGroupMemberUpdate`（`api.go:3591`）
+  广播给全群、成员列表随之更新，全员可见此事实不引入新信息面。`acl`
+- **既有测试断言**（`test`）：
+  - `modules/group/space_member_removal_test.go:307-312`：自助退出必须出现「退出群聊」、
+    不得出现「移除群聊」文案 —— **改后仍须成立**（文案不变）。
+  - `space_member_removal_test.go:334`：解散场景不得逐成员发「移除群聊」 —— 不受影响。
+  - `space_member_removal_test.go:354`：正常踢人仍发「移除群聊」 —— 不受影响（本任务
+    不碰 `SendGroupMemberBeRemove`）。
+  - `modules/group/api_test.go:689` `TestGroupExit` —— 主动退群主流程须仍绿。
+  - IM stub 拦 `/message/send` 原始 body（`space_member_removal_test.go:53-62`），
+    `red_dot` 与 payload 内 `visibles` 均可断言。
+
+## Out of scope
+
+- **不改 `octo-lib config/msg_group.go` 的 `SendGroupExit`**：函数保留原样，仅这两处
+  调用点不再调它。其它仓/其它调用方（若有）行为不变。
+- **不改 octo-im 的未读计算**（`sync.go` / `build.go`）。
+- **不碰被踢/被移除提示** `SendGroupMemberBeRemove`（「你被{0}移除群聊」）—— 仍保持
+  现有可见性语义。
+- **不碰 bot 级联移除 Tip** `sendBotCascadeRemovedTip`（`bot_cascade.go`）—— 已是全员
+  可见 + `RedDot:0`，本任务只是向它对齐。
+- **不碰群主退群转让/邀请入群等其它系统消息**。
+- **跨端已读同步（问题二）**：`unreadClear` CMD 的 `NoPersist:true`、
+  `readed_to_msg_seq` 全链路透出、iOS `WKUnreadStore` 的 `MAX` 本地优先 —— 独立任务，
+  不在本次。
+- **不改 `conversation/clearUnread`、`setUnread`、`sync` 端点**。
+
+## Acceptance
+
+- **单测（新增/改，`modules/group`）**：捕获自助退群 `/message/send` payload，断言：
+  - header `red_dot == 0`；
+  - payload **不含** `visibles` 字段（或为空）；
+  - payload `type == 1021`（GroupMemberQuit）；
+  - `content` 含「退出群聊」，`extra[0]` 含退群者 `uid`/`name`。
+- **差分证据（改前必红）**：把 helper 临时回退成改动前语义（`RedDot:1` + `visibles`
+  白名单）后，上述两条新测**必须失败**，且失败点正是 `visibles` 与 `red_dot` 两条断言。
+  没有这一步，「测试通过」不足以证明它咬得住这个 bug。
+- **回归**：`space_member_removal_test.go` 现有三条断言（自助退出出现「退出群聊」且无
+  「移除群聊」、解散不逐发、踢人仍发「移除群聊」）全绿。
+  > `api_test.go:689 TestGroupExit` **不在**此列：它带着**既有的**
+  > `t.Skip("OCTO migration TODO: issues/17")`，本任务不解除。已实测确认解除后会
+  > `panic: handlers are already registered for path '/v1/group/create'` —— `api_test.go`
+  > 里整片 HTTP handler 测试（19 处 skip）都卡在该路由重复注册问题上，属 issue #17
+  > 范围。修它超出本任务，见「已知覆盖缺口」。
+- **行为**：群内已无其他管理员时，主动退群/清理路径**仍会发出**「X 退出群聊」提示
+  （去掉 `len(visiblesUids)>0` / 无管理员 return 的门槛后），新增一条测试覆盖此场景。
+- **调用面**：`modules/group/api.go` 与 `modules/group/space_member_removal.go` 两处
+  **不再调用** `g.ctx.SendGroupExit`（grep 归零），改调 `modules/group` 内新 helper。
+- **构建/静态**：`go build ./...` 绿；`go test ./modules/group/...` 绿；
+  `golangci-lint run ./modules/group/...` 无新增告警。
+- **i18n**：本改动不新增/修改 `pkg/errcode` 错误码（退群提示是系统消息 payload、非
+  错误信封），`make i18n-extract-check` / `i18n-lint` 不受影响；content 中文串沿用
+  octo-lib 现有文案，与 `bot_cascade.go` 同类（系统消息内容硬编码，非错误码）。
+
+## 已知覆盖缺口
+
+诚实记账 —— 本任务**没有**做到全路径测试覆盖：
+
+| 改动面 | 覆盖状态 |
+|---|---|
+| 消息 payload 契约（本次真正的修复） | ✅ helper 直测，且已验证改动前必红 |
+| 调用点 2 `sendGroupExitTip`（`space_member_removal.go`） | ✅ 端到端覆盖，含「无其他管理员仍发」场景 |
+| 调用点 1 `groupExit` handler 的**发送门槛**改动 | ⚠️ **无运行中的测试** |
+
+调用点 1 的 payload 与调用点 2 共用同一个 helper，故 payload 形状已被覆盖；未被覆盖的
+是它那处门槛改动本身（`!disband && len(visiblesUids)>0` → `!disband`）。原因是
+`api_test.go` 的 HTTP handler 测试整片 skip（issue #17，见上）。当前只有编译期保证 +
+人工 grep 确认「被删除的 `QueryGroupManagerOrCreatorUIDS` / `visiblesUids` 计算确实只
+服务于 visibles、无其它消费者」。
+
+**补齐前置**：先修 issue #17 的路由重复注册，让 `TestGroupExit` 能跑。独立任务。
+
+## 验证记录（本地集成环境实测）
+
+环境：MySQL 8.0.46 + Redis 7 + WuKongIM `v2.2.4-20260313`（`WK_TOKENAUTHON=false`）。
+
+- 两条新测：改动后 **PASS**。差分证据分两段做（回退均已还原，无 TEMP 残留）：
+  1. helper 回退成改动前 payload 语义（`RedDot:1` + `visibles`）→ 两条新测 **双双 FAIL**，
+     失败点即 `不得带 visibles` / `不应点亮红点`。
+  2. 再把 `sendGroupExitTip` 的「查管理员 + 无管理员则 return」早退门槛整段还原 →
+     `TestGroupExitTipSentWhenNoOtherAdmin` 失败于 `"[]" should have 1 item(s), but has 0`，
+     证明改动前该提示确实被**静默吞掉**。
+     （第 1 段只动 helper payload，覆盖不到这条门槛；补第 2 段才算把门槛也钉住。）
+- 已核实 `TestGroupExitTipSentWhenNoOtherAdmin` 真的走「无管理员」路径：
+  `seedGroupInSpace` 只插 `group` 表，而 `QueryGroupManagerOrCreatorUIDS` 查的是
+  `group_member` 的 creator/manager 行 —— 该用例只种了两个 `MemberRoleCommon`，
+  故查询返回空，正是老代码静默跳过的场景。
+- **wire-contract 逐字节核实**：`groupExitNoticeContent` 与 octo-lib
+  `config/msg_group.go:357` 的 content **完全一致**（`{0}` 两侧均为 U+201C `0x201c`，
+  即原有笔误已原样保留），渲染文案零变化。
+- `go test ./modules/group/` → **ok 28.255s**（含上述三条既有回归，全 PASS）。
+- `go test ./modules/message/` → **ok**（未读透传所在模块，无连带影响）。

--- a/.octospec/tasks/group-exit-notice-visibility/context.yaml
+++ b/.octospec/tasks/group-exit-notice-visibility/context.yaml
@@ -1,0 +1,38 @@
+injected:
+  - id: space-isolation
+    source: repo
+    why: >-
+      brief load-bearing tag `acl` + paths modules/**/*.go。本任务移除退群提示的
+      `visibles` 读白名单，必须论证不跨越隔离边界：消息只发往 group channel，
+      订阅者就是群成员本身，群成员资格即边界；且成员变更本已由
+      CMDGroupMemberUpdate 全群广播，全员可见不引入新信息面。
+  - id: trust-boundary
+    source: repo
+    why: >-
+      brief load-bearing tag `wire-contract`（paths 不匹配，按 touches 命中）。
+      退群提示内嵌用户可控的 showName（remark / 登录名）。helper 保持
+      content 为模板 `“{0}“退出群聊` + name 放 extra 结构化字段，
+      不做 fmt.Sprintf 插值，避免把不可信文本拼进渲染敏感串。
+  - id: error-handling
+    source: repo
+    why: >-
+      brief load-bearing tag `wire-contract` + paths modules/**/*.go。
+      本次不新增/修改 errcode；退群提示是系统消息 payload 而非错误信封，
+      发送失败沿用 best-effort 记日志（与 bot_cascade 一致），
+      调用点既有的 httperr.ResponseErrorL 不变。
+  - id: rate-limit
+    source: repo
+    why: >-
+      paths modules/**/*.go 命中。本次不新增/改动路由与中间件，
+      不引入任何手写 Redis 计数器；无实质约束。
+  - id: testing
+    source: repo
+    why: >-
+      brief load-bearing tag `test` + paths **/*_test.go。新增/调整
+      modules/group 下的测试，沿用 testutil + 既有 groupIMStub 形状。
+  - id: commit-style
+    source: repo
+    why: >-
+      brief tag `commit`（paths ** 命中）。Implement 阶段不提交，
+      约束在 Finish 阶段生效。
+brief: .octospec/tasks/group-exit-notice-visibility/brief.md

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -3435,22 +3435,9 @@ func (g *Group) groupExit(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrGroupMemberNotInGroup, nil, nil)
 		return
 	}
-	// 查询群的管理员和群主
-	adminAndCreatorUIDS, err := g.db.QueryGroupManagerOrCreatorUIDS(groupNo)
-	if err != nil {
-		g.Error("查询群管理员失败！", zap.Error(err))
-		httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
-		return
-	}
-	visiblesUids := make([]string, 0)
-	if len(adminAndCreatorUIDS) > 0 {
-		for _, uid := range adminAndCreatorUIDS {
-			if uid != loginUID {
-				visiblesUids = append(visiblesUids, uid)
-				break
-			}
-		}
-	}
+	// 退群提示已改为全员可见（见 sendGroupExitNotice），不再需要查管理员挑
+	// `visibles` 白名单 —— 连带去掉了那次 QueryGroupManagerOrCreatorUIDS：
+	// 它此前失败会直接 500 中断整个退群，而它唯一的用途就是挑一个可见性目标。
 
 	/**
 	如果退出的人是群主，则选择第二个入群的人作为群主。
@@ -3601,14 +3588,15 @@ func (g *Group) groupExit(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrGroupNotifyFailed, nil, nil)
 		return
 	}
-	var showName = loginMember.Remark
-	if showName == "" {
-		showName = c.GetLoginName()
-	}
-	if groupInfo.Status != GroupStatusDisband && len(visiblesUids) > 0 {
-		// 发送群成员退出群聊消息
-		err = g.ctx.SendGroupExit(groupNo, loginUID, showName, visiblesUids)
-		if err != nil {
+	// 展示名口径与 sendGroupExitTip 共用 resolveExitShowName：群内备注优先 →
+	// 登录名 → 中性兜底，绝不落到裸 UID（提示现在全员可见且是持久历史）。
+	showName := resolveExitShowName(loginMember.Remark, c.GetLoginName)
+	// 发送群成员退出群聊消息（全员可见 + RedDot:0，见 sendGroupExitNotice）。
+	// 门槛只剩「群没解散」：此前还要求 len(visiblesUids) > 0，等于「群里还有另一位
+	// 管理员/群主」，否则整条提示被静默吞掉。可见性白名单去掉后该门槛失去意义，
+	// 群里已无其他管理员时同样要发。
+	if groupInfo.Status != GroupStatusDisband {
+		if err := sendGroupExitNotice(g.ctx, groupNo, loginUID, showName); err != nil {
 			g.Error("发送成员退出群聊错误", zap.Error(err))
 		}
 	}

--- a/modules/group/group_exit_notice.go
+++ b/modules/group/group_exit_notice.go
@@ -1,0 +1,104 @@
+package group
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+)
+
+// groupExitNoticeContent 是「某成员退出群聊」系统提示的文案模板，逐字节复刻
+// octo-lib `config.(*Context).SendGroupExit` 原有的 content，客户端据此渲染。
+//
+// 注意：`{0}` 两侧的引号**都是** U+201C（LEFT DOUBLE QUOTATION MARK，UTF-8
+// e2 80 9c），第二个并不是 U+201D。这是 octo-lib 里的既有笔误
+// （config/msg_group.go:357）。这里刻意原样保留 —— 本任务只修「不可见却计未读」
+// 这一缺陷，不改渲染文案；把第二个引号「修正」成 ”会让三端已经在渲染的字符串
+// 发生可见变化，属于本任务范围外的改动。要改请另开任务，并同步 octo-lib。
+const groupExitNoticeContent = "“{0}“退出群聊"
+
+// exitShowNameFallback 是两个调用点共用的兜底展示名。
+//
+// 绝不能兜到裸 uid：提示现在全员可见且是持久历史，后来入群的人也读得到，
+// 把内部 UID 永久写进群历史等于泄露一个不该出现在聊天记录里的标识符
+// （PR #807 review）。宁可显示一个中性词。
+const exitShowNameFallback = "该成员"
+
+// resolveExitShowName 统一两个调用点的展示名口径：群内备注优先 → 全局用户名 →
+// 中性兜底。groupExit 与 sendGroupExitTip 是同一个产品事件，此前一个用
+// group_member.Remark、另一个用 user.Name，同一件事在两条路径上会写出不同的名字。
+//
+// globalName 用闭包传入而不是直接取值：备注命中时就不该为了兜底再打一次 DB。
+func resolveExitShowName(groupRemark string, globalName func() string) string {
+	if groupRemark != "" {
+		return groupRemark
+	}
+	if globalName != nil {
+		if n := globalName(); n != "" {
+			return n
+		}
+	}
+	return exitShowNameFallback
+}
+
+// sendGroupExitNotice 发送「某成员自助退出群聊」的系统提示。
+//
+// 与 octo-lib `SendGroupExit` 的差异（这正是本 helper 存在的理由）：
+//
+//	octo-lib: Header{RedDot: 1}，payload 带 `visibles`（只给一位管理员可见）
+//	本 helper: Header{RedDot: 0}，payload **不带** `visibles`（全员可见）
+//
+// 为什么必须去掉 `visibles`：IM 的未读是纯游标减法
+// （unread = latest_msg_seq − read_seq），与 `red_dot`、`visibles` 都无关。
+// `visibles` 挡得住消息的**内容**（octo-server `from()` 会对未命中白名单的用户把
+// 该条置 is_deleted=1），却挡不住它推高频道的 committed seq。于是非管理员既看不到
+// 这条气泡、又永远没法把 read 游标推过它 —— 未读卡死、红点消不掉。
+// 让它全员可见 ⇒ 可读 ⇒ 可正常清除。RedDot: 0 则让它不实时点亮红点，
+// 与 bot 级联移除 Tip（sendBotCascadeRemovedTip）保持同一套语义。
+//
+// 可见性收敛（space-isolation / acl）：消息只投递到 groupNo 这个 group channel，
+// 订阅者就是群成员本身 —— 群成员资格即边界，不跨 Space、不外溢。
+//
+// 受众分两层，必须分开论证（PR #807 review 指出原论证只覆盖了第一层）：
+//
+//  1. **当时在群的成员**：成员变更本就通过 CMDGroupMemberUpdate 广播给全群、
+//     成员列表随之更新，"某人退群"对他们并非新信息，全员可见不增信息面。
+//
+//  2. **此后才入群的人**：这一条是真正的扩大。消息是持久的（NoPersist:0 /
+//     SyncOnce:0），而入群即获得完整历史，所以半年后加入的人会读到一条他既没
+//     见过成员列表变化、也没收到过 CMD 的退群记录。`visibles` 此前是永久挡住
+//     这一层的。
+//
+// 第 2 层是有意接受的，理由有二：同仓的 bot 级联移除 Tip
+// （sendBotCascadeRemovedTip）本就是全员可见的持久消息，已经建立了这个先例；
+// Slack / Discord 的频道离开事件同样对后来加入者可见。代价是展示名会永久留在
+// 群历史里，因此展示名口径收紧为"群内备注 → 全局名 → 中性兜底"，绝不落到裸 UID
+// （见 resolveExitShowName）。
+//
+// 不可信输入（trust-boundary）：showName 来自成员备注 / 登录名，是用户可控的。
+// 这里**不做**任何字符串插值 —— content 保持模板原样，名字放进结构化的
+// `extra[].name`，由客户端按 `{0}` 占位符填充。因此不存在把不可信文本拼进
+// 渲染敏感串的路径。
+//
+// 返回 error 供调用方按各自策略处理；两个调用点都是 best-effort（只记日志，
+// 不让提示发不出去影响退群/清理本身的成败）。
+func sendGroupExitNotice(ctx *config.Context, groupNo, uid, showName string) error {
+	return ctx.SendMessage(&config.MsgSendReq{
+		Header: config.MsgHeader{
+			NoPersist: 0,
+			RedDot:    0,
+			SyncOnce:  0,
+		},
+		ChannelID:   groupNo,
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		Payload: []byte(util.ToJson(map[string]interface{}{
+			"content": groupExitNoticeContent,
+			"type":    common.GroupMemberQuit,
+			"extra": []config.UserBaseVo{
+				{
+					UID:  uid,
+					Name: showName,
+				},
+			},
+		})),
+	})
+}

--- a/modules/group/group_exit_notice_test.go
+++ b/modules/group/group_exit_notice_test.go
@@ -80,9 +80,18 @@ func TestGroupExitNoticeIsEveryoneVisibleAndSilent(t *testing.T) {
 	assert.False(t, hasVisibles,
 		"退群提示不得带 visibles —— 带了就会「非管理员看不到内容却仍被计未读」")
 
-	// 2) 不点亮红点，与 bot 级联 Tip 一致。
+	// 2) header 三元组一次钉死，不能只钉 red_dot（PR #807 review nit）。
+	//
+	// no_persist / sync_once 是**承重项**，不是陪衬：本次可见性论证明确接受了
+	// "后来入群的人也读得到这条退群记录"，而那正建立在"消息持久、入群即得完整
+	// 历史"之上。谁把 NoPersist 翻成 1，这条契约就静默漂移了，而只断言 red_dot
+	// 的测试照样绿。
 	require.NotNil(t, notice.Header, "header 必须存在")
 	assert.EqualValues(t, 0, notice.Header["red_dot"], "退群提示不应点亮红点")
+	assert.EqualValues(t, 0, notice.Header["no_persist"],
+		"必须持久化 —— 可见性论证接受了『后来入群者也读得到』，靠的就是这一条")
+	assert.EqualValues(t, 0, notice.Header["sync_once"],
+		"不得走 sync_once —— 那会被改写进 command channel，变成一次性提示")
 
 	// 3) 渲染契约：type / content 模板 / extra 结构一律不变。
 	assert.EqualValues(t, 1021, notice.Payload["type"], "必须是 GroupMemberQuit(1021)")

--- a/modules/group/group_exit_notice_test.go
+++ b/modules/group/group_exit_notice_test.go
@@ -1,0 +1,174 @@
+package group
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	spacemod "github.com/Mininglamp-OSS/octo-server/modules/space"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sentExitNotices 从录到的 /message/send 里挑出「退出群聊」那条（可能有多条系统
+// 消息同批发出，例如 bot 级联 Tip），返回 (header, payload) 已解码的对子。
+//
+// payload 在 MsgSendReq 里是 []byte，JSON 编码后是 base64 —— 与 payloadsContain
+// 的解码方式保持一致。
+func sentExitNotices(t *testing.T, payloads []map[string]interface{}) []struct {
+	Header  map[string]interface{}
+	Payload map[string]interface{}
+} {
+	t.Helper()
+	var out []struct {
+		Header  map[string]interface{}
+		Payload map[string]interface{}
+	}
+	for _, p := range payloads {
+		raw, ok := p["payload"]
+		if !ok {
+			continue
+		}
+		decoded, err := base64.StdEncoding.DecodeString(fmt.Sprint(raw))
+		if err != nil {
+			continue
+		}
+		var payload map[string]interface{}
+		if err := json.Unmarshal(decoded, &payload); err != nil {
+			continue
+		}
+		// GroupMemberQuit(1021) 才是退群提示；同批的 bot 级联 Tip 是 Tip(2000)。
+		typ, ok := payload["type"].(float64)
+		if !ok || int(typ) != 1021 {
+			continue
+		}
+		header, _ := p["header"].(map[string]interface{})
+		out = append(out, struct {
+			Header  map[string]interface{}
+			Payload map[string]interface{}
+		}{Header: header, Payload: payload})
+	}
+	return out
+}
+
+// TestGroupExitNoticeIsEveryoneVisibleAndSilent 钉住本次修复的核心 wire 形状。
+//
+// 缺陷是「不可见却计未读」：IM 的未读是纯游标减法
+// （unread = latest_msg_seq − read_seq），与 red_dot / visibles 都无关。payload 里
+// 的 `visibles` 只挡得住内容（octo-server from() 把未命中的用户那条置 is_deleted=1），
+// 挡不住它推高频道 committed seq —— 非管理员既看不到气泡、又永远没法把 read 游标
+// 推过它，红点就永久卡住。
+//
+// 所以这里的两条断言各自独立、缺一不可：
+//   - **没有 visibles** 才真正修好未读（消息可见 ⇒ 可读 ⇒ 可清）；
+//   - red_dot=0 只是附带的「不打扰」，单独改它对未读毫无作用。
+//
+// 同时锁住渲染契约（type=1021 / content 模板 / extra），三端按它渲染系统气泡。
+func TestGroupExitNoticeIsEveryoneVisibleAndSilent(t *testing.T) {
+	ctx, _ := cascadeSetup(t)
+	stub := newGroupIMStub(t, ctx)
+
+	require.NoError(t, sendGroupExitNotice(ctx, "g-notice", "u-leaver", "张三"))
+
+	notices := sentExitNotices(t, stub.sentPayloads())
+	require.Len(t, notices, 1, "应发出且只发出一条退群提示")
+	notice := notices[0]
+
+	// 1) 全员可见：payload 不得带 visibles 白名单。这一条才是未读修复本身。
+	_, hasVisibles := notice.Payload["visibles"]
+	assert.False(t, hasVisibles,
+		"退群提示不得带 visibles —— 带了就会「非管理员看不到内容却仍被计未读」")
+
+	// 2) 不点亮红点，与 bot 级联 Tip 一致。
+	require.NotNil(t, notice.Header, "header 必须存在")
+	assert.EqualValues(t, 0, notice.Header["red_dot"], "退群提示不应点亮红点")
+
+	// 3) 渲染契约：type / content 模板 / extra 结构一律不变。
+	assert.EqualValues(t, 1021, notice.Payload["type"], "必须是 GroupMemberQuit(1021)")
+	// 独立字面量，**不能**拿 groupExitNoticeContent 自比 —— 那样常量被改动时
+	// 测试照样绿，测不出对 octo-lib 既有 wire 文案的漂移（PR #807 review）。
+	// 用 \u 转义把两个引号钉死成 U+201C：第二个**不是** U+201D，那是 octo-lib
+	// config/msg_group.go 里的既有笔误，三端已按它渲染，不能"顺手修正"。
+	const wantContent = "\u201c{0}\u201c退出群聊"
+	assert.Equal(t, wantContent, notice.Payload["content"],
+		"content 必须与 octo-lib 原文案逐字节一致（含 {0} 两侧的 U+201C 笔误）")
+	assert.Equal(t, wantContent, groupExitNoticeContent,
+		"生产常量本身也不得漂移 —— 它就是客户端渲染依赖的那个字符串")
+
+	extra, ok := notice.Payload["extra"].([]interface{})
+	require.True(t, ok, "extra 必须是数组")
+	require.Len(t, extra, 1)
+	first, ok := extra[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "u-leaver", first["uid"])
+	assert.Equal(t, "张三", first["name"],
+		"名字走结构化 extra，不插值进 content —— 不可信文本不进渲染敏感串")
+}
+
+// TestGroupExitTipSentWhenNoOtherAdmin 覆盖本次去掉的隐性门槛。
+//
+// 改动前 sendGroupExitTip 要先查管理员挑 visibles，挑不到（群里没有其他
+// 管理员/群主）就直接 return，提示被静默吞掉。可见性白名单去掉后该门槛失去
+// 意义 —— 这里造一个成员全是普通角色、压根没有管理员的群，退群提示仍须发出。
+func TestGroupExitTipSentWhenNoOtherAdmin(t *testing.T) {
+	ctx, g := cascadeSetup(t)
+	stub := newGroupIMStub(t, ctx)
+	const spaceID, leaver = "sp-noadmin", "u-leaver"
+
+	// 群里只有两名普通成员，没有 creator / manager 的 group_member 行 ——
+	// QueryGroupManagerOrCreatorUIDS 返回空，正是老代码静默跳过的场景。
+	seedGroupInSpace(t, ctx, "g-noadmin", spaceID, "u-absent-creator")
+	seedGroupMember(t, ctx, "g-noadmin", "u-other", MemberRoleCommon)
+	seedGroupMember(t, ctx, "g-noadmin", leaver, MemberRoleCommon)
+
+	require.NoError(t, g.cleanupSpaceMemberGroups(ctx, spacemod.MemberRemoval{
+		SpaceID: spaceID, UID: leaver,
+		OperatorUID: leaver, // 自助退出：操作者就是本人
+		Reason:      spacemod.MemberRemoveReasonLeft,
+	}))
+
+	_, stillIn := liveMemberRole(t, ctx, "g-noadmin", leaver)
+	assert.False(t, stillIn, "清理本身照做")
+
+	notices := sentExitNotices(t, stub.sentPayloads())
+	require.Len(t, notices, 1,
+		"群里没有其他管理员时，退群提示同样要发（改动前会被静默吞掉）")
+	_, hasVisibles := notices[0].Payload["visibles"]
+	assert.False(t, hasVisibles, "退群提示不得带 visibles")
+	assert.EqualValues(t, 0, notices[0].Header["red_dot"], "退群提示不应点亮红点")
+}
+
+// TestResolveExitShowName 钉住两个调用点共用的展示名口径。
+//
+// 关键那条是最后一个 case：兜底**绝不能**是裸 uid。提示现在全员可见且持久，
+// 后来入群的人也读得到——把内部 UID 写进群历史等于永久泄露一个不该出现在
+// 聊天记录里的标识符（PR #807 review）。
+func TestResolveExitShowName(t *testing.T) {
+	cases := []struct {
+		name       string
+		remark     string
+		globalName string
+		want       string
+	}{
+		{"群内备注优先", "群里的老王", "王五", "群里的老王"},
+		{"无备注则用全局名", "", "王五", "王五"},
+		{"两者皆空走中性兜底", "", "", exitShowNameFallback},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := resolveExitShowName(c.remark, func() string { return c.globalName })
+			assert.Equal(t, c.want, got)
+			assert.NotEqual(t, "u-leaver", got, "兜底绝不能是裸 UID")
+		})
+	}
+
+	// globalName 为 nil（调用方没有第二来源）时同样不能 panic、不能吐裸值。
+	assert.Equal(t, exitShowNameFallback, resolveExitShowName("", nil))
+
+	// 备注命中时不该为了兜底再打一次 DB —— 闭包必须没被调用。
+	called := false
+	got := resolveExitShowName("有备注", func() string { called = true; return "不该用到" })
+	assert.Equal(t, "有备注", got)
+	assert.False(t, called, "备注命中时不应触发全局用户名查询")
+}

--- a/modules/group/space_member_removal.go
+++ b/modules/group/space_member_removal.go
@@ -187,35 +187,29 @@ func (g *Group) exitSpaceMemberFromGroup(groupNo string, removal spacemod.Member
 			groupNo, removal.UID)
 	}
 	if selfExit {
-		g.sendGroupExitTip(groupNo, removal.UID)
+		// 群内备注必须用**移除前**读到的这一行：sendGroupExitTip 跑在
+		// RemoveGroupMembers 之后，那时 QueryMemberWithUID（where is_deleted=0）
+		// 已经查不到人了。
+		g.sendGroupExitTip(groupNo, removal.UID, member.Remark)
 	}
 	return nil
 }
 
 // sendGroupExitTip 发「主动退群」提示，可见范围与既有 groupExit 一致：
-// 只给一位管理员/群主看，不打扰全群。best-effort，失败只记日志——文案发不出去
-// 不该让整条清理工单重试。
-func (g *Group) sendGroupExitTip(groupNo, uid string) {
-	adminUIDs, err := g.db.QueryGroupManagerOrCreatorUIDS(groupNo)
-	if err != nil {
-		g.Warn("查询群管理员失败，跳过退群提示", zap.Error(err), zap.String("groupNo", groupNo))
-		return
-	}
-	visibles := make([]string, 0, 1)
-	for _, admin := range adminUIDs {
-		if admin != uid {
-			visibles = append(visibles, admin)
-			break
+// 全员可见 + RedDot:0（见 sendGroupExitNotice）。best-effort，失败只记日志——
+// 文案发不出去不该让整条清理工单重试。
+//
+// 此前这里要先查管理员、把 `visibles` 白名单收窄到一位管理员/群主，且在群里没有
+// 其他管理员时直接 return（提示被静默吞掉）。可见性白名单去掉后这两步都不再需要：
+// 无其他管理员时同样照发。
+func (g *Group) sendGroupExitTip(groupNo, uid, groupRemark string) {
+	showName := resolveExitShowName(groupRemark, func() string {
+		if member, err := g.userDB.QueryByUID(uid); err == nil && member != nil {
+			return member.Name
 		}
-	}
-	if len(visibles) == 0 {
-		return
-	}
-	showName := uid
-	if member, err := g.userDB.QueryByUID(uid); err == nil && member != nil && member.Name != "" {
-		showName = member.Name
-	}
-	if err := g.ctx.SendGroupExit(groupNo, uid, showName, visibles); err != nil {
+		return ""
+	})
+	if err := sendGroupExitNotice(g.ctx, groupNo, uid, showName); err != nil {
 		g.Warn("发送退群提示失败", zap.Error(err), zap.String("groupNo", groupNo))
 	}
 }


### PR DESCRIPTION
## Summary

The "X 退出群聊" system notice was sent with a `visibles` allowlist naming a single admin, plus `RedDot:1`. Non-admin members could not see the bubble, yet each of them got an unread badge for it that they could never clear.

Fixed by sending the notice to the whole group with `RedDot:0`, mirroring the existing bot-cascade tip (`sendBotCascadeRemovedTip`).

**Flipping `red_dot` alone would not have fixed anything.** IM derives unread purely as `latest_msg_seq - read_seq`:

- octo-im `internal/app/build.go` — `loadLatestConversationMessage` takes the message at `CommittedSeq`, reading neither `red_dot` nor `visibles`.
- octo-im `internal/usecase/conversation/sync.go` — `unread = latest.MessageSeq - max(read_seq, delete_seq)`. Nothing in the conversation/unread path branches on `RedDot`.
- octo-server `modules/message/api_conversation.go` — passes `Unread` through verbatim. The `visibles` filter in `from()` only marks recents `is_deleted=1`; it does not touch the unread count.

So `visibles` hides the *content* but not the *seq*. The notice still advanced the group's shared committed seq, while its content stayed locked to one admin — so non-admins could never move their read cursor past it. Making the message readable is what actually clears the stuck unread; `RedDot:0` only suppresses the client-side live badge bump and is there for parity with the sibling tip.

The general rule, worth keeping in mind for any future system message: within one shared channel log, "a persistent bubble only some people see" and "no unread for everybody else" cannot both hold. This was challenged in review against `SendGroupMemberBeRemove`, which appears to attempt exactly that combination; probing the pinned broker showed that shape returns HTTP 400, so the `Subscribers` route is unavailable for persistent messages and the rule holds. Details in the review reply.

## ⚠️ Deploying this does not clear notices already sent

This changes future sends only. Every notice already in production keeps its `visibles`, and every read gate — `from()`, `visiblesAllows`, and the global-search gate — keeps honouring it. By this PR's own root-cause analysis, **those conversations stay stuck after deploy.** Affected users can still clear them through the existing conversation endpoints.

Remediation (a backfill, or a documented "ask affected users to clear") needs a separate issue. Please don't read a green deploy as the originating incident being closed.

## Related Issue

Reported internally with a production repro: a group conversation showed a `"{leaver}"退出群聊` notice as one permanently stuck unread for ordinary members, with the payload carrying `type:1021`, `red_dot:1`, `visibles:[…]`, `is_deleted:1`. (Group and member identifiers omitted — this repository is public.)

No `Closes #<issue>` reference yet, which is why `check-sprint` fails: the report arrived as an internal screenshot rather than a filed issue. A maintainer needs to supply an issue and put it on the Octo Board.

## Linked Spec

`.octospec/tasks/group-exit-notice-visibility/brief.md`

## Changes

- Add `modules/group/group_exit_notice.go` — `sendGroupExitNotice` posts the notice via `ctx.SendMessage` with no `visibles` and `RedDot:0`. **octo-lib's `SendGroupExit` is left untouched**; these two call sites simply stop calling it.
- `groupExit` (`modules/group/api.go`) — drop the `QueryGroupManagerOrCreatorUIDS` lookup that existed only to pick a `visibles` target. That lookup sat between `IMRemoveSubscriber` and the member-row delete, so a transient DB error returned 500 with the user already unsubscribed from the IM channel but still a `group_member` — a silent half-exit whose window is now gone. The send gate is now just "group not disbanded"; it previously also required `len(visiblesUids) > 0`, i.e. another admin being present.
- `sendGroupExitTip` (`modules/group/space_member_removal.go`) — same lookup removed, plus the early `return` that silently swallowed the notice when the group had no other admin. It is now always sent.
- **Display names unified** behind `resolveExitShowName`: group remark → global name → neutral fallback, never a bare UID. The two call sites previously disclosed different strings for the same event, and the cleanup path could fall back to a raw internal UID — now permanent, group-readable history. The remark is captured from the member row the caller already read *before* removal, since `sendGroupExitTip` runs after `RemoveGroupMembers` and `QueryMemberWithUID` filters `is_deleted=0`.
- Rendering contract preserved byte-for-byte: `type=1021`, the same content template, and the leaver's name kept in structured `extra` rather than interpolated into the string. Includes octo-lib's existing U+201C typo on both sides of `{0}`, kept deliberately and commented so nobody "corrects" it and changes what three clients already render.
- Add `modules/group/group_exit_notice_test.go`; record the octospec brief, journal, learning candidate and log entry.

## Visibility: two audiences, both considered

1. **Members present at the time** — the departure is already broadcast to the whole group as `CMDGroupMemberUpdate` carrying the leaver's `uid`, and the roster updates accordingly. No new information.
2. **Future joiners** — this is a genuine widening. The notice is persistent and joining grants full history, so someone who joins months later reads a departure they never saw in any roster and never received a CMD for. `visibles` blocked that forever.

(2) is accepted: `sendBotCascadeRemovedTip` already sets this precedent in-tree, and Slack and Discord both show channel-leave events to later joiners. The cost is that the display name lives in history permanently, which is why the name resolution above was tightened to never emit a bare UID.

## Testing

Local integration environment: MySQL 8.0.46 + Redis + WuKongIM `v2.2.4-20260313`.

- `go test ./modules/group/` and `./modules/message/` → **ok**
- `golangci-lint run ./modules/group/...` → **0 issues**; `go build ./...`, `go vet` clean; `gofmt -l` clean on touched files (the five files it does list are pre-existing drift this PR doesn't touch)
- `make i18n-extract-check` and `make i18n-lint` → OK
- Re-run in full after rebasing onto current `main` and again after the review fixes

**Differential evidence — the tests were confirmed to go red against the pre-fix code, in two separate passes**, because this change removed two gates and reverting only the obvious one proves nothing about the other:

1. Helper reverted to the pre-fix payload (`RedDot:1` + `visibles`) → both new tests fail on `不得带 visibles` and `不应点亮红点`.
2. `sendGroupExitTip`'s admin-lookup-and-early-return restored → `TestGroupExitTipSentWhenNoOtherAdmin` fails with `"[]" should have 1 item(s), but has 0`, proving the notice used to be swallowed silently.

Also confirmed that test genuinely exercises the no-admin path: `seedGroupInSpace` only inserts into `group`, while `QueryGroupManagerOrCreatorUIDS` reads creator/manager rows from `group_member` — the case seeds only two `MemberRoleCommon` members, so the lookup returns empty.

The content assertion pins an independent literal and separately checks the production constant against it, so changing the constant fails the test rather than silently redefining what it asserts.

- [x] Unit tests added/updated
- [x] Manually verified

### Known coverage gap

The **send gate** change in the `groupExit` handler has no running test. Its payload is covered (shared helper), but the gate itself is not: `api_test.go`'s HTTP-handler tests are entirely skipped (19 `t.Skip`s) behind issue #17 — removing the skip panics with `handlers are already registered for path '/v1/group/create'`. Closing this gap requires fixing #17 first. For now it rests on the compiler plus a grep confirming the removed lookup fed nothing but `visibles` (the DB method itself still has other callers and is not dead).

## Follow-ups this PR does not do

- Remediate notices already sent (see the warning above).
- `SendGroupMemberInviteReq` (octo-lib) has the identical commented-out-`Subscribers` + `visibles` shape and is live via `invite.go:82` → `handler.go:214`, so every invite notice should be producing the same phantom unread.
- `SendGroupMemberBeRemove` returns HTTP 400 against this broker, so 「你被 X 移除群聊」 is never delivered. Its test is green only because it asserts against a stub that returns `{}` and never checks the broker's response.
- The broker's `sendMessageRequest` has no `setting` field, so octo-lib's `Setting{NoUpdateConversation:true}` is silently dropped.

## COMPREHENSION

**1. What does this change actually do to the load-bearing path?**

It removes a read-ACL. `visibles`, when non-empty, is enforced by octo-server as an allowlist (`from()` marks the message `is_deleted=1` for anyone outside it; `visiblesAllows` guards the single-message endpoints). After this change the self-exit notice carries no allowlist, so every group member can read it.

Delivery stays confined to the `groupNo` group channel, whose subscribers are the group's own members — group membership *is* the boundary, and nothing crosses a Space. The information exposure is analysed by audience above: none for members present, a real but accepted widening for future joiners.

Secondarily, it removes two gates that were side effects of the allowlist rather than product rules — the no-other-admin skip, and a failed admin lookup 500ing the whole exit — and unifies the display name across both call sites.

**2. What could break because of it (dependents + failure mode)?**

- *Clients rendering the bubble* — the payload is unchanged apart from the dropped `visibles` key, so the `type=1021` renderer on all three clients is unaffected. The failure mode to worry about is content-string drift, which is why the template is byte-compared against an independent literal in the test.
- *Product expectation* — ordinary members now see "X 退出群聊" where previously only one admin did, and so do future joiners. This is deliberate and consistent with the bot-cascade tip. If the product genuinely wants it admin-only, the allowlist is *not* the way to get it (it produces exactly the stuck-unread bug); it would have to become non-persistent instead.
- *No-admin groups* — these now receive a notice that previously vanished. That was a silent swallow, not a rule.
- *Search surface* — the notice is now returned by global message search for every member, since an absent `visibles` is treated as ungated. Consistent with the intent.
- *Everything else* is unchanged: no routes, no middleware, no error codes, no rate limiting; `octo-lib` is untouched.

**3. How do you know it works (specific test/repro/trace)?**

`TestGroupExitNoticeIsEveryoneVisibleAndSilent` asserts no `visibles`, `red_dot=0`, and pins the rendering contract against an independent literal. `TestGroupExitTipSentWhenNoOtherAdmin` drives the real cleanup path through a group with no admins and asserts the notice is still emitted. `TestResolveExitShowName` pins the name precedence and that the fallback is never a bare UID.

Both behavioural tests were confirmed to fail against the pre-fix code in the two separate reverts described above — the second specifically because the first pass had left the early-return gate unverified. The root-cause reasoning was established by reading octo-im's `build.go`/`sync.go` and octo-server's `api_conversation.go` directly, and the disputed broker behaviour was settled by probing the pinned binary rather than by argument.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (octospec brief / journal / learning / log)
- [x] Followed commit message conventions (Conventional Commits)