### PR TITLE
feat(featuregate): generic rollout gate with a user dimension + per-user flags endpoint

### DIFF
--- a/.octospec/journal/shared/featuregate-user-scoped-flags.md
+++ b/.octospec/journal/shared/featuregate-user-scoped-flags.md
@@ -143,3 +143,53 @@ before the count. `delScope` deliberately does *not* validate the prospective
 post-delete state: blocking on it creates an ordering trap where neither entry of a
 `{user, group}` pair can be removed first. That path is left to the read-side
 backstop, which round 1 added and which is now explicitly noted in the code.
+
+## Review round 3 (2026-08-25)
+
+The blocker was a collation mismatch, and it is the sharpest finding of the three
+rounds because the defence I had written did not work and I had asserted in a comment
+that it did.
+
+Both new tables inherited the database default `utf8mb4_general_ci`, while every Go
+comparison of those same values is byte-exact (`s.ID == id`, `rule.Mode != ModeOff`,
+the `switch` in `dimValue`). Reproduced against MySQL 8.0.46:
+
+- `scope_id` `"UserA"` and `"usera"` collide under the unique key. The second `add`
+  hits `ON DUPLICATE KEY UPDATE updated_by=...`, so only `updated_by` changes and the
+  row keeps the first spelling. The operator gets 200; that user is never admitted.
+  And the read side stays quiet too — a usable `user`-dimension entry does exist, so
+  `Evaluate` returns an ordinary `whitelist_miss` with `DimensionUnusable=false` and
+  `AllowDisplay` logs nothing. Write succeeds, read silently misses, both sides mute:
+  the round-1 blocker's exact shape in a different dimension.
+- **The CHECK constraints did not enforce what their own comments claimed.**
+  `REGEXP_LIKE` and `IN` both inherit the column's collation, so under `_ci`,
+  `feature_key='ZZ_UPPER'` passed `'^[a-z][a-z0-9_]*$'` and `mode='OFF'` passed
+  `IN ('off',...)`. I had called the `feature_key` charset check "尤其重要" in the
+  migration header while it was inert.
+- A hand-written `mode='OFF'` splits policy across entry points: `AllowPush` reads it
+  as not-off and allows, `Evaluate` reads it as an unknown mode and denies.
+
+All five identity columns are now explicitly `utf8mb4_bin`, verified: the uppercase
+key and `mode='OFF'` inserts are rejected by the existing CHECKs, and `UserA`/`usera`
+become two distinct rows. The repo had already been bitten by this class — `modules/
+message`'s `message_reaction_emoji_binary` is a forward-only repair ALTER, and
+`card_template_catalog` builds at `_bin` from the start.
+
+**A CHECK constraint written against a `_ci` column is decorative.** Worth checking
+the collation before trusting any string constraint, and worth testing the constraint
+by trying to violate it rather than by reading it.
+
+Also this round: orphan whitelist rows are rejected (`addScope` requires the rule to
+exist — otherwise the row is invisible to `list`, which enumerates rules and joins
+scopes onto them, yet goes live the moment someone creates a matching rule); an empty
+uid now lists every key as `unavailable` instead of returning a definite `false` for
+all of them, which was the one response shape the whole design exists to avoid;
+`AllowCreate` now consumes the same misconfiguration signal `AllowDisplay` does; the
+dimension warning is deduplicated per (key, reason) because the display endpoint
+evaluates once per user per fetch and a single misconfigured rule would otherwise
+flood the log with a message of constant information content.
+
+One of my own edits from round 2 had reversed a negation in the brief's most-read
+section — a blind `省略` → `unavailable 数组` substitution turned "not omitted from
+flags" into nonsense. Mechanical find-and-replace across prose needs the result read
+back.

--- a/.octospec/journal/shared/featuregate-user-scoped-flags.md
+++ b/.octospec/journal/shared/featuregate-user-scoped-flags.md
@@ -3,7 +3,7 @@ type: Journal
 title: "Journal: featuregate-user-scoped-flags"
 description: Revive the generic feature-gate framework, extend it to a user dimension, and expose per-user flags through a new authenticated endpoint.
 tags: [featuregate, rollout, auth, wire-contract, rate-limit, testing]
-timestamp: 2026-08-20T00:00:00+08:00
+timestamp: 2026-08-25T00:00:00+08:00
 task: featuregate-user-scoped-flags
 source: self
 ---
@@ -69,3 +69,41 @@ source: self
   `feature_key` charset at the DB layer, closing the direct-DB-edit bypass.
 - The framework ships with an **empty** client-flag registry: no product feature
   is gated yet. That is deliberate — this change delivers the mechanism.
+
+## Review round 1 (2026-08-25)
+
+One blocking finding, and it was real: `update` validated the incoming `bucket_by`
+but never the **already-persisted** scope rows. The registry is a compile-time list
+while gates are DB rows, so "an internal gate accumulates group scopes, then a later
+deploy makes it client-visible" is the *normal* lifecycle — and after that, an
+`update` to `whitelist`/`bucket_by=user` was accepted with a whitelist that could
+never match. Silent on both sides: `Evaluate` returned `whitelist_miss`, which is
+indistinguishable from a genuine miss, so no log fired either.
+
+Fixed on both sides, matching the write+read pattern used everywhere else here:
+
+- write: `update` now loads the persisted scopes and rejects when none uses a
+  dimension the flags endpoint can supply (an *empty* whitelist stays legal — that
+  is a real state, not a misconfiguration);
+- read: `Evaluate` distinguishes "didn't match" from "couldn't possibly match" via
+  a new `whitelist_dim_unavailable` reason, and `Decision.DimensionUnusable` reports
+  a dimension mismatch **independently of the decision** — which is what lets the
+  `percent` 0%/100% short-circuits keep their (correct) answer while still surfacing
+  a misconfigured `bucket_by`. Two reviewers disagreed on that one: the decision is
+  right at 100% (console and reality agree, and failing closed there would break a
+  rollout at full ramp), but the misconfiguration must not stay invisible, or the
+  operator discovers it the moment they dial 100 down to 50 and everyone drops out.
+
+Also in this round: `updated_by` audit columns on both tables; the
+`unavailable` wire field replacing the omission semantics; a whitelist size cap
+enforced on the **write** side (a `LIMIT` on the evaluation query would have traded
+"slow but correct" for "fast but wrong"); `scope_id` charset validation closing an
+insert-but-cannot-delete asymmetry; `description` counted in runes to match a
+character-counted column; `context.Context` parameters dropped from the cache
+loaders because octo-lib's `redis.Conn` has no ctx-aware methods at all, so honoring
+it was never possible and the signature was lying; a cache schema version in the
+Redis key prefix; and `docs/cutover-framework.md`, which described this module as
+"fail-open" back when it did not exist — two of its three call sites are fail-closed.
+
+Date discipline: the migration filename and three octospec timestamps were all five
+days early. Run `date` before naming anything after today.

--- a/.octospec/journal/shared/featuregate-user-scoped-flags.md
+++ b/.octospec/journal/shared/featuregate-user-scoped-flags.md
@@ -107,3 +107,39 @@ Redis key prefix; and `docs/cutover-framework.md`, which described this module a
 
 Date discipline: the migration filename and three octospec timestamps were all five
 days early. Run `date` before naming anything after today.
+
+## Review round 2 (2026-08-25)
+
+Both reviewers independently landed on the same blocker, and it was a regression
+introduced by round 1's own fix: the new persisted-scope check ran on **every**
+`update`, including a de-escalation. `modeNeedsScopes` excludes `off`/`on` — those
+modes never consult the whitelist or `bucket_by` — so the check was validating a
+precondition the requested state does not use, and a client-visible gate carrying a
+legacy group-only whitelist could not be turned off through its own API. The obvious
+rollback body `{"mode":"off"}` failed twice over: once on the defaulted
+`bucket_by=group`, once on the new scope check. What remained was deleting up to
+1000 scope rows one call at a time, or the env kill switch — which this module's own
+docs position as the last resort for when DB/Redis are down, not as the primary
+rollback.
+
+The rule that came out of it: **turning something off must never be harder than
+turning it on.** Both checks are now gated on `modeNeedsScopes`, and the reasoning is
+that every transition *into* a scope-consuming mode re-validates the request anyway,
+so permitting a stale `bucket_by` to sit in a row that nothing reads costs nothing.
+
+Also this round: the omission→`unavailable` change had landed in code but only in the
+brief's summary — Acceptance and Load-bearing still specified the opposite, as did
+five code comments and an errcode note. Since there is no OpenAPI spec, the brief is
+the only durable description of this contract, so a client team implementing from
+Acceptance would have built exactly the failure the change was made to prevent. All
+of it now says one thing. Worth remembering that changing a contract means changing
+every place that states it, and a dated revision note at the top does not cover the
+document below it.
+
+Smaller: `addScope`'s documented idempotency broke exactly at the quota boundary
+(re-adding an existing entry was rejected before reaching the `ON DUPLICATE` no-op —
+precisely when an operator is most likely retrying), so existence is now checked
+before the count. `delScope` deliberately does *not* validate the prospective
+post-delete state: blocking on it creates an ordering trap where neither entry of a
+`{user, group}` pair can be removed first. That path is left to the read-side
+backstop, which round 1 added and which is now explicitly noted in the code.

--- a/.octospec/journal/shared/featuregate-user-scoped-flags.md
+++ b/.octospec/journal/shared/featuregate-user-scoped-flags.md
@@ -193,3 +193,36 @@ One of my own edits from round 2 had reversed a negation in the brief's most-rea
 section — a blind `省略` → `unavailable 数组` substitution turned "not omitted from
 flags" into nonsense. Mechanical find-and-replace across prose needs the result read
 back.
+
+## Review round 4 (2026-08-25) — approved, with a hardening pass
+
+All three reviewers approved at `353953de`. Ten P2 items remained; two of them get an
+order of magnitude more expensive after merge, so they were taken now and the rest
+left as follow-ups.
+
+**The CHECK constraints were still not doing what their comments claimed, for a
+second and different reason.** Round 3 fixed the collation; this round fixed the
+anchor. MySQL's regex engine is ICU, where `$` matches at end of input **or before a
+final line terminator** — so `REGEXP_LIKE(scope_id, '^[A-Za-z0-9_.:@-]+$')` accepted
+`'u1\n'`, and the `feature_key` check accepted `'zz_nl\n'`. The consequences are the
+two the migration header already argues against: a `scope_id` ending in a newline is
+insertable but not deletable (`delScope` takes it as a path segment and trims it), and
+a `feature_key` ending in a newline derives a kill-switch env name containing a
+newline — the "永久失去 env 级紧急停止" failure verbatim. `\z` fixes it, verified by
+trying to violate it.
+
+Go is unaffected: Go's `$` is end-of-text (`\z` semantics) with `m=false`, which I
+checked rather than assumed, so `featureKeyPattern` and `scopeIDRe` already rejected
+these. The gap was only in the layer that exists specifically to catch direct DB
+edits — which makes it exactly the layer where an inert constraint matters most.
+
+Two rounds in a row, a defence I had written did not do what its comment said. Both
+times the comment read correctly and the constraint was inert. The habit that catches
+this is not re-reading the constraint; it is **trying to violate it**.
+
+The other item taken now was narrowing an overstated claim: the migration header said
+"所有身份列" are pinned to `utf8mb4_bin`, but `description` and the two `updated_by`
+columns keep the table default. One reviewer proposed pinning them, another had
+verified that leaving them is correct — they are display/audit only, never
+byte-compared, absent from every unique index and join key. Pinning them would have
+been over-correction, so the sentence was narrowed to match the code instead.

--- a/.octospec/journal/shared/featuregate-user-scoped-flags.md
+++ b/.octospec/journal/shared/featuregate-user-scoped-flags.md
@@ -1,0 +1,71 @@
+---
+type: Journal
+title: "Journal: featuregate-user-scoped-flags"
+description: Revive the generic feature-gate framework, extend it to a user dimension, and expose per-user flags through a new authenticated endpoint.
+tags: [featuregate, rollout, auth, wire-contract, rate-limit, testing]
+timestamp: 2026-08-20T00:00:00+08:00
+task: featuregate-user-scoped-flags
+source: self
+---
+
+# Journal: featuregate-user-scoped-flags
+
+## What was done
+
+- Revived `pkg/featuregate` (pure `Evaluate`, zero IO) and `modules/featuregate`
+  (MySQL truth + Redis read cache + env kill switch + superadmin management
+  endpoints) from the never-merged PR #280. Only the framework was revived; the
+  PR's second commit, which gated incoming webhooks, was deliberately left out.
+- Extended evaluation to a **user** dimension: `scope_type=user` whitelist
+  entries, and a per-rule `bucket_by` (`group`/`space`/`user`) so one framework
+  can serve both "roll out by group" write gates and "roll out by user" display
+  flags.
+- Added `GET /v1/featuregate/flags` — an authenticated, read-only endpoint that
+  returns the current user's flags. `GET /v1/common/appconfig` was not touched.
+- Added a client-visible flag registry that decouples the ops-facing
+  `feature_key` from the wire-facing `client_key`.
+
+## Structural decisions worth knowing
+
+- **The whitelist now spans modes.** The original `ModePercent` branch never read
+  `scopes`, so the standard rollout path `whitelist (dogfood) -> percent` dropped
+  the whole dogfood cohort at the moment of the switch, and `addScope` during the
+  percent phase was a silent no-op — the write returned 200 and the read path
+  simply did not look. The whitelist is now an exemption list that applies under
+  `whitelist` and `percent`, and is **never** honoured under `off` (an emergency
+  stop must stay unconditional).
+- **Three fail policies, fixed per call site.** `AllowCreate` fail-closed,
+  `AllowPush` fail-open, and a new `AllowDisplay` that returns `(allow, ok)`.
+  `ok=false` means a storage failure and the caller must **omit** that key so the
+  client keeps its previous value; a bare bool cannot express that, because the
+  response carries only booleans and the client otherwise cannot tell "really
+  off" from "the server blipped".
+- **The kill switch must be a definite `false`, never an omission.** Omitting it
+  would make clients keep the previous value, so pressing the emergency stop on
+  an already-rolled-out feature would never converge in the UI.
+- **`bucket_by` defaults to `group`, which collides with the flags endpoint.**
+  That endpoint only has a UID. Bucketing on an empty group_no puts every user in
+  one bucket, so a configured 50% silently becomes 0% or 100% while the console
+  still shows 50%. Blocked on the write path for client-visible keys and
+  fail-closed on the read path — the write check alone is bypassable by editing
+  the DB, the read check alone lets ops believe a broken config took effect.
+
+## Gotchas worth remembering
+
+- **A wrong `Vary` header is worse than none.** `Vary: Authorization` was copied
+  from `modules/bot_api/card_profile.go`, but octo-lib's `AuthMiddleware` reads
+  the **`token`** header. Naming a header that is empty on every request gives a
+  shared cache no discriminator at all.
+- **`CleanAllTables` does not clear Redis, and that includes this module's own
+  cache.** Dropping the test DB while `ft:rule:*` was still warm made the suite
+  fail non-deterministically — and pass again once the 60s TTL expired. Every
+  DB/Redis test now goes through one fixture that flushes both the gate cache and
+  the UID rate-limit buckets.
+- **`X-RateLimit-Scope: uid` is the cheapest proof that the limiter is mounted
+  correctly.** octo-lib's `UIDRateLimitMiddleware` silently skips when it cannot
+  read a uid, so the header's presence proves both "mounted" and "mounted after
+  `AuthMiddleware`" without hammering the endpoint to force a 429.
+- **MySQL 8 enforces `REGEXP_LIKE` inside `CHECK`.** Used to pin the
+  `feature_key` charset at the DB layer, closing the direct-DB-edit bypass.
+- The framework ships with an **empty** client-flag registry: no product feature
+  is gated yet. That is deliberate — this change delivers the mechanism.

--- a/.octospec/learnings/pending/absence-as-semantics-is-undescribable.md
+++ b/.octospec/learnings/pending/absence-as-semantics-is-undescribable.md
@@ -1,9 +1,9 @@
 ---
 type: Learning
 title: "Absence carrying meaning cannot be described — codegen clients get it wrong by default"
-description: If \"the key is missing from the response\" means something other than \"the zero value\", no schema language can express it, so generated clients silently implement the opposite of the intent. Carry the state in a field instead.
+description: "When a missing key means something other than the zero value, no schema language can express it, so generated clients silently implement the opposite of the intent. Carry the state in a field instead."
 tags: ["api", "wire-contract", "openapi", "review"]
-timestamp: 2026-08-20T00:00:00+08:00
+timestamp: 2026-08-25T00:00:00+08:00
 # --- octospec extension fields ---
 source: self
 origin_task: featuregate-user-scoped-flags

--- a/.octospec/learnings/pending/absence-as-semantics-is-undescribable.md
+++ b/.octospec/learnings/pending/absence-as-semantics-is-undescribable.md
@@ -1,0 +1,63 @@
+---
+type: Learning
+title: "Absence carrying meaning cannot be described — codegen clients get it wrong by default"
+description: If \"the key is missing from the response\" means something other than \"the zero value\", no schema language can express it, so generated clients silently implement the opposite of the intent. Carry the state in a field instead.
+tags: ["api", "wire-contract", "openapi", "review"]
+timestamp: 2026-08-20T00:00:00+08:00
+# --- octospec extension fields ---
+source: self
+origin_task: featuregate-user-scoped-flags
+origin_pr: Mininglamp-OSS/octo-server (featuregate user-scoped flags)
+status: pending
+candidate_rule: error-handling
+---
+# Absence carrying meaning cannot be described
+
+A response that must express three states with only two values is tempting to
+solve by dropping the key:
+
+```json
+{"flags": {"docs_on": true, "drive_on": false}}   // reader must infer a third state
+```
+
+Here `true`/`false` are decisions and **a missing key means "could not be
+computed — keep whatever you had"**. That design is sound at the semantic level:
+it is what stops one Redis blip from turning into "every user loses the feature",
+because a bare `false` is indistinguishable from a real "off".
+
+The problem is that the contract is **unexpressible**. OpenAPI (any version),
+JSON Schema, and protobuf can all say a property is optional; none of them has a
+vocabulary for "absence carries a meaning distinct from the zero value".
+It survives only as prose in a `description`.
+
+That matters because of who reads it. A generated client deserializes into
+`map[string]bool` / `Map<String, Boolean>` and the distinction is gone before any
+application code runs — the client will read a missing key as `false` via the
+language's own zero-value rules. **The default behaviour of every codegen
+consumer is the exact failure the design existed to prevent**, and it fails
+silently, on the rare path, in production.
+
+## What to do instead
+
+Put the third state in a field, so it is data rather than an inference:
+
+```json
+{"flags": {"docs_on": true}, "unavailable": ["drive_on"]}
+```
+
+`unavailable` is an ordinary `array of string`: fully describable, impossible to
+lose in deserialization, and it leaks nothing extra (it says "not computed", not
+*why*).
+
+## How to spot it in review
+
+Ask of any response field: **"is there a state here that is encoded by something
+other than a value?"** Absence, `null`, empty string, and empty array all qualify.
+If yes, either the state moves into a value, or the contract only holds for
+hand-written clients — and that assumption needs to be stated out loud, because
+it stops holding the day someone points a generator at the spec.
+
+Related: `json-nil-vs-empty-slice.md` — the request-side counterpart, where
+collapsing nil and empty erases a caller's bug. Same root cause, opposite
+direction: absence is a state, and treating it as a value (or a value as
+absence) loses information.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -1591,3 +1591,21 @@ change-log convention (§7). Newest first.
   author-chosen mutation only proves the test catches what the author already thought
   of. The same guard was green on the real security regression and red on whitespace.
 
+
+## 2026-08-20 (featuregate-user-scoped-flags)
+
+- **Implemented** — Revived the generic feature-gate framework from the
+  never-merged PR #280 (framework only; the incoming-webhook gating commit was
+  left out), extended it with a `user` dimension and a per-rule `bucket_by`, and
+  added `GET /v1/featuregate/flags` for per-user flag delivery. `appconfig` keeps
+  its no-auth contract untouched. Ships with an empty client-flag registry — the
+  mechanism, not any gated feature. See
+  [journal](journal/shared/featuregate-user-scoped-flags.md).
+- **Fixed while reviving** — The original `percent` branch never read the
+  whitelist, so `whitelist -> percent` silently dropped the dogfood cohort and
+  `addScope` during a ramp was a no-op that still returned 200. The whitelist now
+  applies under `whitelist` and `percent`, never under `off`.
+- **Learning** — `learnings/pending/absence-as-semantics-is-undescribable.md`:
+  making "key absent from the response" carry meaning cannot be expressed in
+  OpenAPI 3, so codegen clients get it wrong by default — exactly the failure the
+  design existed to prevent.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -1592,7 +1592,7 @@ change-log convention (§7). Newest first.
   of. The same guard was green on the real security regression and red on whitespace.
 
 
-## 2026-08-20 (featuregate-user-scoped-flags)
+## 2026-08-25 (featuregate-user-scoped-flags)
 
 - **Implemented** — Revived the generic feature-gate framework from the
   never-merged PR #280 (framework only; the incoming-webhook gating commit was

--- a/.octospec/tasks/featuregate-user-scoped-flags/brief.md
+++ b/.octospec/tasks/featuregate-user-scoped-flags/brief.md
@@ -3,7 +3,7 @@ type: Task
 title: "Task: featuregate-user-scoped-flags"
 description: 复活 PR #280 的 pkg/featuregate + modules/featuregate 框架（不含 incomingwebhook 接入），扩展 user 维度的 whitelist/percent，并在 modules/featuregate 下新增需登录的只读端点 GET /v1/featuregate/flags 下发用户级灰度位；appconfig 的免鉴权契约与字段集不动。
 tags: ["auth", "error-response", "i18n", "rate-limit", "wire-contract", "testing"]
-timestamp: 2026-08-18T00:00:00Z
+timestamp: 2026-08-25T00:00:00+08:00
 slug: featuregate-user-scoped-flags
 upstream: Mininglamp-OSS/octo-server#280 （CLOSED，未合并）
 source: self
@@ -19,16 +19,19 @@ source: self
    featuregate），确需与部署位联动时由**服务端**做 AND，客户端只读一个最终布尔——
    AND 绝不放在客户端。理由与实现约束见 Load-bearing 对应条目。
 3. **刷新契约与失败语义**：冷启动 + 登录成功 + 前台化（节流 ≥5 分钟）；单个 key 遭遇
-   存储故障时**从响应中省略**该 key（而非下发 `false`），客户端保留上次值。见
-   Load-bearing 与 Acceptance 对应条目。
+   存储故障时进响应的 **`unavailable` 列表**（而非下发 `false`，也不是从 `flags` 里
+   省略），客户端对这些 key 保留上次值。
+   **2026-08-25 修订**：初稿用「从 `flags` 里省略」来表达这层含义，评审阶段改为显式
+   字段——语义等价，但「缺席携带含义」任何 schema 语言都描述不了，codegen 客户端会把
+   缺席读成 `false`，恰是这套设计要防的失败。见 Load-bearing 与 Acceptance 对应条目。
 4. **对外 JSON key 与 `feature_key` 解耦**：注册表项同时声明运维面的 `feature_key` 与
    对外的 `client_key`，两者独立演进——运维改 gate 名不得破坏客户端。见 Load-bearing
    对应条目。
 
 ## 需要外部对齐（不阻塞服务端开工，但上线前必须完成）
 
-- **客户端团队**：实现上面第 3 条的拉取时机，以及"响应缺该 key = 保留上次值、无历史值
-  = `false`"的本地语义。这半边服务端单方面做不到。
+- **客户端团队**：实现上面第 3 条的拉取时机，以及"key 出现在 `unavailable` 里 = 保留
+  上次值、无历史值 = `false`"的本地语义。这半边服务端单方面做不到。
 - **运营**：生效延迟是**分钟级到小时级，不是秒级**。紧急关停必须走
   `OCTO_FEATUREGATE_<KEY>_KILL=1` + 服务端拒绝相关 API，**不能靠隐藏客户端入口止血**——展示位
   不是安全边界。

--- a/.octospec/tasks/featuregate-user-scoped-flags/brief.md
+++ b/.octospec/tasks/featuregate-user-scoped-flags/brief.md
@@ -20,7 +20,7 @@ source: self
    AND 绝不放在客户端。理由与实现约束见 Load-bearing 对应条目。
 3. **刷新契约与失败语义**：冷启动 + 登录成功 + 前台化（节流 ≥5 分钟）；单个 key 遭遇
    存储故障时进响应的 **`unavailable` 列表**（而非下发 `false`，也不是从 `flags` 里
-   省略），客户端对这些 key 保留上次值。
+   `unavailable` 数组），客户端对这些 key 保留上次值。
    **2026-08-25 修订**：初稿用「从 `flags` 里省略」来表达这层含义，评审阶段改为显式
    字段——语义等价，但「缺席携带含义」任何 schema 语言都描述不了，codegen 客户端会把
    缺席读成 `false`，恰是这套设计要防的失败。见 Load-bearing 与 Acceptance 对应条目。
@@ -234,7 +234,7 @@ percent，因此本任务按当前契约重新评审和落地。
 
   **为什么解耦**：`feature_key` 是运维面标识，重命名（改归类、改前缀）本该是无风险操作；
   若它同时是 wire 契约，运维改个名就静默破坏三端客户端。注意 `killSwitchOn` 是
-  `strings.ToUpper(strings.ReplaceAll(key, "-", "_"))` 从 `feature_key` 推导环境变量名的
+  `strings.ToUpper(key)` 从 `feature_key` 推导环境变量名的（**不折叠连字符**——连字符已被 `validFeatureKey` 禁掉，不折叠才使 key→env 名成为单射）
   ——这进一步说明 `feature_key` 属于运维面词汇表，不该被客户端契约锁死。
 
   **反向约束**：`client_key` 一旦发布即**冻结**，与 appconfig 字段同级别的 wire 契约
@@ -251,12 +251,12 @@ percent，因此本任务按当前契约重新评审和落地。
   mode/percent/scope 等内部细节，防止客户端反推灰度策略。排障所需的区分度通过服务端
   日志（携带 key 与失败原因）实现，**不得为此在响应体里加 `reason`/`source` 之类字段**，
   否则布尔约束当场破掉。
-- **响应体必须是动态 map，禁用 `omitempty`——否则"省略"语义根本无法实现**。
-  本 brief 定了"存储故障省略该 key、规则不存在下发 `false`"，但仓库里最顺手的先例
+- **响应体必须是动态 map，禁用 `omitempty`**。
+  `flags` 里"值为 `false`"必须能被表达出来，但仓库里最顺手的先例
   `appConfigResp` 是**固定字段 struct**（`DocsOn bool \`json:"docs_on"\``）。照抄那个形状
   会连环出两个错：
-  - Go struct 的 bool 字段**永远序列化**，省略无从实现；
-  - 有人为了实现省略而加 `omitempty` → **`false` 会被一起吞掉** → "规则不存在的确定性关"
+  - 固定字段 struct 无法承载动态注册的 key；
+  - 加 `omitempty` → **`false` 会被一起吞掉** → "规则不存在的确定性关"
     与"存储故障"在线上变成同一个样子 → 客户端保留旧值 → **灰度永远关不掉**，正是上一条
     失败语义花大篇幅要防的那件事。
 
@@ -301,19 +301,20 @@ percent，因此本任务按当前契约重新评审和落地。
   限流桶影响可忽略。
 
   **失败语义（服务端与客户端两半，缺一不可）**：
-  - 服务端：单个 key 遭遇**存储故障**（DB/Redis）时 **从响应中省略该 key**，不下发
-    `false`；
+  - 服务端：单个 key 遭遇**存储故障**（DB/Redis）时把它列进响应的 **`unavailable`
+    数组**，不下发 `false`、也不从 `flags` 里省略；
   - 客户端：整请求失败 → **保留上次快照**（不得回落成全 `false`）；响应缺某 key →
     **保留该 key 上次值**；无历史值（新装/清数据）→ `false`。
 
-  **为什么省略而不是下发 false**：响应只有布尔（这是本 brief 自己定的约束），客户端因此
+  **为什么不下发 false**：`flags` 里只有布尔（这是本 brief 自己定的约束），客户端因此
   **无法区分"真的关"与"服务端抖了一下"**。若故障时下发 `false`，Redis 抖 3 秒的后果就是
-  **全体用户功能消失**；改成省略后，影响面缩小到"无本地缓存的新装用户暂时看不到"，
+  **全体用户功能消失**；改成显式列出后，影响面缩小到"无本地缓存的新装用户暂时看不到"，
   而且**依然是 fail-closed**（无历史值时默认 `false`）。这条同时保住了布尔约束——它没有
   引入 `reason`/`source` 之类字段。
 
   **必须与"规则不存在"区分开**：查询成功但表里没有该 key 的规则，是**确定性的关**，
-  正常下发 `false`；只有**存储故障**才省略。两者混淆会让"未配置"变成"保留旧值"，
+  正常进 `flags` 且值为 `false`；只有**存储故障**才进 `unavailable`。两者混淆会让
+  "未配置"变成"保留旧值"，
   灰度就永远关不掉。
 
   **运营预期**：生效延迟 = 用户下次拉取时间，**分钟级到小时级，不是秒级**。
@@ -322,7 +323,7 @@ percent，因此本任务按当前契约重新评审和落地。
   UI 表现。若将来运营确需秒级 UI 收敛，可复用 WuKongIM 长连接推一条重拉信号（列在
   Out of scope），即本决策是可演进的，不是死路。
 - **响应不可被共享缓存**：结果因人而异，但 URL 对所有用户逐字节相同，区分调用者的只有
-  Authorization 头——任何按 URL 缓存的共享代理都会把用户 A 的判定回给用户 B。必须下发
+  `token` 头（本仓 `AuthMiddleware` 读的就是它，不是 Authorization）——任何按 URL 缓存的共享代理都会把用户 A 的判定回给用户 B。必须下发
   `Cache-Control: private, no-store`（`private` 禁共享缓存，`no-store` 连私有副本也不留）。
   同型教训见 `bot-setting-store` 给 `/v1/bot/card/profile` 加 `config` 后的处理。
 - **管理端点鉴权：校验沿用，但拒绝路径必须换成现行写法**。`list`/`update`/`addScope`/
@@ -346,7 +347,7 @@ percent，因此本任务按当前契约重新评审和落地。
   （`request_invalid`/`not_found`/`query_failed`/`operation_failed`）复活时原样保留；
   用户侧只读端点若需新增码，一并归到 `pkg/errcode/featuregate.go`。
   端点已归属 `modules/featuregate`，因此不存在"码散落到别的模块"的问题——但需注意
-  **该端点在正常路径上几乎不该产生错误码**：单 key 故障走省略、规则不存在走 `false`，
+  **该端点在正常路径上几乎不该产生错误码**：单 key 故障进 `unavailable`、规则不存在走 `false`，
   两者都是 200；只有鉴权失败与请求本身不合法才走错误信封。
 - **复活的 `modules/featuregate` 缺一个 `NoLegacyResponseError` 守卫测试**：原分支只有
   `api_i18n.go`，没有对应的 `api_i18n_test.go` 守卫，而仓库约定是每个已迁移模块都要有
@@ -427,7 +428,7 @@ percent，因此本任务按当前契约重新评审和落地。
   值为布尔。
 - **响应体是 `{"flags": map[string]bool}` 动态形状**：一条序列化测试断言"值为 `false`
   的 key 必须出现在 JSON 里"，钉住"不得用固定字段 struct、不得用 `omitempty`"——否则
-  `false` 被吞掉会与"存储故障省略"混淆，使灰度关不掉。
+  `false` 被吞掉会与"判定不可得"混淆，使灰度关不掉。
 - **响应用 `client_key` 而非 `feature_key` 作字段名**：一条测试断言注册表里
   `feature_key != client_key` 的项，在响应 JSON 中出现的是 `client_key`。
 - **注册表唯一性在构造期校验**：注册两项相同 `client_key`（或相同 `feature_key`）时
@@ -437,16 +438,16 @@ percent，因此本任务按当前契约重新评审和落地。
   `bucket_by=group`），该 key fail-closed 返回 `false` 并打 Warn 日志，**不得按空串
   照算**——否则会出现"管理台显示 50%、实际全体开或全体关"的静默错配。
 - 响应头带 `Cache-Control: private, no-store`。
-- **存储故障 → 省略，不是 false**：单个 key 的规则/白名单因 DB/Redis 故障加载失败时，
-  该 key **从响应中省略**，失败原因写日志；**不影响其它 key 正常返回，不导致整个请求
-  500**。用一条测试钉住"故障 key 不出现在响应里"，防止日后被改回下发 `false`。
-- **规则不存在 → 明确 false**：查询成功但表中无该 key 的规则时，正常下发 `false`
-  （确定性的关），**不省略**。与上一条构成一对，用测试同时钉住两侧，避免"未配置"被
-  当成"保留旧值"而使灰度关不掉。
+- **存储故障 → 进 `unavailable`，不是 false**：单个 key 的规则/白名单因 DB/Redis 故障
+  加载失败时，该 key **不出现在 `flags` 里，而是列进 `unavailable` 数组**，失败原因写
+  日志；**不影响其它 key 正常返回，不导致整个请求 500**。用测试同时钉住两边。
+- **规则不存在 → 明确 false**：查询成功但表中无该 key 的规则时，正常进 `flags` 且值为
+  `false`（确定性的关），**不进 `unavailable`**。与上一条构成一对，用测试同时钉住两侧，
+  避免"未配置"被当成"保留旧值"而使灰度关不掉。
 - 用户 A 在某 key 的 `user` 白名单内 → 该 key 为 `true`；用户 B 不在白名单且规则非 `on`、
   未命中 percent → `false`。
 - **全新部署零规则场景**：`feature_gate` 表为空时，端点对每个已注册 key 均返回 `false`
-  （fail-closed 的直接推论，走上面"规则不存在"这一支，而非省略），请求本身成功返回 200。
+  （fail-closed 的直接推论，走上面"规则不存在"这一支，不进 `unavailable`），请求本身成功返回 200。
   这是预期行为——新部署下所有灰度功能默认隐藏，运维需显式建规则才放出；用一条测试钉住，
   避免日后被当成 bug 改成 fail-open。
 

--- a/.octospec/tasks/featuregate-user-scoped-flags/brief.md
+++ b/.octospec/tasks/featuregate-user-scoped-flags/brief.md
@@ -1,0 +1,462 @@
+---
+type: Task
+title: "Task: featuregate-user-scoped-flags"
+description: 复活 PR #280 的 pkg/featuregate + modules/featuregate 框架（不含 incomingwebhook 接入），扩展 user 维度的 whitelist/percent，并在 modules/featuregate 下新增需登录的只读端点 GET /v1/featuregate/flags 下发用户级灰度位；appconfig 的免鉴权契约与字段集不动。
+tags: ["auth", "error-response", "i18n", "rate-limit", "wire-contract", "testing"]
+timestamp: 2026-08-18T00:00:00Z
+slug: featuregate-user-scoped-flags
+upstream: Mininglamp-OSS/octo-server#280 （CLOSED，未合并）
+source: self
+---
+
+# Task: featuregate-user-scoped-flags
+
+## 已定关键决策（本轮拍板，实施按此执行，不要再退回默认方案）
+
+1. **新端点归属**：放 `modules/featuregate` 自己，路由 `GET /v1/featuregate/flags`。
+   **不**放 `modules/user`，**不**另开消费方模块。理由见 Background 对应段落。
+2. **与 appconfig 的关系**：**归属唯一**（存量 appconfig 位一个不动、新功能只进
+   featuregate），确需与部署位联动时由**服务端**做 AND，客户端只读一个最终布尔——
+   AND 绝不放在客户端。理由与实现约束见 Load-bearing 对应条目。
+3. **刷新契约与失败语义**：冷启动 + 登录成功 + 前台化（节流 ≥5 分钟）；单个 key 遭遇
+   存储故障时**从响应中省略**该 key（而非下发 `false`），客户端保留上次值。见
+   Load-bearing 与 Acceptance 对应条目。
+4. **对外 JSON key 与 `feature_key` 解耦**：注册表项同时声明运维面的 `feature_key` 与
+   对外的 `client_key`，两者独立演进——运维改 gate 名不得破坏客户端。见 Load-bearing
+   对应条目。
+
+## 需要外部对齐（不阻塞服务端开工，但上线前必须完成）
+
+- **客户端团队**：实现上面第 3 条的拉取时机，以及"响应缺该 key = 保留上次值、无历史值
+  = `false`"的本地语义。这半边服务端单方面做不到。
+- **运营**：生效延迟是**分钟级到小时级，不是秒级**。紧急关停必须走
+  `OCTO_FEATUREGATE_<KEY>_KILL=1` + 服务端拒绝相关 API，**不能靠隐藏客户端入口止血**——展示位
+  不是安全边界。
+
+PR #280 的历史关闭原因**不作为开工前置**：当前已经出现明确的用户级定向灰度需求，是否
+实施应由当前需求与当前方案本身决定，而不是由历史 PR 的关闭动作决定。PR #280 仅作为可复用
+代码和已知评审问题的参考；本任务不盲目 cherry-pick，也不要求复刻当时的全部设计。
+
+## Goal
+
+给「按用户灰度」提供一条真正能落地的路径：
+
+1. **复活框架本体** `pkg/featuregate` + `modules/featuregate`——以 PR #280 的
+   `03f4bbe9` 为实现参考，复用其中的纯函数 `Evaluate`、DB 真源、Redis 读缓存、env kill
+   switch `OCTO_FEATUREGATE_<KEY>_KILL` 和 `/v1/manager/featuregate` 管理端点；最终实现以本 brief、
+   当前仓库规则和现行代码为准，不照搬已不符合当前契约的细节。**只复活框架，不复活 PR
+   #280 第二个 commit（`eb5cc933`）的 incomingwebhook 接入**——理由见 Out of scope。
+2. **扩展到 user 维度并修掉白名单语义**：`pkg/featuregate.Dims` 已预留 `UID` 字段，但
+   `Evaluate` 当前只消费 `GroupNo`（whitelist 只比 `scope_type=group`，percent 固定
+   `Bucket(rule.Key, dims.GroupNo)`）。三处改动：①新增 `ScopeTypeUser`；②把 percent 的
+   分桶维度做成规则上的一个字段（`bucket_by`），否则一条规则无法既按群放量又按用户放量；
+   ③**把白名单从 whitelist 模式专属，升格为贯穿 mode 的豁免名单**（percent 模式下白名单
+   优先命中）——原实现的 `ModePercent` 分支完全不读 `scopes`，导致标准放量路径
+   `whitelist → percent` 会把内测人员整批甩掉，详见 Load-bearing。
+3. **新增一个需登录的只读端点** `GET /v1/featuregate/flags`（挂在 `modules/featuregate`
+   自己下），把"哪些灰度位对当前用户开放"下发给客户端。
+   **`GET /v1/common/appconfig` 保持不变**——它故意免鉴权（未登录也要拉
+   `local_login_off` 等开关），请求里没有 uid，结构上背不了按用户的判定；本任务不改它的
+   鉴权语义，也不往它身上加任何字段。
+
+## Background
+
+**当前灰度现状（本次会话已核实）**：`system_setting` 表 + `SystemSettings` 内存快照
+（`modules/common/system_settings.go`）是唯一的通用灰度机制，60s 多实例收敛；
+`GET /v1/common/appconfig`（`modules/common/api.go:363` `appConfig`）是唯一下发通道。
+所有位都是**部署级全局 on/off**，没有百分比放量、没有按用户/群/空间定向的能力。唯一的
+例外是 `modules/bot_mention` 自己写的 env-only allowlist（`config.go:172` `featureGate`），
+那是一次性方案，不通用、不走 DB/管理台，本任务不复用它、也不受它影响。
+
+**框架代码在哪（这条之前记错过，已更正）**：曾经有过完整实现，对应 PR #280 的两个
+commit（`03f4bbe9` 框架本体、`eb5cc933` incomingwebhook 接入）。分支
+`webhook-feature-flag-rollout` 已从 `origin` 删除，但 GitHub 保留了
+`refs/pull/280/head` 指向同一 commit，`git fetch origin refs/pull/280/head` 或
+`gh pr diff 280` 可直接取到完整代码，**不依赖任何本地 worktree**。（本地
+Conductor 工作区 `farmerville-v1` 也仍 checkout 着这个分支，是第二个来源。）
+`origin/main` 与当前分支都没有这两个包、没有 `feature_gate`/`feature_gate_scope` 表。
+
+PR #280 于 2026-06-11 关闭且未合并，但其关闭原因不影响本任务立项。历史代码与 review 只用于
+识别可复用实现和已知缺口；当前需求已经独立证明 `system_setting` 无法承载用户级 whitelist /
+percent，因此本任务按当前契约重新评审和落地。
+
+**appconfig 为什么背不了用户维度的判定**：路由挂在 `commonNoAuth` 组
+（`modules/common/api.go:83-93`），没有 `AuthMiddleware`，请求里没有 uid。要在这条路径上
+做用户定向，必须先解决"免鉴权接口里怎么安全识别用户"这个更大的问题，代价和风险都不在
+本任务范围内（见 Out of scope 的方案 A）。本任务选更干净的路：新开一个挂
+`AuthMiddleware` 的端点，`c.GetLoginUID()` 现成可用。
+
+**为什么要 featuregate 而不是继续用 system_setting——理由是"定向维度"，不是"秒级"**
+（这条纠正了立项时的一个错误论证）：featuregate 相对 system_setting 的两个卖点是
+①支持 whitelist/percent 定向，②Redis DEL 失效带来的秒级多实例收敛。**②对本任务的
+展示位基本不成立**：秒级收敛只在"每次请求都在服务端重新评估"的场景有意义（原设计的
+`AllowCreate`/`AllowPush` 正是如此）；而展示位是下发给客户端后由客户端持有，端到端生效
+延迟由**客户端拉取节奏**决定，不由服务端收敛速度决定。
+
+已核实的现有客户端行为可作参照：iOS `WKAppConfig.m:610` 拉 `common/appconfig`，带
+`requestSuccess` 去重（一次成功后不再拉，除非显式强制刷新），由 `WKApp.m`/登录/注册页
+触发；Android `WKCommonService.java:40` 声明 `@GET("common/appconfig")`，由
+`WKUIKitApplication`/`TabActivity`/登录相关 Activity 调用。**两端都没有发现周期性轮询。**
+因此若新端点照搬这个节奏，"关掉开关秒级全量回滚"是一个假承诺。
+
+结论：**立项理由只保留①**。定向维度是 system_setting 结构上做不到的，这才是本任务成立
+的原因；②在展示位场景下不作为收益宣称，运营预期必须按"客户端下次拉取时生效"来管理。
+
+**为什么新端点放 `modules/featuregate` 自己，而不是 `modules/user`**：仓库里有一个逐字
+对应的先例——`modules/common` 同时装着 `SystemSettings`（框架）和
+`GET /v1/common/appconfig`（它面向客户端的下发面），两者同模块。新端点就是 featuregate
+的客户端下发面，同构。
+
+需要区分两类消费者：**执行型消费者**（如 incomingwebhook 调 `AllowCreate` 做拦截）确实
+历来是各业务模块自己 `NewService(ctx)` 直接调、不经 module 注册；但本端点不是执行型
+消费者，它是**框架自己的对外暴露出口**，归属框架。
+
+更硬的理由是「可下发 key 白名单」注册表的归属：这份表登记的是 docs、drive 之类**各业务**
+的 key，与 `modules/user` 没有任何语义关系；它的本质是"gate 框架对客户端暴露了哪些位"，
+属于框架自身。放在 `modules/featuregate` 内，将来某业务要加一个客户端可见的灰度位，只改
+一个模块、一处评审、一个守卫测试即可盖住；放 `modules/user` 则会让一个与用户无关的注册表
+长在用户模块里，并让 `modules/user` 反向依赖 featuregate、继续变胖。
+
+路由取 `GET /v1/featuregate/flags`：与 `/v1/common/appconfig`、`/v1/sticker/user` 同形
+（模块名做第一段），路径归属与模块归属一致，便于从路由定位代码。不用 `/v1/user/...`
+前缀——它不属于 user 模块。
+
+## Load-bearing list
+
+- **`pkg/featuregate.Evaluate` 是零 IO 纯函数**：新增 `ScopeTypeUser` 与可配置分桶维度
+  必须保持这个不变量（零 IO、表驱动可测），不能在这一层引入 DB/Redis 依赖。
+- **`Dims.UID` 参与 whitelist 命中的语义**：`ScopeTypeUser` 命中条件是
+  `dims.UID != "" && s.Type == ScopeTypeUser && s.ID == dims.UID`。空 UID（理论上不会
+  发生，消费方都在 `AuthMiddleware` 之后）不应命中任何用户白名单条目——与现有
+  `GroupNo == ""` 不匹配 group 白名单的处理方式对称。
+- **白名单升格为贯穿 mode 的豁免名单（语义变更，本任务修）**。原实现的 `ModePercent`
+  分支**完全不读 `scopes`**，白名单在 percent 模式下是死的。这会在**最标准的放量路径**上
+  出事：`off → whitelist（内测）→ percent 5%/20%/50% → on`，切到 percent 的瞬间白名单
+  数据还在但不再被读，内测 N 人里只剩恰好 `Bucket(key, uid) < P` 的那部分——N=20、P=5
+  时期望只留 1 人。三个后果按隐蔽度排：①内测账号掉功能且**不可复现**（同事正常），排查
+  方向天然被引向账号/缓存问题；②**数据孤儿**——展示位不承担鉴权，API 与数据都还在，只是
+  入口没了，内测期建过文档的人看得见数据进不去；③最隐蔽的一条：**percent 阶段调
+  `addScope` 是静默失败**——返回 200、表里有行、缓存也失效了，读路径却根本不看。
+
+  **修法**：percent 分支在分桶前先做一次白名单判定（复用 whitelist 分支的谓词），命中即
+  放行并报 `ReasonWhitelistHit`（保留可观测性，能区分"白名单进来的"与"分桶进来的"）。
+  精确语义：
+
+  | mode | 白名单 |
+  |---|---|
+  | `whitelist` | 生效（唯一判据） |
+  | `percent` | 生效，**优先于分桶**（永久豁免 + 其余人群按比例） |
+  | `off` | **无条件失效** |
+  | `on` | 无意义（本就全放） |
+
+  `off` 那行是硬边界：`off` 是回滚/止血语义的一部分，**白名单不得穿透 `off`**，否则
+  kill 的确定性就没了。改完后运维要记的规则反而更简单——"白名单永远优先，除非 off"，
+  而不是"白名单只在 whitelist 模式下有效"。
+
+  **为什么不新增第五个 mode（`whitelist_percent`）**：那样运维照样可能选 `percent` 而不是
+  新 mode，上面第③条静默失败原封不动；且 mode 会随维度增长成笛卡尔积。改语义现在最便宜
+  ——这套东西从未上线，没有存量规则会被影响，零迁移。
+
+  ⚠️ **实现陷阱（必须配集成测试，纯函数单测盖不住）**：Service 层原本只在 whitelist
+  模式下加载 scopes——
+  `if rule.Mode == fg.ModeWhitelist { scopes, err = s.loadScopes(ctx, key) }`
+  ——改语义必须同步加上 `|| rule.Mode == fg.ModePercent`。**漏改这一行的后果与当前缺陷
+  一模一样**（`Evaluate` 收到空 scopes、白名单静默失效），只是从设计缺陷降级为实现遗漏，
+  更难发现。这一行在 Service 层，`pkg/featuregate` 的表驱动测试照不到，必须有一条走
+  Service 的集成测试钉住。
+  （`AllowCreate`/`AllowDisplay` 的 percent 路径因此多一次 scopes 加载，有 Redis 缓存，
+  成本可忽略；`AllowPush` 不受影响，它只判 `mode != off`。）
+- **`feature_gate` 表要加一列 `bucket_by`**：`Rule.BucketBy` 必须持久化，而原表
+  （`feature_key`/`mode`/`percent`/`description`/时间戳）没有这一列。因为这张表从未上过
+  线，直接写进复活后的初始 `CREATE TABLE` 即可，不需要 ALTER。列默认值 `'group'`，使
+  未显式指定的规则语义等同于原设计的"固定按 GroupNo 分桶"。
+  （**注意**：这是"忠实于原设计"的默认值选择，**不是**生产兼容性约束——这套东西从未
+  部署过，不存在需要保持行为不变的既有部署。不要按"byte-identical rollout 红线"的强度
+  去守它。）
+- **`feature_gate_scope` 表结构不变**：只扩 `scope_type` 的合法取值（`group`/`space`/
+  `user`），不迁移、不加列——`scope_type` 本就是自由字符串，`scope_id` 存 uid 与存
+  group_no/space_id 同构。
+- **切换 `bucket_by` 是人群重新洗牌，不是渐进操作**：把一条已在放量的规则从
+  `group` 改成 `user`（或反向），分桶的加盐输入整体改变，**原先命中的对象会掉出去**。
+  原设计"percent 调高只进不出"的单调性保证只在同一分桶维度内成立，不覆盖切维度这个
+  操作。管理端至少要在文档/响应上明示；把它当成普通字段随手改会造成用户侧功能闪退。
+- **`bucket_by` 默认 `'group'` 与展示端点的 UID-only 上下文直接冲突，必须双向堵住**。
+  展示端点只有 UID，没有 GroupNo/SpaceID。而列默认值是 `'group'`（为忠实原设计而定）。
+  两者一撞会产生**静默错配**：运维给一个客户端可见的 key 建 `mode=percent, percent=50`
+  却没设 `bucket_by` → 服务端拿 `Dims{UID:"u123", GroupNo:""}` 评估 →
+  `Bucket(key, "") = crc32(key+":")%100` 是**该 key 的一个固定常数** → 实际结果不是 50%，
+  而是**全体 `true` 或全体 `false`**（取决于那个哈希落在哪）。管理台显示"50%"，真实放量
+  是 0 或 100，**全程无任何报错**。
+
+  按仓库既有的"写侧校验 + 读侧兜底"形状双向堵：
+  - **写侧**：管理端 `update` 时，若 `feature_key` 在"可下发给客户端的 key 白名单"内，
+    拒绝 `bucket_by=group`（以及 `whitelist` 模式下只有 `scope_type=group` 条目的配置），
+    返回 `err.server.featuregate.request_invalid`；
+  - **读侧**：`AllowDisplay` 发现规则要求的分桶维度在传入 `Dims` 中为空时，**fail-closed
+    并打 Warn 日志**（携带 key 与缺失维度），不要按空串照算。
+
+  只做写侧不够——直接改库能绕过；只做读侧不够——运维会以为配置生效了。
+- **端点不做 space 维度，flags 是账号级**。`Dims` 虽有 `SpaceID`，但本端点不接收也不推断
+  空间上下文：一个用户可属多个空间，"当前空间"在这条请求里没有确定答案。因此注册为
+  客户端可见的 key **不得依赖 space 维度**（写侧校验同上一条一并拦）。明写这一条是为了
+  让 space-isolation 评审有据可依——本端点不返回任何跨空间数据，不构成隔离面。
+- **`AllowCreate`（fail-closed）/`AllowPush`（fail-open）的既有非对称语义不可动**：这是
+  原设计"create 误拒 < 数据裸奔；push 误推 < 中断存量推送"的刻意决策，本任务只加维度，
+  不改 fail 策略，也不把 fail 策略做成 per-rule 旋钮（原设计明确拒绝过，以免被配反）。
+- **展示位判定是第三种语义，固定 fail-closed，并明确记录其代价**：它既不是
+  `AllowCreate` 的写时闸门，也不是 `AllowPush` 的推送总开关，服务层需要新增独立方法
+  （如 `AllowDisplay(ctx, key, dims) bool`，复用 `loadRule`/`loadScopes` 缓存路径），
+  不要塞进前两者里混用语义。
+  **选 fail-closed 的理由**：本框架展示位的第一批用途是 dark launch（后端服务尚未部署、
+  功能尚未验收），此时把入口露出去，用户点进去撞上不存在的服务或 403，比短暂看不到入口
+  更糟。
+  **必须同时记录的代价**：对"已上线、只是分批放量"的功能，fail-closed 意味着
+  DB/Redis 抖动期间**所有人**都丢掉入口（可用性代价）；而 fail-open 的代价只是少数人
+  提前看到——因为展示位不承担鉴权，服务端仍独立拦截。本任务仍选 fail-closed（dark
+  launch 是主场景，且与原设计"fail 策略按端固定"的哲学一致），但实施者与运维都应知道
+  这个取舍不是无代价的。将来若某类 key 确实需要 fail-open，做法是**另开一个方法**（像
+  `AllowPush` 那样），不是给规则加一个 fail 模式字段。
+- **端点不接受客户端指定 key，只返回代码内预注册的白名单**：`feature_gate` 表的
+  `feature_key` 是自由字符串，没有区分"哪些 key 允许暴露给客户端"。若按客户端传入的 key
+  查库，等于让任意登录用户可枚举/探测内部 key 是否存在及其状态（信息泄露面，类比
+  `system_setting` 的 `settingDef` 白名单、`bot_setting` 键注册表存在的理由）。本任务
+  必须在代码里固定一份"可下发给客户端的 key 列表"，端点按这份列表批量评估后整体返回，
+  **请求不带任何 key 参数**。
+- **注册表项同时声明 `feature_key` 与 `client_key`，两者解耦**：
+
+  | 字段 | 面向 | 出现在 |
+  |---|---|---|
+  | `feature_key` | 运维 | `feature_gate` 表主键、管理台、**`OCTO_FEATUREGATE_<KEY>_KILL` 环境变量名由它推导** |
+  | `client_key` | 客户端 | `GET /v1/featuregate/flags` 响应 JSON 的字段名 |
+
+  **为什么解耦**：`feature_key` 是运维面标识，重命名（改归类、改前缀）本该是无风险操作；
+  若它同时是 wire 契约，运维改个名就静默破坏三端客户端。注意 `killSwitchOn` 是
+  `strings.ToUpper(strings.ReplaceAll(key, "-", "_"))` 从 `feature_key` 推导环境变量名的
+  ——这进一步说明 `feature_key` 属于运维面词汇表，不该被客户端契约锁死。
+
+  **反向约束**：`client_key` 一旦发布即**冻结**，与 appconfig 字段同级别的 wire 契约
+  （additive-only）；要改就是破坏性变更，须与客户端发版协调。命名沿用 appconfig 的
+  snake_case 风格；因为「归属唯一」规则，它不会与 appconfig 已有字段重名。
+
+  ⚠️ **两个 key 都必须在注册表内唯一，且在构造期校验、重复即 panic**。尤其 `client_key`
+  重复是**静默故障**：响应是 `map[string]bool`，两项声明同一个 `client_key` 时后写的直接
+  覆盖先写的，map 不会报错，线上表现为"某个 flag 的值莫名其妙跟着另一个功能走"。
+  仓库已有同型做法可参照——`mustLookupSharedCode` 在 init 阶段解析并对未注册项
+  大声 panic（见 CLAUDE.md 的 i18n 小节）。
+- **客户端字段只能是布尔；"未命中/未注册"与"评估出错"的区分只能落在日志与指标**：
+  与 appconfig 现有位口径一致（`docs_on`、`tracking_enabled` 都是纯布尔），不暴露
+  mode/percent/scope 等内部细节，防止客户端反推灰度策略。排障所需的区分度通过服务端
+  日志（携带 key 与失败原因）实现，**不得为此在响应体里加 `reason`/`source` 之类字段**，
+  否则布尔约束当场破掉。
+- **响应体必须是动态 map，禁用 `omitempty`——否则"省略"语义根本无法实现**。
+  本 brief 定了"存储故障省略该 key、规则不存在下发 `false`"，但仓库里最顺手的先例
+  `appConfigResp` 是**固定字段 struct**（`DocsOn bool \`json:"docs_on"\``）。照抄那个形状
+  会连环出两个错：
+  - Go struct 的 bool 字段**永远序列化**，省略无从实现；
+  - 有人为了实现省略而加 `omitempty` → **`false` 会被一起吞掉** → "规则不存在的确定性关"
+    与"存储故障"在线上变成同一个样子 → 客户端保留旧值 → **灰度永远关不掉**，正是上一条
+    失败语义花大篇幅要防的那件事。
+
+  因此钉死：响应体形如 `{"flags": {"<key>": true, ...}}`，值类型 `map[string]bool`
+  （动态 key），**不得用固定字段 struct，不得对该 map 或其元素使用 `omitempty`**。
+  用一条序列化测试直接断言"值为 `false` 的 key 必须出现在 JSON 里"。
+- **与 appconfig 的关系：归属唯一 + 服务端 AND（已拍板）**。
+  **主规则是归属唯一，不是组合**：
+  - 存量的十来个 appconfig 展示位（`docs_on`/`drive_on`/`dmloop_on`/`tracking_enabled`/
+    `sticker_custom_enabled`/`message_reaction.*`…）**一个不动**，也不为它们建 featuregate
+    key；
+  - **新功能要用户级定向的，只建 featuregate key，不往 appconfig 加位**；
+  - 存量功能将来要升级成用户级定向，是一次显式迁移，单独设计，不在本任务。
+
+  **为什么不允许同一功能出现在两处**：老客户端只读 appconfig。若 `docs` 既有
+  `docs_on` 又有 featuregate key，老客户端会在灰度批次之外照常显示——灰度当场失效。
+  这不是风格问题，是功能性缺陷。
+
+  **"部署没就绪"不需要 appconfig 那一层来表达**：featuregate 自己的 `mode=off` 就是
+  没就绪，部署好了改 `whitelist`/`percent` 即可。
+
+  **可选挂钩**：确有需要与某个部署位联动时，注册表项可**可选地**声明一个"部署前置位"
+  （指向某个 `SystemSettings` getter），由**服务端**做 AND；未声明即无约束。
+  **AND 永远在服务端完成，客户端永远只看到一个最终布尔**——把组合逻辑放客户端，就是
+  三端各实现一次然后漂移，`SystemBotUIDs` 那段注释记载的正是这个事故。
+
+  ⚠️ **实现陷阱**：读 `SystemSettings` 必须在**构造期**调一次
+  `common.EnsureSystemSettings(ctx)` 拿到实例并持有，**绝不可在每请求路径上调**——该函数
+  每次调用都取进程级 mutex，而 `SystemSettings` 的设计前提是读侧走 `atomic.Pointer`、
+  永不取锁。同一个坑 `bot-setting-store` 已经踩过并写进它的 load-bearing。
+
+  📌 **口径更正**：不要把现状描述成"appconfig = 部署能力、featuregate = 人群"。现有
+  appconfig 位其实是**混的**——`docs_on`/`drive_on`/`dmloop_on`/`tracking_enabled` 确实是
+  部署能力（都依赖外部服务上线），但 `sticker_custom_enabled` 与 `message_reaction.*` 本
+  就是纯灰度开关。上述分工只能作为**今后的**约定，不能用来追溯解释存量。
+- **客户端刷新契约与失败语义（已拍板）**。这是新接口，拉取节奏是本任务要**定义**的
+  契约，不是去猜的既成事实。
+
+  **拉取时机**：冷启动 + 登录成功 + **App 前台化**，前台化带节流（最小间隔 ≥5 分钟）。
+  加"前台化"是关键——移动端 App 常驻后台，冷启动可能几天一次，只按 appconfig 现状
+  （冷启动/登录页）会让回滚对活跃用户几天不生效。5 分钟节流下最坏每小时 12 次，对共享
+  限流桶影响可忽略。
+
+  **失败语义（服务端与客户端两半，缺一不可）**：
+  - 服务端：单个 key 遭遇**存储故障**（DB/Redis）时 **从响应中省略该 key**，不下发
+    `false`；
+  - 客户端：整请求失败 → **保留上次快照**（不得回落成全 `false`）；响应缺某 key →
+    **保留该 key 上次值**；无历史值（新装/清数据）→ `false`。
+
+  **为什么省略而不是下发 false**：响应只有布尔（这是本 brief 自己定的约束），客户端因此
+  **无法区分"真的关"与"服务端抖了一下"**。若故障时下发 `false`，Redis 抖 3 秒的后果就是
+  **全体用户功能消失**；改成省略后，影响面缩小到"无本地缓存的新装用户暂时看不到"，
+  而且**依然是 fail-closed**（无历史值时默认 `false`）。这条同时保住了布尔约束——它没有
+  引入 `reason`/`source` 之类字段。
+
+  **必须与"规则不存在"区分开**：查询成功但表里没有该 key 的规则，是**确定性的关**，
+  正常下发 `false`；只有**存储故障**才省略。两者混淆会让"未配置"变成"保留旧值"，
+  灰度就永远关不掉。
+
+  **运营预期**：生效延迟 = 用户下次拉取时间，**分钟级到小时级，不是秒级**。
+  由此推出一条运维硬规定：**展示位不是止血手段**。真要紧急关停，路径是
+  `OCTO_FEATUREGATE_<KEY>_KILL=1` + 服务端拒绝相关 API（立即生效），客户端隐藏入口只是随后收敛的
+  UI 表现。若将来运营确需秒级 UI 收敛，可复用 WuKongIM 长连接推一条重拉信号（列在
+  Out of scope），即本决策是可演进的，不是死路。
+- **响应不可被共享缓存**：结果因人而异，但 URL 对所有用户逐字节相同，区分调用者的只有
+  Authorization 头——任何按 URL 缓存的共享代理都会把用户 A 的判定回给用户 B。必须下发
+  `Cache-Control: private, no-store`（`private` 禁共享缓存，`no-store` 连私有副本也不留）。
+  同型教训见 `bot-setting-store` 给 `/v1/bot/card/profile` 加 `config` 后的处理。
+- **管理端点鉴权：校验沿用，但拒绝路径必须换成现行写法**。`list`/`update`/`addScope`/
+  `delScope` 继续用 `c.CheckLoginRoleIsSuperAdmin()` 做校验，`scope_type=user` 走同一个
+  `validScopeType`，不新开权限模型——但**拒绝时不得照抄原实现**。
+  原 `03f4bbe9:modules/featuregate/api_manager.go` 四个 handler 均写作
+  `if err := c.CheckLoginRoleIsSuperAdmin(); err != nil { c.ResponseError(err); return }`，
+  其中 `c.ResponseError` 正是 CLAUDE.md 禁止的 legacy 裸响应（这也是原模块能不带守卫
+  测试交付的原因）。既然本任务要补 `TestFeatureGateAPINoLegacyResponseError`，照抄会
+  当场触发守卫。
+  现行正确写法在仓库里已有同型样板：`modules/common/api.go:580` 的 `addAppVersion` 做
+  同一件事（superAdmin 校验 + 拒绝），用
+  `httperr.ResponseErrorL(c, errcode.ErrSharedForbidden, nil, nil)`，并按反枚举约定回
+  通用 403、不透出"需要更高角色"这一具体原因。管理端四个 handler 照此办理。
+  **不要为此新增 `err.server.featuregate.forbidden` 之类的专用码**——鉴权失败统一收敛到
+  一个共享码是既有的反枚举约定，`pkg/errcode/featuregate.go` 仍只保留原有四个业务码。
+- **写后失效路径不变**：`update`/`addScope`/`delScope` 成功后仍调 `svc.Invalidate(key)`，
+  不因新增维度而改变缓存失效触发点。
+- **i18n / 错误码**：新端点走 `httperr.ResponseErrorL` / `ResponseErrorLWithStatus` +
+  注册码，不得用 raw `c.ResponseError`。`pkg/errcode/featuregate.go` 的四个既有码
+  （`request_invalid`/`not_found`/`query_failed`/`operation_failed`）复活时原样保留；
+  用户侧只读端点若需新增码，一并归到 `pkg/errcode/featuregate.go`。
+  端点已归属 `modules/featuregate`，因此不存在"码散落到别的模块"的问题——但需注意
+  **该端点在正常路径上几乎不该产生错误码**：单 key 故障走省略、规则不存在走 `false`，
+  两者都是 200；只有鉴权失败与请求本身不合法才走错误信封。
+- **复活的 `modules/featuregate` 缺一个 `NoLegacyResponseError` 守卫测试**：原分支只有
+  `api_i18n.go`，没有对应的 `api_i18n_test.go` 守卫，而仓库约定是每个已迁移模块都要有
+  （`modules/` 下已有 20 个模块带此守卫）。复活时按既有约定补上，不要原样照搬这个缺口。
+- **限流**：新端点挂 `appwkhttp.SharedUIDRateLimiter(r, ctx)`，且必须在 `AuthMiddleware`
+  **之后**挂（CLAUDE.md 明确的既有陷阱：挂早了读不到 uid，静默 fail-open）。
+  **注意这是一个进程级共享桶**：每个 uid 跨所有已挂载路由共用一份配额（生产现为
+  5 rps / burst 300）。因此若客户端把这个端点做成轮询，吃掉的是该用户其他接口的配额，
+  不是免费的——这也是上一条"刷新契约"要规定拉取节奏的实际约束之一。
+
+## Out of scope
+
+- **`appconfig` 的鉴权语义或字段集**——本任务明确不碰，免鉴权全局位继续走
+  `system_setting`，不因本任务而叠加任何用户维度字段。
+- **软鉴权（方案 A：appconfig 内部可选解析 token）**——已讨论并否决，不在本任务重新
+  评估。未来若确需未登录场景的按用户灰度，是独立任务且需单独安全评审。
+- **PR #280 第二个 commit（`eb5cc933`）的 incomingwebhook 接入**——**明确排除**。
+  incoming webhook 已在生产运行数月且从未有过这个门；现在给一个存量功能加 fail-closed
+  的 create 门 + 种子迁移，是一套与"用户级展示灰度"毫无关系的独立风险面（种子迁移写歪
+  或漏执行，直接后果是全部 create 变 403）。捆在一起只会放大爆炸半径。本任务只复活框架
+  本体，`incomingwebhook` 一行不动。若之后确要给它加门，另立任务。
+- **按 App 版本的灰度维度**——`Dims` 目前只有 `SpaceID`/`GroupNo`/`UID`；加
+  `ClientVersion` 需要客户端在请求里带版本信息，涉及跨端传参契约设计，留给后续任务。
+  本任务只做 user 维度。
+- **服务端主动推送灰度变更**（例如复用 IM 事件通道推一条 `flags_updated` 让客户端立即
+  重拉）——这是让"秒级回滚"对展示位真正成立的唯一途径，但引入新的推送依赖与投递可靠性
+  问题，不在本任务。若运营明确要求秒级，另立任务。
+- **客户端消费本端点后的 UI 行为**（哪个入口读哪个 key、灰度位命名）——本任务只交付
+  服务端能力与一份可扩展的"可下发 key 白名单"机制；具体业务 key 的注册属于各业务功能
+  自己的后续任务。
+- **`feature_gate_scope` 的批量管理端点**（如"一次性拉一批测试账号进白名单"）——本任务
+  只做单条 `addScope`/`delScope`，批量留给后续任务。
+
+## Acceptance
+
+**pkg/featuregate（用户维度）**
+
+- `ScopeTypeUser` 白名单：`Rule{Mode: ModeWhitelist}` + `Scope{Type: ScopeTypeUser,
+  ID: "u1"}` 下，`Dims{UID: "u1"}` → `Allow=true`；`Dims{UID: "u2"}` →
+  `Allow=false, Reason=ReasonWhitelistMiss`；`Dims{UID: ""}` → `Allow=false`。
+- percent 按用户分桶：`Rule{Mode: ModePercent, Percent: 50, BucketBy: "user"}` 下，
+  同一 uid 多次评估结果恒定；两个不同 key 对同一 uid 的分桶相互独立（crc32 按 key 加盐
+  这条既有不变量在 user 维度同样成立）。
+- 同一维度内的单调性保持：`Percent` 调高只会纳入更多对象，已命中的不掉出。
+- `BucketBy` 为空（列默认值 `'group'`）时行为等同于原设计的按 `GroupNo` 分桶——一条
+  回归测试钉住这个默认值语义。
+- **白名单贯穿 mode**：`Rule{Mode: ModePercent, Percent: 0}` + 一条命中的
+  `Scope{Type: ScopeTypeUser, ID: "u1"}` → `Dims{UID:"u1"}` 得 `Allow=true` 且
+  `Reason=ReasonWhitelistHit`（`Percent: 0` 保证放行只可能来自白名单，排除分桶巧合）；
+  同一规则下不在白名单的 `u2` → `Allow=false`。
+- **`off` 不可被白名单穿透**：`Rule{Mode: ModeOff}` + 命中的白名单条目 →
+  `Allow=false, Reason=ReasonOff`。这条是止血语义的硬边界，必须单独有测试。
+
+**modules/featuregate 框架复活**
+
+- `feature_gate`（含新增 `bucket_by` 列）/ `feature_gate_scope` 两表按迁移建出。
+- `/v1/manager/featuregate` 的 list/update/addScope/delScope 四端点以 `03f4bbe9` 的功能
+  语义为基线（superadmin-only，写后 `Invalidate`），错误响应、中间件和守卫遵循当前仓库
+  规则，不要求逐字复刻原实现。
+- `addScope` 接受 `scope_type=user`；非法 `scope_type`（非 group/space/user）→ 400
+  `err.server.featuregate.request_invalid`。
+- **Service 层在 percent 模式下也加载 scopes**：一条走 Service（非纯函数）的集成测试——
+  规则 `mode=percent, percent=0, bucket_by=user` + 白名单含 `u1` → `AllowDisplay` 对 `u1`
+  返回 `true`。这条专门钉住"`loadScopes` 的加载条件漏加 `|| ModePercent`"这个实现遗漏，
+  `pkg/featuregate` 的表驱动测试照不到它。
+- **写侧拒绝对客户端可见的 key 配不可满足的维度**：对已注册为客户端可见的 `feature_key`，
+  `update` 传 `bucket_by=group`（或 `whitelist` 模式下仅含 `scope_type=group`/`space` 条目）
+  → 400 `err.server.featuregate.request_invalid`。
+- env kill switch 生效：设置 `OCTO_FEATUREGATE_<KEY>_KILL=1` 后，无论 DB/Redis 规则为何，该 key
+  的所有判定（含新增的 `AllowDisplay`）一律为拒，且**不查任何存储**。
+- 新增 `TestFeatureGateAPINoLegacyResponseError` 守卫测试，覆盖模块内全部 handler 文件。
+
+**新增用户侧只读端点 `GET /v1/featuregate/flags`**
+
+- 挂 `AuthMiddleware` + `SharedUIDRateLimiter`（鉴权中间件之后）；未登录时的行为与其他
+  已鉴权端点一致（以 `AuthMiddleware` 既有行为为准，不新增分支）。
+- 请求**不接受任何 key 参数**；正常情况下响应包含代码内预注册白名单的**全部**键，
+  值为布尔。
+- **响应体是 `{"flags": map[string]bool}` 动态形状**：一条序列化测试断言"值为 `false`
+  的 key 必须出现在 JSON 里"，钉住"不得用固定字段 struct、不得用 `omitempty`"——否则
+  `false` 被吞掉会与"存储故障省略"混淆，使灰度关不掉。
+- **响应用 `client_key` 而非 `feature_key` 作字段名**：一条测试断言注册表里
+  `feature_key != client_key` 的项，在响应 JSON 中出现的是 `client_key`。
+- **注册表唯一性在构造期校验**：注册两项相同 `client_key`（或相同 `feature_key`）时
+  **panic**，用测试钉住。这是防静默覆盖——`map[string]bool` 下重复 key 后写覆盖先写，
+  不会报任何错。
+- **读侧兜底**：规则要求的分桶维度在 `Dims` 中为空时（如客户端可见 key 被直接改库配成
+  `bucket_by=group`），该 key fail-closed 返回 `false` 并打 Warn 日志，**不得按空串
+  照算**——否则会出现"管理台显示 50%、实际全体开或全体关"的静默错配。
+- 响应头带 `Cache-Control: private, no-store`。
+- **存储故障 → 省略，不是 false**：单个 key 的规则/白名单因 DB/Redis 故障加载失败时，
+  该 key **从响应中省略**，失败原因写日志；**不影响其它 key 正常返回，不导致整个请求
+  500**。用一条测试钉住"故障 key 不出现在响应里"，防止日后被改回下发 `false`。
+- **规则不存在 → 明确 false**：查询成功但表中无该 key 的规则时，正常下发 `false`
+  （确定性的关），**不省略**。与上一条构成一对，用测试同时钉住两侧，避免"未配置"被
+  当成"保留旧值"而使灰度关不掉。
+- 用户 A 在某 key 的 `user` 白名单内 → 该 key 为 `true`；用户 B 不在白名单且规则非 `on`、
+  未命中 percent → `false`。
+- **全新部署零规则场景**：`feature_gate` 表为空时，端点对每个已注册 key 均返回 `false`
+  （fail-closed 的直接推论，走上面"规则不存在"这一支，而非省略），请求本身成功返回 200。
+  这是预期行为——新部署下所有灰度功能默认隐藏，运维需显式建规则才放出；用一条测试钉住，
+  避免日后被当成 bug 改成 fail-open。
+
+**工程门**
+
+- 新增/复活的 handler 文件（管理端四个 + 用户侧只读端点）全部纳入
+  `TestFeatureGateAPINoLegacyResponseError` 的文件列表——本任务不再改动 `modules/user`，
+  因此不涉及该模块的守卫。
+- `go build ./...`、
+  `go test -race ./pkg/featuregate/... ./modules/featuregate/...`、
+  `make i18n-extract-check`、`make i18n-lint` 通过。
+- `appconfig` 相关测试（`modules/common/*_test.go`）**零改动**且全部通过——用以验证本任务
+  确实没有触碰 appconfig 的字段与鉴权契约。
+- `modules/incomingwebhook` 与 `modules/user` **零改动**（`git diff` 对这两个目录为空）
+  ——前者验证 PR #280 第二个 commit 确实被排除，后者验证端点归属决策落到了
+  `modules/featuregate`。

--- a/.octospec/tasks/featuregate-user-scoped-flags/brief.md
+++ b/.octospec/tasks/featuregate-user-scoped-flags/brief.md
@@ -19,8 +19,8 @@ source: self
    featuregate），确需与部署位联动时由**服务端**做 AND，客户端只读一个最终布尔——
    AND 绝不放在客户端。理由与实现约束见 Load-bearing 对应条目。
 3. **刷新契约与失败语义**：冷启动 + 登录成功 + 前台化（节流 ≥5 分钟）；单个 key 遭遇
-   存储故障时进响应的 **`unavailable` 列表**（而非下发 `false`，也不是从 `flags` 里
-   `unavailable` 数组），客户端对这些 key 保留上次值。
+   存储故障时进响应的 **`unavailable` 数组**（既不下发 `false`，也不是从 `flags` 里
+   悄悄省略），客户端对这些 key 保留上次值。
    **2026-08-25 修订**：初稿用「从 `flags` 里省略」来表达这层含义，评审阶段改为显式
    字段——语义等价，但「缺席携带含义」任何 schema 语言都描述不了，codegen 客户端会把
    缺席读成 `false`，恰是这套设计要防的失败。见 Load-bearing 与 Acceptance 对应条目。
@@ -416,6 +416,10 @@ percent，因此本任务按当前契约重新评审和落地。
 - **写侧拒绝对客户端可见的 key 配不可满足的维度**：对已注册为客户端可见的 `feature_key`，
   `update` 传 `bucket_by=group`（或 `whitelist` 模式下仅含 `scope_type=group`/`space` 条目）
   → 400 `err.server.featuregate.request_invalid`。
+  **限定在会读这些输入的 mode（`whitelist`/`percent`）**：`off`/`on` 既不读白名单也不读
+  `bucket_by`，对它们施加同一校验会让「关掉一个 gate」比「打开它」更难——而 `off` 正是本
+  框架的回滚杠杆。放行不留隐患：每次切进 `whitelist`/`percent` 都会重新校验请求里的
+  `bucket_by`。**这条限定是刻意的，不要"修"回无条件校验**（见 journal 的 Review round 2）。
 - env kill switch 生效：设置 `OCTO_FEATUREGATE_<KEY>_KILL=1` 后，无论 DB/Redis 规则为何，该 key
   的所有判定（含新增的 `AllowDisplay`）一律为拒，且**不查任何存储**。
 - 新增 `TestFeatureGateAPINoLegacyResponseError` 守卫测试，覆盖模块内全部 handler 文件。

--- a/.octospec/tasks/featuregate-user-scoped-flags/context.yaml
+++ b/.octospec/tasks/featuregate-user-scoped-flags/context.yaml
@@ -1,0 +1,20 @@
+injected:
+  - id: space-isolation
+    source: repo
+    why: brief tags 含 auth；将新增 modules/**/*.go 路由与鉴权
+  - id: trust-boundary
+    source: repo
+    why: brief tags 含 wire-contract；正文多数条款（转义/markdown/adapter 对等）对本任务不适用，仅"在调用方无法跨越的边界上校验"与"限制载荷"两条原则被采纳（注册表白名单 = 客户端无法跨越的边界）
+  - id: error-handling
+    source: repo
+    why: brief tags 含 error-response/i18n/wire-contract；新增 pkg/errcode/featuregate.go 与 modules handler
+  - id: rate-limit
+    source: repo
+    why: brief tags 含 rate-limit；新增已鉴权端点须挂 SharedUIDRateLimiter
+  - id: testing
+    source: repo
+    why: brief tags 含 testing；新增 *_test.go
+  - id: commit-style
+    source: repo
+    why: paths ["**"] 全匹配；本阶段不 commit，规则在 Finish 阶段生效
+brief: .octospec/tasks/featuregate-user-scoped-flags/brief.md

--- a/docs/cutover-framework.md
+++ b/docs/cutover-framework.md
@@ -24,7 +24,10 @@
 
 ## 与 featuregate 的分界
 
-`modules/featuregate` 是 **fail-open、可来回切**的灰度开关，适合行为开关。
+`modules/featuregate` 是**可来回切**的灰度开关，适合行为开关。它的 fail 策略**按调用端
+固定、不是统一 fail-open**：`AllowPush`（推送总开关）fail-open——绝不能因灰度框架故障
+中断存量推送；`AllowCreate`（写时闸门）与 `AllowDisplay`（客户端展示位）fail-closed——
+配置拿不到时拒绝，胜过数据裸奔或展示一个实际不可用的入口。
 cutover 是 **fail-closed、单向、带水位校验**的数据面迁移：切换的先决条件是一个
 经过证据校验的水位（floor），切换后退回去会重现原 bug。两者语义不兼容——
 不要用 featuregate 做号段切换，也不要用 cutover 做可逆的功能灰度。

--- a/internal/modules.go
+++ b/internal/modules.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/Mininglamp-OSS/octo-server/modules/channel"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/common"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/featuregate"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/file"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/group"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/incomingwebhook"

--- a/modules/featuregate/1module.go
+++ b/modules/featuregate/1module.go
@@ -1,0 +1,23 @@
+package featuregate
+
+import (
+	"embed"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
+)
+
+//go:embed sql
+var sqlFS embed.FS
+
+func init() {
+	register.AddModule(func(ctx interface{}) register.Module {
+		return register.Module{
+			Name: "featuregate",
+			SetupAPI: func() register.APIRouter {
+				return NewManager(ctx.(*config.Context))
+			},
+			SQLDir: register.NewSQLFS(sqlFS),
+		}
+	})
+}

--- a/modules/featuregate/api_flags.go
+++ b/modules/featuregate/api_flags.go
@@ -89,25 +89,40 @@ func (a *flagsAPI) get(c *wkhttp.Context) {
 	// 到位」的中间层来说，等于宣告"这些响应可以互换"。
 	c.Header("Vary", "token")
 
-	uid := c.GetLoginUID()
-	if uid == "" {
-		// 不可达：本路由挂在 AuthMiddleware 之后，uid 必然已注入。真出现说明鉴权
-		// 链被改动了。判定本身仍会 fail-closed（白名单不匹配空值、按 user 分桶走
-		// dim_unavailable），但那样只会表现为"功能全没了"，排查会绕远路；显式记一条
-		// Error 让根因一眼可见。
+	if uid := c.GetLoginUID(); uid != "" {
+		c.Response(a.evaluateAll(c.Request.Context(), fg.Dims{UID: uid}))
+		return
+	}
+	a.respondUnknowable(c)
+}
+
+// respondUnknowable 处理「没有 uid」这条不可达分支。
+func (a *flagsAPI) respondUnknowable(c *wkhttp.Context) {
+	{
+		// 不可达：本路由挂在 AuthMiddleware 之后，uid 必然已注入。真出现说明鉴权链
+		// 被改动了。
+		//
+		// 此时**不能**照常评估：白名单匹配不上空值、按 user 分桶走 dim_unavailable，
+		// 结果会是「每个 key 都确定性地 false」——恰恰是本模块最想避免的那个形状，
+		// 客户端会拿它覆盖本地缓存，功能对所有人消失。没有 uid 时答案本就**不可知**，
+		// 而不可知正是 unavailable 的语义。让不变量由代码保证，而不是靠注释声称
+		// "不会发生"。
 		a.Error("flags endpoint reached without a login uid; auth chain may be misconfigured")
 	}
+	c.Response(flagsResp{Flags: map[string]bool{}, Unavailable: a.registry.clientKeys()})
+}
 
-	// 本端点只有 UID 维度：不接收也不推断空间/群上下文。一个用户可属多个空间，
-	// "当前空间"在这条请求里没有确定答案，因此 flags 是**账号级**的，不构成跨空间
-	// 读取面。凡是要下发到客户端的规则都必须按 user 维度配置（管理端写侧已拦，
-	// AllowDisplay 读侧还会再兜一次）。
-	dims := fg.Dims{UID: uid}
-
+// evaluateAll 对注册表全集求值。
+//
+// 本端点只有 UID 维度：不接收也不推断空间/群上下文。一个用户可属多个空间，"当前
+// 空间"在这条请求里没有确定答案，因此 flags 是**账号级**的，不构成跨空间读取面。
+// 凡是要下发到客户端的规则都必须按 user 维度配置（管理端写侧已拦，AllowDisplay
+// 读侧还会再兜一次）。
+func (a *flagsAPI) evaluateAll(ctx context.Context, dims fg.Dims) flagsResp {
 	flags := make(map[string]bool, len(a.registry.flags))
 	unavailable := make([]string, 0)
 	for _, f := range a.registry.flags {
-		allow, ok := a.resolve(c.Request.Context(), f, dims)
+		allow, ok := a.resolve(ctx, f, dims)
 		if !ok {
 			// 存储故障：判定不可得，显式列出让客户端保留上次值。
 			// 已在 AllowDisplay 内打过 Warn。
@@ -116,8 +131,7 @@ func (a *flagsAPI) get(c *wkhttp.Context) {
 		}
 		flags[f.ClientKey] = allow
 	}
-
-	c.Response(flagsResp{Flags: flags, Unavailable: unavailable})
+	return flagsResp{Flags: flags, Unavailable: unavailable}
 }
 
 // resolve 求出单个 flag 对本次调用者的最终值。

--- a/modules/featuregate/api_flags.go
+++ b/modules/featuregate/api_flags.go
@@ -1,0 +1,136 @@
+package featuregate
+
+import (
+	"context"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/common"
+	fg "github.com/Mininglamp-OSS/octo-server/pkg/featuregate"
+	"go.uber.org/zap"
+)
+
+// flagsResp 是 GET /v1/featuregate/flags 的响应体。
+//
+// Flags 刻意是 map[string]bool（动态 key）而不是固定字段的 struct，且**不得**加
+// omitempty。这不是风格选择，是失败语义的前提：
+//
+//   - 固定字段 struct 的 bool 永远序列化，做不到「省略某个 key」；
+//   - 而一旦为了省略去加 omitempty，值为 false 的 key 会被一起吞掉——「规则不存在
+//     的确定性的关」就和「存储故障」在线上长得一模一样，客户端会保留旧值，灰度
+//     永远关不掉。
+//
+// 值只有布尔：不下发 mode/percent/scope 等内部细节，避免客户端反推灰度策略。
+// 排障所需的「为什么是这个值」只进服务端日志。
+type flagsResp struct {
+	Flags map[string]bool `json:"flags"`
+}
+
+// displayEvaluator 是 flagsAPI 需要的最小能力面，在使用处定义（而不是在
+// Service 侧）。抽这一层不是为了将来换实现，而是为了让「存储故障 → 省略该 key」
+// 这条路径可被确定性地测到：真去制造一次 DB/Redis 故障要么污染同包其它测试
+// （drop 表），要么依赖时序，两者都比一个 stub 差。
+type displayEvaluator interface {
+	// AllowDisplay 返回 (allow, ok)，语义见 Service.AllowDisplay。
+	AllowDisplay(ctx context.Context, key string, dims fg.Dims) (bool, bool)
+}
+
+// flagsAPI 承载用户侧只读端点。
+type flagsAPI struct {
+	svc      displayEvaluator
+	registry *clientRegistry
+	// systemSettings 仅在注册表里存在声明了 DeploymentGate 的 flag 时才解析。
+	//
+	// 必须在**构造期**取一次并持有：common.EnsureSystemSettings 每次调用都取一个
+	// 进程级 mutex，而 SystemSettings 的设计前提是读侧走 atomic.Pointer、永不取锁。
+	// 在每请求路径上调它等于把全局锁加到热路径上。
+	systemSettings *common.SystemSettings
+	log.Log
+}
+
+func newFlagsAPI(ctx *config.Context, svc displayEvaluator, registry *clientRegistry) *flagsAPI {
+	a := &flagsAPI{
+		svc:      svc,
+		registry: registry,
+		Log:      log.NewTLog("featureGateFlags"),
+	}
+	// 没有任何 flag 需要部署前置位时不去触碰 SystemSettings 单例——构造它会做一次
+	// DB Load 并起一个后台 goroutine，没人用就不该付这个代价。注册表里一旦出现
+	// 声明了 DeploymentGate 的 flag，这里会自动开始解析，无需另行改动。
+	if registry.needsSettings {
+		a.systemSettings = common.EnsureSystemSettings(ctx)
+	}
+	return a
+}
+
+// get 返回当前登录用户的全部灰度位。
+//
+// 契约要点：
+//   - 请求**不接受任何 key 参数**。响应恒为注册表全集，客户端因此无法用一个精心
+//     构造的 key 去探测某个内部 gate 是否存在——注册表就是调用方跨不过去的边界。
+//   - 单个 key 遇到**存储故障**时从响应中省略（客户端保留上次值），其余 key 照常
+//     返回，整个请求仍然 200。一次 Redis 抖动不该让全体用户丢功能。
+//   - 「规则不存在」是确定性的关，下发 false，**不省略**。两者混淆会让「未配置」
+//     变成「保留旧值」，灰度就永远关不掉。
+func (a *flagsAPI) get(c *wkhttp.Context) {
+	// 结果因人而异，而 URL 对所有用户逐字节相同——区分调用者的只有鉴权头。
+	// 任何按 URL 缓存的共享代理都会把用户 A 的判定回给用户 B。
+	// private 禁共享缓存，no-store 连私有副本也不留（开关变更要即时可见）。
+	c.Header("Cache-Control", "private, no-store")
+	// Vary 必须点名**本仓实际使用的**鉴权头。octo-lib 的 AuthMiddleware 读的是
+	// `token`（不是 Authorization —— 那是 bot API 的用法）。写错头名比不写更糟：
+	// 一个所有请求都为空的头没有任何区分度，对某些「认 Vary 但对 no-store 处理不
+	// 到位」的中间层来说，等于宣告"这些响应可以互换"。
+	c.Header("Vary", "token")
+
+	uid := c.GetLoginUID()
+	if uid == "" {
+		// 不可达：本路由挂在 AuthMiddleware 之后，uid 必然已注入。真出现说明鉴权
+		// 链被改动了。判定本身仍会 fail-closed（白名单不匹配空值、按 user 分桶走
+		// dim_unavailable），但那样只会表现为"功能全没了"，排查会绕远路；显式记一条
+		// Error 让根因一眼可见。
+		a.Error("flags endpoint reached without a login uid; auth chain may be misconfigured")
+	}
+
+	// 本端点只有 UID 维度：不接收也不推断空间/群上下文。一个用户可属多个空间，
+	// "当前空间"在这条请求里没有确定答案，因此 flags 是**账号级**的，不构成跨空间
+	// 读取面。凡是要下发到客户端的规则都必须按 user 维度配置（管理端写侧已拦，
+	// AllowDisplay 读侧还会再兜一次）。
+	dims := fg.Dims{UID: uid}
+
+	flags := make(map[string]bool, len(a.registry.flags))
+	for _, f := range a.registry.flags {
+		allow, ok := a.resolve(c.Request.Context(), f, dims)
+		if !ok {
+			// 存储故障：省略该 key，让客户端保留上次值。已在 AllowDisplay 内打过 Warn。
+			continue
+		}
+		flags[f.ClientKey] = allow
+	}
+
+	c.Response(flagsResp{Flags: flags})
+}
+
+// resolve 求出单个 flag 对本次调用者的最终值。
+//
+// 返回 (allow, ok)：ok=false 表示存储故障、判定不可得，调用方应省略该 key。
+func (a *flagsAPI) resolve(ctx context.Context, f ClientFlag, dims fg.Dims) (bool, bool) {
+	allow, ok := a.svc.AllowDisplay(ctx, f.FeatureKey, dims)
+	if !ok {
+		return false, false
+	}
+	if !allow || f.DeploymentGate == nil {
+		return allow, true
+	}
+	// 部署前置位：在服务端完成 AND，客户端只看到最终布尔。
+	// 组合逻辑绝不下放给客户端——三端各实现一次必然漂移。
+	if a.systemSettings == nil {
+		// 不可达：needsSettings 由同一份注册表推导。真出现说明注册表与构造期解析
+		// 脱节了，此时宁可关掉也不要按 gate 单独放行。
+		a.Error("deployment gate declared but SystemSettings unresolved; failing closed",
+			zap.String("feature_key", f.FeatureKey))
+		return false, true
+	}
+	return f.DeploymentGate(a.systemSettings), true
+}

--- a/modules/featuregate/api_flags.go
+++ b/modules/featuregate/api_flags.go
@@ -13,18 +13,23 @@ import (
 
 // flagsResp 是 GET /v1/featuregate/flags 的响应体。
 //
-// Flags 刻意是 map[string]bool（动态 key）而不是固定字段的 struct，且**不得**加
-// omitempty。这不是风格选择，是失败语义的前提：
-//
-//   - 固定字段 struct 的 bool 永远序列化，做不到「省略某个 key」；
-//   - 而一旦为了省略去加 omitempty，值为 false 的 key 会被一起吞掉——「规则不存在
-//     的确定性的关」就和「存储故障」在线上长得一模一样，客户端会保留旧值，灰度
-//     永远关不掉。
+// Flags 是 map[string]bool（动态 key），且**不得**加 omitempty —— 值为 false 的
+// key 必须出现在 JSON 里。固定字段 struct 或 omitempty 都会让「确定性的关」丢失。
 //
 // 值只有布尔：不下发 mode/percent/scope 等内部细节，避免客户端反推灰度策略。
 // 排障所需的「为什么是这个值」只进服务端日志。
+//
+// Unavailable 列出**判定不可得**的 key（存储故障），客户端应对这些 key 保留上次
+// 值。早先的设计是把它们从 Flags 里省略、用「缺席」来表达这层含义，语义上等价，
+// 但**任何 schema 语言都描述不了「缺席携带含义」**：OpenAPI / JSON Schema 只能说
+// 某属性可选，没有词汇表达「不出现 ≠ 零值」。于是 codegen 出来的客户端反序列化进
+// map 之后，那个区分在任何业务代码跑起来之前就已经丢了，语言的零值规则会把缺席读
+// 成 false —— 恰好是这套设计要防的那个失败。改成显式字段后契约完全可描述，
+// 客户端不可能"默认做错"，而且它只说"没算出来"、不说为什么，不泄露灰度策略。
 type flagsResp struct {
 	Flags map[string]bool `json:"flags"`
+	// 恒为非 nil：空时序列化成 []，避免弱类型客户端在 null 上解引用炸掉。
+	Unavailable []string `json:"unavailable"`
 }
 
 // displayEvaluator 是 flagsAPI 需要的最小能力面，在使用处定义（而不是在
@@ -69,9 +74,9 @@ func newFlagsAPI(ctx *config.Context, svc displayEvaluator, registry *clientRegi
 // 契约要点：
 //   - 请求**不接受任何 key 参数**。响应恒为注册表全集，客户端因此无法用一个精心
 //     构造的 key 去探测某个内部 gate 是否存在——注册表就是调用方跨不过去的边界。
-//   - 单个 key 遇到**存储故障**时从响应中省略（客户端保留上次值），其余 key 照常
-//     返回，整个请求仍然 200。一次 Redis 抖动不该让全体用户丢功能。
-//   - 「规则不存在」是确定性的关，下发 false，**不省略**。两者混淆会让「未配置」
+//   - 单个 key 遇到**存储故障**时进 unavailable 列表（客户端保留上次值），其余 key
+//     照常返回，整个请求仍然 200。一次 Redis 抖动不该让全体用户丢功能。
+//   - 「规则不存在」是确定性的关，进 flags 且值为 false。两者混淆会让「未配置」
 //     变成「保留旧值」，灰度就永远关不掉。
 func (a *flagsAPI) get(c *wkhttp.Context) {
 	// 结果因人而异，而 URL 对所有用户逐字节相同——区分调用者的只有鉴权头。
@@ -100,16 +105,19 @@ func (a *flagsAPI) get(c *wkhttp.Context) {
 	dims := fg.Dims{UID: uid}
 
 	flags := make(map[string]bool, len(a.registry.flags))
+	unavailable := make([]string, 0)
 	for _, f := range a.registry.flags {
 		allow, ok := a.resolve(c.Request.Context(), f, dims)
 		if !ok {
-			// 存储故障：省略该 key，让客户端保留上次值。已在 AllowDisplay 内打过 Warn。
+			// 存储故障：判定不可得，显式列出让客户端保留上次值。
+			// 已在 AllowDisplay 内打过 Warn。
+			unavailable = append(unavailable, f.ClientKey)
 			continue
 		}
 		flags[f.ClientKey] = allow
 	}
 
-	c.Response(flagsResp{Flags: flags})
+	c.Response(flagsResp{Flags: flags, Unavailable: unavailable})
 }
 
 // resolve 求出单个 flag 对本次调用者的最终值。

--- a/modules/featuregate/api_flags.go
+++ b/modules/featuregate/api_flags.go
@@ -33,7 +33,7 @@ type flagsResp struct {
 }
 
 // displayEvaluator 是 flagsAPI 需要的最小能力面，在使用处定义（而不是在
-// Service 侧）。抽这一层不是为了将来换实现，而是为了让「存储故障 → 省略该 key」
+// Service 侧）。抽这一层不是为了将来换实现，而是为了让「存储故障 → 进 unavailable」
 // 这条路径可被确定性地测到：真去制造一次 DB/Redis 故障要么污染同包其它测试
 // （drop 表），要么依赖时序，两者都比一个 stub 差。
 type displayEvaluator interface {
@@ -122,7 +122,7 @@ func (a *flagsAPI) get(c *wkhttp.Context) {
 
 // resolve 求出单个 flag 对本次调用者的最终值。
 //
-// 返回 (allow, ok)：ok=false 表示存储故障、判定不可得，调用方应省略该 key。
+// 返回 (allow, ok)：ok=false 表示存储故障、判定不可得，调用方应把该 key 列进 unavailable。
 func (a *flagsAPI) resolve(ctx context.Context, f ClientFlag, dims fg.Dims) (bool, bool) {
 	allow, ok := a.svc.AllowDisplay(ctx, f.FeatureKey, dims)
 	if !ok {

--- a/modules/featuregate/api_flags_test.go
+++ b/modules/featuregate/api_flags_test.go
@@ -1,0 +1,244 @@
+package featuregate
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	libwkhttp "github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	fg "github.com/Mininglamp-OSS/octo-server/pkg/featuregate"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/go-redis/redis"
+	"github.com/stretchr/testify/require"
+)
+
+// stubEvaluator 让「存储故障 → 省略」这条路径可被确定性地断言，而不必真去弄坏
+// DB/Redis（那会污染同包其它用例，或引入时序依赖）。
+type stubEvaluator struct {
+	// allow[key] 是确定性结论；unavailable[key] 为 true 时模拟存储故障。
+	allow       map[string]bool
+	unavailable map[string]bool
+}
+
+func (s stubEvaluator) AllowDisplay(_ context.Context, key string, _ fg.Dims) (bool, bool) {
+	if s.unavailable[key] {
+		return false, false
+	}
+	return s.allow[key], true
+}
+
+// newIntegrationCtx 是本包所有 DB/Redis 集成测试的**唯一**入口。
+//
+// 除了建库跑迁移，它还清掉两类**跨运行存活**的 Redis 状态。CleanAllTables 只清
+// MySQL，Redis 一概不动，于是「drop 测试库重跑」这个本地标准动作会留下：
+//
+//   - ft:rule:* / ft:scope:*  ——  featuregate 自己的规则读缓存（TTL 60s）。
+//     上一轮跑完留下的缓存会让新一轮把「规则不存在」读成上一轮写过的规则，
+//     症状是随机失败、且两次运行间隔超过 60s 就自动消失（最难查的那种）。
+//   - ratelimit:uid:*         ——  共享令牌桶，先跑的用例会消耗后跑用例的配额。
+//
+// 收敛到一个 fixture 是为了消灭「这个用例有没有记得重置」这一整类问题：新增用例
+// 只要用它，就不可能漏。
+func newIntegrationCtx(t *testing.T) *config.Context {
+	t.Helper()
+	_, ctx := testutil.NewTestServer()
+	flushRedisPrefixes(t, ctx, "ft:rule:*", "ft:scope:*", "ratelimit:uid:*")
+	return ctx
+}
+
+// flushRedisPrefixes 按模式删除 key。测试 Redis 是专用容器，与仓库既有做法一致
+// （见 modules/category 的 resetUIDRateLimit）。
+func flushRedisPrefixes(t *testing.T, ctx *config.Context, patterns ...string) {
+	t.Helper()
+	rds := redis.NewClient(&redis.Options{
+		Addr:     ctx.GetConfig().DB.RedisAddr,
+		Password: ctx.GetConfig().DB.RedisPass,
+	})
+	defer rds.Close()
+	for _, p := range patterns {
+		keys, err := rds.Keys(p).Result()
+		if err == nil && len(keys) > 0 {
+			_ = rds.Del(keys...).Err()
+		}
+	}
+}
+
+// mountFlags 在一条干净的路由上挂载指定注册表 + 指定判定器的 flags 端点。
+//
+// 不复用 testutil.NewTestServer 自动挂载的那份路由，是因为它绑的是生产注册表
+// （当前为空）。同时显式装上 i18n ErrorRenderer —— NewTestServer 不装，缺了它
+// 错误响应里拿不到 error.code。
+func mountFlags(t *testing.T, ctx *config.Context, flags []ClientFlag, eval displayEvaluator) *libwkhttp.WKHttp {
+	t.Helper()
+	r := libwkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	registry := mustNewClientRegistry(flags)
+	api := newFlagsAPI(ctx, eval, registry)
+	g := r.Group("/v1/featuregate", ctx.AuthMiddleware(r))
+	g.GET("/flags", api.get)
+	return r
+}
+
+func getFlags(t *testing.T, r *libwkhttp.WKHttp) (*httptest.ResponseRecorder, map[string]bool) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/v1/featuregate/flags", nil)
+	req.Header.Set("token", testutil.Token)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		return w, nil
+	}
+	var body struct {
+		Flags map[string]bool `json:"flags"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body), "body: %s", w.Body.String())
+	return w, body.Flags
+}
+
+// TestFlagsEndpointWireContract 覆盖响应的三条 wire 约定：用 client_key 作字段名、
+// 值为 false 的 key 必须出现、存储故障的 key 必须缺席。
+func TestFlagsEndpointWireContract(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+
+	flags := []ClientFlag{
+		{FeatureKey: "alpha_rollout", ClientKey: "alpha"},
+		{FeatureKey: "beta_rollout", ClientKey: "beta"},
+		{FeatureKey: "gamma_rollout", ClientKey: "gamma"},
+	}
+	eval := stubEvaluator{
+		allow:       map[string]bool{"alpha_rollout": true, "beta_rollout": false},
+		unavailable: map[string]bool{"gamma_rollout": true},
+	}
+
+	w, got := getFlags(t, mountFlags(t, ctx, flags, eval))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	// 用 client_key 作字段名，feature_key 不得出现在 wire 上——两者解耦正是为了
+	// 让运维改 feature_key 不破坏客户端。
+	require.Contains(t, got, "alpha")
+	require.NotContains(t, got, "alpha_rollout", "响应必须用 client_key，不能透出 feature_key")
+
+	require.True(t, got["alpha"])
+
+	// 值为 false 的 key **必须**出现（不得被 omitempty 吞掉），否则它会与
+	// 「存储故障省略」混为一谈，客户端保留旧值，灰度关不掉。
+	v, ok := got["beta"]
+	require.True(t, ok, "确定性的 false 必须出现在响应里，实际 body: %s", w.Body.String())
+	require.False(t, v)
+
+	// 存储故障的 key **必须**缺席，让客户端保留上次值。
+	_, ok = got["gamma"]
+	require.False(t, ok, "存储故障的 key 应从响应中省略，而不是下发 false；body: %s", w.Body.String())
+
+	// 结果因人而异但 URL 对所有用户相同：必须禁掉共享缓存。
+	require.Equal(t, "private, no-store", w.Header().Get("Cache-Control"))
+	// Vary 必须点名本仓实际使用的鉴权头（octo-lib AuthMiddleware 读 `token`）。
+	// 写成 Authorization 会指向一个所有请求都为空的头 —— 没有区分度，反而像是在
+	// 宣告这些响应可以互换。
+	require.Equal(t, "token", w.Header().Get("Vary"))
+}
+
+// TestFlagsEndpointIgnoresClientSuppliedKeys 钉住「请求不接受任何 key 参数」。
+// 端点恒返回注册表全集，客户端因此无法用构造的 key 去探测内部 gate 是否存在。
+func TestFlagsEndpointIgnoresClientSuppliedKeys(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+
+	r := mountFlags(t, ctx,
+		[]ClientFlag{{FeatureKey: "alpha_rollout", ClientKey: "alpha"}},
+		stubEvaluator{allow: map[string]bool{"alpha_rollout": true}})
+
+	w := httptest.NewRecorder()
+	// 试图指定一个未注册的内部 key，并试图只要某一个 key。
+	req, _ := http.NewRequest(http.MethodGet,
+		"/v1/featuregate/flags?keys=internal_secret_gate&key=alpha", nil)
+	req.Header.Set("token", testutil.Token)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var body struct {
+		Flags map[string]bool `json:"flags"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Len(t, body.Flags, 1, "响应必须恒为注册表全集，不受 query 参数影响")
+	require.Contains(t, body.Flags, "alpha")
+	require.NotContains(t, w.Body.String(), "internal_secret_gate",
+		"未注册 key 不得以任何形式回显，否则就是一个枚举探针")
+}
+
+// TestFlagsEndpointRequiresAuth 确认端点在 AuthMiddleware 之后，未登录拿不到。
+func TestFlagsEndpointRequiresAuth(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+
+	r := mountFlags(t, ctx,
+		[]ClientFlag{{FeatureKey: "alpha_rollout", ClientKey: "alpha"}},
+		stubEvaluator{allow: map[string]bool{"alpha_rollout": true}})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/v1/featuregate/flags", nil) // 不带 token
+	r.ServeHTTP(w, req)
+
+	require.NotEqual(t, http.StatusOK, w.Code, "未登录必须拿不到灰度位；body: %s", w.Body.String())
+}
+
+// TestFlagsEndpointEmptyRegistry 覆盖生产当前状态（注册表为空）：请求成功，
+// flags 是一个空对象而不是 null。null 会让弱类型客户端在解引用时炸掉。
+func TestFlagsEndpointEmptyRegistry(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+
+	r := mountFlags(t, ctx, []ClientFlag{}, stubEvaluator{})
+	w, got := getFlags(t, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, got, "空注册表必须序列化为 {}，不能是 null；body: %s", w.Body.String())
+	require.Empty(t, got)
+}
+
+// TestFlagsEndpointZeroRulesDeployment 是全新部署场景的端到端版本：走**真实**
+// Service，feature_gate 表里一条规则都没有时，每个已注册 key 都下发 false
+// （确定性的关，非省略），请求本身 200。
+//
+// 用一条测试钉住，避免日后有人把「新部署什么都看不到」当成 bug 改成 fail-open。
+func TestFlagsEndpointZeroRulesDeployment(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+
+	flags := []ClientFlag{
+		{FeatureKey: "fgtest_zero_a", ClientKey: "zero_a"},
+		{FeatureKey: "fgtest_zero_b", ClientKey: "zero_b"},
+	}
+	r := mountFlags(t, ctx, flags, NewService(ctx))
+	w, got := getFlags(t, r)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Len(t, got, 2, "无规则时仍应下发全部已注册 key（值为 false），而不是省略")
+	require.False(t, got["zero_a"])
+	require.False(t, got["zero_b"])
+}
+
+// TestFlagsEndpointUserWhitelistEndToEnd 走真实 Service：用户在 user 白名单内得
+// true，不在的得 false。
+func TestFlagsEndpointUserWhitelistEndToEnd(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+
+	const featureKey = "fgtest_e2e_whitelist"
+	svc := NewService(ctx)
+	db := newDB(ctx)
+	seedRule(t, svc, db, featureKey, string(fg.ModeWhitelist), 0, fg.ScopeTypeUser)
+	seedScope(t, svc, db, featureKey, fg.ScopeTypeUser, testutil.UID)
+
+	r := mountFlags(t, ctx, []ClientFlag{{FeatureKey: featureKey, ClientKey: "e2e"}}, svc)
+	w, got := getFlags(t, r)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.True(t, got["e2e"], "登录用户在 user 白名单内应当为 true")
+
+	// 把白名单换成别人，同一个登录用户应当变 false。
+	_, err := db.deleteScope(featureKey, fg.ScopeTypeUser, testutil.UID)
+	require.NoError(t, err)
+	seedScope(t, svc, db, featureKey, fg.ScopeTypeUser, "someone_else")
+
+	_, got = getFlags(t, r)
+	require.False(t, got["e2e"], "不在白名单的用户应当为 false")
+}

--- a/modules/featuregate/api_flags_test.go
+++ b/modules/featuregate/api_flags_test.go
@@ -255,3 +255,30 @@ func TestFlagsEndpointUserWhitelistEndToEnd(t *testing.T) {
 	_, body = getFlags(t, r)
 	require.False(t, body.Flags["e2e"], "不在白名单的用户应当为 false")
 }
+
+// TestFlagsEndpointEmptyUIDReportsUnavailable 钉住空 uid 走 unavailable 而非全 false。
+//
+// AuthMiddleware 之后 uid 必然非空，所以这是不可达路径——但它一旦发生，返回「每个
+// key 都确定性地 false」恰恰是本模块最想避免的那个形状：客户端会用它覆盖本地缓存，
+// 功能对所有人消失。没有 uid 时答案本就**不可知**，而不可知正是 unavailable 的语义。
+// 让不变量由代码保证，而不是靠注释声称"不会发生"。
+func TestFlagsEndpointEmptyUIDReportsUnavailable(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+
+	flags := []ClientFlag{
+		{FeatureKey: "alpha_rollout", ClientKey: "alpha"},
+		{FeatureKey: "beta_rollout", ClientKey: "beta"},
+	}
+	// 绕过 AuthMiddleware 直接挂 handler，模拟鉴权链被改坏的情形。
+	r := libwkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	api := newFlagsAPI(ctx, stubEvaluator{allow: map[string]bool{"alpha_rollout": true}},
+		mustNewClientRegistry(flags))
+	r.GET("/v1/featuregate/flags", api.get)
+
+	w, body := getFlags(t, r)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Empty(t, body.Flags, "没有 uid 时不得给出任何确定性判定；body: %s", w.Body.String())
+	require.ElementsMatch(t, []string{"alpha", "beta"}, body.Unavailable,
+		"答案不可知时每个 key 都应进 unavailable，客户端才会保留旧值")
+}

--- a/modules/featuregate/api_flags_test.go
+++ b/modules/featuregate/api_flags_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// stubEvaluator 让「存储故障 → 省略」这条路径可被确定性地断言，而不必真去弄坏
+// stubEvaluator 让「存储故障 → 进 unavailable」这条路径可被确定性地断言，而不必真去弄坏
 // DB/Redis（那会污染同包其它用例，或引入时序依赖）。
 type stubEvaluator struct {
 	// allow[key] 是确定性结论；unavailable[key] 为 true 时模拟存储故障。
@@ -36,7 +36,7 @@ func (s stubEvaluator) AllowDisplay(_ context.Context, key string, _ fg.Dims) (b
 // 除了建库跑迁移，它还清掉两类**跨运行存活**的 Redis 状态。CleanAllTables 只清
 // MySQL，Redis 一概不动，于是「drop 测试库重跑」这个本地标准动作会留下：
 //
-//   - ft:rule:* / ft:scope:*  ——  featuregate 自己的规则读缓存（TTL 60s）。
+//   - featuregate:*           ——  本模块的规则读缓存（TTL 60s，键含 schema 版本）。
 //     上一轮跑完留下的缓存会让新一轮把「规则不存在」读成上一轮写过的规则，
 //     症状是随机失败、且两次运行间隔超过 60s 就自动消失（最难查的那种）。
 //   - ratelimit:uid:*         ——  共享令牌桶，先跑的用例会消耗后跑用例的配额。
@@ -46,7 +46,10 @@ func (s stubEvaluator) AllowDisplay(_ context.Context, key string, _ fg.Dims) (b
 func newIntegrationCtx(t *testing.T) *config.Context {
 	t.Helper()
 	_, ctx := testutil.NewTestServer()
-	flushRedisPrefixes(t, ctx, "ft:rule:*", "ft:scope:*", "ratelimit:uid:*")
+	flushRedisPrefixes(t, ctx, "featuregate:*", "ratelimit:uid:*")
+	// 跑完把表清掉，与仓库约定的 `defer testutil.CleanAllTables(ctx)` 同效，
+	// 但集中在 fixture 里，新增用例不会漏。
+	t.Cleanup(func() { _ = testutil.CleanAllTables(ctx) })
 	return ctx
 }
 
@@ -83,24 +86,27 @@ func mountFlags(t *testing.T, ctx *config.Context, flags []ClientFlag, eval disp
 	return r
 }
 
-func getFlags(t *testing.T, r *libwkhttp.WKHttp) (*httptest.ResponseRecorder, map[string]bool) {
+type flagsBody struct {
+	Flags       map[string]bool `json:"flags"`
+	Unavailable []string        `json:"unavailable"`
+}
+
+func getFlags(t *testing.T, r *libwkhttp.WKHttp) (*httptest.ResponseRecorder, flagsBody) {
 	t.Helper()
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodGet, "/v1/featuregate/flags", nil)
 	req.Header.Set("token", testutil.Token)
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
-		return w, nil
+		return w, flagsBody{}
 	}
-	var body struct {
-		Flags map[string]bool `json:"flags"`
-	}
+	var body flagsBody
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body), "body: %s", w.Body.String())
-	return w, body.Flags
+	return w, body
 }
 
 // TestFlagsEndpointWireContract 覆盖响应的三条 wire 约定：用 client_key 作字段名、
-// 值为 false 的 key 必须出现、存储故障的 key 必须缺席。
+// 值为 false 的 key 必须出现在 flags 里、判定不可得的 key 必须显式出现在 unavailable。
 func TestFlagsEndpointWireContract(t *testing.T) {
 	ctx := newIntegrationCtx(t)
 
@@ -114,25 +120,29 @@ func TestFlagsEndpointWireContract(t *testing.T) {
 		unavailable: map[string]bool{"gamma_rollout": true},
 	}
 
-	w, got := getFlags(t, mountFlags(t, ctx, flags, eval))
+	w, body := getFlags(t, mountFlags(t, ctx, flags, eval))
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 
 	// 用 client_key 作字段名，feature_key 不得出现在 wire 上——两者解耦正是为了
 	// 让运维改 feature_key 不破坏客户端。
-	require.Contains(t, got, "alpha")
-	require.NotContains(t, got, "alpha_rollout", "响应必须用 client_key，不能透出 feature_key")
+	require.Contains(t, body.Flags, "alpha")
+	require.NotContains(t, w.Body.String(), "alpha_rollout", "响应必须用 client_key，不能透出 feature_key")
 
-	require.True(t, got["alpha"])
+	require.True(t, body.Flags["alpha"])
 
-	// 值为 false 的 key **必须**出现（不得被 omitempty 吞掉），否则它会与
-	// 「存储故障省略」混为一谈，客户端保留旧值，灰度关不掉。
-	v, ok := got["beta"]
-	require.True(t, ok, "确定性的 false 必须出现在响应里，实际 body: %s", w.Body.String())
+	// 值为 false 的 key **必须**出现在 flags 里（不得被 omitempty 吞掉）。
+	v, ok := body.Flags["beta"]
+	require.True(t, ok, "确定性的 false 必须出现在 flags 里，实际 body: %s", w.Body.String())
 	require.False(t, v)
 
-	// 存储故障的 key **必须**缺席，让客户端保留上次值。
-	_, ok = got["gamma"]
-	require.False(t, ok, "存储故障的 key 应从响应中省略，而不是下发 false；body: %s", w.Body.String())
+	// 判定不可得的 key：不进 flags，而是**显式**列进 unavailable。
+	//
+	// 早先用"从 flags 里缺席"来表达这层含义，语义等价但任何 schema 语言都描述不了
+	// 「缺席携带含义」，codegen 客户端会把缺席读成 false —— 正是这套设计要防的失败。
+	_, ok = body.Flags["gamma"]
+	require.False(t, ok, "判定不可得的 key 不应出现在 flags 里；body: %s", w.Body.String())
+	require.Equal(t, []string{"gamma"}, body.Unavailable,
+		"判定不可得的 key 必须显式列出；body: %s", w.Body.String())
 
 	// 结果因人而异但 URL 对所有用户相同：必须禁掉共享缓存。
 	require.Equal(t, "private, no-store", w.Header().Get("Cache-Control"))
@@ -190,11 +200,13 @@ func TestFlagsEndpointEmptyRegistry(t *testing.T) {
 	ctx := newIntegrationCtx(t)
 
 	r := mountFlags(t, ctx, []ClientFlag{}, stubEvaluator{})
-	w, got := getFlags(t, r)
+	w, body := getFlags(t, r)
 
 	require.Equal(t, http.StatusOK, w.Code)
-	require.NotNil(t, got, "空注册表必须序列化为 {}，不能是 null；body: %s", w.Body.String())
-	require.Empty(t, got)
+	require.NotNil(t, body.Flags, "空注册表必须序列化为 {}，不能是 null；body: %s", w.Body.String())
+	require.Empty(t, body.Flags)
+	require.NotNil(t, body.Unavailable, "unavailable 空时必须是 []，不能是 null；body: %s", w.Body.String())
+	require.Empty(t, body.Unavailable)
 }
 
 // TestFlagsEndpointZeroRulesDeployment 是全新部署场景的端到端版本：走**真实**
@@ -210,12 +222,13 @@ func TestFlagsEndpointZeroRulesDeployment(t *testing.T) {
 		{FeatureKey: "fgtest_zero_b", ClientKey: "zero_b"},
 	}
 	r := mountFlags(t, ctx, flags, NewService(ctx))
-	w, got := getFlags(t, r)
+	w, body := getFlags(t, r)
 
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
-	require.Len(t, got, 2, "无规则时仍应下发全部已注册 key（值为 false），而不是省略")
-	require.False(t, got["zero_a"])
-	require.False(t, got["zero_b"])
+	require.Len(t, body.Flags, 2, "无规则时仍应下发全部已注册 key（值为 false）")
+	require.False(t, body.Flags["zero_a"])
+	require.False(t, body.Flags["zero_b"])
+	require.Empty(t, body.Unavailable, "规则不存在是确定性的关，不是判定不可得")
 }
 
 // TestFlagsEndpointUserWhitelistEndToEnd 走真实 Service：用户在 user 白名单内得
@@ -230,15 +243,15 @@ func TestFlagsEndpointUserWhitelistEndToEnd(t *testing.T) {
 	seedScope(t, svc, db, featureKey, fg.ScopeTypeUser, testutil.UID)
 
 	r := mountFlags(t, ctx, []ClientFlag{{FeatureKey: featureKey, ClientKey: "e2e"}}, svc)
-	w, got := getFlags(t, r)
+	w, body := getFlags(t, r)
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
-	require.True(t, got["e2e"], "登录用户在 user 白名单内应当为 true")
+	require.True(t, body.Flags["e2e"], "登录用户在 user 白名单内应当为 true")
 
 	// 把白名单换成别人，同一个登录用户应当变 false。
 	_, err := db.deleteScope(featureKey, fg.ScopeTypeUser, testutil.UID)
 	require.NoError(t, err)
 	seedScope(t, svc, db, featureKey, fg.ScopeTypeUser, "someone_else")
 
-	_, got = getFlags(t, r)
-	require.False(t, got["e2e"], "不在白名单的用户应当为 false")
+	_, body = getFlags(t, r)
+	require.False(t, body.Flags["e2e"], "不在白名单的用户应当为 false")
 }

--- a/modules/featuregate/api_i18n.go
+++ b/modules/featuregate/api_i18n.go
@@ -1,0 +1,45 @@
+package featuregate
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+// 本模块的 i18n 错误 responder。全部端点都是新增的、无 legacy client，因此统一走
+// ResponseErrorLWithStatus 保留真实语义状态（400/403/404/500），而不是 D14 兼容期
+// 的固定 400。
+
+// gateRequestInvalid 返回 400；reason ∈ {key,body,mode,percent,bucket_by,
+// description,scope_type,scope_id,client_visible_dimension} 经安全 Details 透出。
+func gateRequestInvalid(c *wkhttp.Context, reason string) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrFeatureGateRequestInvalid, nil, i18n.Details{"reason": reason})
+}
+
+// gateForbidden 返回 403 —— superadmin 校验未通过。
+//
+// 刻意复用共享码 err.shared.auth.forbidden 而不是新增
+// err.server.featuregate.forbidden：鉴权失败统一收敛到一个通用码是本仓的反枚举
+// 约定，per-reason 的专用码会把「你差在哪个角色」透给调用方。具体原因只进日志。
+//
+// 本框架初版在四个 handler 里写的是 c.ResponseError(c.CheckLoginRoleIsSuperAdmin())
+// —— 那是绕开 i18n 信封的 legacy 裸响应（也正因当时没有守卫测试才没被拦下）。
+func gateForbidden(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedForbidden, nil, nil)
+}
+
+// gateNotFound 返回 404 —— 要删除的白名单条目不存在。
+func gateNotFound(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrFeatureGateNotFound, nil, nil)
+}
+
+// gateQueryFailed 返回 500（Internal）—— 读失败，真实错误仅日志。
+func gateQueryFailed(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrFeatureGateQueryFailed, nil, nil)
+}
+
+// gateOperationFailed 返回 500（Internal）—— 写失败，真实错误仅日志。
+func gateOperationFailed(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrFeatureGateOperationFailed, nil, nil)
+}

--- a/modules/featuregate/api_i18n.go
+++ b/modules/featuregate/api_i18n.go
@@ -11,8 +11,9 @@ import (
 // ResponseErrorLWithStatus 保留真实语义状态（400/403/404/500），而不是 D14 兼容期
 // 的固定 400。
 
-// gateRequestInvalid 返回 400；reason ∈ {key,body,mode,percent,bucket_by,
-// description,scope_type,scope_id,client_visible_dimension} 经安全 Details 透出。
+// gateRequestInvalid 返回 400；reason ∈ {key,body,mode,percent,bucket_by,description,
+// scope_type,scope_id,scope_quota,client_visible_dimension,client_visible_scopes}
+// 经安全 Details 透出。这份清单要与 api_manager.go 的各处校验保持穷尽一致。
 func gateRequestInvalid(c *wkhttp.Context, reason string) {
 	httperr.ResponseErrorLWithStatus(c, errcode.ErrFeatureGateRequestInvalid, nil, i18n.Details{"reason": reason})
 }

--- a/modules/featuregate/api_i18n_test.go
+++ b/modules/featuregate/api_i18n_test.go
@@ -18,7 +18,8 @@ import (
 // m.Error(...) / m.Warn(...) zap LOG calls are not responses and stay allowed.
 func TestFeatureGateAPINoLegacyResponseError(t *testing.T) {
 	files := []string{"api_manager.go", "api_flags.go", "api_i18n.go", "manager.go"}
-	banned := []string{".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(", "AbortWithStatusJSON("}
+	banned := []string{".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(",
+		"AbortWithStatusJSON(", ".AbortWithStatus(", "c.Response(\""}
 	for _, f := range files {
 		t.Run(f, func(t *testing.T) {
 			data, err := os.ReadFile(f)

--- a/modules/featuregate/api_i18n_test.go
+++ b/modules/featuregate/api_i18n_test.go
@@ -1,0 +1,70 @@
+package featuregate
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestFeatureGateAPINoLegacyResponseError pins that every handler in this module
+// goes through the localized error envelope (httperr.ResponseErrorL* via the
+// gate* helpers in api_i18n.go) instead of octo-lib's raw error responses.
+//
+// This guard did not exist when the framework was first written, which is
+// precisely why its four manager handlers shipped with
+// `c.ResponseError(c.CheckLoginRoleIsSuperAdmin())` — a raw, unlocalized
+// rejection. Comments are stripped first so commented-out breadcrumbs (and the
+// explanatory note in api_i18n.go about the legacy shape) do not trip the guard;
+// m.Error(...) / m.Warn(...) zap LOG calls are not responses and stay allowed.
+func TestFeatureGateAPINoLegacyResponseError(t *testing.T) {
+	files := []string{"api_manager.go", "api_flags.go", "api_i18n.go", "manager.go"}
+	banned := []string{".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(", "AbortWithStatusJSON("}
+	for _, f := range files {
+		t.Run(f, func(t *testing.T) {
+			data, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", f, err)
+			}
+			var clean strings.Builder
+			for _, line := range strings.Split(string(data), "\n") {
+				if idx := strings.Index(line, "//"); idx >= 0 {
+					line = line[:idx]
+				}
+				clean.WriteString(line)
+				clean.WriteByte('\n')
+			}
+			cleaned := clean.String()
+			for _, b := range banned {
+				if strings.Contains(cleaned, b) {
+					t.Fatalf("modules/featuregate/%s must use the gate* helpers in api_i18n.go "+
+						"(httperr.ResponseErrorLWithStatus + a registered errcode) instead of legacy %s", f, b)
+				}
+			}
+		})
+	}
+}
+
+// TestHandlerFilesAreGuarded fails when a new api*.go lands without being added
+// to the guard list above. Without it the guard silently stops covering new
+// handlers — the failure mode is invisible, which is the worst kind.
+func TestHandlerFilesAreGuarded(t *testing.T) {
+	guarded := map[string]struct{}{
+		"api_manager.go": {}, "api_flags.go": {}, "api_i18n.go": {}, "manager.go": {},
+	}
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read module dir: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasPrefix(name, "api") || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		if _, ok := guarded[name]; !ok {
+			t.Fatalf("%s is a handler file but is missing from TestFeatureGateAPINoLegacyResponseError's file list", name)
+		}
+	}
+}

--- a/modules/featuregate/api_manager.go
+++ b/modules/featuregate/api_manager.go
@@ -1,7 +1,9 @@
 package featuregate
 
 import (
+	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	fg "github.com/Mininglamp-OSS/octo-server/pkg/featuregate"
@@ -11,9 +13,26 @@ import (
 const (
 	// feature_key 的长度与字符集校验统一走 validFeatureKey（registry.go），
 	// 与注册表共用同一口径，避免两处漂移。
-	maxScopeIDLen     = 64
+	maxScopeIDLen = 64
+	// maxDescriptionLen 按**字符**计，对齐 VARCHAR(255) 在 utf8mb4 下的语义。
+	// 早先按字节校验虽然不会溢出列，却把中文描述砍到约 85 字并拒掉合法输入。
 	maxDescriptionLen = 255
+	// maxScopesPerKey 是单个 key 的白名单条数上限。
+	//
+	// 评估路径会把某 key 的全部条目一次读出并整体缓存进 Redis，所以无上限的名单
+	// 同时放大查询量与缓存值大小。上限设在写侧而不是给查询加 LIMIT：后者会静默
+	// 丢条目，等于把「慢但正确」换成「快但答案错」。真需要给大批人开灰度时，用
+	// percent 而不是万人白名单。
+	maxScopesPerKey = 1000
 )
+
+// scopeIDRe 约束白名单条目的 ID 字面量。
+//
+// 关键是**禁掉空白与 `/`**：delScope 把 scope_id 当作单个 URL 路径段取（gin 匹配
+// 的是已解码路径，`%2F` 也绕不过），所以一个含 `/` 的条目插得进去却永远删不掉。
+// 与其在删除侧改协议，不如在写入侧就不让这种条目存在。字符集覆盖了实际会出现的
+// uid / group_no / space_id 形态。
+var scopeIDRe = regexp.MustCompile(`^[A-Za-z0-9_.:@-]+$`)
 
 // list 列出所有规则及其白名单条目。
 func (m *Manager) list(c *wkhttp.Context) {
@@ -63,7 +82,26 @@ func (m *Manager) update(c *wkhttp.Context) {
 		gateRequestInvalid(c, reason)
 		return
 	}
-	if err := m.db.upsertRule(key, plan.mode, plan.percent, plan.bucketBy, plan.description); err != nil {
+	m.commitUpdate(c, key, plan)
+}
+
+// commitUpdate 做落库前的最后一道校验（存量白名单）并写入。
+//
+// 存量白名单也要校验，不只是本次请求的字段：注册表是编译期清单、gate 是 DB 行，
+// 所以「先有内部 gate 和 group 白名单，之后某次发版把它变成 client-visible」是
+// **正常生命周期**而非异常路径。那之后这条 update 若放行，白名单里就全是永远命不中
+// 的条目——而运维看到的是名单有行、mode 对、写入 200、日志无声。addScope 侧的检查
+// 只覆盖「已是 client-visible 之后新加的条目」，盖不住这个顺序。
+func (m *Manager) commitUpdate(c *wkhttp.Context, key string, plan updatePlan) {
+	if ok, reason := m.clientVisibleScopesUsable(key); !ok {
+		if reason != "" {
+			gateRequestInvalid(c, reason)
+			return
+		}
+		gateQueryFailed(c)
+		return
+	}
+	if err := m.db.upsertRule(key, plan.mode, plan.percent, plan.bucketBy, plan.description, c.GetLoginUID()); err != nil {
 		m.Error("upsert feature gate failed", zap.String("key", key), zap.Error(err))
 		gateOperationFailed(c)
 		return
@@ -108,7 +146,7 @@ func (m *Manager) planUpdate(key string, req updateGateReq) (updatePlan, string)
 			zap.String("key", key), zap.String("bucket_by", bucketBy))
 		return updatePlan{}, "client_visible_dimension"
 	}
-	if len(req.Description) > maxDescriptionLen {
+	if utf8.RuneCountInString(req.Description) > maxDescriptionLen {
 		return updatePlan{}, "description"
 	}
 	return updatePlan{mode: mode, percent: req.Percent, bucketBy: bucketBy, description: req.Description}, ""
@@ -131,28 +169,24 @@ func (m *Manager) addScope(c *wkhttp.Context) {
 		gateRequestInvalid(c, "body")
 		return
 	}
-	scopeType := strings.TrimSpace(req.ScopeType)
-	if scopeType == "" {
-		scopeType = fg.DefaultBucketBy // 缺省 group，与初版一致
-	}
-	if !fg.ValidDimension(scopeType) {
-		gateRequestInvalid(c, "scope_type")
+	scopeType, scopeID, reason := m.planScope(key, req)
+	if reason != "" {
+		gateRequestInvalid(c, reason)
 		return
 	}
-	// 同 update：客户端可见的 key 只认 user 维度的白名单条目。允许写入一条永远
-	// 不可能命中的 group 条目，等于让运维以为自己开了灰度而实际没有。
-	if m.registry.isClientVisible(key) && !validateClientVisibleDimension(scopeType) {
-		m.Warn("rejected client-visible gate scope with an unusable dimension",
-			zap.String("key", key), zap.String("scope_type", scopeType))
-		gateRequestInvalid(c, "client_visible_dimension")
+	n, err := m.db.countScopes(key)
+	if err != nil {
+		m.Error("count feature gate scopes failed", zap.String("key", key), zap.Error(err))
+		gateQueryFailed(c)
 		return
 	}
-	scopeID := strings.TrimSpace(req.ScopeID)
-	if scopeID == "" || len(scopeID) > maxScopeIDLen {
-		gateRequestInvalid(c, "scope_id")
+	if n >= maxScopesPerKey {
+		m.Warn("feature gate whitelist quota exceeded",
+			zap.String("key", key), zap.Int("count", n), zap.Int("max", maxScopesPerKey))
+		gateRequestInvalid(c, "scope_quota")
 		return
 	}
-	if err := m.db.addScope(key, scopeType, scopeID); err != nil {
+	if err := m.db.addScope(key, scopeType, scopeID, c.GetLoginUID()); err != nil {
 		m.Error("add feature gate scope failed",
 			zap.String("key", key), zap.String("scope_id", scopeID), zap.Error(err))
 		gateOperationFailed(c)
@@ -160,6 +194,31 @@ func (m *Manager) addScope(c *wkhttp.Context) {
 	}
 	m.svc.Invalidate(key)
 	c.ResponseOK()
+}
+
+// planScope 校验并规范化一条白名单条目的写入请求。reason 非空表示校验失败。
+//
+// 与 planUpdate 同样保持纯逻辑（只依赖注册表），便于单测直接覆盖。
+func (m *Manager) planScope(key string, req scopeReq) (scopeType, scopeID, reason string) {
+	scopeType = strings.TrimSpace(req.ScopeType)
+	if scopeType == "" {
+		scopeType = fg.DefaultBucketBy // 缺省 group，与初版一致
+	}
+	if !fg.ValidDimension(scopeType) {
+		return "", "", "scope_type"
+	}
+	// 同 update：客户端可见的 key 只认 user 维度的白名单条目。允许写入一条永远
+	// 不可能命中的 group 条目，等于让运维以为自己开了灰度而实际没有。
+	if m.registry.isClientVisible(key) && !validateClientVisibleDimension(scopeType) {
+		m.Warn("rejected client-visible gate scope with an unusable dimension",
+			zap.String("key", key), zap.String("scope_type", scopeType))
+		return "", "", "client_visible_dimension"
+	}
+	scopeID = strings.TrimSpace(req.ScopeID)
+	if scopeID == "" || len(scopeID) > maxScopeIDLen || !scopeIDRe.MatchString(scopeID) {
+		return "", "", "scope_id"
+	}
+	return scopeType, scopeID, ""
 }
 
 // delScope 删除一条白名单条目；条目不存在返回 404。scope_type 走 query，缺省 group。
@@ -200,4 +259,33 @@ func (m *Manager) delScope(c *wkhttp.Context) {
 	}
 	m.svc.Invalidate(key)
 	c.ResponseOK()
+}
+
+// clientVisibleScopesUsable 校验某 client-visible key 的**存量**白名单里至少有一条
+// 维度可用的条目。
+//
+// 返回 (true, "") 表示通过；(false, reason) 表示校验失败；(false, "") 表示查询出错，
+// 调用方回 500。空名单视为通过——那是合法状态（mode=whitelist 且暂时谁都不放），
+// 不是错配。
+func (m *Manager) clientVisibleScopesUsable(key string) (bool, string) {
+	if !m.registry.isClientVisible(key) {
+		return true, ""
+	}
+	scopes, err := m.db.queryScopes(key)
+	if err != nil {
+		m.Error("query feature gate scopes for client-visible check failed",
+			zap.String("key", key), zap.Error(err))
+		return false, ""
+	}
+	if len(scopes) == 0 {
+		return true, ""
+	}
+	for _, s := range scopes {
+		if validateClientVisibleDimension(s.ScopeType) {
+			return true, ""
+		}
+	}
+	m.Warn("client-visible gate has a whitelist that can never match at the flags endpoint",
+		zap.String("key", key), zap.Int("scopes", len(scopes)))
+	return false, "client_visible_scopes"
 }

--- a/modules/featuregate/api_manager.go
+++ b/modules/featuregate/api_manager.go
@@ -179,12 +179,7 @@ func (m *Manager) addScope(c *wkhttp.Context) {
 		gateRequestInvalid(c, reason)
 		return
 	}
-	if ok, reason := m.scopeQuotaAllows(key, scopeType, scopeID); !ok {
-		if reason != "" {
-			gateRequestInvalid(c, reason)
-			return
-		}
-		gateQueryFailed(c)
+	if !m.scopeWritable(c, key, scopeType, scopeID) {
 		return
 	}
 	if err := m.db.addScope(key, scopeType, scopeID, c.GetLoginUID()); err != nil {
@@ -220,6 +215,34 @@ func (m *Manager) planScope(key string, req scopeReq) (scopeType, scopeID, reaso
 		return "", "", "scope_id"
 	}
 	return scopeType, scopeID, ""
+}
+
+// scopeWritable 做 addScope 落库前的两道准入：规则存在 + 未超配额。
+// 返回 false 时已写好响应，调用方直接 return。
+//
+// 规则必须先存在：否则这条记录会落进一张 list 看不见的表——list 是按规则枚举再挂
+// scope 的，孤儿条目在任何管理界面上都不可见，却会在某天有人建了同名规则时立刻开始
+// 放人，而新建那条 whitelist gate 的 superadmin 无从得知它已经有成员了。
+func (m *Manager) scopeWritable(c *wkhttp.Context, key, scopeType, scopeID string) bool {
+	rule, err := m.db.queryRule(key)
+	if err != nil {
+		m.Error("query feature gate before adding scope failed", zap.String("key", key), zap.Error(err))
+		gateQueryFailed(c)
+		return false
+	}
+	if rule == nil {
+		gateNotFound(c)
+		return false
+	}
+	if ok, reason := m.scopeQuotaAllows(key, scopeType, scopeID); !ok {
+		if reason != "" {
+			gateRequestInvalid(c, reason)
+			return false
+		}
+		gateQueryFailed(c)
+		return false
+	}
+	return true
 }
 
 // scopeQuotaAllows 判定这次 addScope 是否被单 key 配额允许。

--- a/modules/featuregate/api_manager.go
+++ b/modules/featuregate/api_manager.go
@@ -1,0 +1,203 @@
+package featuregate
+
+import (
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	fg "github.com/Mininglamp-OSS/octo-server/pkg/featuregate"
+	"go.uber.org/zap"
+)
+
+const (
+	// feature_key 的长度与字符集校验统一走 validFeatureKey（registry.go），
+	// 与注册表共用同一口径，避免两处漂移。
+	maxScopeIDLen     = 64
+	maxDescriptionLen = 255
+)
+
+// list 列出所有规则及其白名单条目。
+func (m *Manager) list(c *wkhttp.Context) {
+	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
+		m.Warn("featuregate manager list denied", zap.String("uid", c.GetLoginUID()), zap.Error(err))
+		gateForbidden(c)
+		return
+	}
+	rules, err := m.db.listRules()
+	if err != nil {
+		m.Error("list feature gates failed", zap.Error(err))
+		gateQueryFailed(c)
+		return
+	}
+	gates := make([]gateResp, 0, len(rules))
+	for _, ru := range rules {
+		scopes, err := m.db.queryScopes(ru.FeatureKey)
+		if err != nil {
+			m.Error("list feature gate scopes failed", zap.String("key", ru.FeatureKey), zap.Error(err))
+			gateQueryFailed(c)
+			return
+		}
+		gates = append(gates, toGateResp(ru, scopes, m.registry.isClientVisible(ru.FeatureKey)))
+	}
+	c.Response(map[string]interface{}{"gates": gates})
+}
+
+// update 创建/覆盖一条规则。先全量校验，再 upsert，最后失效缓存。
+func (m *Manager) update(c *wkhttp.Context) {
+	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
+		m.Warn("featuregate manager update denied", zap.String("uid", c.GetLoginUID()), zap.Error(err))
+		gateForbidden(c)
+		return
+	}
+	key := strings.TrimSpace(c.Param("key"))
+	if !validFeatureKey(key) {
+		gateRequestInvalid(c, "key")
+		return
+	}
+	var req updateGateReq
+	if err := c.BindJSON(&req); err != nil {
+		gateRequestInvalid(c, "body")
+		return
+	}
+	plan, reason := m.planUpdate(key, req)
+	if reason != "" {
+		gateRequestInvalid(c, reason)
+		return
+	}
+	if err := m.db.upsertRule(key, plan.mode, plan.percent, plan.bucketBy, plan.description); err != nil {
+		m.Error("upsert feature gate failed", zap.String("key", key), zap.Error(err))
+		gateOperationFailed(c)
+		return
+	}
+	m.svc.Invalidate(key)
+	c.ResponseOK()
+}
+
+// updatePlan 是校验通过后要落库的规范化取值。
+type updatePlan struct {
+	mode        string
+	percent     int
+	bucketBy    string
+	description string
+}
+
+// planUpdate 校验并规范化一次 update 请求。reason 非空表示校验失败，其值即
+// 回给客户端的 details.reason。
+//
+// 抽成独立函数而非内联在 handler 里：校验链本身是纯逻辑（唯一的外部依赖是
+// 注册表），拆开后 handler 只剩编排，校验也能被单测直接覆盖而不必走 HTTP。
+func (m *Manager) planUpdate(key string, req updateGateReq) (updatePlan, string) {
+	mode := strings.TrimSpace(req.Mode)
+	if !validMode(mode) {
+		return updatePlan{}, "mode"
+	}
+	if req.Percent < 0 || req.Percent > 100 {
+		return updatePlan{}, "percent"
+	}
+	// 空 bucket_by 归一到默认维度后再校验：DB 列有 CHECK 约束，不能落空串进去。
+	bucketBy := strings.TrimSpace(req.BucketBy)
+	if bucketBy == "" {
+		bucketBy = fg.DefaultBucketBy
+	}
+	if !fg.ValidDimension(bucketBy) {
+		return updatePlan{}, "bucket_by"
+	}
+	// 客户端可见的 key 只能按 user 维度分桶 —— 展示端点没有群/空间上下文。
+	// 见 validateClientVisibleDimension 的注释：这里不拦就是一个无报错的错配。
+	if m.registry.isClientVisible(key) && !validateClientVisibleDimension(bucketBy) {
+		m.Warn("rejected client-visible gate with a dimension the flags endpoint cannot provide",
+			zap.String("key", key), zap.String("bucket_by", bucketBy))
+		return updatePlan{}, "client_visible_dimension"
+	}
+	if len(req.Description) > maxDescriptionLen {
+		return updatePlan{}, "description"
+	}
+	return updatePlan{mode: mode, percent: req.Percent, bucketBy: bucketBy, description: req.Description}, ""
+}
+
+// addScope 幂等加入一条白名单条目。
+func (m *Manager) addScope(c *wkhttp.Context) {
+	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
+		m.Warn("featuregate manager addScope denied", zap.String("uid", c.GetLoginUID()), zap.Error(err))
+		gateForbidden(c)
+		return
+	}
+	key := strings.TrimSpace(c.Param("key"))
+	if !validFeatureKey(key) {
+		gateRequestInvalid(c, "key")
+		return
+	}
+	var req scopeReq
+	if err := c.BindJSON(&req); err != nil {
+		gateRequestInvalid(c, "body")
+		return
+	}
+	scopeType := strings.TrimSpace(req.ScopeType)
+	if scopeType == "" {
+		scopeType = fg.DefaultBucketBy // 缺省 group，与初版一致
+	}
+	if !fg.ValidDimension(scopeType) {
+		gateRequestInvalid(c, "scope_type")
+		return
+	}
+	// 同 update：客户端可见的 key 只认 user 维度的白名单条目。允许写入一条永远
+	// 不可能命中的 group 条目，等于让运维以为自己开了灰度而实际没有。
+	if m.registry.isClientVisible(key) && !validateClientVisibleDimension(scopeType) {
+		m.Warn("rejected client-visible gate scope with an unusable dimension",
+			zap.String("key", key), zap.String("scope_type", scopeType))
+		gateRequestInvalid(c, "client_visible_dimension")
+		return
+	}
+	scopeID := strings.TrimSpace(req.ScopeID)
+	if scopeID == "" || len(scopeID) > maxScopeIDLen {
+		gateRequestInvalid(c, "scope_id")
+		return
+	}
+	if err := m.db.addScope(key, scopeType, scopeID); err != nil {
+		m.Error("add feature gate scope failed",
+			zap.String("key", key), zap.String("scope_id", scopeID), zap.Error(err))
+		gateOperationFailed(c)
+		return
+	}
+	m.svc.Invalidate(key)
+	c.ResponseOK()
+}
+
+// delScope 删除一条白名单条目；条目不存在返回 404。scope_type 走 query，缺省 group。
+func (m *Manager) delScope(c *wkhttp.Context) {
+	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
+		m.Warn("featuregate manager delScope denied", zap.String("uid", c.GetLoginUID()), zap.Error(err))
+		gateForbidden(c)
+		return
+	}
+	key := strings.TrimSpace(c.Param("key"))
+	scopeID := strings.TrimSpace(c.Param("scope_id"))
+	if !validFeatureKey(key) {
+		gateRequestInvalid(c, "key")
+		return
+	}
+	if scopeID == "" || len(scopeID) > maxScopeIDLen {
+		gateRequestInvalid(c, "scope_id")
+		return
+	}
+	scopeType := strings.TrimSpace(c.Query("scope_type"))
+	if scopeType == "" {
+		scopeType = fg.DefaultBucketBy
+	}
+	if !fg.ValidDimension(scopeType) {
+		gateRequestInvalid(c, "scope_type")
+		return
+	}
+	n, err := m.db.deleteScope(key, scopeType, scopeID)
+	if err != nil {
+		m.Error("delete feature gate scope failed",
+			zap.String("key", key), zap.String("scope_id", scopeID), zap.Error(err))
+		gateOperationFailed(c)
+		return
+	}
+	if n == 0 {
+		gateNotFound(c)
+		return
+	}
+	m.svc.Invalidate(key)
+	c.ResponseOK()
+}

--- a/modules/featuregate/api_manager.go
+++ b/modules/featuregate/api_manager.go
@@ -93,7 +93,7 @@ func (m *Manager) update(c *wkhttp.Context) {
 // 的条目——而运维看到的是名单有行、mode 对、写入 200、日志无声。addScope 侧的检查
 // 只覆盖「已是 client-visible 之后新加的条目」，盖不住这个顺序。
 func (m *Manager) commitUpdate(c *wkhttp.Context, key string, plan updatePlan) {
-	if ok, reason := m.clientVisibleScopesUsable(key); !ok {
+	if ok, reason := m.clientVisibleScopesUsable(plan.mode, key); !ok {
 		if reason != "" {
 			gateRequestInvalid(c, reason)
 			return
@@ -140,8 +140,13 @@ func (m *Manager) planUpdate(key string, req updateGateReq) (updatePlan, string)
 		return updatePlan{}, "bucket_by"
 	}
 	// 客户端可见的 key 只能按 user 维度分桶 —— 展示端点没有群/空间上下文。
-	// 见 validateClientVisibleDimension 的注释：这里不拦就是一个无报错的错配。
-	if m.registry.isClientVisible(key) && !validateClientVisibleDimension(bucketBy) {
+	//
+	// 只在**会读这些输入的 mode** 下施加（modeNeedsScopes）。off/on 既不读白名单也
+	// 不读 bucket_by（见 Evaluate 的对应分支），对它们校验一个目标状态压根不使用的
+	// 前置条件，只会让「关掉一个 gate」比「打开它」更难 —— 而 off 正是本框架的回滚
+	// 杠杆。放行不会留下隐患：每一次切进 whitelist/percent 都会重新校验请求里的
+	// bucket_by，坏值不可能悄悄生效。
+	if modeNeedsScopes(fg.Mode(mode)) && m.registry.isClientVisible(key) && !validateClientVisibleDimension(bucketBy) {
 		m.Warn("rejected client-visible gate with a dimension the flags endpoint cannot provide",
 			zap.String("key", key), zap.String("bucket_by", bucketBy))
 		return updatePlan{}, "client_visible_dimension"
@@ -174,16 +179,12 @@ func (m *Manager) addScope(c *wkhttp.Context) {
 		gateRequestInvalid(c, reason)
 		return
 	}
-	n, err := m.db.countScopes(key)
-	if err != nil {
-		m.Error("count feature gate scopes failed", zap.String("key", key), zap.Error(err))
+	if ok, reason := m.scopeQuotaAllows(key, scopeType, scopeID); !ok {
+		if reason != "" {
+			gateRequestInvalid(c, reason)
+			return
+		}
 		gateQueryFailed(c)
-		return
-	}
-	if n >= maxScopesPerKey {
-		m.Warn("feature gate whitelist quota exceeded",
-			zap.String("key", key), zap.Int("count", n), zap.Int("max", maxScopesPerKey))
-		gateRequestInvalid(c, "scope_quota")
 		return
 	}
 	if err := m.db.addScope(key, scopeType, scopeID, c.GetLoginUID()); err != nil {
@@ -219,6 +220,37 @@ func (m *Manager) planScope(key string, req scopeReq) (scopeType, scopeID, reaso
 		return "", "", "scope_id"
 	}
 	return scopeType, scopeID, ""
+}
+
+// scopeQuotaAllows 判定这次 addScope 是否被单 key 配额允许。
+//
+// 返回 (true, "") 放行；(false, reason) 拒绝；(false, "") 查询出错，调用方回 500。
+//
+// 先判存在再计数：满额时重加一条**已存在**的条目必须仍然幂等成功。先数后插会把它
+// 一并拒掉，而那正是运维最可能重试的时刻（网络抖动后重放）。
+//
+// 这仍是 check-then-act，并发 add 可能略微冲破上限。它是一道用于限制资源规模的
+// 整形阈值，不是硬性资源边界，且写侧是 superadmin-only，故不为此引入事务。
+func (m *Manager) scopeQuotaAllows(key, scopeType, scopeID string) (bool, string) {
+	exists, err := m.db.scopeExists(key, scopeType, scopeID)
+	if err != nil {
+		m.Error("check feature gate scope existence failed", zap.String("key", key), zap.Error(err))
+		return false, ""
+	}
+	if exists {
+		return true, ""
+	}
+	n, err := m.db.countScopes(key)
+	if err != nil {
+		m.Error("count feature gate scopes failed", zap.String("key", key), zap.Error(err))
+		return false, ""
+	}
+	if n >= maxScopesPerKey {
+		m.Warn("feature gate whitelist quota exceeded",
+			zap.String("key", key), zap.Int("count", n), zap.Int("max", maxScopesPerKey))
+		return false, "scope_quota"
+	}
+	return true, ""
 }
 
 // delScope 删除一条白名单条目；条目不存在返回 404。scope_type 走 query，缺省 group。
@@ -267,7 +299,11 @@ func (m *Manager) delScope(c *wkhttp.Context) {
 // 返回 (true, "") 表示通过；(false, reason) 表示校验失败；(false, "") 表示查询出错，
 // 调用方回 500。空名单视为通过——那是合法状态（mode=whitelist 且暂时谁都不放），
 // 不是错配。
-func (m *Manager) clientVisibleScopesUsable(key string) (bool, string) {
+func (m *Manager) clientVisibleScopesUsable(mode, key string) (bool, string) {
+	// off/on 不读白名单，校验它没有意义，还会挡住关停。见 planUpdate 里同源的注释。
+	if !modeNeedsScopes(fg.Mode(mode)) {
+		return true, ""
+	}
 	if !m.registry.isClientVisible(key) {
 		return true, ""
 	}
@@ -289,3 +325,9 @@ func (m *Manager) clientVisibleScopesUsable(key string) (bool, string) {
 		zap.String("key", key), zap.Int("scopes", len(scopes)))
 	return false, "client_visible_scopes"
 }
+
+// 关于 delScope：它**刻意不做**这项校验。删除最后一条可用条目确实能把白名单重新
+// 带回「全都用不上」的状态，但按删除后的预期状态去拦会造成顺序陷阱——运维想把
+// {user:u1, group:g1} 清空时，删哪一条都可能先被拒，于是连清理都做不了。
+// 这条路径交给读侧兜底：Evaluate 会报 whitelist_dim_unavailable，AllowDisplay 打
+// Warn，不再像 round 1 那样两侧皆哑。

--- a/modules/featuregate/api_manager_test.go
+++ b/modules/featuregate/api_manager_test.go
@@ -2,6 +2,7 @@ package featuregate
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -439,6 +440,7 @@ func TestManagerRejectsScopeIDWithPathSeparator(t *testing.T) {
 	loginAs(t, ctx, string(libwkhttp.SuperAdmin))
 	r := mountManager(t, ctx, nil)
 
+	require.NoError(t, newDB(ctx).upsertRule("fgtest_sep", string(fg.ModeWhitelist), 0, fg.ScopeTypeUser, "sep", "seed"))
 	for _, bad := range []string{"a/b", "a b", "a\tb"} {
 		w := doJSON(t, r, http.MethodPost, "/v1/manager/featuregate/gates/fgtest_sep/scopes",
 			map[string]any{"scope_type": "user", "scope_id": bad})
@@ -478,6 +480,8 @@ func TestManagerCapsWhitelistSize(t *testing.T) {
 
 	const key = "fgtest_cap"
 	db := newDB(ctx)
+	// 规则必须先存在——addScope 现在拒绝孤儿条目。
+	require.NoError(t, db.upsertRule(key, string(fg.ModeWhitelist), 0, fg.ScopeTypeUser, "cap", "seed"))
 	for i := 0; i < maxScopesPerKey; i++ {
 		require.NoError(t, db.addScope(key, fg.ScopeTypeUser, fmt.Sprintf("u%d", i), "seed"))
 	}
@@ -558,6 +562,7 @@ func TestAddScopeStaysIdempotentAtQuota(t *testing.T) {
 
 	const key = "fgtest_quota_idem"
 	db := newDB(ctx)
+	require.NoError(t, db.upsertRule(key, string(fg.ModeWhitelist), 0, fg.ScopeTypeUser, "idem", "seed"))
 	for i := 0; i < maxScopesPerKey; i++ {
 		require.NoError(t, db.addScope(key, fg.ScopeTypeUser, fmt.Sprintf("u%d", i), "seed"))
 	}
@@ -574,4 +579,66 @@ func TestAddScopeStaysIdempotentAtQuota(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
 	_, reason := errCodeOf(t, w)
 	require.Equal(t, "scope_quota", reason)
+}
+
+// TestAddScopeRejectsUnknownGate 关掉孤儿白名单条目这条路。
+//
+// 没有这道校验时：给一个不存在的 gate 加白名单返回 200，但 list 是按规则枚举再挂
+// scope 的，所以这条记录**在任何管理界面上都看不见**；等某天有人建了同名规则，它
+// 立刻开始放人——一个 superadmin 新建 whitelist gate 时无从得知它已经有成员了。
+func TestAddScopeRejectsUnknownGate(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+	loginAs(t, ctx, string(libwkhttp.SuperAdmin))
+	r := mountManager(t, ctx, nil)
+
+	w := doJSON(t, r, http.MethodPost, "/v1/manager/featuregate/gates/fgtest_orphan/scopes",
+		map[string]any{"scope_type": "user", "scope_id": "u1"})
+	require.Equal(t, http.StatusNotFound, w.Code,
+		"给不存在的 gate 加白名单必须拒，否则会留下看不见却会生效的记录；body: %s", w.Body.String())
+	code, _ := errCodeOf(t, w)
+	require.Equal(t, "err.server.featuregate.not_found", code)
+
+	// 先建规则，再加就应当成功。
+	require.Equal(t, http.StatusOK, doJSON(t, r, http.MethodPut,
+		"/v1/manager/featuregate/gates/fgtest_orphan",
+		map[string]any{"mode": "whitelist", "bucket_by": "user"}).Code)
+	require.Equal(t, http.StatusOK, doJSON(t, r, http.MethodPost,
+		"/v1/manager/featuregate/gates/fgtest_orphan/scopes",
+		map[string]any{"scope_type": "user", "scope_id": "u1"}).Code)
+}
+
+// TestScopeIDIsCaseSensitive 钉住身份列的逐字节语义。
+//
+// 库默认的 utf8mb4_general_ci 大小写不敏感，而 Go 侧比较是逐字节的。两者不一致时
+// "UserA" 与 "usera" 在唯一键下撞成一行，第二次 add 只更新 updated_by，库里留的仍是
+// 首次的拼写——运维拿到 200，那个用户却永远进不了白名单，且读侧因为存在可用的 user
+// 条目而只报普通 whitelist_miss，一行告警都没有。写成功、读静默、两侧皆哑。
+func TestScopeIDIsCaseSensitive(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+	loginAs(t, ctx, string(libwkhttp.SuperAdmin))
+	r := mountManager(t, ctx, nil)
+
+	const key = "fgtest_case"
+	require.Equal(t, http.StatusOK, doJSON(t, r, http.MethodPut,
+		"/v1/manager/featuregate/gates/"+key,
+		map[string]any{"mode": "whitelist", "bucket_by": "user"}).Code)
+
+	for _, id := range []string{"UserA", "usera"} {
+		require.Equal(t, http.StatusOK, doJSON(t, r, http.MethodPost,
+			"/v1/manager/featuregate/gates/"+key+"/scopes",
+			map[string]any{"scope_type": "user", "scope_id": id}).Code)
+	}
+
+	scopes, err := newDB(ctx).queryScopes(key)
+	require.NoError(t, err)
+	require.Len(t, scopes, 2, "大小写不同的 scope_id 必须是两条独立记录，否则第二个用户永远进不来")
+
+	// 两个用户都应当真正被放行。
+	svc := NewService(ctx)
+	svc.Invalidate(key)
+	for _, uid := range []string{"UserA", "usera"} {
+		allow, ok := svc.AllowDisplay(context.Background(), key, fg.Dims{UID: uid})
+		require.True(t, ok)
+		require.True(t, allow, "uid=%q 已在白名单中，必须放行", uid)
+	}
 }

--- a/modules/featuregate/api_manager_test.go
+++ b/modules/featuregate/api_manager_test.go
@@ -642,3 +642,47 @@ func TestScopeIDIsCaseSensitive(t *testing.T) {
 		require.True(t, allow, "uid=%q 已在白名单中，必须放行", uid)
 	}
 }
+
+// TestMigrationRejectsTrailingNewline 钉住 DB 层 CHECK 用的是 \z 而非 $。
+//
+// MySQL 的正则是 ICU，`$` 匹配「输入末尾**或最后一个换行符之前**」，所以 `...$` 会放行
+// 'u1\n' 这类尾部带换行的值。Go 侧不受影响（Go 的 $ 是 end-of-text），但 CHECK 存在的
+// 全部理由就是挡住「绕过 handler 直接改库」这条路——放行了就等于没有。
+//
+// 后果与本迁移已论证过的两条同型：带 \n 的 scope_id 插得进却删不掉（delScope 按单个
+// 路径段取值并 TrimSpace），带 \n 的 feature_key 推出的杀开关环境变量名含换行，永久
+// 失去 env 级急停。
+//
+// 这条测试走真实 DB，因为它验证的正是「Go 挡不住时 DB 还挡不挡得住」。
+func TestMigrationRejectsTrailingNewline(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+	db := ctx.DB()
+
+	// 前置：合法值必须能插，确认约束没有误伤。
+	_, err := db.InsertBySql(
+		"INSERT INTO `octo_feature_gate` (feature_key, mode, percent, bucket_by) VALUES (?,?,?,?)",
+		"fgtest_nl_ok", "off", 0, "user").Exec()
+	require.NoError(t, err, "合法 feature_key 必须可插入")
+
+	for _, bad := range []string{"fgtest_nl\n", "fgtest_nl\r"} {
+		_, err := db.InsertBySql(
+			"INSERT INTO `octo_feature_gate` (feature_key, mode, percent, bucket_by) VALUES (?,?,?,?)",
+			bad, "off", 0, "user").Exec()
+		require.Error(t, err, "feature_key=%q 必须被 CHECK 拒绝（用 \\z 而非 $）", bad)
+		require.Contains(t, err.Error(), "chk_octo_feature_gate_key")
+	}
+
+	for _, bad := range []string{"u1\n", "u1\r"} {
+		_, err := db.InsertBySql(
+			"INSERT INTO `octo_feature_gate_scope` (feature_key, scope_type, scope_id) VALUES (?,?,?)",
+			"fgtest_nl_ok", "user", bad).Exec()
+		require.Error(t, err, "scope_id=%q 必须被 CHECK 拒绝", bad)
+		require.Contains(t, err.Error(), "chk_octo_fgs_scope_id")
+	}
+
+	// 合法 scope_id（含全部允许字符）不受影响。
+	_, err = db.InsertBySql(
+		"INSERT INTO `octo_feature_gate_scope` (feature_key, scope_type, scope_id) VALUES (?,?,?)",
+		"fgtest_nl_ok", "user", "a.b:c@d-e_1").Exec()
+	require.NoError(t, err, "合法 scope_id 必须可插入")
+}

--- a/modules/featuregate/api_manager_test.go
+++ b/modules/featuregate/api_manager_test.go
@@ -1,0 +1,340 @@
+package featuregate
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	libwkhttp "github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	fg "github.com/Mininglamp-OSS/octo-server/pkg/featuregate"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/stretchr/testify/require"
+)
+
+// mountManager 在干净路由上挂管理端 + 用户端，并装上 i18n ErrorRenderer
+// （NewTestServer 不装，缺了它错误响应里拿不到 error.code）。
+func mountManager(t *testing.T, ctx *config.Context, flags []ClientFlag) *libwkhttp.WKHttp {
+	t.Helper()
+	r := libwkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	newManagerWithRegistry(ctx, mustNewClientRegistry(flags)).Route(r)
+	return r
+}
+
+func loginAs(t *testing.T, ctx *config.Context, role string) {
+	t.Helper()
+	v := testutil.UID + "@test"
+	if role != "" {
+		v += "@" + role
+	}
+	require.NoError(t, ctx.Cache().Set(ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token, v))
+}
+
+func doJSON(t *testing.T, r *libwkhttp.WKHttp, method, path string, payload any) *httptest.ResponseRecorder {
+	t.Helper()
+	var body *bytes.Buffer
+	if payload != nil {
+		raw, err := json.Marshal(payload)
+		require.NoError(t, err)
+		body = bytes.NewBuffer(raw)
+	} else {
+		body = bytes.NewBuffer(nil)
+	}
+	req, _ := http.NewRequest(method, path, body)
+	req.Header.Set("token", testutil.Token)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// errCodeOf 取出 i18n 错误信封里的 error.code / error.details.reason。
+func errCodeOf(t *testing.T, w *httptest.ResponseRecorder) (code, reason string) {
+	t.Helper()
+	var env struct {
+		Error struct {
+			Code    string         `json:"code"`
+			Details map[string]any `json:"details"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env), "body: %s", w.Body.String())
+	if v, ok := env.Error.Details["reason"].(string); ok {
+		reason = v
+	}
+	return env.Error.Code, reason
+}
+
+// TestManagerRejectsNonSuperAdminViaEnvelope 钉住拒绝路径走 i18n 信封。
+//
+// 本框架初版四个 handler 写的是 c.ResponseError(c.CheckLoginRoleIsSuperAdmin())
+// —— 绕开信封的 legacy 裸响应。同时确认用的是共享的 403 通用码而不是新造的
+// featuregate 专用码：鉴权失败统一收敛到一个码是反枚举约定。
+func TestManagerRejectsNonSuperAdminViaEnvelope(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+	loginAs(t, ctx, "") // 普通用户
+	r := mountManager(t, ctx, nil)
+
+	for _, tc := range []struct{ method, path string }{
+		{http.MethodGet, "/v1/manager/featuregate/gates"},
+		{http.MethodPut, "/v1/manager/featuregate/gates/k"},
+		{http.MethodPost, "/v1/manager/featuregate/gates/k/scopes"},
+		{http.MethodDelete, "/v1/manager/featuregate/gates/k/scopes/s"},
+	} {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			w := doJSON(t, r, tc.method, tc.path, map[string]any{})
+			require.Equal(t, http.StatusForbidden, w.Code, w.Body.String())
+			code, _ := errCodeOf(t, w)
+			require.Equal(t, "err.shared.auth.forbidden", code,
+				"鉴权失败必须收敛到共享 403 码，不得新造 featuregate 专用码（反枚举）")
+		})
+	}
+}
+
+// TestManagerUpdateValidation 覆盖字段级校验，每条都断言 details.reason，
+// 好让运维从响应里就知道是哪个字段不合法。
+func TestManagerUpdateValidation(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+	loginAs(t, ctx, string(libwkhttp.SuperAdmin))
+	r := mountManager(t, ctx, nil)
+
+	cases := []struct {
+		name       string
+		payload    map[string]any
+		wantReason string
+	}{
+		{"未知 mode", map[string]any{"mode": "rollout"}, "mode"},
+		{"percent 超上界", map[string]any{"mode": "percent", "percent": 101}, "percent"},
+		{"percent 负数", map[string]any{"mode": "percent", "percent": -1}, "percent"},
+		{"未知 bucket_by", map[string]any{"mode": "percent", "percent": 10, "bucket_by": "tenant"}, "bucket_by"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := doJSON(t, r, http.MethodPut, "/v1/manager/featuregate/gates/fgtest_validate", tc.payload)
+			require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+			code, reason := errCodeOf(t, w)
+			require.Equal(t, "err.server.featuregate.request_invalid", code)
+			require.Equal(t, tc.wantReason, reason)
+		})
+	}
+}
+
+// TestManagerRejectsMalformedFeatureKey 钉住 feature_key 的字符集校验。
+//
+// 只校验长度不校验字符集时，后果不是脏数据而是**丢掉急停能力**：feature_key
+// "my gate" 推导出的 OCTO_FEATUREGATE_MY GATE_KILL 含空格、常规手段设不进去，
+// 这条 gate 就
+// 永久失去 env 级紧急停止 —— 而那是「DB/Redis 全挂时仍能一键停」的最后一条路径。
+// 连字符则会破坏 key → env 名的单射（docs-beta 与 docs_beta 共用一个开关）。
+func TestManagerRejectsMalformedFeatureKey(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+	loginAs(t, ctx, string(libwkhttp.SuperAdmin))
+	r := mountManager(t, ctx, nil)
+
+	// URL 路径段里能直接表达的非法形态（空格走 %20，连字符/大写直接给）。
+	for _, badKey := range []string{"my%20gate", "docs-beta", "Docs", "1abc", "docs.beta"} {
+		t.Run(badKey, func(t *testing.T) {
+			w := doJSON(t, r, http.MethodPut, "/v1/manager/featuregate/gates/"+badKey,
+				map[string]any{"mode": "on"})
+			require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+			code, reason := errCodeOf(t, w)
+			require.Equal(t, "err.server.featuregate.request_invalid", code)
+			require.Equal(t, "key", reason)
+		})
+	}
+
+	// addScope / delScope 同样受约束，否则能给一条非法 key 挂白名单。
+	w := doJSON(t, r, http.MethodPost, "/v1/manager/featuregate/gates/docs-beta/scopes",
+		map[string]any{"scope_type": "user", "scope_id": "u1"})
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	_, reason := errCodeOf(t, w)
+	require.Equal(t, "key", reason)
+
+	w = doJSON(t, r, http.MethodDelete,
+		"/v1/manager/featuregate/gates/docs-beta/scopes/u1?scope_type=user", nil)
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	_, reason = errCodeOf(t, w)
+	require.Equal(t, "key", reason)
+
+	// 合法 key 仍应通过，确认校验没有误伤。
+	w = doJSON(t, r, http.MethodPut, "/v1/manager/featuregate/gates/docs_beta",
+		map[string]any{"mode": "on"})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
+// TestRoutesMountUIDRateLimiterAfterAuth 验证两组路由都挂了 SharedUIDRateLimiter，
+// 且挂在 AuthMiddleware **之后**。
+//
+// 断言 X-RateLimit-Scope=uid 同时覆盖了这两件事：octo-lib 的
+// UIDRateLimitMiddleware 在 uid 取不到时会直接跳过（不写任何头），所以这个头存在
+// 就意味着中间件既被挂上、又读到了 uid。挂错顺序的失败模式是**静默 fail-open**，
+// 线上不会报错，只是限流不生效——没有测试就无从发现。
+func TestRoutesMountUIDRateLimiterAfterAuth(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+	loginAs(t, ctx, string(libwkhttp.SuperAdmin))
+	r := mountManager(t, ctx, nil) // 走真实 Route()，不是测试自建的路由组
+
+	for _, path := range []string{
+		"/v1/featuregate/flags",         // 用户侧只读端点
+		"/v1/manager/featuregate/gates", // 管理面
+	} {
+		t.Run(path, func(t *testing.T) {
+			w := doJSON(t, r, http.MethodGet, path, nil)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+			require.Equal(t, "uid", w.Header().Get("X-RateLimit-Scope"),
+				"缺 X-RateLimit-Scope=uid 说明限流没挂，或挂在了 AuthMiddleware 之前（读不到 uid 会静默跳过）")
+			require.NotEmpty(t, w.Header().Get("X-RateLimit-Limit"))
+		})
+	}
+}
+
+// TestManagerRejectsUnusableDimensionForClientVisibleKey 是写侧的错配拦截。
+//
+// 客户端展示端点只有 UID：一条配成 bucket_by=group 的客户端可见规则，评估时
+// GroupNo 为空，管理台却仍显示「50%」——一个无报错的静默错配。读侧另有 fail-closed
+// 兜底，但直接改库能绕过写侧，所以两侧都要。
+func TestManagerRejectsUnusableDimensionForClientVisibleKey(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+	loginAs(t, ctx, string(libwkhttp.SuperAdmin))
+
+	const visibleKey = "fgtest_visible"
+	r := mountManager(t, ctx, []ClientFlag{{FeatureKey: visibleKey, ClientKey: "visible"}})
+
+	t.Run("update 拒绝 group 分桶", func(t *testing.T) {
+		w := doJSON(t, r, http.MethodPut, "/v1/manager/featuregate/gates/"+visibleKey,
+			map[string]any{"mode": "percent", "percent": 50, "bucket_by": "group"})
+		require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+		code, reason := errCodeOf(t, w)
+		require.Equal(t, "err.server.featuregate.request_invalid", code)
+		require.Equal(t, "client_visible_dimension", reason)
+	})
+
+	t.Run("update 拒绝空 bucket_by（归一后是 group）", func(t *testing.T) {
+		w := doJSON(t, r, http.MethodPut, "/v1/manager/featuregate/gates/"+visibleKey,
+			map[string]any{"mode": "percent", "percent": 50})
+		require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+		_, reason := errCodeOf(t, w)
+		require.Equal(t, "client_visible_dimension", reason,
+			"缺省 bucket_by 归一到 group，对客户端可见的 key 同样不可用")
+	})
+
+	t.Run("update 接受 user 分桶", func(t *testing.T) {
+		w := doJSON(t, r, http.MethodPut, "/v1/manager/featuregate/gates/"+visibleKey,
+			map[string]any{"mode": "percent", "percent": 50, "bucket_by": "user"})
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	})
+
+	t.Run("addScope 拒绝 group 条目", func(t *testing.T) {
+		w := doJSON(t, r, http.MethodPost, "/v1/manager/featuregate/gates/"+visibleKey+"/scopes",
+			map[string]any{"scope_type": "group", "scope_id": "g1"})
+		require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+		_, reason := errCodeOf(t, w)
+		require.Equal(t, "client_visible_dimension", reason,
+			"允许写入一条永不可能命中的 group 条目，等于让运维以为灰度开了而实际没开")
+	})
+
+	t.Run("addScope 接受 user 条目", func(t *testing.T) {
+		w := doJSON(t, r, http.MethodPost, "/v1/manager/featuregate/gates/"+visibleKey+"/scopes",
+			map[string]any{"scope_type": "user", "scope_id": "u1"})
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	})
+
+	t.Run("非客户端可见的 key 不受此约束", func(t *testing.T) {
+		w := doJSON(t, r, http.MethodPut, "/v1/manager/featuregate/gates/fgtest_internal_only",
+			map[string]any{"mode": "percent", "percent": 50, "bucket_by": "group"})
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	})
+}
+
+// TestManagerScopeLifecycle 覆盖白名单增删与 404，并确认 user 维度被接受。
+func TestManagerScopeLifecycle(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+	loginAs(t, ctx, string(libwkhttp.SuperAdmin))
+	r := mountManager(t, ctx, nil)
+
+	const key = "fgtest_scope_lifecycle"
+	require.Equal(t, http.StatusOK, doJSON(t, r, http.MethodPut,
+		"/v1/manager/featuregate/gates/"+key,
+		map[string]any{"mode": "whitelist", "bucket_by": "user"}).Code)
+
+	// 未知 scope_type 拒绝。
+	w := doJSON(t, r, http.MethodPost, "/v1/manager/featuregate/gates/"+key+"/scopes",
+		map[string]any{"scope_type": "tenant", "scope_id": "x"})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	_, reason := errCodeOf(t, w)
+	require.Equal(t, "scope_type", reason)
+
+	// user 维度接受，且幂等（重复加仍 200）。
+	for i := 0; i < 2; i++ {
+		w = doJSON(t, r, http.MethodPost, "/v1/manager/featuregate/gates/"+key+"/scopes",
+			map[string]any{"scope_type": "user", "scope_id": "u1"})
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	}
+
+	// 删不存在的条目 → 404。
+	w = doJSON(t, r, http.MethodDelete,
+		"/v1/manager/featuregate/gates/"+key+"/scopes/nobody?scope_type=user", nil)
+	require.Equal(t, http.StatusNotFound, w.Code, w.Body.String())
+	code, _ := errCodeOf(t, w)
+	require.Equal(t, "err.server.featuregate.not_found", code)
+
+	// 删存在的条目 → 200。
+	w = doJSON(t, r, http.MethodDelete,
+		"/v1/manager/featuregate/gates/"+key+"/scopes/u1?scope_type=user", nil)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
+// TestManagerListSurfacesOperatorAffordances 验证列表回显运维需要的三项：
+// 归一后的 bucket_by、是否客户端可见、以及 env 杀开关名。
+func TestManagerListSurfacesOperatorAffordances(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+	loginAs(t, ctx, string(libwkhttp.SuperAdmin))
+
+	const visibleKey = "fgtest_list_visible"
+	r := mountManager(t, ctx, []ClientFlag{{FeatureKey: visibleKey, ClientKey: "list_visible"}})
+
+	require.Equal(t, http.StatusOK, doJSON(t, r, http.MethodPut,
+		"/v1/manager/featuregate/gates/"+visibleKey,
+		map[string]any{"mode": "whitelist", "bucket_by": "user"}).Code)
+
+	w := doJSON(t, r, http.MethodGet, "/v1/manager/featuregate/gates", nil)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var body struct {
+		Gates []struct {
+			FeatureKey    string `json:"feature_key"`
+			Mode          string `json:"mode"`
+			BucketBy      string `json:"bucket_by"`
+			ClientVisible bool   `json:"client_visible"`
+			KillSwitchEnv string `json:"kill_switch_env"`
+		} `json:"gates"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body), w.Body.String())
+	require.NotEmpty(t, body.Gates)
+
+	var found bool
+	for _, g := range body.Gates {
+		if g.FeatureKey != visibleKey {
+			continue
+		}
+		found = true
+		require.Equal(t, string(fg.ModeWhitelist), g.Mode)
+		require.Equal(t, fg.ScopeTypeUser, g.BucketBy)
+		require.True(t, g.ClientVisible, "运维需要知道这条规则会影响终端展示")
+		require.Equal(t, "OCTO_FEATUREGATE_FGTEST_LIST_VISIBLE_KILL", g.KillSwitchEnv,
+			"回显 env 杀开关名，省得运维手工推导大小写/连字符")
+	}
+	require.True(t, found, "列表里应能找到刚写入的规则")
+}
+
+// TestManagerListNormalizesEmptyBucketBy 确认历史/直改库留下的空 bucket_by 在回显
+// 时归一成实际生效的维度，而不是给运维一个空白让他去猜默认值是什么。
+func TestManagerListNormalizesEmptyBucketBy(t *testing.T) {
+	got := toGateResp(&gateModel{FeatureKey: "k", Mode: "percent", Percent: 10, BucketBy: ""}, nil, false)
+	require.Equal(t, fg.ScopeTypeGroup, got.BucketBy, "空 bucket_by 应回显为实际生效的默认维度")
+	require.Equal(t, "OCTO_FEATUREGATE_K_KILL", got.KillSwitchEnv)
+	require.NotNil(t, got.Scopes, "scopes 必须序列化为 []，不能是 null")
+}

--- a/modules/featuregate/api_manager_test.go
+++ b/modules/featuregate/api_manager_test.go
@@ -487,3 +487,91 @@ func TestManagerCapsWhitelistSize(t *testing.T) {
 	_, reason := errCodeOf(t, w)
 	require.Equal(t, "scope_quota", reason)
 }
+
+// TestOffAndOnStayWritableForClientVisibleKeyWithUnusableScopes 是 round-2 阻塞项：
+// 上一轮为了堵「白名单全是用不上的维度」而加的校验跑在**每一次** update 上，包括
+// 降级。后果是一条 client-visible 且带遗留 group 白名单的 gate **关不掉**——
+// `{"mode":"off"}` 先被 bucket_by 默认成 group 拦掉，显式写 bucket_by=user 又被
+// 存量 scope 检查拦掉，只剩逐条删白名单（最多 1000 次）或 env 杀开关。
+//
+// 而 off/on 根本不读白名单也不读 bucket_by（见 modeNeedsScopes 与 Evaluate 的
+// ModeOff/ModeOn 分支），校验的是一个目标状态压根不使用的前置条件。
+//
+// 原则：**关掉一个东西永远不该比打开它更难。**
+func TestOffAndOnStayWritableForClientVisibleKeyWithUnusableScopes(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+	loginAs(t, ctx, string(libwkhttp.SuperAdmin))
+
+	const key = "fgtest_off_rollback"
+	db := newDB(ctx)
+
+	// 造出这条检查存在的理由所描述的状态：内部 gate + 全 group 白名单，之后被
+	// 某次发版变成 client-visible。
+	require.NoError(t, db.upsertRule(key, string(fg.ModeWhitelist), 0, fg.ScopeTypeGroup, "legacy", "seed"))
+	require.NoError(t, db.addScope(key, fg.ScopeTypeGroup, "g1", "seed"))
+	r := mountManager(t, ctx, []ClientFlag{{FeatureKey: key, ClientKey: "off_rollback"}})
+
+	t.Run("最朴素的回滚 body 必须可用", func(t *testing.T) {
+		w := doJSON(t, r, http.MethodPut, "/v1/manager/featuregate/gates/"+key,
+			map[string]any{"mode": "off"})
+		require.Equal(t, http.StatusOK, w.Code,
+			"关停不该被一个 off 模式根本不读的前置条件拦住；body: %s", w.Body.String())
+	})
+
+	t.Run("显式 bucket_by 的 off 同样可用", func(t *testing.T) {
+		w := doJSON(t, r, http.MethodPut, "/v1/manager/featuregate/gates/"+key,
+			map[string]any{"mode": "off", "bucket_by": "user"})
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	})
+
+	t.Run("on 同理：不读 scope 也不读 bucket_by", func(t *testing.T) {
+		w := doJSON(t, r, http.MethodPut, "/v1/manager/featuregate/gates/"+key,
+			map[string]any{"mode": "on"})
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	})
+
+	t.Run("切回真正会读白名单的模式仍必须被拦", func(t *testing.T) {
+		w := doJSON(t, r, http.MethodPut, "/v1/manager/featuregate/gates/"+key,
+			map[string]any{"mode": "whitelist", "bucket_by": "user"})
+		require.Equal(t, http.StatusBadRequest, w.Code,
+			"whitelist 会读白名单，存量全不可用时必须仍然拒绝；body: %s", w.Body.String())
+		_, reason := errCodeOf(t, w)
+		require.Equal(t, "client_visible_scopes", reason)
+	})
+
+	// 关停后规则确实落库为 off。
+	require.Equal(t, http.StatusOK, doJSON(t, r, http.MethodPut,
+		"/v1/manager/featuregate/gates/"+key, map[string]any{"mode": "off"}).Code)
+	rule, err := db.queryRule(key)
+	require.NoError(t, err)
+	require.Equal(t, string(fg.ModeOff), rule.Mode)
+}
+
+// TestAddScopeStaysIdempotentAtQuota 钉住配额检查不得破坏 addScope 的幂等承诺。
+//
+// 先数后插的写法在**恰好满额**时会把「重加一条已存在的条目」也拒掉——而那正是
+// 运维最可能重试的时刻（网络抖动后重放）。已存在的条目不占新增名额。
+func TestAddScopeStaysIdempotentAtQuota(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+	loginAs(t, ctx, string(libwkhttp.SuperAdmin))
+	r := mountManager(t, ctx, nil)
+
+	const key = "fgtest_quota_idem"
+	db := newDB(ctx)
+	for i := 0; i < maxScopesPerKey; i++ {
+		require.NoError(t, db.addScope(key, fg.ScopeTypeUser, fmt.Sprintf("u%d", i), "seed"))
+	}
+
+	// 满额时重加**已存在**的条目：幂等，应当成功。
+	w := doJSON(t, r, http.MethodPost, "/v1/manager/featuregate/gates/"+key+"/scopes",
+		map[string]any{"scope_type": "user", "scope_id": "u0"})
+	require.Equal(t, http.StatusOK, w.Code,
+		"已存在的条目不占新增名额，重试必须仍然幂等；body: %s", w.Body.String())
+
+	// 满额时加**新**条目：仍应被配额拒绝。
+	w = doJSON(t, r, http.MethodPost, "/v1/manager/featuregate/gates/"+key+"/scopes",
+		map[string]any{"scope_type": "user", "scope_id": "brand_new"})
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	_, reason := errCodeOf(t, w)
+	require.Equal(t, "scope_quota", reason)
+}

--- a/modules/featuregate/api_manager_test.go
+++ b/modules/featuregate/api_manager_test.go
@@ -3,8 +3,10 @@ package featuregate
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -337,4 +339,151 @@ func TestManagerListNormalizesEmptyBucketBy(t *testing.T) {
 	require.Equal(t, fg.ScopeTypeGroup, got.BucketBy, "空 bucket_by 应回显为实际生效的默认维度")
 	require.Equal(t, "OCTO_FEATUREGATE_K_KILL", got.KillSwitchEnv)
 	require.NotNil(t, got.Scopes, "scopes 必须序列化为 []，不能是 null")
+}
+
+// TestUpdateRejectsClientVisibleKeyWhoseScopesAreAllUnusable 是评审抓到的 P1 阻塞项，
+// 也是 brief 验收里我漏实现的那半条。
+//
+// 触发顺序正是注册表的**正常生命周期**（注册表是编译期清单、gate 是 DB 行）：
+//  1. gate 还不是 client-visible，ops 加了 group 白名单 —— 当时完全正确；
+//  2. 后续发版把它加进 clientFlagList；
+//  3. ops 改成 whitelist + bucket_by=user。
+//
+// 第 3 步若放行，白名单里就全是永远命不中的条目，而运维看到的是：名单有行、mode
+// 对、写入 200、日志无声，flag 对所有人 false。这是本模块唯一一处写侧读侧皆无信号
+// 的错配，必须在写侧挡住。
+func TestUpdateRejectsClientVisibleKeyWhoseScopesAreAllUnusable(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+	loginAs(t, ctx, string(libwkhttp.SuperAdmin))
+
+	const key = "fgtest_lifecycle"
+	db := newDB(ctx)
+
+	// 阶段一：key 还不是 client-visible，group 白名单是合法配置。
+	internalOnly := mountManager(t, ctx, nil)
+	require.Equal(t, http.StatusOK, doJSON(t, internalOnly, http.MethodPut,
+		"/v1/manager/featuregate/gates/"+key,
+		map[string]any{"mode": "whitelist", "bucket_by": "group"}).Code)
+	require.Equal(t, http.StatusOK, doJSON(t, internalOnly, http.MethodPost,
+		"/v1/manager/featuregate/gates/"+key+"/scopes",
+		map[string]any{"scope_type": "group", "scope_id": "g1"}).Code)
+
+	// 阶段二：一次发版把它变成 client-visible。
+	visible := mountManager(t, ctx, []ClientFlag{{FeatureKey: key, ClientKey: "lifecycle"}})
+
+	// 阶段三：这次 update 必须被拒 —— 白名单存量全是用不上的维度。
+	w := doJSON(t, visible, http.MethodPut, "/v1/manager/featuregate/gates/"+key,
+		map[string]any{"mode": "whitelist", "bucket_by": "user"})
+	require.Equal(t, http.StatusBadRequest, w.Code,
+		"存量白名单全是 group 条目，改成 client-visible 后必须拒绝；body: %s", w.Body.String())
+	code, reason := errCodeOf(t, w)
+	require.Equal(t, "err.server.featuregate.request_invalid", code)
+	require.Equal(t, "client_visible_scopes", reason)
+
+	// 补一条 user 条目后，同样的 update 应当放行。
+	require.NoError(t, db.addScope(key, fg.ScopeTypeUser, "u1", "tester"))
+	require.Equal(t, http.StatusOK, doJSON(t, visible, http.MethodPut,
+		"/v1/manager/featuregate/gates/"+key,
+		map[string]any{"mode": "whitelist", "bucket_by": "user"}).Code,
+		"存在可用维度条目后不应再拒")
+}
+
+// TestUpdateAllowsClientVisibleKeyWithEmptyScopes 钉住边界：空白名单是**合法状态**
+// （mode=whitelist 且暂时谁都不放），不能被上面那条检查误伤。
+func TestUpdateAllowsClientVisibleKeyWithEmptyScopes(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+	loginAs(t, ctx, string(libwkhttp.SuperAdmin))
+
+	const key = "fgtest_empty_scopes"
+	r := mountManager(t, ctx, []ClientFlag{{FeatureKey: key, ClientKey: "empty_scopes"}})
+	w := doJSON(t, r, http.MethodPut, "/v1/manager/featuregate/gates/"+key,
+		map[string]any{"mode": "whitelist", "bucket_by": "user"})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
+// TestManagerRecordsUpdatedBy 钉住审计列：能对全体用户关功能的开关必须留下操作人。
+// 仓库既有惯例见 octo_space_welcome_config / bot_mention_pref 的 updated_by。
+func TestManagerRecordsUpdatedBy(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+	loginAs(t, ctx, string(libwkhttp.SuperAdmin))
+	r := mountManager(t, ctx, nil)
+
+	const key = "fgtest_audit"
+	require.Equal(t, http.StatusOK, doJSON(t, r, http.MethodPut,
+		"/v1/manager/featuregate/gates/"+key, map[string]any{"mode": "on"}).Code)
+	require.Equal(t, http.StatusOK, doJSON(t, r, http.MethodPost,
+		"/v1/manager/featuregate/gates/"+key+"/scopes",
+		map[string]any{"scope_type": "user", "scope_id": "u1"}).Code)
+
+	rule, err := newDB(ctx).queryRule(key)
+	require.NoError(t, err)
+	require.NotNil(t, rule)
+	require.Equal(t, testutil.UID, rule.UpdatedBy, "规则必须记录最后修改人")
+
+	scopes, err := newDB(ctx).queryScopes(key)
+	require.NoError(t, err)
+	require.Len(t, scopes, 1)
+	require.Equal(t, testutil.UID, scopes[0].UpdatedBy, "白名单条目必须记录添加人")
+
+	// 管理端列表要回显，否则运维得去查库。
+	w := doJSON(t, r, http.MethodGet, "/v1/manager/featuregate/gates", nil)
+	require.Contains(t, w.Body.String(), `"updated_by"`)
+	require.Contains(t, w.Body.String(), testutil.UID)
+}
+
+// TestManagerRejectsScopeIDWithPathSeparator 关掉「能建不能删」的不对称：scope_id
+// 含 '/' 时可插入、但 delScope 按单个路径段取值，永远删不掉（gin 匹配的是已解码
+// 路径，%2F 也绕不过）。
+func TestManagerRejectsScopeIDWithPathSeparator(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+	loginAs(t, ctx, string(libwkhttp.SuperAdmin))
+	r := mountManager(t, ctx, nil)
+
+	for _, bad := range []string{"a/b", "a b", "a\tb"} {
+		w := doJSON(t, r, http.MethodPost, "/v1/manager/featuregate/gates/fgtest_sep/scopes",
+			map[string]any{"scope_type": "user", "scope_id": bad})
+		require.Equal(t, http.StatusBadRequest, w.Code, "scope_id=%q 应被拒；body: %s", bad, w.Body.String())
+		_, reason := errCodeOf(t, w)
+		require.Equal(t, "scope_id", reason)
+	}
+}
+
+// TestManagerDescriptionCountedInRunes 钉住 description 按字符而非字节计数 —— 列是
+// VARCHAR(255) 即 255 个字符，按字节校验会把中文描述砍到 ~85 字。
+func TestManagerDescriptionCountedInRunes(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+	loginAs(t, ctx, string(libwkhttp.SuperAdmin))
+	r := mountManager(t, ctx, nil)
+
+	w := doJSON(t, r, http.MethodPut, "/v1/manager/featuregate/gates/fgtest_desc",
+		map[string]any{"mode": "on", "description": strings.Repeat("灰", 200)})
+	require.Equal(t, http.StatusOK, w.Code, "200 个汉字（600 字节）在 255 字符列内，应当接受；body: %s", w.Body.String())
+
+	w = doJSON(t, r, http.MethodPut, "/v1/manager/featuregate/gates/fgtest_desc",
+		map[string]any{"mode": "on", "description": strings.Repeat("灰", 256)})
+	require.Equal(t, http.StatusBadRequest, w.Code, "超过 255 字符必须拒")
+	_, reason := errCodeOf(t, w)
+	require.Equal(t, "description", reason)
+}
+
+// TestManagerCapsWhitelistSize 给单个 key 的白名单条数设上限。
+//
+// 评审建议给 queryScopes 加 LIMIT，但那会在**评估路径**上静默丢条目 —— 把「慢但
+// 正确」换成「快但答案错」。改在写侧封顶：同时封住查询量和 Redis 缓存值大小，且
+// 超限时运维会收到明确拒绝而不是悄悄少了几个人。
+func TestManagerCapsWhitelistSize(t *testing.T) {
+	ctx := newIntegrationCtx(t)
+	loginAs(t, ctx, string(libwkhttp.SuperAdmin))
+	r := mountManager(t, ctx, nil)
+
+	const key = "fgtest_cap"
+	db := newDB(ctx)
+	for i := 0; i < maxScopesPerKey; i++ {
+		require.NoError(t, db.addScope(key, fg.ScopeTypeUser, fmt.Sprintf("u%d", i), "seed"))
+	}
+	w := doJSON(t, r, http.MethodPost, "/v1/manager/featuregate/gates/"+key+"/scopes",
+		map[string]any{"scope_type": "user", "scope_id": "one_too_many"})
+	require.Equal(t, http.StatusBadRequest, w.Code, "超过上限必须拒；body: %s", w.Body.String())
+	_, reason := errCodeOf(t, w)
+	require.Equal(t, "scope_quota", reason)
 }

--- a/modules/featuregate/db.go
+++ b/modules/featuregate/db.go
@@ -112,3 +112,15 @@ func (d *gateDB) countScopes(key string) (int, error) {
 	}
 	return n, nil
 }
+
+// scopeExists 报告某条白名单条目是否已存在。addScope 用它把「重加已有条目」与
+// 「新增条目」分开：前者是幂等重试，不该占配额。
+func (d *gateDB) scopeExists(key, scopeType, scopeID string) (bool, error) {
+	var n int
+	err := d.session.Select("COUNT(*)").From(tableGateScopeQuoted).
+		Where("feature_key=? AND scope_type=? AND scope_id=?", key, scopeType, scopeID).LoadOne(&n)
+	if err != nil {
+		return false, fmt.Errorf("featuregate: check scope %q/%s/%s: %w", key, scopeType, scopeID, err)
+	}
+	return n > 0, nil
+}

--- a/modules/featuregate/db.go
+++ b/modules/featuregate/db.go
@@ -54,13 +54,13 @@ func (d *gateDB) listRules() ([]*gateModel, error) {
 
 // upsertRule 按 feature_key 写入/覆盖规则。靠唯一键 uk_octo_feature_gate_key 幂等：
 // 不存在则创建（注册新功能 gate），存在则覆盖 mode/percent/bucket_by/description。
-func (d *gateDB) upsertRule(key, mode string, percent int, bucketBy, description string) error {
+func (d *gateDB) upsertRule(key, mode string, percent int, bucketBy, description, updatedBy string) error {
 	_, err := d.session.InsertBySql(
-		"INSERT INTO "+tableGateQuoted+" (feature_key, mode, percent, bucket_by, description) "+
-			"VALUES (?, ?, ?, ?, ?) "+
+		"INSERT INTO "+tableGateQuoted+" (feature_key, mode, percent, bucket_by, description, updated_by) "+
+			"VALUES (?, ?, ?, ?, ?, ?) "+
 			"ON DUPLICATE KEY UPDATE mode=VALUES(mode), percent=VALUES(percent), "+
-			"bucket_by=VALUES(bucket_by), description=VALUES(description)",
-		key, mode, percent, bucketBy, description,
+			"bucket_by=VALUES(bucket_by), description=VALUES(description), updated_by=VALUES(updated_by)",
+		key, mode, percent, bucketBy, description, updatedBy,
 	).Exec()
 	if err != nil {
 		return fmt.Errorf("featuregate: upsert rule %q: %w", key, err)
@@ -70,12 +70,12 @@ func (d *gateDB) upsertRule(key, mode string, percent int, bucketBy, description
 
 // addScope 幂等地加入一条白名单条目；重复 (key,type,id) 命中唯一键走 no-op
 // 更新，对调用方表现为成功。
-func (d *gateDB) addScope(key, scopeType, scopeID string) error {
+func (d *gateDB) addScope(key, scopeType, scopeID, updatedBy string) error {
 	_, err := d.session.InsertBySql(
-		"INSERT INTO "+tableGateScopeQuoted+" (feature_key, scope_type, scope_id) "+
-			"VALUES (?, ?, ?) "+
-			"ON DUPLICATE KEY UPDATE feature_key=feature_key",
-		key, scopeType, scopeID,
+		"INSERT INTO "+tableGateScopeQuoted+" (feature_key, scope_type, scope_id, updated_by) "+
+			"VALUES (?, ?, ?, ?) "+
+			"ON DUPLICATE KEY UPDATE updated_by=VALUES(updated_by)",
+		key, scopeType, scopeID, updatedBy,
 	).Exec()
 	if err != nil {
 		return fmt.Errorf("featuregate: add scope %q/%s/%s: %w", key, scopeType, scopeID, err)
@@ -94,6 +94,21 @@ func (d *gateDB) deleteScope(key, scopeType, scopeID string) (int64, error) {
 	n, err := res.RowsAffected()
 	if err != nil {
 		return 0, fmt.Errorf("featuregate: delete scope rows affected: %w", err)
+	}
+	return n, nil
+}
+
+// countScopes 统计某 key 的白名单条目数，供写侧配额校验。
+//
+// 上限设在写侧而非给 queryScopes 加 LIMIT：后者会在**评估路径**上静默丢条目，把
+// 「慢但正确」换成「快但答案错」。写侧封顶同时封住了查询量与 Redis 缓存值大小，
+// 而且超限时运维收到的是明确拒绝，不是悄悄少了几个人。
+func (d *gateDB) countScopes(key string) (int, error) {
+	var n int
+	err := d.session.Select("COUNT(*)").From(tableGateScopeQuoted).
+		Where("feature_key=?", key).LoadOne(&n)
+	if err != nil {
+		return 0, fmt.Errorf("featuregate: count scopes %q: %w", key, err)
 	}
 	return n, nil
 }

--- a/modules/featuregate/db.go
+++ b/modules/featuregate/db.go
@@ -1,0 +1,99 @@
+package featuregate
+
+import (
+	"fmt"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/gocraft/dbr/v2"
+)
+
+// 表名常量。Select/From 需要手写反引号（dbr 只对 InsertInto/Update/DeleteFrom
+// 的表名自动 quote），故这里备两份，避免调用点各写各的拼错。
+const (
+	tableGate            = "octo_feature_gate"
+	tableGateQuoted      = "`octo_feature_gate`"
+	tableGateScope       = "octo_feature_gate_scope"
+	tableGateScopeQuoted = "`octo_feature_gate_scope`"
+)
+
+// gateDB 是 octo_feature_gate / octo_feature_gate_scope 两张表的持久化层。
+// DB 是规则的单一真源；Service 在其上叠加 Redis 读缓存。
+type gateDB struct {
+	session *dbr.Session
+}
+
+func newDB(ctx *config.Context) *gateDB {
+	return &gateDB{session: ctx.DB()}
+}
+
+// queryRule 按 feature_key 取规则；不存在返回 (nil, nil)（Load 到 **struct，
+// 无结果时指针保持 nil），调用方按 m == nil 判定未注册。
+func (d *gateDB) queryRule(key string) (*gateModel, error) {
+	var m *gateModel
+	_, err := d.session.Select("*").From(tableGateQuoted).
+		Where("feature_key=?", key).Load(&m)
+	return m, err
+}
+
+// queryScopes 取某 key 的全部白名单条目。
+func (d *gateDB) queryScopes(key string) ([]*scopeModel, error) {
+	var list []*scopeModel
+	_, err := d.session.Select("*").From(tableGateScopeQuoted).
+		Where("feature_key=?", key).
+		OrderDir("scope_id", true).Load(&list)
+	return list, err
+}
+
+// listRules 列出所有规则，供管理端列表。
+func (d *gateDB) listRules() ([]*gateModel, error) {
+	var list []*gateModel
+	_, err := d.session.Select("*").From(tableGateQuoted).
+		OrderDir("feature_key", true).Load(&list)
+	return list, err
+}
+
+// upsertRule 按 feature_key 写入/覆盖规则。靠唯一键 uk_octo_feature_gate_key 幂等：
+// 不存在则创建（注册新功能 gate），存在则覆盖 mode/percent/bucket_by/description。
+func (d *gateDB) upsertRule(key, mode string, percent int, bucketBy, description string) error {
+	_, err := d.session.InsertBySql(
+		"INSERT INTO "+tableGateQuoted+" (feature_key, mode, percent, bucket_by, description) "+
+			"VALUES (?, ?, ?, ?, ?) "+
+			"ON DUPLICATE KEY UPDATE mode=VALUES(mode), percent=VALUES(percent), "+
+			"bucket_by=VALUES(bucket_by), description=VALUES(description)",
+		key, mode, percent, bucketBy, description,
+	).Exec()
+	if err != nil {
+		return fmt.Errorf("featuregate: upsert rule %q: %w", key, err)
+	}
+	return nil
+}
+
+// addScope 幂等地加入一条白名单条目；重复 (key,type,id) 命中唯一键走 no-op
+// 更新，对调用方表现为成功。
+func (d *gateDB) addScope(key, scopeType, scopeID string) error {
+	_, err := d.session.InsertBySql(
+		"INSERT INTO "+tableGateScopeQuoted+" (feature_key, scope_type, scope_id) "+
+			"VALUES (?, ?, ?) "+
+			"ON DUPLICATE KEY UPDATE feature_key=feature_key",
+		key, scopeType, scopeID,
+	).Exec()
+	if err != nil {
+		return fmt.Errorf("featuregate: add scope %q/%s/%s: %w", key, scopeType, scopeID, err)
+	}
+	return nil
+}
+
+// deleteScope 删除一条白名单条目，返回受影响行数（0 表示该条目不存在，调用方
+// 据此回 404）。
+func (d *gateDB) deleteScope(key, scopeType, scopeID string) (int64, error) {
+	res, err := d.session.DeleteFrom(tableGateScope).
+		Where("feature_key=? AND scope_type=? AND scope_id=?", key, scopeType, scopeID).Exec()
+	if err != nil {
+		return 0, fmt.Errorf("featuregate: delete scope %q/%s/%s: %w", key, scopeType, scopeID, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("featuregate: delete scope rows affected: %w", err)
+	}
+	return n, nil
+}

--- a/modules/featuregate/main_test.go
+++ b/modules/featuregate/main_test.go
@@ -1,0 +1,22 @@
+package featuregate
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"testing"
+)
+
+// TestMain ensures OCTO_MASTER_KEY is set before any test boots. This module
+// imports modules/common (for the optional DeploymentGate hook), whose Setup
+// refuses to start without a 32-byte master key used to encrypt the IM private
+// key. Mirrors modules/sticker and modules/user main_test.go: don't overwrite an
+// externally-provided key so CI / dev shells can pin one.
+func TestMain(m *testing.M) {
+	if os.Getenv("OCTO_MASTER_KEY") == "" {
+		key := make([]byte, 16)
+		_, _ = rand.Read(key)
+		_ = os.Setenv("OCTO_MASTER_KEY", hex.EncodeToString(key))
+	}
+	os.Exit(m.Run())
+}

--- a/modules/featuregate/manager.go
+++ b/modules/featuregate/manager.go
@@ -152,9 +152,10 @@ const clientVisibleDimension = fg.ScopeTypeUser
 // 全体开或全体关。读侧（AllowDisplay）另有 fail-closed 兜底 —— 两侧都要：只做
 // 写侧会被直接改库绕过，只做读侧则运维以为自己配置生效了。
 //
-// 对 mode 不做区分（即便当前是 whitelist 也要求 bucket_by=user）：bucket_by 虽然
-// 只在 percent 生效，但先存一个坏值、之后切到 percent 就会踩雷，不如在写入时就
-// 保证这张表里客户端可见的行恒定合法。
+// **按 mode 门控**（见 planUpdate 里的 modeNeedsScopes 判断）：off/on 既不读白名单也
+// 不读 bucket_by，对它们施加此校验会挡住关停，而 off 是本框架的回滚杠杆。代价是
+// off/on 的行里可能留下一个未经校验的 bucket_by——这不构成隐患，因为每次切进
+// whitelist/percent 都会重新校验请求里的值，坏值不可能悄悄生效。
 func validateClientVisibleDimension(dim string) bool {
 	return dim == clientVisibleDimension
 }

--- a/modules/featuregate/manager.go
+++ b/modules/featuregate/manager.go
@@ -51,18 +51,23 @@ func newManagerWithRegistry(ctx *config.Context, registry *clientRegistry) *Mana
 // 用户侧端点用 /v1/featuregate/... 而非 /v1/user/...：路径首段跟模块名走
 // （同 /v1/common/appconfig、/v1/sticker/user），从路由能直接定位到代码。
 func (m *Manager) Route(r *wkhttp.WKHttp) {
-	mgr := r.Group("/v1/manager/featuregate", m.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, m.ctx))
-	{
-		mgr.GET("/gates", m.list)                              // 列出所有规则（含白名单）
-		mgr.PUT("/gates/:key", m.update)                       // 改 mode/percent/bucket_by/description
-		mgr.POST("/gates/:key/scopes", m.addScope)             // 加白名单条目
-		mgr.DELETE("/gates/:key/scopes/:scope_id", m.delScope) // 删白名单条目
-	}
+	m.routeManager(r)
+	m.routeUser(r)
+}
 
-	user := r.Group("/v1/featuregate", m.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, m.ctx))
-	{
-		user.GET("/flags", m.flags.get) // 当前登录用户的灰度位
-	}
+// routeManager 挂 superadmin 管理面。角色校验在每个 handler 内再做一次。
+func (m *Manager) routeManager(r *wkhttp.WKHttp) {
+	g := r.Group("/v1/manager/featuregate", m.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, m.ctx))
+	g.GET("/gates", m.list)                              // 列出所有规则（含白名单）
+	g.PUT("/gates/:key", m.update)                       // 改 mode/percent/bucket_by/description
+	g.POST("/gates/:key/scopes", m.addScope)             // 加白名单条目
+	g.DELETE("/gates/:key/scopes/:scope_id", m.delScope) // 删白名单条目
+}
+
+// routeUser 挂已登录用户的只读下发面。
+func (m *Manager) routeUser(r *wkhttp.WKHttp) {
+	g := r.Group("/v1/featuregate", m.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, m.ctx))
+	g.GET("/flags", m.flags.get) // 当前登录用户的灰度位
 }
 
 // ---- 请求/响应模型 ----
@@ -83,15 +88,19 @@ type scopeReq struct {
 type scopeResp struct {
 	ScopeType string `json:"scope_type"`
 	ScopeID   string `json:"scope_id"`
+	UpdatedBy string `json:"updated_by"`
 }
 
 type gateResp struct {
-	FeatureKey  string      `json:"feature_key"`
-	Mode        string      `json:"mode"`
-	Percent     int         `json:"percent"`
-	BucketBy    string      `json:"bucket_by"`
-	Description string      `json:"description"`
-	Scopes      []scopeResp `json:"scopes"`
+	FeatureKey  string `json:"feature_key"`
+	Mode        string `json:"mode"`
+	Percent     int    `json:"percent"`
+	BucketBy    string `json:"bucket_by"`
+	Description string `json:"description"`
+	// UpdatedBy 是最近修改该规则的管理员 uid。一个能对全体用户关功能的开关必须
+	// 留下操作人，否则事后无从追溯是谁在什么时候翻的。
+	UpdatedBy string      `json:"updated_by"`
+	Scopes    []scopeResp `json:"scopes"`
 	// ClientVisible 标示该 key 是否会被下发到客户端。运维据此知道这条规则受
 	// 「维度必须是 user」的额外约束，也知道改它会影响终端展示。
 	ClientVisible bool `json:"client_visible"`
@@ -102,7 +111,7 @@ type gateResp struct {
 func toGateResp(g *gateModel, scopes []*scopeModel, clientVisible bool) gateResp {
 	sr := make([]scopeResp, 0, len(scopes))
 	for _, s := range scopes {
-		sr = append(sr, scopeResp{ScopeType: s.ScopeType, ScopeID: s.ScopeID})
+		sr = append(sr, scopeResp{ScopeType: s.ScopeType, ScopeID: s.ScopeID, UpdatedBy: s.UpdatedBy})
 	}
 	return gateResp{
 		FeatureKey: g.FeatureKey,
@@ -111,6 +120,7 @@ func toGateResp(g *gateModel, scopes []*scopeModel, clientVisible bool) gateResp
 		// 空值在回显里也归一成实际生效的维度，避免运维看到空白去猜默认是什么。
 		BucketBy:      fg.BucketDimension(fg.Rule{BucketBy: g.BucketBy}),
 		Description:   g.Description,
+		UpdatedBy:     g.UpdatedBy,
 		Scopes:        sr,
 		ClientVisible: clientVisible,
 		KillSwitchEnv: KillSwitchEnv(g.FeatureKey),

--- a/modules/featuregate/manager.go
+++ b/modules/featuregate/manager.go
@@ -1,0 +1,150 @@
+package featuregate
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	fg "github.com/Mininglamp-OSS/octo-server/pkg/featuregate"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
+)
+
+// Manager 是 featuregate 的路由入口：superadmin 管理端点 + 用户侧只读下发端点。
+// 读规则/白名单走 db，写后调 svc.Invalidate 让缓存秒级失效。
+type Manager struct {
+	ctx *config.Context
+	log.Log
+	db       *gateDB
+	svc      *Service
+	registry *clientRegistry
+	flags    *flagsAPI
+}
+
+// NewManager 构造模块入口。svc 既用于写后失效缓存，也是用户侧端点的判定来源，
+// 与业务模块的运行时评估共享同一 Redis/DB。
+func NewManager(ctx *config.Context) *Manager {
+	return newManagerWithRegistry(ctx, defaultClientRegistry)
+}
+
+// newManagerWithRegistry 是 NewManager 的可注入变体。生产只有 defaultClientRegistry
+// 一份；测试用它注入自己的注册表，从而在不往生产清单里塞假 key 的前提下覆盖
+// 「客户端可见 key」相关的分支。
+func newManagerWithRegistry(ctx *config.Context, registry *clientRegistry) *Manager {
+	svc := NewService(ctx)
+	return &Manager{
+		ctx:      ctx,
+		Log:      log.NewTLog("featureGateManager"),
+		db:       newDB(ctx),
+		svc:      svc,
+		registry: registry,
+		flags:    newFlagsAPI(ctx, svc, registry),
+	}
+}
+
+// Route 注册两组路由：
+//
+//	/v1/manager/featuregate  superadmin 管理面（每个 handler 内再校验角色）
+//	/v1/featuregate          已登录用户的只读下发面
+//
+// 两组都在 AuthMiddleware 之后挂 SharedUIDRateLimiter —— 挂在鉴权中间件之前
+// 读不到 uid，会静默 fail-open。
+//
+// 用户侧端点用 /v1/featuregate/... 而非 /v1/user/...：路径首段跟模块名走
+// （同 /v1/common/appconfig、/v1/sticker/user），从路由能直接定位到代码。
+func (m *Manager) Route(r *wkhttp.WKHttp) {
+	mgr := r.Group("/v1/manager/featuregate", m.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, m.ctx))
+	{
+		mgr.GET("/gates", m.list)                              // 列出所有规则（含白名单）
+		mgr.PUT("/gates/:key", m.update)                       // 改 mode/percent/bucket_by/description
+		mgr.POST("/gates/:key/scopes", m.addScope)             // 加白名单条目
+		mgr.DELETE("/gates/:key/scopes/:scope_id", m.delScope) // 删白名单条目
+	}
+
+	user := r.Group("/v1/featuregate", m.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, m.ctx))
+	{
+		user.GET("/flags", m.flags.get) // 当前登录用户的灰度位
+	}
+}
+
+// ---- 请求/响应模型 ----
+
+type updateGateReq struct {
+	Mode    string `json:"mode"`
+	Percent int    `json:"percent"`
+	// BucketBy 是 percent 分桶维度；空 = 沿用默认（group）。
+	BucketBy    string `json:"bucket_by"`
+	Description string `json:"description"`
+}
+
+type scopeReq struct {
+	ScopeType string `json:"scope_type"`
+	ScopeID   string `json:"scope_id"`
+}
+
+type scopeResp struct {
+	ScopeType string `json:"scope_type"`
+	ScopeID   string `json:"scope_id"`
+}
+
+type gateResp struct {
+	FeatureKey  string      `json:"feature_key"`
+	Mode        string      `json:"mode"`
+	Percent     int         `json:"percent"`
+	BucketBy    string      `json:"bucket_by"`
+	Description string      `json:"description"`
+	Scopes      []scopeResp `json:"scopes"`
+	// ClientVisible 标示该 key 是否会被下发到客户端。运维据此知道这条规则受
+	// 「维度必须是 user」的额外约束，也知道改它会影响终端展示。
+	ClientVisible bool `json:"client_visible"`
+	// KillSwitchEnv 回显该 key 的 env 杀开关名，省得运维手工推导大小写/连字符。
+	KillSwitchEnv string `json:"kill_switch_env"`
+}
+
+func toGateResp(g *gateModel, scopes []*scopeModel, clientVisible bool) gateResp {
+	sr := make([]scopeResp, 0, len(scopes))
+	for _, s := range scopes {
+		sr = append(sr, scopeResp{ScopeType: s.ScopeType, ScopeID: s.ScopeID})
+	}
+	return gateResp{
+		FeatureKey: g.FeatureKey,
+		Mode:       g.Mode,
+		Percent:    g.Percent,
+		// 空值在回显里也归一成实际生效的维度，避免运维看到空白去猜默认是什么。
+		BucketBy:      fg.BucketDimension(fg.Rule{BucketBy: g.BucketBy}),
+		Description:   g.Description,
+		Scopes:        sr,
+		ClientVisible: clientVisible,
+		KillSwitchEnv: KillSwitchEnv(g.FeatureKey),
+	}
+}
+
+// ---- 字段校验 ----
+
+func validMode(mode string) bool {
+	switch fg.Mode(mode) {
+	case fg.ModeOff, fg.ModeOn, fg.ModeWhitelist, fg.ModePercent:
+		return true
+	}
+	return false
+}
+
+// clientVisibleDimension 是【客户端展示端点】唯一能提供的维度。
+//
+// GET /v1/featuregate/flags 只有登录用户的 UID：它不接收也不推断空间/群上下文
+// （一个用户可属多个空间，"当前空间"在那条请求里没有确定答案）。因此凡是会下发到
+// 客户端的 key，其分桶维度与白名单维度都必须是 user。
+const clientVisibleDimension = fg.ScopeTypeUser
+
+// validateClientVisibleDimension 是写侧的错配拦截：对已注册为客户端可见的
+// feature_key，拒绝它用上一个展示端点提供不了的维度。
+//
+// 不拦的后果是一个**无报错的静默错配**：配 bucket_by=group 时，展示端点评估到的
+// GroupNo 为空，若按空串照算则所有用户落进同一个桶，管理台显示的 50% 实际会变成
+// 全体开或全体关。读侧（AllowDisplay）另有 fail-closed 兜底 —— 两侧都要：只做
+// 写侧会被直接改库绕过，只做读侧则运维以为自己配置生效了。
+//
+// 对 mode 不做区分（即便当前是 whitelist 也要求 bucket_by=user）：bucket_by 虽然
+// 只在 percent 生效，但先存一个坏值、之后切到 percent 就会踩雷，不如在写入时就
+// 保证这张表里客户端可见的行恒定合法。
+func validateClientVisibleDimension(dim string) bool {
+	return dim == clientVisibleDimension
+}

--- a/modules/featuregate/model.go
+++ b/modules/featuregate/model.go
@@ -11,6 +11,7 @@ type gateModel struct {
 	Percent     int
 	BucketBy    string
 	Description string
+	UpdatedBy   string
 	db.BaseModel
 }
 
@@ -19,5 +20,6 @@ type scopeModel struct {
 	FeatureKey string
 	ScopeType  string
 	ScopeID    string
+	UpdatedBy  string
 	db.BaseModel
 }

--- a/modules/featuregate/model.go
+++ b/modules/featuregate/model.go
@@ -1,0 +1,23 @@
+package featuregate
+
+import "github.com/Mininglamp-OSS/octo-lib/pkg/db"
+
+// gateModel 对应 octo_feature_gate 表（每个功能 key 一行规则）。
+// 嵌入 BaseModel 提供 id/created_at/updated_at；util.AttrToUnderscore 会跳过
+// 嵌入的 struct，故 INSERT 仅写顶层标量列，时间戳交给 DB 默认值。
+type gateModel struct {
+	FeatureKey  string
+	Mode        string
+	Percent     int
+	BucketBy    string
+	Description string
+	db.BaseModel
+}
+
+// scopeModel 对应 octo_feature_gate_scope 表（白名单条目，逐条加删）。
+type scopeModel struct {
+	FeatureKey string
+	ScopeType  string
+	ScopeID    string
+	db.BaseModel
+}

--- a/modules/featuregate/registry.go
+++ b/modules/featuregate/registry.go
@@ -1,0 +1,156 @@
+package featuregate
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/Mininglamp-OSS/octo-server/modules/common"
+)
+
+// ClientFlag 是一条【可下发给客户端】的灰度位注册项。
+//
+// 为什么需要这份注册表：octo_feature_gate.feature_key 是自由字符串，没有区分
+// 「哪些 key 允许暴露给客户端查询」。若端点按客户端传入的 key 查库，任意登录用户
+// 就能枚举/探测内部 gate 是否存在及其状态。端点因此【不接受任何 key 参数】，
+// 只按这份代码内的清单批量评估——注册表就是客户端无法跨越的那道边界。
+//
+// FeatureKey 与 ClientKey 刻意分开：
+//
+//	FeatureKey  运维面标识：octo_feature_gate 主键、管理台展示，且
+//	            OCTO_FEATUREGATE_<大写>_KILL 环境变量名由它推导（见 KillSwitchEnv）。
+//	ClientKey   wire 契约：GET /v1/featuregate/flags 响应 JSON 的字段名。
+//
+// 绑成一个会让「运维改 gate 名」这种本该无风险的操作静默破坏三端客户端。反过来
+// 的约束是：ClientKey 一旦发布即冻结，与 appconfig 字段同级别（additive-only），
+// 要改就是破坏性变更、须与客户端发版协调。
+type ClientFlag struct {
+	// FeatureKey 是 octo_feature_gate.feature_key。
+	FeatureKey string
+	// ClientKey 是下发给客户端的 JSON 字段名。
+	ClientKey string
+	// DeploymentGate 是可选的「部署前置位」。非 nil 时，该 flag 的最终值 =
+	// gate 判定 AND DeploymentGate(...)。
+	//
+	// 用途：某功能既依赖外部服务是否部署（system_setting 里已有的位），又需要
+	// 按用户放量时，把两者的 AND 做在【服务端】。绝不能把组合逻辑丢给客户端——
+	// 三端各实现一次必然漂移。
+	//
+	// 多数 flag 不需要它：featuregate 自己的 mode=off 就足以表达「部署没就绪」。
+	DeploymentGate func(*common.SystemSettings) bool
+}
+
+// clientKeyPattern / featureKeyPattern 约束两个 key 的字面量。
+//
+// 两者都限定在 [a-z0-9_]，**刻意不允许连字符**。原因在 feature_key 这一侧：
+// 它要推导 env 杀开关名（见 KillSwitchEnv）。若同时允许 `-` 和 `_`，就得在推导时
+// 把 `-` 折成 `_`，于是 `docs-beta` 与 `docs_beta` 这两条**不同**的规则（唯一性
+// 校验都能过）会映射到**同一个** OCTO_FEATUREGATE_DOCS_BETA_KILL ——
+// 想停其中一个会把另一个
+// 一起停掉。禁掉连字符使 key → env 名成为单射，这一整类碰撞在结构上就不存在了。
+//
+// ClientKey 用同样的 snake_case，与 appconfig 现有字段（docs_on、tracking_enabled）
+// 风格一致。
+var (
+	clientKeyPattern  = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+	featureKeyPattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+)
+
+// maxFeatureKeyLen 对齐 octo_feature_gate.feature_key 的 VARCHAR(64)。在注册期
+// 拦住超长值，好过等到写库时才失败。
+const maxFeatureKeyLen = 64
+
+// validFeatureKey 是 feature_key 的**唯一**校验口径，注册表与管理端写路径共用。
+//
+// 管理端一度只校验长度不校验字符集，后果不是脏数据而是**丢掉急停能力**：
+// feature_key = "my gate" 推导出的 OCTO_FEATUREGATE_MY GATE_KILL 含空格，
+// 常规手段设不进去，
+// 这条 gate 就永久失去了 env 级紧急停止 —— 而那正是「DB/Redis 全挂时仍能一键停」
+// 的最后一条路径（主回滚 mode=off 要读 DB，恰恰在故障时不可用）。
+func validFeatureKey(key string) bool {
+	return len(key) <= maxFeatureKeyLen && featureKeyPattern.MatchString(key)
+}
+
+// clientRegistry 是校验过的注册表。构造后不可变，读侧无锁。
+type clientRegistry struct {
+	flags []ClientFlag
+	// needsSettings 缓存「是否有任一 flag 声明了 DeploymentGate」，让 API 层
+	// 只在真的需要时才去取 SystemSettings 单例。
+	needsSettings bool
+}
+
+// newClientRegistry 校验并构造注册表。
+//
+// 两个 key 都必须唯一。ClientKey 重复尤其致命且**静默**：响应是 map[string]bool，
+// 两项声明同一个 ClientKey 时后写的直接覆盖先写的，map 不会报任何错，线上表现为
+// 「某个 flag 的值莫名其妙跟着另一个功能走」。
+func newClientRegistry(flags []ClientFlag) (*clientRegistry, error) {
+	seenFeature := make(map[string]struct{}, len(flags))
+	seenClient := make(map[string]struct{}, len(flags))
+	needsSettings := false
+	for i, f := range flags {
+		if !featureKeyPattern.MatchString(f.FeatureKey) {
+			return nil, fmt.Errorf("featuregate registry[%d]: invalid FeatureKey %q (want %s)", i, f.FeatureKey, featureKeyPattern)
+		}
+		if len(f.FeatureKey) > maxFeatureKeyLen {
+			return nil, fmt.Errorf("featuregate registry[%d]: FeatureKey %q exceeds %d bytes", i, f.FeatureKey, maxFeatureKeyLen)
+		}
+		if !clientKeyPattern.MatchString(f.ClientKey) {
+			return nil, fmt.Errorf("featuregate registry[%d]: invalid ClientKey %q (want %s)", i, f.ClientKey, clientKeyPattern)
+		}
+		if _, dup := seenFeature[f.FeatureKey]; dup {
+			return nil, fmt.Errorf("featuregate registry: duplicate FeatureKey %q", f.FeatureKey)
+		}
+		if _, dup := seenClient[f.ClientKey]; dup {
+			return nil, fmt.Errorf("featuregate registry: duplicate ClientKey %q", f.ClientKey)
+		}
+		seenFeature[f.FeatureKey] = struct{}{}
+		seenClient[f.ClientKey] = struct{}{}
+		if f.DeploymentGate != nil {
+			needsSettings = true
+		}
+	}
+	// 拷贝一份再持有：直接存调用方的 slice 会让构造后对其元素的原地修改
+	// （如 clientFlagList[0].ClientKey = "x"）穿透进来，绕过上面刚做的唯一性与
+	// 命名校验。注册表构造后必须是不可变的。
+	owned := make([]ClientFlag, len(flags))
+	copy(owned, flags)
+	return &clientRegistry{flags: owned, needsSettings: needsSettings}, nil
+}
+
+// mustNewClientRegistry 是 newClientRegistry 的启动期变体：注册表写错直接 panic，
+// 而不是带着一个会静默串值的表上线。同 pkg/i18n 的 codes 注册与
+// mustLookupSharedCode 的取向——注册表错误属于部署事故，越早越响越好。
+func mustNewClientRegistry(flags []ClientFlag) *clientRegistry {
+	r, err := newClientRegistry(flags)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+// isClientVisible 报告某 feature_key 是否会被下发给客户端。管理端写侧用它决定
+// 要不要施加「维度必须是调用点能提供的」这条额外约束。
+func (r *clientRegistry) isClientVisible(featureKey string) bool {
+	for _, f := range r.flags {
+		if f.FeatureKey == featureKey {
+			return true
+		}
+	}
+	return false
+}
+
+// clientFlagList 是**可下发给客户端的灰度位清单**。
+//
+// 当前为空 —— 本任务交付的是机制，不是具体业务开关。某个功能要用户级灰度时，在此
+// 追加一行即可，客户端无需为「发现新 flag」发版（它读到的就是这份清单的全集）。
+//
+// 追加时注意：
+//   - ClientKey 一经发布即冻结（wire 契约），命名用 snake_case；
+//   - 归属唯一——已经在 appconfig 有展示位的功能【不要】再建 featuregate key，
+//     老客户端只读 appconfig，双挂会让灰度当场失效；
+//   - 规则必须配 bucket_by=user / scope_type=user，因为本端点只有 UID 维度
+//     （管理端写侧会拦，读侧也会 fail-closed）。
+var clientFlagList = []ClientFlag{}
+
+// defaultClientRegistry 是进程内的注册表实例。包初始化期完成校验。
+var defaultClientRegistry = mustNewClientRegistry(clientFlagList)

--- a/modules/featuregate/registry.go
+++ b/modules/featuregate/registry.go
@@ -128,8 +128,6 @@ func mustNewClientRegistry(flags []ClientFlag) *clientRegistry {
 	return r
 }
 
-// isClientVisible 报告某 feature_key 是否会被下发给客户端。管理端写侧用它决定
-
 // clientKeys 返回全部对外 key，供「答案整体不可知」时一次性列进 unavailable。
 func (r *clientRegistry) clientKeys() []string {
 	keys := make([]string, 0, len(r.flags))
@@ -139,6 +137,7 @@ func (r *clientRegistry) clientKeys() []string {
 	return keys
 }
 
+// isClientVisible 报告某 feature_key 是否会被下发给客户端。管理端写侧用它决定
 // 要不要施加「维度必须是调用点能提供的」这条额外约束。
 func (r *clientRegistry) isClientVisible(featureKey string) bool {
 	for _, f := range r.flags {

--- a/modules/featuregate/registry.go
+++ b/modules/featuregate/registry.go
@@ -129,6 +129,16 @@ func mustNewClientRegistry(flags []ClientFlag) *clientRegistry {
 }
 
 // isClientVisible 报告某 feature_key 是否会被下发给客户端。管理端写侧用它决定
+
+// clientKeys 返回全部对外 key，供「答案整体不可知」时一次性列进 unavailable。
+func (r *clientRegistry) clientKeys() []string {
+	keys := make([]string, 0, len(r.flags))
+	for _, f := range r.flags {
+		keys = append(keys, f.ClientKey)
+	}
+	return keys
+}
+
 // 要不要施加「维度必须是调用点能提供的」这条额外约束。
 func (r *clientRegistry) isClientVisible(featureKey string) bool {
 	for _, f := range r.flags {

--- a/modules/featuregate/registry_test.go
+++ b/modules/featuregate/registry_test.go
@@ -189,7 +189,9 @@ func TestValidFeatureKey(t *testing.T) {
 		"my gate",                               // 空格 → 杀开关环境变量名设不进去
 		"docs.beta",                             // 点
 		"docs/beta",                             // 斜杠
-		"docs\nbeta",                            // 换行
+		"docs\nbeta",                            // 内嵌换行
+		"docs_beta\n",                           // **尾部**换行：Go 的 $ 是 end-of-text 故拒；
+		"docs_beta\r",                           //   MySQL 的 ICU $ 不拒，迁移里用 \\z 对齐
 		strings.Repeat("a", maxFeatureKeyLen+1), // 超 DB 列长
 	} {
 		if validFeatureKey(bad) {

--- a/modules/featuregate/registry_test.go
+++ b/modules/featuregate/registry_test.go
@@ -1,0 +1,263 @@
+package featuregate
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/modules/common"
+)
+
+func TestNewClientRegistryValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		flags   []ClientFlag
+		wantErr string // 空 = 应当成功
+	}{
+		{
+			name:  "空注册表合法",
+			flags: []ClientFlag{},
+		},
+		{
+			name: "正常两项",
+			flags: []ClientFlag{
+				{FeatureKey: "docs_user_rollout", ClientKey: "docs"},
+				{FeatureKey: "drive_beta", ClientKey: "drive_beta"},
+			},
+		},
+		{
+			// 静默故障防线：响应是 map[string]bool，两项同 ClientKey 时后写覆盖
+			// 先写，map 不报错，线上表现为「某 flag 的值跟着另一个功能走」。
+			name: "重复 ClientKey 必须报错",
+			flags: []ClientFlag{
+				{FeatureKey: "a_rollout", ClientKey: "same"},
+				{FeatureKey: "b_rollout", ClientKey: "same"},
+			},
+			wantErr: "duplicate ClientKey",
+		},
+		{
+			name: "重复 FeatureKey 必须报错",
+			flags: []ClientFlag{
+				{FeatureKey: "same_key", ClientKey: "a"},
+				{FeatureKey: "same_key", ClientKey: "b"},
+			},
+			wantErr: "duplicate FeatureKey",
+		},
+		{
+			name:    "ClientKey 必须 snake_case",
+			flags:   []ClientFlag{{FeatureKey: "ok_key", ClientKey: "DocsOn"}},
+			wantErr: "invalid ClientKey",
+		},
+		{
+			name:    "ClientKey 不得含连字符（JSON 字段风格对齐 appconfig）",
+			flags:   []ClientFlag{{FeatureKey: "ok_key", ClientKey: "docs-on"}},
+			wantErr: "invalid ClientKey",
+		},
+		{
+			// 连字符会让 key → env 名不再是单射（见 KillSwitchEnv）。
+			name:    "FeatureKey 不得含连字符",
+			flags:   []ClientFlag{{FeatureKey: "docs-beta", ClientKey: "docs_beta"}},
+			wantErr: "invalid FeatureKey",
+		},
+		{
+			name:    "FeatureKey 不得含空格（否则杀开关环境变量名设不进去）",
+			flags:   []ClientFlag{{FeatureKey: "my gate", ClientKey: "ok"}},
+			wantErr: "invalid FeatureKey",
+		},
+		{
+			name:    "空 ClientKey 非法",
+			flags:   []ClientFlag{{FeatureKey: "ok_key", ClientKey: ""}},
+			wantErr: "invalid ClientKey",
+		},
+		{
+			name:    "空 FeatureKey 非法",
+			flags:   []ClientFlag{{FeatureKey: "", ClientKey: "ok"}},
+			wantErr: "invalid FeatureKey",
+		},
+		{
+			// 超长 key 写库时才失败太晚 —— 在注册期就挡住。
+			name:    "FeatureKey 超过 DB 列长度非法",
+			flags:   []ClientFlag{{FeatureKey: strings.Repeat("a", maxFeatureKeyLen+1), ClientKey: "ok"}},
+			wantErr: "exceeds",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := newClientRegistry(tc.flags)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("期望成功，得到错误：%v", err)
+				}
+				if r == nil {
+					t.Fatal("成功时 registry 不应为 nil")
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("期望错误包含 %q，却成功了", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("错误 %q 未包含 %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestMustNewClientRegistryPanics 钉住注册表写错时是启动期 panic，而不是带着一个
+// 会静默串值的表上线。
+func TestMustNewClientRegistryPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("重复 ClientKey 必须 panic")
+		}
+	}()
+	mustNewClientRegistry([]ClientFlag{
+		{FeatureKey: "a_rollout", ClientKey: "same"},
+		{FeatureKey: "b_rollout", ClientKey: "same"},
+	})
+}
+
+// TestRegistryNeedsSettings 验证「只在真有 flag 声明部署前置位时才去取
+// SystemSettings 单例」的判定。取那个单例会做一次 DB Load 并起后台 goroutine，
+// 没人用就不该付这个代价。
+func TestRegistryNeedsSettings(t *testing.T) {
+	plain := mustNewClientRegistry([]ClientFlag{{FeatureKey: "a_rollout", ClientKey: "a"}})
+	if plain.needsSettings {
+		t.Fatal("无 DeploymentGate 时不应要求 SystemSettings")
+	}
+	gated := mustNewClientRegistry([]ClientFlag{
+		{FeatureKey: "a_rollout", ClientKey: "a"},
+		{FeatureKey: "b_rollout", ClientKey: "b", DeploymentGate: func(*common.SystemSettings) bool { return true }},
+	})
+	if !gated.needsSettings {
+		t.Fatal("有 DeploymentGate 时必须要求 SystemSettings")
+	}
+}
+
+func TestRegistryIsClientVisible(t *testing.T) {
+	r := mustNewClientRegistry([]ClientFlag{{FeatureKey: "docs_user_rollout", ClientKey: "docs"}})
+	if !r.isClientVisible("docs_user_rollout") {
+		t.Fatal("已注册的 feature_key 应为 client-visible")
+	}
+	// 按 feature_key 判定，不是 client_key —— 管理端拿到的是前者。
+	if r.isClientVisible("docs") {
+		t.Fatal("client_key 不应被当成 feature_key 命中")
+	}
+	if r.isClientVisible("unregistered") {
+		t.Fatal("未注册的 key 不应为 client-visible")
+	}
+}
+
+// TestDefaultRegistryIsValid 确保生产清单本身能通过校验。清单当前为空（本任务交付
+// 机制而非具体业务开关），但这条测试会在有人追加条目后继续守住唯一性与命名。
+func TestDefaultRegistryIsValid(t *testing.T) {
+	if _, err := newClientRegistry(clientFlagList); err != nil {
+		t.Fatalf("生产注册表非法：%v", err)
+	}
+}
+
+// TestRegistryIsImmutableAfterConstruction 钉住注册表构造后不可被绕过校验地改写。
+// 直接持有调用方 slice 时，对其元素的原地修改会穿透进已校验的注册表。
+func TestRegistryIsImmutableAfterConstruction(t *testing.T) {
+	src := []ClientFlag{{FeatureKey: "a_rollout", ClientKey: "a"}}
+	r := mustNewClientRegistry(src)
+
+	src[0].FeatureKey = "hijacked"
+	src[0].ClientKey = "hijacked"
+
+	if !r.isClientVisible("a_rollout") {
+		t.Fatal("注册表被外部改写：构造时必须拷贝一份，而不是持有调用方的 slice")
+	}
+	if r.flags[0].ClientKey != "a" {
+		t.Fatalf("ClientKey 被外部改写为 %q，绕过了构造期的唯一性/命名校验", r.flags[0].ClientKey)
+	}
+}
+
+// TestValidFeatureKey 是 feature_key 的单一校验口径，注册表与管理端写路径共用。
+func TestValidFeatureKey(t *testing.T) {
+	for _, ok := range []string{"a", "docs_beta", "incoming_webhook_create", "a1_2"} {
+		if !validFeatureKey(ok) {
+			t.Fatalf("%q 应为合法 feature_key", ok)
+		}
+	}
+	for _, bad := range []string{
+		"",                                      // 空
+		"1abc",                                  // 数字开头
+		"Docs",                                  // 大写
+		"docs-beta",                             // 连字符 → 破坏 key→env 单射
+		"my gate",                               // 空格 → 杀开关环境变量名设不进去
+		"docs.beta",                             // 点
+		"docs/beta",                             // 斜杠
+		"docs\nbeta",                            // 换行
+		strings.Repeat("a", maxFeatureKeyLen+1), // 超 DB 列长
+	} {
+		if validFeatureKey(bad) {
+			t.Fatalf("%q 不应为合法 feature_key", bad)
+		}
+	}
+}
+
+// TestKillSwitchEnvIsInjective 钉住 feature_key → env 名的单射性。
+//
+// 早先 featureKeyPattern 允许连字符、KillSwitchEnv 把 `-` 折成 `_`，于是
+// docs-beta 与 docs_beta 这两条不同的规则会共用一个 OCTO_FEATUREGATE_DOCS_BETA_KILL ——
+// 停一个会把另一个一起停掉。现在连字符被禁，且推导不做任何折叠。
+func TestKillSwitchEnvIsInjective(t *testing.T) {
+	keys := []string{"docs_beta", "docsbeta", "a", "a_b", "ab", "incoming_webhook_push"}
+	seen := make(map[string]string, len(keys))
+	for _, k := range keys {
+		if !validFeatureKey(k) {
+			t.Fatalf("用例 key %q 本身应合法", k)
+		}
+		env := KillSwitchEnv(k)
+		if prev, dup := seen[env]; dup {
+			t.Fatalf("key %q 与 %q 映射到同一个杀开关 %q：停一个会误停另一个", k, prev, env)
+		}
+		seen[env] = k
+	}
+	if got := KillSwitchEnv("docs_beta"); got != "OCTO_FEATUREGATE_DOCS_BETA_KILL" {
+		t.Fatalf("KillSwitchEnv 推导有变：%q", got)
+	}
+}
+
+// TestFlagsRespSerialization 钉住 wire 形状：动态 map、且值为 false 的 key 必须
+// 出现在 JSON 里。
+//
+// 这不是风格测试。若有人把 Flags 换成固定字段 struct，「省略某个 key」就实现不了；
+// 若为了实现省略而加 omitempty，false 会被一起吞掉——「规则不存在的确定性的关」
+// 与「存储故障」在线上就长得一模一样，客户端会保留旧值，灰度永远关不掉。
+func TestFlagsRespSerialization(t *testing.T) {
+	raw, err := json.Marshal(flagsResp{Flags: map[string]bool{"on_flag": true, "off_flag": false}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back struct {
+		Flags map[string]bool `json:"flags"`
+	}
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	v, ok := back.Flags["off_flag"]
+	if !ok {
+		t.Fatalf("值为 false 的 key 被从 JSON 中吞掉了（omitempty？）：%s", raw)
+	}
+	if v {
+		t.Fatalf("off_flag 应为 false，得到 true：%s", raw)
+	}
+	if !back.Flags["on_flag"] {
+		t.Fatalf("on_flag 应为 true：%s", raw)
+	}
+}
+
+// TestFlagsRespEmptyMapSerializesAsObject 确保空注册表下响应是 {"flags":{}} 而不是
+// {"flags":null} —— 后者会让弱类型客户端在解引用时炸掉。
+func TestFlagsRespEmptyMapSerializesAsObject(t *testing.T) {
+	raw, err := json.Marshal(flagsResp{Flags: map[string]bool{}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if got := string(raw); got != `{"flags":{}}` {
+		t.Fatalf("空 flags 应序列化为 {\"flags\":{}}，得到 %s", got)
+	}
+}

--- a/modules/featuregate/registry_test.go
+++ b/modules/featuregate/registry_test.go
@@ -228,7 +228,7 @@ func TestKillSwitchEnvIsInjective(t *testing.T) {
 // 若为了实现省略而加 omitempty，false 会被一起吞掉——「规则不存在的确定性的关」
 // 与「存储故障」在线上就长得一模一样，客户端会保留旧值，灰度永远关不掉。
 func TestFlagsRespSerialization(t *testing.T) {
-	raw, err := json.Marshal(flagsResp{Flags: map[string]bool{"on_flag": true, "off_flag": false}})
+	raw, err := json.Marshal(flagsResp{Flags: map[string]bool{"on_flag": true, "off_flag": false}, Unavailable: []string{}})
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
@@ -253,11 +253,11 @@ func TestFlagsRespSerialization(t *testing.T) {
 // TestFlagsRespEmptyMapSerializesAsObject 确保空注册表下响应是 {"flags":{}} 而不是
 // {"flags":null} —— 后者会让弱类型客户端在解引用时炸掉。
 func TestFlagsRespEmptyMapSerializesAsObject(t *testing.T) {
-	raw, err := json.Marshal(flagsResp{Flags: map[string]bool{}})
+	raw, err := json.Marshal(flagsResp{Flags: map[string]bool{}, Unavailable: []string{}})
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if got := string(raw); got != `{"flags":{}}` {
-		t.Fatalf("空 flags 应序列化为 {\"flags\":{}}，得到 %s", got)
+	if got := string(raw); got != `{"flags":{},"unavailable":[]}` {
+		t.Fatalf("空响应应序列化为 {\"flags\":{},\"unavailable\":[]}，得到 %s", got)
 	}
 }

--- a/modules/featuregate/service.go
+++ b/modules/featuregate/service.go
@@ -1,0 +1,321 @@
+package featuregate
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	octoredis "github.com/Mininglamp-OSS/octo-lib/pkg/redis"
+	fg "github.com/Mininglamp-OSS/octo-server/pkg/featuregate"
+	"go.uber.org/zap"
+)
+
+// 缓存键前缀与兜底 TTL。Redis 是规则的读缓存（DB 才是真源）；管理端写后主动
+// DEL 失效以达成秒级全实例一致，TTL 仅作 DEL 漏掉时的最终一致兜底。
+const (
+	ruleKeyPrefix  = "ft:rule:"
+	scopeKeyPrefix = "ft:scope:"
+	cacheTTL       = 60 * time.Second
+	// nilSentinel 缓存「DB 也没有此规则」，防止未注册 key 每次穿透到 DB。
+	nilSentinel = "__nil__"
+)
+
+// Dims 是评估维度，pkg/featuregate.Dims 的别名 —— 调用方只 import 本模块即可
+// 构造维度，无需再引入纯逻辑包。
+type Dims = fg.Dims
+
+// Service 是 featuregate 的带 IO 编排层：在 pkg/featuregate 纯逻辑之上叠加
+// DB 真源 + Redis 读缓存 + env kill switch + 按端固定的 fail 兜底。
+//
+// fail 策略不可按规则配置，而是按调用端固定：
+//
+//	AllowCreate  写时闸门     fail-closed  （误拒 < 数据裸奔）
+//	AllowPush    推送总开关   fail-open    （误推 < 中断存量推送）
+//	AllowDisplay 展示位下发   fail-closed，且把「存储故障」与「确定性的关」分开回报
+//
+// 这是刻意的安全不对称，不暴露为运维旋钮以免被配反。
+//
+// 由调用方直接 NewService(ctx) 构造，不经 module 注册，与 group.NewDB(ctx) 同
+// 模式，保持依赖图单向无环。
+type Service struct {
+	db    *gateDB
+	redis *octoredis.Conn
+	log.Log
+}
+
+// NewService 构造 Service，自取 DB 与 Redis。
+func NewService(ctx *config.Context) *Service {
+	return &Service{
+		db:    newDB(ctx),
+		redis: ctx.GetRedisConn(),
+		Log:   log.NewTLog("FeatureGate"),
+	}
+}
+
+// cachedRule 是规则在 Redis 中的序列化形态（不含 key —— key 已在 Redis key 里）。
+type cachedRule struct {
+	Mode     string `json:"mode"`
+	Percent  int    `json:"percent"`
+	BucketBy string `json:"bucket_by,omitempty"`
+}
+
+// AllowCreate 是写时闸门（fail-closed）：env kill / 存储故障 / 无规则 一律拒绝，
+// 否则交给纯函数评估。用于 create 类操作 —— 配置拿不到时拒绝新功能，胜过裸奔。
+func (s *Service) AllowCreate(ctx context.Context, key string, dims fg.Dims) bool {
+	if killSwitchOn(key) {
+		return false
+	}
+	rule, scopes, err := s.loadRuleAndScopes(ctx, key)
+	if err != nil {
+		s.Warn("featuregate load failed; create fail-closed",
+			zap.String("key", key), zap.Error(err))
+		return false
+	}
+	if rule == nil {
+		return false // 未注册规则 → fail-closed
+	}
+	return fg.Evaluate(*rule, scopes, dims).Allow
+}
+
+// AllowPush 是推送总开关（fail-open）：仅在 env kill 或规则被显式置为 off 时
+// 拒绝；存储故障 / 无规则 / 其余 mode 一律放行。push 是群广播热路径，绝不能因
+// 灰度框架故障中断存量推送，也不做维度灰度（按群灰度对群广播无意义）。
+func (s *Service) AllowPush(ctx context.Context, key string) bool {
+	if killSwitchOn(key) {
+		return false
+	}
+	rule, err := s.loadRule(ctx, key)
+	if err != nil {
+		s.Warn("featuregate load rule failed; push fail-open",
+			zap.String("key", key), zap.Error(err))
+		return true
+	}
+	if rule == nil {
+		return true // 未注册规则 → fail-open
+	}
+	// off 是管理员主动关停（确定性），与「故障 fail-open」区分开。
+	return rule.Mode != fg.ModeOff
+}
+
+// AllowDisplay 是客户端展示位判定，返回 (allow, ok) 两态：
+//
+//   - ok == false ：**存储故障**（DB/Redis）导致判定不可得。调用方应把该 key
+//     从响应中【省略】，让客户端保留上一次的值。绝不能下发 false —— 响应只有
+//     布尔，客户端分不清「真的关」和「服务端抖了一下」，一次 Redis 抖动就会让
+//     全体用户丢功能。
+//   - ok == true  ：allow 是**确定性**结论。规则不存在 → false（未配置即关），
+//     维度不可用 → false，kill switch → false。
+//
+// 为什么 kill switch 必须走确定性 false 而不是省略：省略意味着客户端保留旧值，
+// 那么对一个已经放量的功能按下 kill 开关，客户端界面永远不会收敛——紧急关停
+// 在展示面上完全失效。kill 的语义是「立刻确定性地关」，只能是 false。
+//
+// 维度不可用（如展示端点只有 UID，规则却配了 bucket_by=group）同样是确定性
+// 结论而非可用性问题，故也走 false，并打 Warn 让运维能发现这个错配。
+func (s *Service) AllowDisplay(ctx context.Context, key string, dims fg.Dims) (allow bool, ok bool) {
+	if killSwitchOn(key) {
+		return false, true
+	}
+	rule, scopes, err := s.loadRuleAndScopes(ctx, key)
+	if err != nil {
+		s.Warn("featuregate load failed; display key omitted from response",
+			zap.String("key", key), zap.Error(err))
+		return false, false
+	}
+	if rule == nil {
+		return false, true // 未注册规则 → 确定性的关
+	}
+	decision := fg.Evaluate(*rule, scopes, dims)
+	if decision.Reason == fg.ReasonDimUnavailable {
+		// 配置与调用点不匹配：规则要求的分桶维度这里提供不了。若按空串照算，
+		// 所有用户会落进同一个桶，配置的 50% 会静默变成全体开或全体关。
+		s.Warn("featuregate display rule requires a dimension this call site cannot provide; fail-closed",
+			zap.String("key", key),
+			zap.String("bucket_by", fg.BucketDimension(*rule)))
+	}
+	return decision.Allow, true
+}
+
+// loadRuleAndScopes 载入规则与（按需的）白名单。
+//
+// 「哪些 mode 需要白名单」在此处是**唯一定义**，AllowCreate 与 AllowDisplay 共用。
+// 初版把这个条件内联在 AllowCreate 里写作 `if rule.Mode == ModeWhitelist`，当
+// percent 也开始支持白名单后，那种写法极易漏改一处，症状是白名单静默失效——写入
+// 成功、读路径拿到空 scopes。收敛到一处就没有「漏改哪一处」这回事。
+func (s *Service) loadRuleAndScopes(ctx context.Context, key string) (*fg.Rule, []fg.Scope, error) {
+	rule, err := s.loadRule(ctx, key)
+	if err != nil || rule == nil {
+		return nil, nil, err
+	}
+	if !modeNeedsScopes(rule.Mode) {
+		return rule, nil, nil
+	}
+	scopes, err := s.loadScopes(ctx, key)
+	if err != nil {
+		return nil, nil, err
+	}
+	return rule, scopes, nil
+}
+
+// modeNeedsScopes 报告某 mode 的判定是否要读白名单。与
+// pkg/featuregate.Evaluate 的白名单作用域严格对应：whitelist 与 percent 生效，
+// off（不可穿透）与 on（无意义）不需要。
+func modeNeedsScopes(mode fg.Mode) bool {
+	return mode == fg.ModeWhitelist || mode == fg.ModePercent
+}
+
+// Invalidate 失效某 key 的规则与白名单缓存。管理端写操作提交后调用，使变更秒级
+// 在所有实例生效（Redis 共享，DEL 后各实例下次读 miss 回填新值）。
+func (s *Service) Invalidate(key string) {
+	if err := s.redis.Del(ruleKeyPrefix + key); err != nil {
+		s.Warn("featuregate invalidate rule cache failed",
+			zap.String("key", key), zap.Error(err))
+	}
+	if err := s.redis.Del(scopeKeyPrefix + key); err != nil {
+		s.Warn("featuregate invalidate scope cache failed",
+			zap.String("key", key), zap.Error(err))
+	}
+}
+
+// loadRule 读规则：Redis 命中即用；miss / 缓存损坏都走 fetchRuleAndCache（查 DB
+// 并回填，损坏值被新值覆盖，避免 TTL 内反复穿透）；Redis 真实故障则绕过缓存直查
+// DB（不回填）。
+func (s *Service) loadRule(_ context.Context, key string) (*fg.Rule, error) {
+	cached, err := s.redis.GetString(ruleKeyPrefix + key)
+	if err != nil {
+		return s.queryRuleFromDB(key) // Redis 故障：绕过缓存，DB 失败时由调用方走 fail 语义
+	}
+	switch cached {
+	case "":
+		return s.fetchRuleAndCache(key)
+	case nilSentinel:
+		return nil, nil
+	default:
+		var cr cachedRule
+		if err := json.Unmarshal([]byte(cached), &cr); err != nil {
+			s.Warn("featuregate rule cache corrupt; refetch from DB",
+				zap.String("key", key), zap.Error(err))
+			return s.fetchRuleAndCache(key) // 回填覆盖损坏值
+		}
+		return &fg.Rule{Key: key, Mode: fg.Mode(cr.Mode), Percent: cr.Percent, BucketBy: cr.BucketBy}, nil
+	}
+}
+
+// fetchRuleAndCache 查 DB 并回填缓存（无规则回填 nilSentinel 防穿透）。
+func (s *Service) fetchRuleAndCache(key string) (*fg.Rule, error) {
+	rule, err := s.queryRuleFromDB(key)
+	if err != nil {
+		return nil, err
+	}
+	if rule == nil {
+		s.cacheSet(ruleKeyPrefix+key, nilSentinel)
+		return nil, nil
+	}
+	s.cacheSet(ruleKeyPrefix+key, mustJSON(cachedRule{
+		Mode: string(rule.Mode), Percent: rule.Percent, BucketBy: rule.BucketBy,
+	}))
+	return rule, nil
+}
+
+// loadScopes 读白名单条目：语义同 loadRule。空列表序列化为 "[]"（非空串），与
+// miss（空串）天然区分，不会反复回查；miss / 缓存损坏都走 fetchScopesAndCache。
+func (s *Service) loadScopes(_ context.Context, key string) ([]fg.Scope, error) {
+	cached, err := s.redis.GetString(scopeKeyPrefix + key)
+	if err != nil {
+		return s.queryScopesFromDB(key)
+	}
+	if cached == "" {
+		return s.fetchScopesAndCache(key)
+	}
+	var scopes []fg.Scope
+	if err := json.Unmarshal([]byte(cached), &scopes); err != nil {
+		s.Warn("featuregate scope cache corrupt; refetch from DB",
+			zap.String("key", key), zap.Error(err))
+		return s.fetchScopesAndCache(key) // 回填覆盖损坏值
+	}
+	return scopes, nil
+}
+
+// fetchScopesAndCache 查 DB 并回填白名单缓存。
+func (s *Service) fetchScopesAndCache(key string) ([]fg.Scope, error) {
+	scopes, err := s.queryScopesFromDB(key)
+	if err != nil {
+		return nil, err
+	}
+	s.cacheSet(scopeKeyPrefix+key, mustJSON(scopes))
+	return scopes, nil
+}
+
+func (s *Service) queryRuleFromDB(key string) (*fg.Rule, error) {
+	m, err := s.db.queryRule(key)
+	if err != nil {
+		return nil, err
+	}
+	if m == nil {
+		return nil, nil
+	}
+	return &fg.Rule{Key: key, Mode: fg.Mode(m.Mode), Percent: m.Percent, BucketBy: m.BucketBy}, nil
+}
+
+func (s *Service) queryScopesFromDB(key string) ([]fg.Scope, error) {
+	rows, err := s.db.queryScopes(key)
+	if err != nil {
+		return nil, err
+	}
+	scopes := make([]fg.Scope, 0, len(rows))
+	for _, r := range rows {
+		scopes = append(scopes, fg.Scope{Type: r.ScopeType, ID: r.ScopeID})
+	}
+	return scopes, nil
+}
+
+// cacheSet 写缓存，失败仅 Warn（不阻断主流程，TTL/下次 miss 自愈）。空串跳过，
+// 避免把「未配置」状态写成可被误判为 miss 的值。
+func (s *Service) cacheSet(k, v string) {
+	if v == "" {
+		return
+	}
+	if err := s.redis.SetAndExpire(k, v, cacheTTL); err != nil {
+		s.Warn("featuregate cache set failed", zap.String("key", k), zap.Error(err))
+	}
+}
+
+// envKillPrefix / envKillSuffix 拼出 env 终极开关名。前缀取 OCTO_ 是本仓当前约定
+// （DM_ 系列均为遗留），并按 OCTO_<模块>_<项> 的既有样式带上模块名。
+const (
+	envKillPrefix = "OCTO_FEATUREGATE_"
+	envKillSuffix = "_KILL"
+)
+
+// killSwitchOn 读 env 终极开关。不查任何存储，DB/Redis 全挂时仍可一键停。
+func killSwitchOn(key string) bool {
+	return os.Getenv(KillSwitchEnv(key)) == "1"
+}
+
+// KillSwitchEnv 返回某 feature_key 对应的 kill 开关环境变量名，形如
+// incoming_webhook_push → OCTO_FEATUREGATE_INCOMING_WEBHOOK_PUSH_KILL。
+// 导出是为了让管理端/文档/测试与判定共用同一套推导，不各写一遍字符串拼接。
+//
+// 这里**不做任何字符折叠**，映射因此是单射：feature_key 被 validFeatureKey 限定在
+// [a-z][a-z0-9_]*，ToUpper 在该字符集上一一对应，所以两条不同的 gate 不可能落到
+// 同一个 env 名上。早先允许连字符并把 `-` 折成 `_` 时，`docs-beta` 与 `docs_beta`
+// 会共用一个开关——停一个会把另一个一起停掉。禁掉连字符 + 不折叠，这类碰撞在
+// 结构上消失，而不是靠约定回避。
+//
+// 注意这条推导把 feature_key 绑进了运维词汇表：改 feature_key 就等于改环境变量
+// 名。这正是对外 JSON 用独立 client_key 的原因之一（见 registry.go）。
+func KillSwitchEnv(key string) string {
+	return envKillPrefix + strings.ToUpper(key) + envKillSuffix
+}
+
+func mustJSON(v interface{}) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "" // 极罕见；返回空串使下次仍 miss 重试，而非缓存坏值
+	}
+	return string(b)
+}

--- a/modules/featuregate/service.go
+++ b/modules/featuregate/service.go
@@ -15,7 +15,15 @@ import (
 )
 
 // 缓存键前缀与兜底 TTL。Redis 是规则的读缓存（DB 才是真源）；管理端写后主动
-// DEL 失效以达成秒级全实例一致，TTL 仅作 DEL 漏掉时的最终一致兜底。
+// DEL 失效，正常情况下变更秒级到达所有实例。
+//
+// TTL 兜的是两种情况，不止一种：
+//  1. DEL 本身失败（Invalidate 只 Warn，不阻断写入）；
+//  2. **cache-aside 回填竞态**——一个在写事务提交前就查过 DB 的读者，可能在 DEL
+//     之后才把旧值写回缓存。于是一条刚被置为 off 的规则最长可能再放行 cacheTTL。
+//
+// 所以"秒级全实例一致"是**常态**而非保证；确定性的关停要走 env kill switch，它在
+// 三个入口都先于任何缓存/DB 读取被检查，完全绕开这个窗口。
 const (
 	// 缓存键带 schema 版本号：给 fg.Rule 加字段后，上一版二进制写入的缓存值会缺
 	// 新字段，读出来是零值并在 TTL 内（最长 60s）被当作真实配置使用。版本号一升，
@@ -107,14 +115,14 @@ func (s *Service) AllowPush(ctx context.Context, key string) bool {
 
 // AllowDisplay 是客户端展示位判定，返回 (allow, ok) 两态：
 //
-//   - ok == false ：**存储故障**（DB/Redis）导致判定不可得。调用方应把该 key
-//     从响应中【省略】，让客户端保留上一次的值。绝不能下发 false —— 响应只有
+//   - ok == false ：**存储故障**（DB/Redis）导致判定不可得。调用方应把该 key 列进
+//     响应的 unavailable 数组，让客户端保留上一次的值。绝不能下发 false —— flags 里只有
 //     布尔，客户端分不清「真的关」和「服务端抖了一下」，一次 Redis 抖动就会让
 //     全体用户丢功能。
 //   - ok == true  ：allow 是**确定性**结论。规则不存在 → false（未配置即关），
 //     维度不可用 → false，kill switch → false。
 //
-// 为什么 kill switch 必须走确定性 false 而不是省略：省略意味着客户端保留旧值，
+// 为什么 kill switch 必须走确定性 false 而不能进 unavailable：那意味着客户端保留旧值，
 // 那么对一个已经放量的功能按下 kill 开关，客户端界面永远不会收敛——紧急关停
 // 在展示面上完全失效。kill 的语义是「立刻确定性地关」，只能是 false。
 //
@@ -126,7 +134,7 @@ func (s *Service) AllowDisplay(ctx context.Context, key string, dims fg.Dims) (a
 	}
 	rule, scopes, err := s.loadRuleAndScopes(key)
 	if err != nil {
-		s.Warn("featuregate load failed; display key omitted from response",
+		s.Warn("featuregate load failed; display key reported as unavailable",
 			zap.String("key", key), zap.Error(err))
 		return false, false
 	}

--- a/modules/featuregate/service.go
+++ b/modules/featuregate/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -34,6 +35,8 @@ const (
 	cacheTTL           = 60 * time.Second
 	// nilSentinel 缓存「DB 也没有此规则」，防止未注册 key 每次穿透到 DB。
 	nilSentinel = "__nil__"
+	// warnInterval 是维度错配告警的去重窗口，见 warnIfDimensionUnusable。
+	warnInterval = 5 * time.Minute
 )
 
 // Dims 是评估维度，pkg/featuregate.Dims 的别名 —— 调用方只 import 本模块即可
@@ -56,6 +59,8 @@ type Dims = fg.Dims
 type Service struct {
 	db    *gateDB
 	redis *octoredis.Conn
+	// dimWarnAt 给维度错配告警做 (key,reason) 级去重，见 warnIfDimensionUnusable。
+	dimWarnAt sync.Map
 	log.Log
 }
 
@@ -90,7 +95,11 @@ func (s *Service) AllowCreate(ctx context.Context, key string, dims fg.Dims) boo
 	if rule == nil {
 		return false // 未注册规则 → fail-closed
 	}
-	return fg.Evaluate(*rule, scopes, dims).Allow
+	decision := fg.Evaluate(*rule, scopes, dims)
+	// 与 AllowDisplay 同源：写时闸门的维度错配同样 fail-closed、同样不可见，
+	// 没理由只在展示端报警。
+	s.warnIfDimensionUnusable(key, *rule, decision)
+	return decision.Allow
 }
 
 // AllowPush 是推送总开关（fail-open）：仅在 env kill 或规则被显式置为 off 时
@@ -142,19 +151,7 @@ func (s *Service) AllowDisplay(ctx context.Context, key string, dims fg.Dims) (a
 		return false, true // 未注册规则 → 确定性的关
 	}
 	decision := fg.Evaluate(*rule, scopes, dims)
-	if decision.DimensionUnusable {
-		// 配置与调用点不匹配：规则引用的某个维度这里提供不了。
-		//
-		// 用 DimensionUnusable 而非只认 ReasonDimUnavailable，是为了把三种错配一网
-		// 打尽：分桶维度缺失（fail-closed）、白名单条目全都用不上（同样 fail-closed）、
-		// 以及 percent 0%/100% 短路——后者**决策仍然正确**所以不改结果，但配置确实
-		// 是错的，不报的话运维会在把 100 调到 50 的那一刻突然全员掉线。
-		s.Warn("featuregate display rule references a dimension this call site cannot provide",
-			zap.String("key", key),
-			zap.String("reason", decision.Reason),
-			zap.Bool("allow", decision.Allow),
-			zap.String("bucket_by", fg.BucketDimension(*rule)))
-	}
+	s.warnIfDimensionUnusable(key, *rule, decision)
 	return decision.Allow, true
 }
 
@@ -340,4 +337,34 @@ func mustJSON(v interface{}) string {
 		return "" // 极罕见；返回空串使下次仍 miss 重试，而非缓存坏值
 	}
 	return string(b)
+}
+
+// warnIfDimensionUnusable 在规则引用了本调用点提供不了的维度时告警。
+//
+// 用 Decision.DimensionUnusable 而非只认 ReasonDimUnavailable，是为了把三种错配一网
+// 打尽：分桶维度缺失（fail-closed）、白名单条目全都用不上（同样 fail-closed）、以及
+// percent 0%/100% 短路——后者**决策仍然正确**所以不改结果，但配置确实是错的，不报的话
+// 运维会在把 100 调到 50 的那一刻突然全员掉线。
+//
+// **按 (key, reason) 去重**：这条日志的信息量是恒定的，而展示端点是每用户每次拉取都
+// 评估一遍——一条配错的 client-visible 规则会让同一行日志按用户数×拉取频率刷屏，把
+// 真正的信号淹掉。同一 (key, reason) 每 warnInterval 只打一次；运维改了配置换成别的
+// reason，或过了间隔，都会重新出现。
+func (s *Service) warnIfDimensionUnusable(key string, rule fg.Rule, decision fg.Decision) {
+	if !decision.DimensionUnusable {
+		return
+	}
+	dedupKey := key + "|" + decision.Reason
+	now := time.Now()
+	if last, ok := s.dimWarnAt.Load(dedupKey); ok {
+		if t, _ := last.(time.Time); now.Sub(t) < warnInterval {
+			return
+		}
+	}
+	s.dimWarnAt.Store(dedupKey, now)
+	s.Warn("featuregate rule references a dimension this call site cannot provide",
+		zap.String("key", key),
+		zap.String("reason", decision.Reason),
+		zap.Bool("allow", decision.Allow),
+		zap.String("bucket_by", fg.BucketDimension(rule)))
 }

--- a/modules/featuregate/service.go
+++ b/modules/featuregate/service.go
@@ -17,9 +17,13 @@ import (
 // 缓存键前缀与兜底 TTL。Redis 是规则的读缓存（DB 才是真源）；管理端写后主动
 // DEL 失效以达成秒级全实例一致，TTL 仅作 DEL 漏掉时的最终一致兜底。
 const (
-	ruleKeyPrefix  = "ft:rule:"
-	scopeKeyPrefix = "ft:scope:"
-	cacheTTL       = 60 * time.Second
+	// 缓存键带 schema 版本号：给 fg.Rule 加字段后，上一版二进制写入的缓存值会缺
+	// 新字段，读出来是零值并在 TTL 内（最长 60s）被当作真实配置使用。版本号一升，
+	// 新旧二进制读写不同 keyspace，这个窗口就不存在了。改 Rule 结构时必须同步升。
+	cacheSchemaVersion = "v1"
+	ruleKeyPrefix      = "featuregate:rule:" + cacheSchemaVersion + ":"
+	scopeKeyPrefix     = "featuregate:scope:" + cacheSchemaVersion + ":"
+	cacheTTL           = 60 * time.Second
 	// nilSentinel 缓存「DB 也没有此规则」，防止未注册 key 每次穿透到 DB。
 	nilSentinel = "__nil__"
 )
@@ -69,7 +73,7 @@ func (s *Service) AllowCreate(ctx context.Context, key string, dims fg.Dims) boo
 	if killSwitchOn(key) {
 		return false
 	}
-	rule, scopes, err := s.loadRuleAndScopes(ctx, key)
+	rule, scopes, err := s.loadRuleAndScopes(key)
 	if err != nil {
 		s.Warn("featuregate load failed; create fail-closed",
 			zap.String("key", key), zap.Error(err))
@@ -88,7 +92,7 @@ func (s *Service) AllowPush(ctx context.Context, key string) bool {
 	if killSwitchOn(key) {
 		return false
 	}
-	rule, err := s.loadRule(ctx, key)
+	rule, err := s.loadRule(key)
 	if err != nil {
 		s.Warn("featuregate load rule failed; push fail-open",
 			zap.String("key", key), zap.Error(err))
@@ -120,7 +124,7 @@ func (s *Service) AllowDisplay(ctx context.Context, key string, dims fg.Dims) (a
 	if killSwitchOn(key) {
 		return false, true
 	}
-	rule, scopes, err := s.loadRuleAndScopes(ctx, key)
+	rule, scopes, err := s.loadRuleAndScopes(key)
 	if err != nil {
 		s.Warn("featuregate load failed; display key omitted from response",
 			zap.String("key", key), zap.Error(err))
@@ -130,11 +134,17 @@ func (s *Service) AllowDisplay(ctx context.Context, key string, dims fg.Dims) (a
 		return false, true // 未注册规则 → 确定性的关
 	}
 	decision := fg.Evaluate(*rule, scopes, dims)
-	if decision.Reason == fg.ReasonDimUnavailable {
-		// 配置与调用点不匹配：规则要求的分桶维度这里提供不了。若按空串照算，
-		// 所有用户会落进同一个桶，配置的 50% 会静默变成全体开或全体关。
-		s.Warn("featuregate display rule requires a dimension this call site cannot provide; fail-closed",
+	if decision.DimensionUnusable {
+		// 配置与调用点不匹配：规则引用的某个维度这里提供不了。
+		//
+		// 用 DimensionUnusable 而非只认 ReasonDimUnavailable，是为了把三种错配一网
+		// 打尽：分桶维度缺失（fail-closed）、白名单条目全都用不上（同样 fail-closed）、
+		// 以及 percent 0%/100% 短路——后者**决策仍然正确**所以不改结果，但配置确实
+		// 是错的，不报的话运维会在把 100 调到 50 的那一刻突然全员掉线。
+		s.Warn("featuregate display rule references a dimension this call site cannot provide",
 			zap.String("key", key),
+			zap.String("reason", decision.Reason),
+			zap.Bool("allow", decision.Allow),
 			zap.String("bucket_by", fg.BucketDimension(*rule)))
 	}
 	return decision.Allow, true
@@ -146,15 +156,15 @@ func (s *Service) AllowDisplay(ctx context.Context, key string, dims fg.Dims) (a
 // 初版把这个条件内联在 AllowCreate 里写作 `if rule.Mode == ModeWhitelist`，当
 // percent 也开始支持白名单后，那种写法极易漏改一处，症状是白名单静默失效——写入
 // 成功、读路径拿到空 scopes。收敛到一处就没有「漏改哪一处」这回事。
-func (s *Service) loadRuleAndScopes(ctx context.Context, key string) (*fg.Rule, []fg.Scope, error) {
-	rule, err := s.loadRule(ctx, key)
+func (s *Service) loadRuleAndScopes(key string) (*fg.Rule, []fg.Scope, error) {
+	rule, err := s.loadRule(key)
 	if err != nil || rule == nil {
 		return nil, nil, err
 	}
 	if !modeNeedsScopes(rule.Mode) {
 		return rule, nil, nil
 	}
-	scopes, err := s.loadScopes(ctx, key)
+	scopes, err := s.loadScopes(key)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -181,10 +191,14 @@ func (s *Service) Invalidate(key string) {
 	}
 }
 
-// loadRule 读规则：Redis 命中即用；miss / 缓存损坏都走 fetchRuleAndCache（查 DB
+// loadRule 读规则。**不接收 context**：octo-lib 的 redis.Conn 没有任何 ctx 版本方法
+// （实测 0 个），所以 Redis 那半边根本无法遵守取消/超时。与其一半遵守一半假装、
+// 让下一个调用者误以为 ctx 生效，不如让签名如实反映能力。
+//
+// Redis 命中即用；miss / 缓存损坏都走 fetchRuleAndCache（查 DB
 // 并回填，损坏值被新值覆盖，避免 TTL 内反复穿透）；Redis 真实故障则绕过缓存直查
 // DB（不回填）。
-func (s *Service) loadRule(_ context.Context, key string) (*fg.Rule, error) {
+func (s *Service) loadRule(key string) (*fg.Rule, error) {
 	cached, err := s.redis.GetString(ruleKeyPrefix + key)
 	if err != nil {
 		return s.queryRuleFromDB(key) // Redis 故障：绕过缓存，DB 失败时由调用方走 fail 语义
@@ -223,7 +237,7 @@ func (s *Service) fetchRuleAndCache(key string) (*fg.Rule, error) {
 
 // loadScopes 读白名单条目：语义同 loadRule。空列表序列化为 "[]"（非空串），与
 // miss（空串）天然区分，不会反复回查；miss / 缓存损坏都走 fetchScopesAndCache。
-func (s *Service) loadScopes(_ context.Context, key string) ([]fg.Scope, error) {
+func (s *Service) loadScopes(key string) ([]fg.Scope, error) {
 	cached, err := s.redis.GetString(scopeKeyPrefix + key)
 	if err != nil {
 		return s.queryScopesFromDB(key)

--- a/modules/featuregate/service_integration_test.go
+++ b/modules/featuregate/service_integration_test.go
@@ -23,13 +23,13 @@ func newServiceFixture(t *testing.T) (*Service, *gateDB, *config.Context) {
 // seedRule 写一条规则并清掉它的缓存，保证后续读走的是刚写的值。
 func seedRule(t *testing.T, svc *Service, db *gateDB, key, mode string, percent int, bucketBy string) {
 	t.Helper()
-	require.NoError(t, db.upsertRule(key, mode, percent, bucketBy, "test"))
+	require.NoError(t, db.upsertRule(key, mode, percent, bucketBy, "test", "tester"))
 	svc.Invalidate(key)
 }
 
 func seedScope(t *testing.T, svc *Service, db *gateDB, key, scopeType, scopeID string) {
 	t.Helper()
-	require.NoError(t, db.addScope(key, scopeType, scopeID))
+	require.NoError(t, db.addScope(key, scopeType, scopeID, "tester"))
 	svc.Invalidate(key)
 }
 
@@ -179,7 +179,7 @@ func TestInvalidateRefreshesCachedRule(t *testing.T) {
 	require.True(t, allow)
 
 	// 只改库、不失效缓存：仍应读到旧值（证明缓存确实生效，否则下一步的断言没有意义）。
-	require.NoError(t, db.upsertRule(key, string(fg.ModeOff), 0, fg.ScopeTypeGroup, "test"))
+	require.NoError(t, db.upsertRule(key, string(fg.ModeOff), 0, fg.ScopeTypeGroup, "test", "tester"))
 	allow, _ = svc.AllowDisplay(context.Background(), key, fg.Dims{UID: "u1"})
 	require.True(t, allow, "未失效前应仍读到缓存里的旧规则")
 
@@ -200,7 +200,7 @@ func TestNilRuleCachedAsSentinel(t *testing.T) {
 	require.False(t, allow)
 
 	// 直接写库但不失效缓存：若哨兵生效，这一步不应被看到。
-	require.NoError(t, db.upsertRule(key, string(fg.ModeOn), 0, fg.ScopeTypeGroup, "test"))
+	require.NoError(t, db.upsertRule(key, string(fg.ModeOn), 0, fg.ScopeTypeGroup, "test", "tester"))
 	allow, _ = svc.AllowDisplay(context.Background(), key, fg.Dims{UID: "u1"})
 	require.False(t, allow, "nil 哨兵未生效：未注册 key 每次都在穿透 DB")
 

--- a/modules/featuregate/service_integration_test.go
+++ b/modules/featuregate/service_integration_test.go
@@ -1,0 +1,210 @@
+package featuregate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	fg "github.com/Mininglamp-OSS/octo-server/pkg/featuregate"
+	"github.com/stretchr/testify/require"
+)
+
+// newServiceFixture 起一个真实 ctx（MySQL + Redis），返回 Service 与其 DB 句柄。
+// 每个用例用独立的 feature_key，避免相互串扰；跨运行的 Redis 残留由
+// newIntegrationCtx 统一清理。
+func newServiceFixture(t *testing.T) (*Service, *gateDB, *config.Context) {
+	t.Helper()
+	ctx := newIntegrationCtx(t)
+	svc := NewService(ctx)
+	db := newDB(ctx)
+	return svc, db, ctx
+}
+
+// seedRule 写一条规则并清掉它的缓存，保证后续读走的是刚写的值。
+func seedRule(t *testing.T, svc *Service, db *gateDB, key, mode string, percent int, bucketBy string) {
+	t.Helper()
+	require.NoError(t, db.upsertRule(key, mode, percent, bucketBy, "test"))
+	svc.Invalidate(key)
+}
+
+func seedScope(t *testing.T, svc *Service, db *gateDB, key, scopeType, scopeID string) {
+	t.Helper()
+	require.NoError(t, db.addScope(key, scopeType, scopeID))
+	svc.Invalidate(key)
+}
+
+// TestServiceLoadsScopesInPercentMode 是本次语义变更最重要的一条防线，且**必须**
+// 走 Service 而不是 pkg/featuregate 的纯函数测试。
+//
+// 纯函数层照不到的那行代码是 Service 里「哪些 mode 需要加载白名单」的条件。初版
+// 写作 `if rule.Mode == ModeWhitelist { loadScopes(...) }`；当 percent 也开始支持
+// 白名单后，漏改这一处的症状与语义没改时**一模一样**——白名单写得进去、读路径拿到
+// 空 scopes、判定静默忽略它。Evaluate 的单测全绿，线上却在放量切档时把内测人员
+// 整批甩掉。
+//
+// percent=0 让「放行」只可能来自白名单，排除分桶巧合。
+func TestServiceLoadsScopesInPercentMode(t *testing.T) {
+	svc, db, _ := newServiceFixture(t)
+	const key = "fgtest_percent_scopes"
+
+	seedRule(t, svc, db, key, string(fg.ModePercent), 0, fg.ScopeTypeUser)
+	seedScope(t, svc, db, key, fg.ScopeTypeUser, "u_allow")
+
+	allow, ok := svc.AllowDisplay(context.Background(), key, fg.Dims{UID: "u_allow"})
+	require.True(t, ok, "白名单命中不应被当作存储故障")
+	require.True(t, allow, "percent 模式下白名单必须生效——若为 false，多半是 Service 没在 percent 模式加载 scopes")
+
+	allow, ok = svc.AllowDisplay(context.Background(), key, fg.Dims{UID: "u_other"})
+	require.True(t, ok)
+	require.False(t, allow, "percent=0 且不在白名单的用户必须被拒")
+
+	// AllowCreate 走同一条加载路径，一并钉住。
+	require.True(t, svc.AllowCreate(context.Background(), key, fg.Dims{UID: "u_allow"}))
+	require.False(t, svc.AllowCreate(context.Background(), key, fg.Dims{UID: "u_other"}))
+}
+
+// TestServiceWhitelistAcrossModes 覆盖白名单的作用域矩阵，其中 off 不可穿透是
+// 止血语义的硬边界。
+func TestServiceWhitelistAcrossModes(t *testing.T) {
+	svc, db, _ := newServiceFixture(t)
+
+	cases := []struct {
+		name  string
+		key   string
+		mode  fg.Mode
+		want  bool
+		scope bool // 是否写入命中当前用户的白名单
+	}{
+		{name: "whitelist 命中放行", key: "fgtest_wl_hit", mode: fg.ModeWhitelist, scope: true, want: true},
+		{name: "whitelist 未命中拒绝", key: "fgtest_wl_miss", mode: fg.ModeWhitelist, scope: false, want: false},
+		{name: "percent 0% 白名单仍放行", key: "fgtest_pc_wl", mode: fg.ModePercent, scope: true, want: true},
+		{name: "off 不可被白名单穿透", key: "fgtest_off_wl", mode: fg.ModeOff, scope: true, want: false},
+		{name: "on 全放", key: "fgtest_on", mode: fg.ModeOn, scope: false, want: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			seedRule(t, svc, db, tc.key, string(tc.mode), 0, fg.ScopeTypeUser)
+			if tc.scope {
+				seedScope(t, svc, db, tc.key, fg.ScopeTypeUser, "u1")
+			}
+			allow, ok := svc.AllowDisplay(context.Background(), tc.key, fg.Dims{UID: "u1"})
+			require.True(t, ok)
+			require.Equal(t, tc.want, allow)
+		})
+	}
+}
+
+// TestAllowDisplayRuleMissingIsDefiniteOff 钉住「规则不存在」与「存储故障」的区分。
+//
+// 规则不存在必须是 ok=true + allow=false（确定性的关）。若把它做成 ok=false（省略），
+// 客户端会一直保留旧值，灰度就永远关不掉。
+func TestAllowDisplayRuleMissingIsDefiniteOff(t *testing.T) {
+	svc, _, _ := newServiceFixture(t)
+
+	allow, ok := svc.AllowDisplay(context.Background(), "fgtest_never_registered", fg.Dims{UID: "u1"})
+	require.True(t, ok, "规则不存在是确定性结论，不能报成存储故障")
+	require.False(t, allow, "未配置即关（fail-closed）")
+}
+
+// TestAllowDisplayKillSwitchIsDefiniteOff 钉住 kill switch 必须走确定性 false 而
+// 不是省略。
+//
+// 若 kill 走省略，客户端会保留旧值——对一个已经放量的功能按下紧急开关，界面永远
+// 不会收敛，止血在展示面上完全失效。
+func TestAllowDisplayKillSwitchIsDefiniteOff(t *testing.T) {
+	svc, db, _ := newServiceFixture(t)
+	const key = "fgtest_killed"
+
+	seedRule(t, svc, db, key, string(fg.ModeOn), 0, fg.ScopeTypeUser)
+
+	allow, ok := svc.AllowDisplay(context.Background(), key, fg.Dims{UID: "u1"})
+	require.True(t, ok)
+	require.True(t, allow, "前置条件：kill 之前应当放行")
+
+	t.Setenv(KillSwitchEnv(key), "1")
+
+	allow, ok = svc.AllowDisplay(context.Background(), key, fg.Dims{UID: "u1"})
+	require.True(t, ok, "kill switch 必须是确定性结论，绝不能表现为存储故障（省略 → 客户端保留旧值 → 关不掉）")
+	require.False(t, allow)
+
+	// kill 对另外两个调用端同样是硬拒。
+	require.False(t, svc.AllowCreate(context.Background(), key, fg.Dims{UID: "u1"}))
+	require.False(t, svc.AllowPush(context.Background(), key))
+}
+
+// TestAllowDisplayDimensionUnavailableFailsClosed 是读侧兜底：规则要求的分桶维度
+// 在展示端点提供不了时必须 fail-closed，而不是按空串照算。
+//
+// 按空串照算的后果是所有用户落进同一个桶，管理台显示的 50% 会静默变成全体开或
+// 全体关——一个无任何报错的错配。写侧另有拦截，但直接改库能绕过写侧，故两侧都要。
+func TestAllowDisplayDimensionUnavailableFailsClosed(t *testing.T) {
+	svc, db, _ := newServiceFixture(t)
+	const key = "fgtest_dim_missing"
+
+	// 模拟「绕过管理端直接改库」：客户端可见的场景下配了 group 维度。
+	seedRule(t, svc, db, key, string(fg.ModePercent), 100-1, fg.ScopeTypeGroup)
+
+	allow, ok := svc.AllowDisplay(context.Background(), key, fg.Dims{UID: "u1"}) // 无 GroupNo
+	require.True(t, ok, "维度不可用是确定性判定结论，不是存储故障")
+	require.False(t, allow, "分桶维度缺失必须 fail-closed，不得按空串照算")
+}
+
+// TestAllowPushFailOpenSemantics 钉住 push 端的非对称 fail 策略未被本次改动带偏：
+// 只有显式 off（与 env kill）才拒，其余一律放行。
+func TestAllowPushFailOpenSemantics(t *testing.T) {
+	svc, db, _ := newServiceFixture(t)
+
+	require.True(t, svc.AllowPush(context.Background(), "fgtest_push_unregistered"),
+		"未注册规则对 push 必须 fail-open")
+
+	seedRule(t, svc, db, "fgtest_push_off", string(fg.ModeOff), 0, fg.ScopeTypeGroup)
+	require.False(t, svc.AllowPush(context.Background(), "fgtest_push_off"),
+		"显式 off 是管理员主动关停，必须拒")
+
+	seedRule(t, svc, db, "fgtest_push_wl", string(fg.ModeWhitelist), 0, fg.ScopeTypeGroup)
+	require.True(t, svc.AllowPush(context.Background(), "fgtest_push_wl"),
+		"push 不做维度灰度：非 off 一律放行")
+}
+
+// TestInvalidateRefreshesCachedRule 验证写后失效：改了规则再 Invalidate，下一次读
+// 必须看到新值（而不是等 TTL）。这是「秒级多实例一致」赖以成立的机制。
+func TestInvalidateRefreshesCachedRule(t *testing.T) {
+	svc, db, _ := newServiceFixture(t)
+	const key = "fgtest_invalidate"
+
+	seedRule(t, svc, db, key, string(fg.ModeOn), 0, fg.ScopeTypeGroup)
+	allow, ok := svc.AllowDisplay(context.Background(), key, fg.Dims{UID: "u1"})
+	require.True(t, ok)
+	require.True(t, allow)
+
+	// 只改库、不失效缓存：仍应读到旧值（证明缓存确实生效，否则下一步的断言没有意义）。
+	require.NoError(t, db.upsertRule(key, string(fg.ModeOff), 0, fg.ScopeTypeGroup, "test"))
+	allow, _ = svc.AllowDisplay(context.Background(), key, fg.Dims{UID: "u1"})
+	require.True(t, allow, "未失效前应仍读到缓存里的旧规则")
+
+	svc.Invalidate(key)
+	allow, ok = svc.AllowDisplay(context.Background(), key, fg.Dims{UID: "u1"})
+	require.True(t, ok)
+	require.False(t, allow, "Invalidate 后必须立刻读到新规则")
+}
+
+// TestNilRuleCachedAsSentinel 验证未注册 key 会被缓存成 nil 哨兵，避免每次请求
+// 穿透到 DB —— 展示端点会对注册表里每个 key 各评估一次，穿透代价是线性放大的。
+func TestNilRuleCachedAsSentinel(t *testing.T) {
+	svc, db, _ := newServiceFixture(t)
+	const key = "fgtest_sentinel"
+
+	allow, ok := svc.AllowDisplay(context.Background(), key, fg.Dims{UID: "u1"})
+	require.True(t, ok)
+	require.False(t, allow)
+
+	// 直接写库但不失效缓存：若哨兵生效，这一步不应被看到。
+	require.NoError(t, db.upsertRule(key, string(fg.ModeOn), 0, fg.ScopeTypeGroup, "test"))
+	allow, _ = svc.AllowDisplay(context.Background(), key, fg.Dims{UID: "u1"})
+	require.False(t, allow, "nil 哨兵未生效：未注册 key 每次都在穿透 DB")
+
+	svc.Invalidate(key)
+	allow, _ = svc.AllowDisplay(context.Background(), key, fg.Dims{UID: "u1"})
+	require.True(t, allow)
+}

--- a/modules/featuregate/sql/20260820000001_featuregate_init.sql
+++ b/modules/featuregate/sql/20260820000001_featuregate_init.sql
@@ -1,0 +1,56 @@
+-- +migrate Up
+
+-- 通用功能灰度规则表：每个功能 key 一行。
+--
+-- 表名带 octo_ 前缀（本仓新表约定）。本框架初版（未合并的 PR #280）建的是无前缀
+-- 的 feature_gate / feature_gate_scope；因为那套表从未上线，此处直接按现行约定命名，
+-- 不存在改名成本。
+--
+-- CHECK 约束是纵深防御：管理端写路径已校验 key/mode/percent/bucket_by，这里再挡一层
+-- 直接改库的旁路。少了它，一条手写的 mode='rollout' 只会在读侧静默 fail-safe 拒绝，
+-- 运维看不出配错在哪。
+--
+-- feature_key 的字符集约束尤其重要：它要推导 env 杀开关名（OCTO_FEATUREGATE_<大写>_KILL）。
+-- 一个含空格的 key 推出的环境变量名设不进去，这条 gate 就永久失去 env 级紧急停止 ——
+-- 而那是「DB/Redis 全挂时仍能一键停」的最后一条路径。限定在 [a-z0-9_] 同时保证
+-- key → env 名是单射，不会出现两条 gate 共用一个杀开关。
+CREATE TABLE `octo_feature_gate` (
+  `id`          BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  `feature_key` VARCHAR(64)  NOT NULL DEFAULT ''      COMMENT '功能键（运维面标识；OCTO_FEATUREGATE_<大写>_KILL 环境变量名由它推导）',
+  `mode`        VARCHAR(16)  NOT NULL DEFAULT 'off'   COMMENT 'off/on/whitelist/percent',
+  `percent`     SMALLINT     NOT NULL DEFAULT 0       COMMENT 'percent 模式阈值 [0,100]，bucket < percent 即命中',
+  `bucket_by`   VARCHAR(16)  NOT NULL DEFAULT 'group' COMMENT 'percent 分桶维度 group/space/user；选了调用点提供不了的维度会在读侧 fail-closed',
+  `description` VARCHAR(255) NOT NULL DEFAULT ''      COMMENT '说明',
+  `created_at`  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at`  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY `uk_octo_feature_gate_key` (`feature_key`),
+  CONSTRAINT `chk_octo_feature_gate_key` CHECK (REGEXP_LIKE(`feature_key`, '^[a-z][a-z0-9_]*$')),
+  CONSTRAINT `chk_octo_feature_gate_mode` CHECK (`mode` IN ('off', 'on', 'whitelist', 'percent')),
+  CONSTRAINT `chk_octo_feature_gate_percent` CHECK (`percent` BETWEEN 0 AND 100),
+  CONSTRAINT `chk_octo_feature_gate_bucket_by` CHECK (`bucket_by` IN ('group', 'space', 'user'))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='通用功能灰度规则';
+
+-- 灰度白名单条目表：逐条加删。
+--
+-- scope_type 三个维度在读侧【都】参与命中判定（见 pkg/featuregate.whitelistHit）。
+-- 初版曾出现 space 写得进去、读侧却忽略的状态——那种「写成功但不生效」比不支持更难
+-- 排查，故此处三者对等。
+--
+-- 白名单在 whitelist 与 percent 两个 mode 下均生效（percent 下优先于分桶），
+-- 在 off 下无条件失效。
+CREATE TABLE `octo_feature_gate_scope` (
+  `id`          BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  `feature_key` VARCHAR(64)  NOT NULL DEFAULT ''      COMMENT '关联 octo_feature_gate.feature_key',
+  `scope_type`  VARCHAR(16)  NOT NULL DEFAULT 'group' COMMENT 'group/space/user',
+  `scope_id`    VARCHAR(64)  NOT NULL DEFAULT ''      COMMENT 'group_no / space_id / uid',
+  `created_at`  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY `uk_octo_fgs_key_type_id` (`feature_key`, `scope_type`, `scope_id`),
+  KEY `idx_octo_fgs_key` (`feature_key`),
+  CONSTRAINT `chk_octo_fgs_feature_key` CHECK (REGEXP_LIKE(`feature_key`, '^[a-z][a-z0-9_]*$')),
+  CONSTRAINT `chk_octo_fgs_scope_type` CHECK (`scope_type` IN ('group', 'space', 'user')),
+  CONSTRAINT `chk_octo_fgs_scope_id` CHECK (`scope_id` <> '')
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='通用功能灰度白名单条目';
+
+-- +migrate Down
+DROP TABLE IF EXISTS `octo_feature_gate_scope`;
+DROP TABLE IF EXISTS `octo_feature_gate`;

--- a/modules/featuregate/sql/20260825000001_featuregate_init.sql
+++ b/modules/featuregate/sql/20260825000001_featuregate_init.sql
@@ -9,6 +9,21 @@
 -- 注意 feature_key / scope_id 刻意**不设** DEFAULT ''：空串永远无法满足下面的 CHECK，
 -- 留一个不可能成立的默认值只会让人误以为空 key 是合法状态。
 --
+-- **所有身份列显式 COLLATE utf8mb4_bin**（feature_key / mode / bucket_by / scope_type /
+-- scope_id）。库默认的 utf8mb4_general_ci 大小写不敏感，而 Go 侧对这些值的比较全部是
+-- 逐字节的（whitelistHit 的 s.ID == id、rule.Mode != ModeOff、dimValue 的 switch）。
+-- 两边口径不一致会同时造成三个后果，均已实测：
+--   1. scope_id "UserA" 与 "usera" 在唯一键下撞成一行，第二次 add 走 ON DUPLICATE 只更新
+--      updated_by，库里留的仍是 "UserA" —— 运维拿到 200，而那个用户永远进不了白名单；
+--      更糟的是读侧也不报警：存在可用的 user 维度条目，Evaluate 返回普通 whitelist_miss、
+--      DimensionUnusable=false，于是 AllowDisplay 一行日志都不打。写成功、读静默、两侧皆哑。
+--   2. 下面这些 CHECK **形同虚设**：REGEXP_LIKE 与 IN 都继承列的 collation，_ci 下
+--      'ZZ_UPPER' 能通过 '^[a-z][a-z0-9_]*$'、mode='OFF' 能通过 IN ('off',...)。
+--   3. 手写的 mode='OFF' 会让三个入口口径分裂：AllowPush 判它 != off 而放行，
+--      Evaluate 判它是未知 mode 而拒绝。
+-- 本仓已被同一类问题咬过（modules/message 的 message_reaction_emoji_binary 是一次
+-- 只能向前的补救 ALTER），card_template_catalog 则从建表起就用 _bin。
+--
 -- CHECK 约束是纵深防御：管理端写路径已校验 key/mode/percent/bucket_by，这里再挡一层
 -- 直接改库的旁路。少了它，一条手写的 mode='rollout' 只会在读侧静默 fail-safe 拒绝，
 -- 运维看不出配错在哪。
@@ -19,10 +34,10 @@
 -- key → env 名是单射，不会出现两条 gate 共用一个杀开关。
 CREATE TABLE `octo_feature_gate` (
   `id`          BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  `feature_key` VARCHAR(64)  NOT NULL                 COMMENT '功能键（运维面标识；OCTO_FEATUREGATE_<大写>_KILL 环境变量名由它推导）',
-  `mode`        VARCHAR(16)  NOT NULL DEFAULT 'off'   COMMENT 'off/on/whitelist/percent',
+  `feature_key` VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin  NOT NULL                 COMMENT '功能键（运维面标识；OCTO_FEATUREGATE_<大写>_KILL 环境变量名由它推导）',
+  `mode`        VARCHAR(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin  NOT NULL DEFAULT 'off'   COMMENT 'off/on/whitelist/percent',
   `percent`     SMALLINT     NOT NULL DEFAULT 0       COMMENT 'percent 模式阈值 [0,100]，bucket < percent 即命中',
-  `bucket_by`   VARCHAR(16)  NOT NULL DEFAULT 'group' COMMENT 'percent 分桶维度 group/space/user；选了调用点提供不了的维度会在读侧 fail-closed',
+  `bucket_by`   VARCHAR(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin  NOT NULL DEFAULT 'group' COMMENT 'percent 分桶维度 group/space/user；选了调用点提供不了的维度会在读侧 fail-closed',
   `description` VARCHAR(255) NOT NULL DEFAULT ''      COMMENT '说明（按字符计，非字节）',
   `updated_by`  VARCHAR(40)  NOT NULL DEFAULT ''      COMMENT '最近修改的管理员 uid（审计）',
   `created_at`  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -44,16 +59,16 @@ CREATE TABLE `octo_feature_gate` (
 -- 在 off 下无条件失效。
 CREATE TABLE `octo_feature_gate_scope` (
   `id`          BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  `feature_key` VARCHAR(64)  NOT NULL                 COMMENT '关联 octo_feature_gate.feature_key',
-  `scope_type`  VARCHAR(16)  NOT NULL DEFAULT 'group' COMMENT 'group/space/user',
-  `scope_id`    VARCHAR(64)  NOT NULL                 COMMENT 'group_no / space_id / uid（禁空白与 /，见 delScope 的路径段取值）',
+  `feature_key` VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin  NOT NULL                 COMMENT '关联 octo_feature_gate.feature_key',
+  `scope_type`  VARCHAR(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin  NOT NULL DEFAULT 'group' COMMENT 'group/space/user',
+  `scope_id`    VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin  NOT NULL                 COMMENT 'group_no / space_id / uid（禁空白与 /，见 delScope 的路径段取值）',
   `updated_by`  VARCHAR(40)  NOT NULL DEFAULT ''      COMMENT '添加该条目的管理员 uid（审计）',
   `created_at`  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
   UNIQUE KEY `uk_octo_fgs_key_type_id` (`feature_key`, `scope_type`, `scope_id`),
   KEY `idx_octo_fgs_key` (`feature_key`),
   CONSTRAINT `chk_octo_fgs_feature_key` CHECK (REGEXP_LIKE(`feature_key`, '^[a-z][a-z0-9_]*$')),
   CONSTRAINT `chk_octo_fgs_scope_type` CHECK (`scope_type` IN ('group', 'space', 'user')),
-  CONSTRAINT `chk_octo_fgs_scope_id` CHECK (`scope_id` <> '')
+  CONSTRAINT `chk_octo_fgs_scope_id` CHECK (REGEXP_LIKE(`scope_id`, '^[A-Za-z0-9_.:@-]+$'))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='通用功能灰度白名单条目';
 
 -- +migrate Down

--- a/modules/featuregate/sql/20260825000001_featuregate_init.sql
+++ b/modules/featuregate/sql/20260825000001_featuregate_init.sql
@@ -6,6 +6,9 @@
 -- 的 feature_gate / feature_gate_scope；因为那套表从未上线，此处直接按现行约定命名，
 -- 不存在改名成本。
 --
+-- 注意 feature_key / scope_id 刻意**不设** DEFAULT ''：空串永远无法满足下面的 CHECK，
+-- 留一个不可能成立的默认值只会让人误以为空 key 是合法状态。
+--
 -- CHECK 约束是纵深防御：管理端写路径已校验 key/mode/percent/bucket_by，这里再挡一层
 -- 直接改库的旁路。少了它，一条手写的 mode='rollout' 只会在读侧静默 fail-safe 拒绝，
 -- 运维看不出配错在哪。
@@ -16,11 +19,12 @@
 -- key → env 名是单射，不会出现两条 gate 共用一个杀开关。
 CREATE TABLE `octo_feature_gate` (
   `id`          BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  `feature_key` VARCHAR(64)  NOT NULL DEFAULT ''      COMMENT '功能键（运维面标识；OCTO_FEATUREGATE_<大写>_KILL 环境变量名由它推导）',
+  `feature_key` VARCHAR(64)  NOT NULL                 COMMENT '功能键（运维面标识；OCTO_FEATUREGATE_<大写>_KILL 环境变量名由它推导）',
   `mode`        VARCHAR(16)  NOT NULL DEFAULT 'off'   COMMENT 'off/on/whitelist/percent',
   `percent`     SMALLINT     NOT NULL DEFAULT 0       COMMENT 'percent 模式阈值 [0,100]，bucket < percent 即命中',
   `bucket_by`   VARCHAR(16)  NOT NULL DEFAULT 'group' COMMENT 'percent 分桶维度 group/space/user；选了调用点提供不了的维度会在读侧 fail-closed',
-  `description` VARCHAR(255) NOT NULL DEFAULT ''      COMMENT '说明',
+  `description` VARCHAR(255) NOT NULL DEFAULT ''      COMMENT '说明（按字符计，非字节）',
+  `updated_by`  VARCHAR(40)  NOT NULL DEFAULT ''      COMMENT '最近修改的管理员 uid（审计）',
   `created_at`  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at`  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   UNIQUE KEY `uk_octo_feature_gate_key` (`feature_key`),
@@ -40,9 +44,10 @@ CREATE TABLE `octo_feature_gate` (
 -- 在 off 下无条件失效。
 CREATE TABLE `octo_feature_gate_scope` (
   `id`          BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  `feature_key` VARCHAR(64)  NOT NULL DEFAULT ''      COMMENT '关联 octo_feature_gate.feature_key',
+  `feature_key` VARCHAR(64)  NOT NULL                 COMMENT '关联 octo_feature_gate.feature_key',
   `scope_type`  VARCHAR(16)  NOT NULL DEFAULT 'group' COMMENT 'group/space/user',
-  `scope_id`    VARCHAR(64)  NOT NULL DEFAULT ''      COMMENT 'group_no / space_id / uid',
+  `scope_id`    VARCHAR(64)  NOT NULL                 COMMENT 'group_no / space_id / uid（禁空白与 /，见 delScope 的路径段取值）',
+  `updated_by`  VARCHAR(40)  NOT NULL DEFAULT ''      COMMENT '添加该条目的管理员 uid（审计）',
   `created_at`  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
   UNIQUE KEY `uk_octo_fgs_key_type_id` (`feature_key`, `scope_type`, `scope_id`),
   KEY `idx_octo_fgs_key` (`feature_key`),

--- a/modules/featuregate/sql/20260825000001_featuregate_init.sql
+++ b/modules/featuregate/sql/20260825000001_featuregate_init.sql
@@ -9,8 +9,10 @@
 -- 注意 feature_key / scope_id 刻意**不设** DEFAULT ''：空串永远无法满足下面的 CHECK，
 -- 留一个不可能成立的默认值只会让人误以为空 key 是合法状态。
 --
--- **所有身份列显式 COLLATE utf8mb4_bin**（feature_key / mode / bucket_by / scope_type /
--- scope_id）。库默认的 utf8mb4_general_ci 大小写不敏感，而 Go 侧对这些值的比较全部是
+-- **参与比较的 5 个列显式 COLLATE utf8mb4_bin**：feature_key / mode / bucket_by /
+-- scope_type / scope_id。**description 与两个 updated_by 刻意保持表默认**——它们只用于
+-- 展示和审计，从不参与字节比较，也不出现在任何唯一索引或 join key 里，pin 它们属于
+-- 过度修正。库默认的 utf8mb4_general_ci 大小写不敏感，而 Go 侧对这些值的比较全部是
 -- 逐字节的（whitelistHit 的 s.ID == id、rule.Mode != ModeOff、dimValue 的 switch）。
 -- 两边口径不一致会同时造成三个后果，均已实测：
 --   1. scope_id "UserA" 与 "usera" 在唯一键下撞成一行，第二次 add 走 ON DUPLICATE 只更新
@@ -23,6 +25,13 @@
 --      Evaluate 判它是未知 mode 而拒绝。
 -- 本仓已被同一类问题咬过（modules/message 的 message_reaction_emoji_binary 是一次
 -- 只能向前的补救 ALTER），card_template_catalog 则从建表起就用 _bin。
+--
+-- 下面的 REGEXP_LIKE 用 \z 而**不是** $ 收尾。MySQL 的正则是 ICU，`$` 匹配「输入末尾
+-- 或最后一个换行符之前」，于是 'u1\n' / 'zz_nl\n' 这类尾部带换行的值能通过 `...$`。
+-- 后果正是本文件上面论证过的那两条：带 \n 的 scope_id 插得进却删不掉（delScope 按单个
+-- 路径段取值并 TrimSpace），带 \n 的 feature_key 推出的杀开关环境变量名含换行，等于
+-- 永久失去 env 级急停。Go 侧不受影响——Go 的 $ 是 end-of-text（\z 语义），
+-- featureKeyPattern / scopeIDRe 本来就拒；这里补的是「直接改库」这条 CHECK 存在的理由。
 --
 -- CHECK 约束是纵深防御：管理端写路径已校验 key/mode/percent/bucket_by，这里再挡一层
 -- 直接改库的旁路。少了它，一条手写的 mode='rollout' 只会在读侧静默 fail-safe 拒绝，
@@ -43,7 +52,7 @@ CREATE TABLE `octo_feature_gate` (
   `created_at`  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at`  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   UNIQUE KEY `uk_octo_feature_gate_key` (`feature_key`),
-  CONSTRAINT `chk_octo_feature_gate_key` CHECK (REGEXP_LIKE(`feature_key`, '^[a-z][a-z0-9_]*$')),
+  CONSTRAINT `chk_octo_feature_gate_key` CHECK (REGEXP_LIKE(`feature_key`, '^[a-z][a-z0-9_]*\\z')),
   CONSTRAINT `chk_octo_feature_gate_mode` CHECK (`mode` IN ('off', 'on', 'whitelist', 'percent')),
   CONSTRAINT `chk_octo_feature_gate_percent` CHECK (`percent` BETWEEN 0 AND 100),
   CONSTRAINT `chk_octo_feature_gate_bucket_by` CHECK (`bucket_by` IN ('group', 'space', 'user'))
@@ -66,9 +75,9 @@ CREATE TABLE `octo_feature_gate_scope` (
   `created_at`  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
   UNIQUE KEY `uk_octo_fgs_key_type_id` (`feature_key`, `scope_type`, `scope_id`),
   KEY `idx_octo_fgs_key` (`feature_key`),
-  CONSTRAINT `chk_octo_fgs_feature_key` CHECK (REGEXP_LIKE(`feature_key`, '^[a-z][a-z0-9_]*$')),
+  CONSTRAINT `chk_octo_fgs_feature_key` CHECK (REGEXP_LIKE(`feature_key`, '^[a-z][a-z0-9_]*\\z')),
   CONSTRAINT `chk_octo_fgs_scope_type` CHECK (`scope_type` IN ('group', 'space', 'user')),
-  CONSTRAINT `chk_octo_fgs_scope_id` CHECK (REGEXP_LIKE(`scope_id`, '^[A-Za-z0-9_.:@-]+$'))
+  CONSTRAINT `chk_octo_fgs_scope_id` CHECK (REGEXP_LIKE(`scope_id`, '^[A-Za-z0-9_.:@-]+\\z'))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='通用功能灰度白名单条目';
 
 -- +migrate Down

--- a/pkg/errcode/featuregate.go
+++ b/pkg/errcode/featuregate.go
@@ -1,0 +1,49 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+// err.server.featuregate.* — modules/featuregate 管理端点错误码（list / update /
+// addScope / delScope）。superadmin-only、无 legacy client，统一经
+// httperr.ResponseErrorLWithStatus 渲染并保留真实 HTTP status。zh-CN 翻译在
+// pkg/i18n/locales/active.zh-CN.toml。
+//
+// 用户侧只读端点 GET /v1/featuregate/flags 刻意不新增错误码：它的失败模式都不走
+// 错误信封——单个 key 的存储故障从响应中省略、规则不存在下发 false，两者都是 200；
+// 只有鉴权失败（复用 err.shared.auth.* 的通用码，反枚举）才会走信封。
+var (
+	// ErrFeatureGateRequestInvalid (400) — 请求体或字段非法（mode/percent/
+	// bucket_by/scope_type/scope_id）；具体字段经 Details["reason"] 透出。
+	ErrFeatureGateRequestInvalid = register(codes.Code{
+		ID:             "err.server.featuregate.request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid request.",
+		SafeDetailKeys: []string{"reason"},
+	})
+
+	// ErrFeatureGateNotFound (404) — 要删除的白名单条目不存在。
+	ErrFeatureGateNotFound = register(codes.Code{
+		ID:             "err.server.featuregate.not_found",
+		HTTPStatus:     http.StatusNotFound,
+		DefaultMessage: "The feature gate scope does not exist.",
+	})
+
+	// ErrFeatureGateQueryFailed (500, Internal) — 读规则/白名单失败；真实错误仅日志。
+	ErrFeatureGateQueryFailed = register(codes.Code{
+		ID:             "err.server.featuregate.query_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to query feature gate.",
+		Internal:       true,
+	})
+
+	// ErrFeatureGateOperationFailed (500, Internal) — 写规则/白名单失败；真实错误仅日志。
+	ErrFeatureGateOperationFailed = register(codes.Code{
+		ID:             "err.server.featuregate.operation_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "The operation failed. Please try again later.",
+		Internal:       true,
+	})
+)

--- a/pkg/errcode/featuregate.go
+++ b/pkg/errcode/featuregate.go
@@ -12,7 +12,7 @@ import (
 // pkg/i18n/locales/active.zh-CN.toml。
 //
 // 用户侧只读端点 GET /v1/featuregate/flags 刻意不新增错误码：它的失败模式都不走
-// 错误信封——单个 key 的存储故障从响应中省略、规则不存在下发 false，两者都是 200；
+// 错误信封——单个 key 的存储故障进 unavailable 数组、规则不存在下发 false，两者都是 200；
 // 只有鉴权失败（复用 err.shared.auth.* 的通用码，反枚举）才会走信封。
 var (
 	// ErrFeatureGateRequestInvalid (400) — 请求体或字段非法（mode/percent/

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -1,0 +1,209 @@
+// Package featuregate 提供通用的功能灰度评估纯逻辑：给定一条规则、一组白名单
+// 条目和一个评估维度，判定某次调用是否放行。
+//
+// 本包刻意保持「零 IO、零 module 依赖」：不读 env、不查 DB/Redis、不判 kill
+// switch（kill switch 由调用方在评估前短路处理）。所有外部状态（规则、白名单）
+// 由调用方加载后以参数传入，使 Evaluate 可被表驱动单测完整覆盖。
+//
+// 持久化、Redis 缓存、env kill、fail-open/closed 兜底等带 IO 的编排逻辑放在
+// modules/featuregate 的 Service 中，Service 在准备好 Rule/Scope 后调用本包。
+package featuregate
+
+import "hash/crc32"
+
+// Mode 是某个功能 key 的放量模式。
+type Mode string
+
+const (
+	// ModeOff 全部拒绝。白名单不可穿透（见 Evaluate）。
+	ModeOff Mode = "off"
+	// ModeOn 全部放行。
+	ModeOn Mode = "on"
+	// ModeWhitelist 仅白名单命中放行。
+	ModeWhitelist Mode = "whitelist"
+	// ModePercent 白名单优先，其余按 hash 稳定分桶的百分比放量。
+	ModePercent Mode = "percent"
+)
+
+// 白名单条目维度类型 / 分桶维度。两者取值域刻意相同：一条 scope 记录的
+// scope_type 与一条规则的 bucket_by 都在回答「按哪个维度识别对象」，共用一套
+// 词汇表可以让 dimValue 一处解析、避免两套 switch 漂移。
+const (
+	ScopeTypeGroup = "group"
+	ScopeTypeSpace = "space"
+	ScopeTypeUser  = "user"
+)
+
+// DefaultBucketBy 是 bucket_by 未显式配置时的分桶维度。
+//
+// 取 group 是为了忠实于本框架初版设计（percent 固定按 group_no 分桶）。它**不是**
+// 生产兼容性约束——这套框架从未上线，不存在需要保持行为不变的既有部署；仅仅是
+// 一个可预测的缺省。注意它与「只有 UID 可用」的调用方（如客户端灰度位下发端点）
+// 天然不匹配，那种场景必须显式声明 bucket_by=user，否则 percentDecision 会因维度
+// 缺失而 fail-closed（见 ReasonDimUnavailable）。
+const DefaultBucketBy = ScopeTypeGroup
+
+// 决策原因，用于可观测与测试断言。
+const (
+	ReasonOff           = "off"
+	ReasonOn            = "on"
+	ReasonWhitelistHit  = "whitelist_hit"
+	ReasonWhitelistMiss = "whitelist_miss"
+	ReasonPercentIn     = "percent_in"
+	ReasonPercentOut    = "percent_out"
+	ReasonUnknownMode   = "unknown_mode"
+	// ReasonDimUnavailable 表示规则要求的分桶维度在本次评估的 Dims 中为空，
+	// 判定因此 fail-closed。这是配置与调用点不匹配的信号，调用方应记日志告警。
+	ReasonDimUnavailable = "dim_unavailable"
+)
+
+// Rule 是某个功能 key 的规则快照（纯数据）。
+type Rule struct {
+	Key     string
+	Mode    Mode
+	Percent int // [0,100]，仅 ModePercent 使用
+	// BucketBy 是 percent 模式的分桶维度（group/space/user）。空值归一到
+	// DefaultBucketBy。让它可配置，是因为同一套框架既要服务「按群放量」的写时
+	// 闸门，也要服务「按用户放量」的展示位——固定单一维度无法同时表达。
+	BucketBy string
+}
+
+// Scope 是一条白名单条目。
+type Scope struct {
+	Type string // ScopeTypeGroup / ScopeTypeSpace / ScopeTypeUser
+	ID   string // group_no / space_id / uid
+}
+
+// Dims 是一次评估的维度取值。调用点能提供哪几个维度取决于它自身的上下文：
+// 写时闸门通常三者齐备，而用户级灰度位下发端点只有 UID。
+type Dims struct {
+	SpaceID string
+	GroupNo string
+	UID     string
+}
+
+// Decision 是评估结果。Reason 取上面的 Reason* 常量之一。
+type Decision struct {
+	Allow  bool
+	Reason string
+}
+
+// Evaluate 是纯函数：按 rule.Mode 判定是否放行。不读 env、不判 kill switch。
+// 未知 mode 一律保守拒绝（fail-safe），避免规则写坏时意外放量。
+//
+// 白名单的作用域：它在 whitelist 与 percent 两个 mode 下都生效（percent 下优先于
+// 分桶，即「永久豁免名单 + 其余人群按比例」），在 off 下**无条件失效**，在 on 下
+// 无意义。
+//
+// off 不可被白名单穿透是硬边界：off 是回滚/止血语义的一部分，若白名单能穿透，
+// 关停就失去了确定性。
+//
+// 白名单跨 mode 生效是本框架初版的一处修正。初版的 percent 分支完全不读 scopes，
+// 于是标准放量路径 off → whitelist（内测）→ percent 会在切档瞬间把内测人员整批
+// 甩掉（只剩恰好分桶命中的那部分），而且 percent 阶段新加白名单条目是静默失败——
+// 写入返回成功、读路径根本不看。
+func Evaluate(rule Rule, scopes []Scope, dims Dims) Decision {
+	switch rule.Mode {
+	case ModeOff:
+		return Decision{Allow: false, Reason: ReasonOff}
+	case ModeOn:
+		return Decision{Allow: true, Reason: ReasonOn}
+	case ModeWhitelist:
+		if whitelistHit(scopes, dims) {
+			return Decision{Allow: true, Reason: ReasonWhitelistHit}
+		}
+		return Decision{Allow: false, Reason: ReasonWhitelistMiss}
+	case ModePercent:
+		if whitelistHit(scopes, dims) {
+			return Decision{Allow: true, Reason: ReasonWhitelistHit}
+		}
+		return percentDecision(rule, dims)
+	default:
+		return Decision{Allow: false, Reason: ReasonUnknownMode}
+	}
+}
+
+// whitelistHit 逐条比对白名单。条目按自己的 scope_type 取对应维度值；该维度在本次
+// 评估中为空时跳过该条目——空值绝不匹配，否则一条 scope_id="" 的脏数据会命中所有
+// 缺维度的调用。
+func whitelistHit(scopes []Scope, dims Dims) bool {
+	for _, s := range scopes {
+		id := dimValue(s.Type, dims)
+		if id == "" {
+			continue
+		}
+		if s.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// percentDecision 判定 percent 模式。0（及负数）全拒、>=100 全放，这两档与维度
+// 无关，故先短路——否则一条 100% 的规则会因维度缺失而反直觉地全拒。
+//
+// 只有真正需要分桶时才要求维度可用：维度为空时**绝不按空串照算**。空串会让所有
+// 对象落进同一个桶（Bucket(key,"") 是该 key 的一个常数），使配置的 50% 静默变成
+// 全体开或全体关，且管理台仍显示 50%——一个无任何报错的错配。
+func percentDecision(rule Rule, dims Dims) Decision {
+	if rule.Percent <= 0 {
+		return Decision{Allow: false, Reason: ReasonPercentOut}
+	}
+	if rule.Percent >= 100 {
+		return Decision{Allow: true, Reason: ReasonPercentIn}
+	}
+	dimID := dimValue(BucketDimension(rule), dims)
+	if dimID == "" {
+		return Decision{Allow: false, Reason: ReasonDimUnavailable}
+	}
+	if Bucket(rule.Key, dimID) < rule.Percent {
+		return Decision{Allow: true, Reason: ReasonPercentIn}
+	}
+	return Decision{Allow: false, Reason: ReasonPercentOut}
+}
+
+// dimValue 把维度名解析为本次评估里的取值。未知维度返回空串，交由调用点按
+// 「维度不可用」处理，而不是静默回退到某个别的维度。
+func dimValue(dim string, dims Dims) string {
+	switch dim {
+	case ScopeTypeGroup:
+		return dims.GroupNo
+	case ScopeTypeSpace:
+		return dims.SpaceID
+	case ScopeTypeUser:
+		return dims.UID
+	default:
+		return ""
+	}
+}
+
+// BucketDimension 返回规则实际使用的分桶维度，空值归一到 DefaultBucketBy。
+// 导出是为了让写侧校验与可观测日志能拿到与判定完全一致的口径。
+func BucketDimension(rule Rule) string {
+	if rule.BucketBy == "" {
+		return DefaultBucketBy
+	}
+	return rule.BucketBy
+}
+
+// ValidDimension 报告 dim 是否是合法的维度名（同时用于 scope_type 与 bucket_by
+// 的写侧校验）。空串在此视为非法：调用方若要表达「未配置」，应在传入前判空并走
+// DefaultBucketBy，而不是把空串当合法值存进库。
+func ValidDimension(dim string) bool {
+	switch dim {
+	case ScopeTypeGroup, ScopeTypeSpace, ScopeTypeUser:
+		return true
+	}
+	return false
+}
+
+// Bucket 把 (key, dimID) 稳定映射到 [0,100)。同一对入参结果恒定，保证放量曲线
+// 单调（percent 调高只会纳入更多桶，已命中的不会掉出）；按 key 加盐，使不同功能
+// 的分桶相互独立、不会同涨同落。
+//
+// 注意分桶维度本身不参与加盐。切换 bucket_by 会整体改变入参，因此是一次人群
+// 重新洗牌而非渐进操作——单调性保证只在同一维度内成立。
+func Bucket(key, dimID string) int {
+	h := crc32.ChecksumIEEE([]byte(key + ":" + dimID))
+	return int(h % 100)
+}

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -49,9 +49,15 @@ const (
 	ReasonOn            = "on"
 	ReasonWhitelistHit  = "whitelist_hit"
 	ReasonWhitelistMiss = "whitelist_miss"
-	ReasonPercentIn     = "percent_in"
-	ReasonPercentOut    = "percent_out"
-	ReasonUnknownMode   = "unknown_mode"
+	// ReasonWhitelistDimUnavailable 表示白名单**非空**、但每一条的维度在本次评估
+	// 中都取不到值 —— 即这份名单在这个调用点永远不可能命中。它与 whitelist_miss
+	// 的区别是「命不中」还是「没法命中」：前者是正常结果，后者是配置与调用点不
+	// 匹配。少了这个区分，一条全是 group 条目的 client-visible 白名单会表现得和
+	// 「用户确实不在名单里」一模一样，两侧都无声。
+	ReasonWhitelistDimUnavailable = "whitelist_dim_unavailable"
+	ReasonPercentIn               = "percent_in"
+	ReasonPercentOut              = "percent_out"
+	ReasonUnknownMode             = "unknown_mode"
 	// ReasonDimUnavailable 表示规则要求的分桶维度在本次评估的 Dims 中为空，
 	// 判定因此 fail-closed。这是配置与调用点不匹配的信号，调用方应记日志告警。
 	ReasonDimUnavailable = "dim_unavailable"
@@ -86,6 +92,14 @@ type Dims struct {
 type Decision struct {
 	Allow  bool
 	Reason string
+	// DimensionUnusable 标记「这条规则引用的某个维度在本次评估中取不到值」，
+	// **独立于 Allow**。
+	//
+	// 之所以不并进 Reason：percent 的 0%/100% 短路在维度不可用时**决策依然正确**
+	// （0=谁都不放、100=所有人都放，与维度无关），把它们改成 fail-closed 会为了
+	// 一个不影响结果的错配去打挂一条正在全量的规则。但错配必须可见，否则运维会在
+	// 把 100 调到 50 的那一刻突然全员掉线。于是决策照旧、另开一个位回报。
+	DimensionUnusable bool
 }
 
 // Evaluate 是纯函数：按 rule.Mode 判定是否放行。不读 env、不判 kill switch。
@@ -109,15 +123,25 @@ func Evaluate(rule Rule, scopes []Scope, dims Dims) Decision {
 	case ModeOn:
 		return Decision{Allow: true, Reason: ReasonOn}
 	case ModeWhitelist:
-		if whitelistHit(scopes, dims) {
+		hit, allUnusable := whitelistHit(scopes, dims)
+		if hit {
 			return Decision{Allow: true, Reason: ReasonWhitelistHit}
+		}
+		if allUnusable {
+			return Decision{Allow: false, Reason: ReasonWhitelistDimUnavailable, DimensionUnusable: true}
 		}
 		return Decision{Allow: false, Reason: ReasonWhitelistMiss}
 	case ModePercent:
-		if whitelistHit(scopes, dims) {
+		hit, allUnusable := whitelistHit(scopes, dims)
+		if hit {
 			return Decision{Allow: true, Reason: ReasonWhitelistHit}
 		}
-		return percentDecision(rule, dims)
+		d := percentDecision(rule, dims)
+		// 白名单用不上也是错配，即便分桶本身判得出结果。
+		if allUnusable {
+			d.DimensionUnusable = true
+		}
+		return d
 	default:
 		return Decision{Allow: false, Reason: ReasonUnknownMode}
 	}
@@ -126,17 +150,23 @@ func Evaluate(rule Rule, scopes []Scope, dims Dims) Decision {
 // whitelistHit 逐条比对白名单。条目按自己的 scope_type 取对应维度值；该维度在本次
 // 评估中为空时跳过该条目——空值绝不匹配，否则一条 scope_id="" 的脏数据会命中所有
 // 缺维度的调用。
-func whitelistHit(scopes []Scope, dims Dims) bool {
+//
+// 第二个返回值 allDimsUnusable 报告「名单非空，但每一条都因维度取不到值而被跳过」。
+// 调用方据此把「没命中」和「没法命中」分开：空名单不算（那是合法状态），有可用维度
+// 的条目只是没匹配上也不算。
+func whitelistHit(scopes []Scope, dims Dims) (hit bool, allDimsUnusable bool) {
+	usable := 0
 	for _, s := range scopes {
 		id := dimValue(s.Type, dims)
 		if id == "" {
 			continue
 		}
+		usable++
 		if s.ID == id {
-			return true
+			return true, false
 		}
 	}
-	return false
+	return false, len(scopes) > 0 && usable == 0
 }
 
 // percentDecision 判定 percent 模式。0（及负数）全拒、>=100 全放，这两档与维度
@@ -146,16 +176,18 @@ func whitelistHit(scopes []Scope, dims Dims) bool {
 // 对象落进同一个桶（Bucket(key,"") 是该 key 的一个常数），使配置的 50% 静默变成
 // 全体开或全体关，且管理台仍显示 50%——一个无任何报错的错配。
 func percentDecision(rule Rule, dims Dims) Decision {
+	// 短路分支的决策与维度无关，但错配仍要回报（见 Decision.DimensionUnusable）。
+	unusable := dimValue(BucketDimension(rule), dims) == ""
 	if rule.Percent <= 0 {
-		return Decision{Allow: false, Reason: ReasonPercentOut}
+		return Decision{Allow: false, Reason: ReasonPercentOut, DimensionUnusable: unusable}
 	}
 	if rule.Percent >= 100 {
-		return Decision{Allow: true, Reason: ReasonPercentIn}
+		return Decision{Allow: true, Reason: ReasonPercentIn, DimensionUnusable: unusable}
+	}
+	if unusable {
+		return Decision{Allow: false, Reason: ReasonDimUnavailable, DimensionUnusable: true}
 	}
 	dimID := dimValue(BucketDimension(rule), dims)
-	if dimID == "" {
-		return Decision{Allow: false, Reason: ReasonDimUnavailable}
-	}
 	if Bucket(rule.Key, dimID) < rule.Percent {
 		return Decision{Allow: true, Reason: ReasonPercentIn}
 	}

--- a/pkg/featuregate/featuregate_test.go
+++ b/pkg/featuregate/featuregate_test.go
@@ -73,28 +73,36 @@ func TestEvaluate(t *testing.T) {
 			wantReason: ReasonWhitelistMiss,
 		},
 		{
-			name:       "whitelist 空 UID 不命中任何用户条目",
+			// 「空 UID 不命中」的保证仍在（Allow=false）。Reason 是 dim_unavailable：
+			// 名单里全是 user 条目而这次调用没有 UID —— 没法判，不是判了没中。
+			// 与 api_flags.go 对空 uid 打 Error 的处理同调。
+			name:       "whitelist 空 UID 不命中任何用户条目，且错配可见",
 			rule:       Rule{Key: "k", Mode: ModeWhitelist},
 			scopes:     userScope,
 			dims:       Dims{UID: ""},
 			wantAllow:  false,
-			wantReason: ReasonWhitelistMiss,
+			wantReason: ReasonWhitelistDimUnavailable,
 		},
 		{
+			// 报 dim_unavailable 而非 miss 是刻意的：UID 本身取不到值，这是
+			// 「没法判」不是「判了没中」。脏数据防御（空 scope_id 不匹配空维度）
+			// 由 Allow=false 保证，与 Reason 取值无关。
 			name:       "whitelist 空 scope_id 不匹配空维度（脏数据防御）",
 			rule:       Rule{Key: "k", Mode: ModeWhitelist},
 			scopes:     []Scope{{Type: ScopeTypeUser, ID: ""}},
 			dims:       Dims{UID: ""},
 			wantAllow:  false,
-			wantReason: ReasonWhitelistMiss,
+			wantReason: ReasonWhitelistDimUnavailable,
 		},
 		{
+			// 维度不交叉的保证仍在（Allow=false）；Reason 是 dim_unavailable 因为
+			// 这次调用根本没有 UID 维度可比。
 			name:       "whitelist 维度不交叉：用户条目不会被同值的 group_no 命中",
 			rule:       Rule{Key: "k", Mode: ModeWhitelist},
 			scopes:     userScope,
 			dims:       Dims{GroupNo: "u1"},
 			wantAllow:  false,
-			wantReason: ReasonWhitelistMiss,
+			wantReason: ReasonWhitelistDimUnavailable,
 		},
 
 		// ---- whitelist：group / space 维度 ----
@@ -115,12 +123,14 @@ func TestEvaluate(t *testing.T) {
 			wantReason: ReasonWhitelistHit,
 		},
 		{
-			name:       "whitelist 未知 scope_type 永不命中",
+			// 三个维度都有值，唯独 "tenant" 这个维度不存在 —— 该条目永远命不中。
+			// 报 dim_unavailable 让这类配置错误可见，比静默 miss 好。
+			name:       "whitelist 未知 scope_type 永不命中，且错配可见",
 			rule:       Rule{Key: "k", Mode: ModeWhitelist},
 			scopes:     []Scope{{Type: "tenant", ID: "t1"}},
 			dims:       Dims{UID: "t1", GroupNo: "t1", SpaceID: "t1"},
 			wantAllow:  false,
-			wantReason: ReasonWhitelistMiss,
+			wantReason: ReasonWhitelistDimUnavailable,
 		},
 
 		// ---- percent：白名单优先（本任务修的语义） ----
@@ -291,5 +301,95 @@ func TestValidDimension(t *testing.T) {
 		if ValidDimension(bad) {
 			t.Fatalf("%q 不应为合法维度", bad)
 		}
+	}
+}
+
+// TestWhitelistDimUnavailableIsDistinguishable 钉住读侧对「白名单条目全都用不上」的
+// 可辨识性。
+//
+// 这是评审抓到的那个盲区：一条 client-visible 规则的白名单若全是 group 条目，展示
+// 端点（只有 UID）跳过每一条后返回 whitelist_miss —— 与「用户确实不在名单里」完全
+// 同形。运维看到的是白名单有行、mode 是 whitelist、写入都 200、日志无声，而 flag 对
+// 所有人是 false。bucket_by 那条错配有 ReasonDimUnavailable 兜底，这条一直没有。
+func TestWhitelistDimUnavailableIsDistinguishable(t *testing.T) {
+	cases := []struct {
+		name       string
+		scopes     []Scope
+		dims       Dims
+		wantReason string
+	}{
+		{
+			// 全部条目的维度都取不到值 —— 这不是"没命中"，是"根本没法命中"。
+			name:       "条目维度全不可用",
+			scopes:     []Scope{{Type: ScopeTypeGroup, ID: "g1"}, {Type: ScopeTypeSpace, ID: "s1"}},
+			dims:       Dims{UID: "u1"},
+			wantReason: ReasonWhitelistDimUnavailable,
+		},
+		{
+			// 有可用维度的条目，只是没匹配上 —— 这是真正的 miss。
+			name:       "维度可用但未匹配",
+			scopes:     []Scope{{Type: ScopeTypeUser, ID: "someone_else"}},
+			dims:       Dims{UID: "u1"},
+			wantReason: ReasonWhitelistMiss,
+		},
+		{
+			// 混合：只要有一条维度可用，就是普通 miss，不该报维度不可用。
+			name:       "混合维度，有一条可用",
+			scopes:     []Scope{{Type: ScopeTypeGroup, ID: "g1"}, {Type: ScopeTypeUser, ID: "other"}},
+			dims:       Dims{UID: "u1"},
+			wantReason: ReasonWhitelistMiss,
+		},
+		{
+			// 空白名单是合法状态（mode=whitelist 且谁都不放），不是错配。
+			name:       "空白名单仍是普通 miss",
+			scopes:     nil,
+			dims:       Dims{UID: "u1"},
+			wantReason: ReasonWhitelistMiss,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Evaluate(Rule{Key: "k", Mode: ModeWhitelist}, tc.scopes, tc.dims)
+			if got.Allow {
+				t.Fatalf("均不应放行，得到 Allow=true")
+			}
+			if got.Reason != tc.wantReason {
+				t.Fatalf("Reason = %q, want %q", got.Reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+// TestPercentShortcutStillReportsUnusableDimension 钉住 percent 的 0%/100% 短路
+// **不改变决策**、但要让错配可被上层发现。
+//
+// 两位评审在这里意见相左：一位主张把维度校验提到 100% 短路之前（即 fail-closed），
+// 另一位主张决策是对的、只需可见。取后者——percent=100 的意图无歧义（"所有人"），
+// 管理台显示与实际一致，为一个不影响结果的错配去打挂一条正在全量的规则是本末倒置。
+// 但错配必须留下痕迹，否则运维会在把 100 调到 50 的那一刻突然全员掉线。
+func TestPercentShortcutStillReportsUnusableDimension(t *testing.T) {
+	// 展示端点只有 UID，规则却配了 group 分桶。
+	dims := Dims{UID: "u1"}
+
+	full := Evaluate(Rule{Key: "k", Mode: ModePercent, Percent: 100, BucketBy: ScopeTypeGroup}, nil, dims)
+	if !full.Allow {
+		t.Fatalf("100%% 必须放行（决策不因维度错配而改变），得到 %+v", full)
+	}
+	if !full.DimensionUnusable {
+		t.Fatalf("100%% 短路仍须把维度不可用回报给上层，得到 %+v", full)
+	}
+
+	zero := Evaluate(Rule{Key: "k", Mode: ModePercent, Percent: 0, BucketBy: ScopeTypeGroup}, nil, dims)
+	if zero.Allow {
+		t.Fatalf("0%% 必须拒绝")
+	}
+	if !zero.DimensionUnusable {
+		t.Fatalf("0%% 短路同样须回报维度不可用，得到 %+v", zero)
+	}
+
+	// 维度可用时不得误报。
+	ok := Evaluate(Rule{Key: "k", Mode: ModePercent, Percent: 100, BucketBy: ScopeTypeUser}, nil, dims)
+	if ok.DimensionUnusable {
+		t.Fatalf("维度可用时不应报 DimensionUnusable，得到 %+v", ok)
 	}
 }

--- a/pkg/featuregate/featuregate_test.go
+++ b/pkg/featuregate/featuregate_test.go
@@ -1,0 +1,295 @@
+package featuregate
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestEvaluate 覆盖四个 mode × 三个维度的判定矩阵。每个用例都断言 Reason，
+// 因为 Reason 是运维排障时唯一能区分「白名单进来的」「分桶进来的」「维度缺失
+// 被拒的」的信号，回归时静默改掉 Reason 与改掉 Allow 同样有害。
+func TestEvaluate(t *testing.T) {
+	userScope := []Scope{{Type: ScopeTypeUser, ID: "u1"}}
+	groupScope := []Scope{{Type: ScopeTypeGroup, ID: "g1"}}
+	spaceScope := []Scope{{Type: ScopeTypeSpace, ID: "s1"}}
+
+	cases := []struct {
+		name       string
+		rule       Rule
+		scopes     []Scope
+		dims       Dims
+		wantAllow  bool
+		wantReason string
+	}{
+		// ---- off：无条件关，白名单不可穿透 ----
+		{
+			name:       "off 全拒",
+			rule:       Rule{Key: "k", Mode: ModeOff},
+			dims:       Dims{UID: "u1"},
+			wantAllow:  false,
+			wantReason: ReasonOff,
+		},
+		{
+			name:       "off 不可被用户白名单穿透（止血语义的硬边界）",
+			rule:       Rule{Key: "k", Mode: ModeOff},
+			scopes:     userScope,
+			dims:       Dims{UID: "u1"},
+			wantAllow:  false,
+			wantReason: ReasonOff,
+		},
+		{
+			name:       "off 不可被群白名单穿透",
+			rule:       Rule{Key: "k", Mode: ModeOff},
+			scopes:     groupScope,
+			dims:       Dims{GroupNo: "g1"},
+			wantAllow:  false,
+			wantReason: ReasonOff,
+		},
+
+		// ---- on ----
+		{
+			name:       "on 全放",
+			rule:       Rule{Key: "k", Mode: ModeOn},
+			dims:       Dims{},
+			wantAllow:  true,
+			wantReason: ReasonOn,
+		},
+
+		// ---- whitelist：user 维度（本任务新增） ----
+		{
+			name:       "whitelist 用户命中",
+			rule:       Rule{Key: "k", Mode: ModeWhitelist},
+			scopes:     userScope,
+			dims:       Dims{UID: "u1"},
+			wantAllow:  true,
+			wantReason: ReasonWhitelistHit,
+		},
+		{
+			name:       "whitelist 用户未命中",
+			rule:       Rule{Key: "k", Mode: ModeWhitelist},
+			scopes:     userScope,
+			dims:       Dims{UID: "u2"},
+			wantAllow:  false,
+			wantReason: ReasonWhitelistMiss,
+		},
+		{
+			name:       "whitelist 空 UID 不命中任何用户条目",
+			rule:       Rule{Key: "k", Mode: ModeWhitelist},
+			scopes:     userScope,
+			dims:       Dims{UID: ""},
+			wantAllow:  false,
+			wantReason: ReasonWhitelistMiss,
+		},
+		{
+			name:       "whitelist 空 scope_id 不匹配空维度（脏数据防御）",
+			rule:       Rule{Key: "k", Mode: ModeWhitelist},
+			scopes:     []Scope{{Type: ScopeTypeUser, ID: ""}},
+			dims:       Dims{UID: ""},
+			wantAllow:  false,
+			wantReason: ReasonWhitelistMiss,
+		},
+		{
+			name:       "whitelist 维度不交叉：用户条目不会被同值的 group_no 命中",
+			rule:       Rule{Key: "k", Mode: ModeWhitelist},
+			scopes:     userScope,
+			dims:       Dims{GroupNo: "u1"},
+			wantAllow:  false,
+			wantReason: ReasonWhitelistMiss,
+		},
+
+		// ---- whitelist：group / space 维度 ----
+		{
+			name:       "whitelist 群命中",
+			rule:       Rule{Key: "k", Mode: ModeWhitelist},
+			scopes:     groupScope,
+			dims:       Dims{GroupNo: "g1"},
+			wantAllow:  true,
+			wantReason: ReasonWhitelistHit,
+		},
+		{
+			name:       "whitelist 空间命中（初版写侧接受但读侧忽略，此处已打通）",
+			rule:       Rule{Key: "k", Mode: ModeWhitelist},
+			scopes:     spaceScope,
+			dims:       Dims{SpaceID: "s1"},
+			wantAllow:  true,
+			wantReason: ReasonWhitelistHit,
+		},
+		{
+			name:       "whitelist 未知 scope_type 永不命中",
+			rule:       Rule{Key: "k", Mode: ModeWhitelist},
+			scopes:     []Scope{{Type: "tenant", ID: "t1"}},
+			dims:       Dims{UID: "t1", GroupNo: "t1", SpaceID: "t1"},
+			wantAllow:  false,
+			wantReason: ReasonWhitelistMiss,
+		},
+
+		// ---- percent：白名单优先（本任务修的语义） ----
+		{
+			// Percent: 0 保证放行只可能来自白名单，排除分桶巧合。
+			name:       "percent 0% 下白名单仍然命中",
+			rule:       Rule{Key: "k", Mode: ModePercent, Percent: 0, BucketBy: ScopeTypeUser},
+			scopes:     userScope,
+			dims:       Dims{UID: "u1"},
+			wantAllow:  true,
+			wantReason: ReasonWhitelistHit,
+		},
+		{
+			name:       "percent 0% 下非白名单被拒",
+			rule:       Rule{Key: "k", Mode: ModePercent, Percent: 0, BucketBy: ScopeTypeUser},
+			scopes:     userScope,
+			dims:       Dims{UID: "u2"},
+			wantAllow:  false,
+			wantReason: ReasonPercentOut,
+		},
+		{
+			// 白名单维度与分桶维度可以不同：按群豁免、按用户放量。
+			name:       "percent 按用户分桶时群白名单仍生效",
+			rule:       Rule{Key: "k", Mode: ModePercent, Percent: 0, BucketBy: ScopeTypeUser},
+			scopes:     groupScope,
+			dims:       Dims{GroupNo: "g1", UID: "whoever"},
+			wantAllow:  true,
+			wantReason: ReasonWhitelistHit,
+		},
+
+		// ---- percent：边界与维度可用性 ----
+		{
+			name:       "percent 100% 全放，且不要求维度可用",
+			rule:       Rule{Key: "k", Mode: ModePercent, Percent: 100, BucketBy: ScopeTypeGroup},
+			dims:       Dims{UID: "u1"}, // 无 GroupNo
+			wantAllow:  true,
+			wantReason: ReasonPercentIn,
+		},
+		{
+			name:       "percent 负数视同 0",
+			rule:       Rule{Key: "k", Mode: ModePercent, Percent: -1, BucketBy: ScopeTypeUser},
+			dims:       Dims{UID: "u1"},
+			wantAllow:  false,
+			wantReason: ReasonPercentOut,
+		},
+		{
+			// 这是「管理台显示 50%、实际全体开或全体关」那个静默错配的防线。
+			name:       "percent 分桶维度缺失时 fail-closed 且原因可辨",
+			rule:       Rule{Key: "k", Mode: ModePercent, Percent: 50, BucketBy: ScopeTypeGroup},
+			dims:       Dims{UID: "u1"}, // 只有 UID，配置却要按 group 分桶
+			wantAllow:  false,
+			wantReason: ReasonDimUnavailable,
+		},
+		{
+			name:       "percent 未知 bucket_by 同样 fail-closed，不回退到别的维度",
+			rule:       Rule{Key: "k", Mode: ModePercent, Percent: 50, BucketBy: "tenant"},
+			dims:       Dims{UID: "u1", GroupNo: "g1", SpaceID: "s1"},
+			wantAllow:  false,
+			wantReason: ReasonDimUnavailable,
+		},
+
+		// ---- 未知 mode ----
+		{
+			name:       "未知 mode 保守拒绝",
+			rule:       Rule{Key: "k", Mode: Mode("rollout")},
+			dims:       Dims{UID: "u1"},
+			wantAllow:  false,
+			wantReason: ReasonUnknownMode,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Evaluate(tc.rule, tc.scopes, tc.dims)
+			if got.Allow != tc.wantAllow || got.Reason != tc.wantReason {
+				t.Fatalf("Evaluate = {Allow:%v Reason:%q}, want {Allow:%v Reason:%q}",
+					got.Allow, got.Reason, tc.wantAllow, tc.wantReason)
+			}
+		})
+	}
+}
+
+// TestBucketDimensionDefault 钉住「bucket_by 为空 == 按 group 分桶」这个缺省语义。
+func TestBucketDimensionDefault(t *testing.T) {
+	if got := BucketDimension(Rule{Key: "k"}); got != ScopeTypeGroup {
+		t.Fatalf("空 BucketBy 应归一到 %q，得到 %q", ScopeTypeGroup, got)
+	}
+	if got := BucketDimension(Rule{Key: "k", BucketBy: ScopeTypeUser}); got != ScopeTypeUser {
+		t.Fatalf("显式 BucketBy 应原样返回，得到 %q", got)
+	}
+}
+
+// TestPercentEmptyBucketByEqualsGroup 验证未指定 bucket_by 的规则与显式
+// bucket_by=group 的规则判定完全一致——这是缺省值语义的回归防线。
+func TestPercentEmptyBucketByEqualsGroup(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		groupNo := fmt.Sprintf("g%d", i)
+		dims := Dims{GroupNo: groupNo, UID: "u", SpaceID: "s"}
+		implicit := Evaluate(Rule{Key: "k", Mode: ModePercent, Percent: 50}, nil, dims)
+		explicit := Evaluate(Rule{Key: "k", Mode: ModePercent, Percent: 50, BucketBy: ScopeTypeGroup}, nil, dims)
+		if implicit != explicit {
+			t.Fatalf("group_no=%s: 隐式 %v != 显式 %v", groupNo, implicit, explicit)
+		}
+	}
+}
+
+// TestBucketStable 验证同一 (key, dimID) 分桶恒定。
+func TestBucketStable(t *testing.T) {
+	first := Bucket("k", "u1")
+	for i := 0; i < 100; i++ {
+		if got := Bucket("k", "u1"); got != first {
+			t.Fatalf("第 %d 次 Bucket = %d，首次 %d：分桶必须恒定", i, got, first)
+		}
+	}
+	if first < 0 || first >= 100 {
+		t.Fatalf("Bucket 必须落在 [0,100)，得到 %d", first)
+	}
+}
+
+// TestBucketIndependentAcrossKeys 验证按 key 加盐生效：同一个 uid 在不同功能 key
+// 下不会同涨同落。断言「不是全部相同」而非某个具体值，避免把哈希实现钉死。
+func TestBucketIndependentAcrossKeys(t *testing.T) {
+	const uid = "u1"
+	seen := make(map[int]struct{})
+	for i := 0; i < 32; i++ {
+		seen[Bucket(fmt.Sprintf("feature_%d", i), uid)] = struct{}{}
+	}
+	if len(seen) < 2 {
+		t.Fatalf("32 个不同 key 对同一 uid 只产生 %d 个桶值，按 key 加盐未生效", len(seen))
+	}
+}
+
+// TestPercentMonotonic 验证放量单调性：percent 调高只会纳入更多对象，已命中的
+// 不会掉出。直接取该 (key,uid) 的真实桶值做边界断言，比抽样更严格。
+func TestPercentMonotonic(t *testing.T) {
+	const key, uid = "k", "u1"
+	b := Bucket(key, uid)
+
+	allowedAt := func(p int) bool {
+		return Evaluate(Rule{Key: key, Mode: ModePercent, Percent: p, BucketBy: ScopeTypeUser},
+			nil, Dims{UID: uid}).Allow
+	}
+
+	// 边界：桶值 b 在 percent=b 时落在窗口外，percent=b+1 时进入。
+	if allowedAt(b) {
+		t.Fatalf("桶值 %d 在 percent=%d 时不应命中（判据是 bucket < percent）", b, b)
+	}
+	if !allowedAt(b + 1) {
+		t.Fatalf("桶值 %d 在 percent=%d 时应当命中", b, b+1)
+	}
+	// 单调：一旦命中，继续调高不得掉出。
+	for p := b + 1; p <= 100; p++ {
+		if !allowedAt(p) {
+			t.Fatalf("percent 从 %d 调到 %d 时对象掉出，违反单调性", b+1, p)
+		}
+	}
+}
+
+// TestValidDimension 钉住写侧校验的取值域。空串视为非法：调用方要表达「未配置」
+// 应在传入前判空，而不是把空串当合法值存库。
+func TestValidDimension(t *testing.T) {
+	for _, ok := range []string{ScopeTypeGroup, ScopeTypeSpace, ScopeTypeUser} {
+		if !ValidDimension(ok) {
+			t.Fatalf("%q 应为合法维度", ok)
+		}
+	}
+	for _, bad := range []string{"", "tenant", "Group", "user "} {
+		if ValidDimension(bad) {
+			t.Fatalf("%q 不应为合法维度", bad)
+		}
+	}
+}

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -1398,3 +1398,17 @@ other = "通知暂停时间无效。"
 
 ["err.server.notification.pause.update_failed"]
 other = "更新通知暂停状态失败。"
+
+# ---- err.server.featuregate.* (modules/featuregate 管理端点) ----
+
+["err.server.featuregate.request_invalid"]
+other = "请求参数无效。"
+
+["err.server.featuregate.not_found"]
+other = "灰度白名单条目不存在。"
+
+["err.server.featuregate.query_failed"]
+other = "查询灰度配置失败。"
+
+["err.server.featuregate.operation_failed"]
+other = "操作失败，请稍后再试。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -354,6 +354,18 @@ other = "Invalid space welcome configuration."
 ["err.server.common.thread_archive_window_ordering"]
 other = "Thread auto-archive window must not be shorter than the recent-tab thread window."
 
+["err.server.featuregate.not_found"]
+other = "The feature gate scope does not exist."
+
+["err.server.featuregate.operation_failed"]
+other = "The operation failed. Please try again later."
+
+["err.server.featuregate.query_failed"]
+other = "Failed to query feature gate."
+
+["err.server.featuregate.request_invalid"]
+other = "Invalid request."
+
 ["err.server.group.already_member"]
 other = "You are already a member of this group."
 


### PR DESCRIPTION
## Summary

Revives the feature-gate framework from the never-merged PR #280 and extends it so a
feature can be rolled out to **specific users** — something `system_setting` cannot
express, since it only carries deployment-wide on/off converging in 60s.

**Framework only.** PR #280's second commit, which put incoming webhooks behind a
fail-closed create gate, is deliberately left out: that feature has been in production
for months without the gate, and adding one is an independent risk surface unrelated to
user-scoped rollout. `modules/incomingwebhook` is untouched.

The client-flag registry **ships empty**. This delivers the mechanism; gating an actual
product feature is a follow-up that adds one registry line plus a rule.

> **Four review rounds are folded in** (`78d6be71`, `4c9775a2`, `353953de`, `81d809b4`),
> and the branch is rebased on the current `main`. All three reviewers approved at
> `353953de`; `81d809b4` is a hardening pass taking the two remaining P2 items that get
> an order of magnitude more expensive after merge. See "Changes across review rounds".

## Related Issue

None — there is no tracking issue for this work. The spec is the linked brief below.

## Linked Spec

`.octospec/tasks/featuregate-user-scoped-flags/brief.md`

## Changes

- **`pkg/featuregate`** (pure, zero IO)
  - `user` dimension: `scope_type=user` whitelist entries alongside `group`/`space` —
    all three are now actually consulted on read (`space` was previously writable but
    silently ignored).
  - Per-rule `bucket_by` (`group`/`space`/`user`). Empty defaults to `group`.
  - **The whitelist spans modes**: it applies under `whitelist` AND `percent` (as an
    exemption list evaluated before bucketing), and never under `off`.
  - Dimension mismatches are reported, not swallowed: `dim_unavailable` and
    `whitelist_dim_unavailable` reasons, plus `Decision.DimensionUnusable` which flags a
    mismatch **independently of the decision**.
- **`modules/featuregate`**
  - MySQL truth + Redis read cache (DEL-on-write invalidation, versioned key prefix),
    env kill switch `OCTO_FEATUREGATE_<KEY>_KILL`, superadmin endpoints under
    `/v1/manager/featuregate`, `updated_by` audit columns on both tables.
  - `AllowDisplay` returns `(allow, ok)`; `ok=false` means the decision is unobtainable.
  - `GET /v1/featuregate/flags`: authenticated, read-only, takes **no key parameter** and
    always returns the full registered set, so a client cannot probe for internal gates.
    Undecidable keys are listed in an explicit `unavailable` array.
    `Cache-Control: private, no-store` + `Vary: token`.
  - Client-visible flags are registered in code with `feature_key` (ops-facing, and the
    source of the kill-switch env name) decoupled from `client_key` (the wire contract).
  - Client-visible keys are restricted to the `user` dimension on both write and read
    paths — including the **already-persisted** scope rows, not just the incoming request.
  - `feature_key` constrained to `[a-z][a-z0-9_]*` in the handlers and by a
    `REGEXP_LIKE` CHECK; `scope_id` charset-validated; whitelist size capped per key.
- `GET /v1/common/appconfig` is **untouched**.
- `docs/cutover-framework.md` corrected: it described this module as fail-open, written
  when the module did not exist. Two of its three call sites are fail-closed.

## Changes across review rounds

**Round 1 — persisted scopes were never validated.** `update` checked the incoming
`bucket_by` but not the already-stored scope rows. The registry is a compile-time list
while gates are DB rows, so "an internal gate accumulates `group` scopes, then a later
deploy makes it client-visible" is the *normal* lifecycle — after which an `update` to
`whitelist`/`bucket_by=user` was accepted with a whitelist that could never match, silent
on both sides. Fixed on the write side (`clientVisibleScopesUsable`) and the read side
(`whitelist_dim_unavailable` + `Decision.DimensionUnusable`).

**Round 2 — that fix blocked the rollback path.** The new check ran on *every* `update`,
including a de-escalation, while `modeNeedsScopes` excludes `off`/`on`. A client-visible
gate with a legacy group-only whitelist could not be turned off through its own API.
Both checks are now gated on `modeNeedsScopes`: **turning something off must never be
harder than turning it on**, and permitting a stale `bucket_by` in a row nothing reads
costs nothing, since every transition into a scope-consuming mode revalidates.

**Round 3 — the CHECK constraints were inert.** Both tables inherited
`utf8mb4_general_ci` while every Go comparison is byte-exact. `REGEXP_LIKE` and `IN`
inherit the column collation, so `feature_key='ZZ_UPPER'` passed `^[a-z][a-z0-9_]*$` and
`mode='OFF'` passed `IN ('off',...)`. Worse, `scope_id` `'UserA'` and `'usera'` collided
under the unique key: the second `add` hit `ON DUPLICATE KEY` and only touched
`updated_by`, so the operator got a 200 for a user who would never be admitted — and the
read side stayed quiet, because a usable `user`-dimension entry did exist. All five
compared columns are now `utf8mb4_bin`.

**Round 4 (this head) — the same constraints were still inert, for a different reason.**
MySQL's regex engine is ICU, where `$` matches at end of input **or before a final line
terminator**, so `'u1\n'` and `'zz_nl\n'` passed. The consequences are the two the
migration header already argues against: a `scope_id` ending in a newline is insertable
but not deletable, and a `feature_key` ending in a newline derives a kill-switch env name
containing a newline. Now anchored with `\z`, verified by trying to violate it. Go needed
no change — its `$` is end-of-text — so the gap was only in the layer that exists to catch
direct DB edits, which is where an inert constraint matters most.

**Two suggestions were implemented differently, deliberately:**

- *Add a `LIMIT` to the scope query* — on the **evaluation** path that silently drops
  whitelist entries, trading "slow but correct" for "fast but wrong". Capped on the write
  path instead, where exceeding it is an explicit rejection.
- *Honor `context.Context` in the cache loaders* — octo-lib's `redis.Conn` exposes no
  ctx-aware method, so cancellation was never possible. The parameter was dropped from
  those two so the signature stops lying.

Also across these rounds: `updated_by` audit columns; orphan scope rows rejected
(`addScope` requires the rule to exist, since an orphan is invisible to `list` yet goes
live the moment a matching rule appears); an empty uid now reports every key as
`unavailable` rather than a definite `false` for all of them; `AllowCreate` consumes the
same misconfiguration signal `AllowDisplay` does; the dimension Warn is deduplicated per
(key, reason); `scope_id` charset validated on both layers; `description` counted in
runes; a cache schema version; and `docs/cutover-framework.md`, which described this
module as fail-open — two of its three call sites are fail-closed.

## Note for developers who checked out an earlier revision of this branch

The migration was renamed (`20260820000001` → `20260825000001`, the original filename was
misdated) and then edited in place. `main` never carried the old ID, so **no CI or
production database is affected**. But a local database that applied any earlier revision
will abort with `unknown migration in database`, or keep the pre-fix table definition —
an already-applied migration does not upgrade itself. Drop and recreate the local `test`
database.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

```
go build ./...                                                      OK
go test -race -count=2 ./modules/featuregate/ ./pkg/featuregate/     ok (55 tests)
golangci-lint run ./modules/featuregate/... ./pkg/featuregate/...    0 issues
make i18n-extract-check && make i18n-lint                            OK
go test ./modules/common/ -run 'AppConfig|Appconfig'                 ok
git diff --stat -- modules/incomingwebhook modules/user modules/common   (empty)
```

Integration tests run against real MySQL + Redis through `testutil.NewTestServer`
(migrations applied, HTTP stack, auth middleware, rate limiter, i18n envelope). Verified
**re-runnable**: the suite passes twice back-to-back with no DB or Redis reset in between,
and passes when the DB is dropped while the Redis cache is still warm.

## COMPREHENSION

**1. What does this change actually do to the load-bearing path?**

It adds a new decision layer and touches no existing one. Every existing rollout switch
resolves exactly as before: `appconfig` is byte-identical, `system_setting` is untouched,
and no module calls the new evaluation API — so on merge, runtime behaviour is unchanged
everywhere.

The load-bearing part is what happens *once* a feature is gated. Three fail policies are
fixed per call site and are not operator-tunable, so they cannot be misconfigured into the
wrong failure: `AllowCreate` fail-closed (a wrong reject beats exposed data), `AllowPush`
fail-open (a wrong push beats severing live delivery), and `AllowDisplay` fail-closed but
**three-state**.

That third state is the subtle one. The response carries only booleans, so a client cannot
distinguish "really off" from "the server blipped". Sending `false` on a Redis error would
drop the feature for *every* user at once; listing the key in `unavailable` lets each
client keep its previous value, shrinking the blast radius to users with no cached value.
The kill switch deliberately stays a definite `false` — it must never land in
`unavailable`, or pressing the emergency stop on an already-rolled-out feature would never
converge in the UI.

**2. What could break because of it (dependents + failure mode)?**

- **Migration**: two new tables, no ALTER on existing ones. Failure mode is a failed
  migration at boot, which is loud. `REGEXP_LIKE` in `CHECK` needs MySQL 8.0.16+; CI runs
  `mysql:8.0` and this repo already ships `CHECK` constraints.
- **`internal/modules.go`**: one blank import. A broken module `init()` would fail startup.
- **Redis keyspace**: `featuregate:{rule,scope}:v1:*` with a 60s TTL, bounded by the number
  of registered gates (currently zero) and by the per-key whitelist cap.
- **Shared UID rate-limit bucket**: the new endpoint draws from the same per-uid quota as
  every other route, which is why the client contract specifies fetch-on-foreground with a
  ≥5 min throttle rather than an interval poll.
- **Biggest realistic failure is a misconfiguration, not a crash.** Two shapes exist — a
  client-visible rule bucketing on `group` (every user in one bucket, so a configured 50%
  becomes 0% or 100% while the console still shows 50%), and a client-visible whitelist
  made entirely of unusable entries. Both are now blocked on the write path *and* reported
  on the read path: the write check alone is bypassable by editing the DB, and the read
  check alone would let ops believe a broken config took effect.

**3. How do you know it works (specific test/repro/trace)?**

49 tests, with the non-obvious invariants pinned individually rather than covered
incidentally:

- `TestServiceLoadsScopesInPercentMode` runs through the **Service**, not the pure
  function, because the bug it guards lives in one `if` deciding whether to load scopes at
  all. `Evaluate`'s table tests stay green while the whitelist is silently empty. Uses
  `percent=0` so a pass can only come from the whitelist, never from a lucky bucket.
- `TestUpdateRejectsClientVisibleKeyWhoseScopesAreAllUnusable` reproduces the blocking
  finding's exact three-step lifecycle, and
  `TestUpdateAllowsClientVisibleKeyWithEmptyScopes` pins the boundary so the new check
  cannot misfire on a legitimately empty whitelist.
- `TestWhitelistDimUnavailableIsDistinguishable` and
  `TestPercentShortcutStillReportsUnusableDimension` pin the read-side signals, including
  that the 100% short-circuit keeps its decision while still reporting the mismatch.
- `TestAllowDisplayKillSwitchIsDefiniteOff` and `...RuleMissingIsDefiniteOff` pin what must
  *not* land in `unavailable`.
- `TestFlagsEndpointWireContract` asserts a `false` key is present in `flags` while an
  undecidable key appears in `unavailable` — the two states a fixed-field struct or
  `omitempty` would collapse.
- `TestRoutesMountUIDRateLimiterAfterAuth` asserts `X-RateLimit-Scope: uid` on the real
  `Route()`. octo-lib's limiter silently skips when it cannot read a uid, so the header
  proves both "mounted" and "mounted after `AuthMiddleware`".
- `TestKillSwitchEnvIsInjective` proves two gates can never share one kill switch.
- The `REGEXP_LIKE` CHECK constraints were verified by hand against MySQL 8: direct
  `INSERT`s of `'my gate'` and `'docs-beta'` are both rejected.

A test-isolation defect was found and fixed while verifying: `CleanAllTables` does not
clear Redis, so a warm rule cache made the suite fail non-deterministically after a DB
reset — and pass again once the 60s TTL expired. All DB/Redis tests now go through one
fixture that flushes the module's cache and the UID buckets, and the original trigger was
re-run to confirm.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation — `docs/cutover-framework.md` corrected; no OpenAPI spec yet,
      see follow-up 1
- [x] Followed commit message conventions (Conventional Commits)

## Follow-ups (not in this PR)

Carried from the round-4 approval; none blocks the merge, and the reviewer preferred one
follow-up over a fifth round.

1. **No OpenAPI spec.** `1module.go` does not set `Swagger`, so the endpoints are absent
   from the API docs. Convention for a new module would be `openapi: 3.0.3`. Note that
   `modules/notification`'s spec declares `bearerAuth`, which is inaccurate for this repo
   — `AuthMiddleware` reads the `token` header — so it should not be copied verbatim.
2. **Client refresh contract needs client-team sign-off**: cold start + after login + on
   foreground (≥5 min throttle), and "key listed in `unavailable` → keep last value; no
   history → `false`". Ops expectation is minutes-to-hours, **not** seconds.
3. **`addScope`'s new 404 reuses `ErrFeatureGateNotFound`**, whose message names the scope
   rather than the gate, pointing diagnosis away from a mistyped key.
4. **The dimension-Warn dedup is `Load`-then-`Store`** (not atomic, so the first burst all
   log) and its key omits the dimension, so switching between two unusable dimensions
   looks like success for up to five minutes. It is also per-`Service`, which matters if a
   future caller constructs one per request.
5. **`list` is an N+1**, and the flags endpoint issues 1–2 Redis round trips per registered
   flag. Both are bounded today (superadmin-only; registry ships empty and is expected to
   stay single-digit) and the second is not locally fixable — octo-lib's `redis.Conn` has
   no `MGet` and no pipeline.
6. **The three exported `Allow*` still take a `context.Context` they cannot honour**, for
   the same reason the loaders dropped theirs.
