### PR TITLE
fix(user): distinguish manager MFA verify lockout from send rate-limit

### DIFF
--- a/modules/base/common/service_email.go
+++ b/modules/base/common/service_email.go
@@ -147,9 +147,27 @@ func (s *EmailService) EmailSendRateLimitRetryAfter(email string, codeType CodeT
 	return retryAfter, nil
 }
 
+// ErrManagerCodeLocked is a sentinel for errors.Is checks; the concrete error
+// type is *ManagerCodeLockedError which carries the remaining TTL.
+var ErrManagerCodeLocked = errors.New("too many failed attempts, locked for 10 minutes")
+
+// ManagerCodeLockedError is returned when verify attempts are exhausted and
+// the operator is locked out for ten minutes. RetryAfter is the remaining
+// lock TTL in seconds (>= 1) so callers can surface a countdown.
+type ManagerCodeLockedError struct {
+	RetryAfter int
+}
+
+func (e *ManagerCodeLockedError) Error() string {
+	return fmt.Sprintf("too many failed attempts, locked for ~%ds", e.RetryAfter)
+}
+
+func (e *ManagerCodeLockedError) Is(target error) bool {
+	return target == ErrManagerCodeLocked
+}
+
 var (
 	ErrManagerCodeInvalid       = errors.New("invalid manager verification code")
-	ErrManagerCodeLocked        = errors.New("too many failed attempts, locked for 10 minutes")
 	errEmailCodeSuperseded      = errors.New("email verification status was superseded")
 	errInvalidTrackedCodeResult = errors.New("invalid tracked email code result")
 )
@@ -777,10 +795,17 @@ func (s *EmailService) verifyRedis() *rd.Client {
 // this makes the password-validated challenge single-use even if token
 // issuance later fails.
 func (s *EmailService) VerifyManagerCodeAtomically(ctx context.Context, email, code, challengeID string, activeKey, sendStateKey, challengeKey string) error {
+	const lockTTL = 10 * time.Minute
 	const script = `
-local lock = redis.call('GET', KEYS[4])
-if lock then return 2 end
-if redis.call('GET', KEYS[5]) ~= ARGV[2] then return 0 end
+local lock_ttl = redis.call('TTL', KEYS[4])
+if lock_ttl ~= -2 then
+  if lock_ttl == -1 then
+    redis.call('EXPIRE', KEYS[4], ARGV[3])
+    return {2, tonumber(ARGV[3])}
+  end
+  return {2, lock_ttl}
+end
+if redis.call('GET', KEYS[5]) ~= ARGV[2] then return {0, 0} end
 local expected = redis.call('GET', KEYS[1])
 local status = redis.call('GET', KEYS[2])
 local sendStatus = redis.call('HGET', KEYS[6], 'status')
@@ -790,17 +815,18 @@ if expected and sendStatus == 'sent' and attemptID and status == ('sent:' .. att
 	if redis.call('GET', KEYS[5]) == ARGV[2] then
 	  redis.call('DEL', KEYS[5], KEYS[7])
 	end
-	return 1
+	return {1, 0}
 end
 local count = tonumber(redis.call('GET', KEYS[3]) or '0') + 1
 if count >= 3 then
   redis.call('SET', KEYS[4], '1', 'EX', ARGV[3])
   redis.call('DEL', KEYS[3])
-  return 2
+  return {2, tonumber(ARGV[3])}
 end
 redis.call('SET', KEYS[3], tostring(count), 'EX', ARGV[4])
-return 0
+return {0, 0}
 `
+	lockTTLSecs := int(lockTTL / time.Second)
 	result, err := s.verifyRedis().WithContext(ctx).Eval(script, []string{
 		EmailCodeKey(email, CodeTypeManagerLogin),
 		EmailCodeStatusKey(email, CodeTypeManagerLogin),
@@ -809,20 +835,48 @@ return 0
 		activeKey,
 		sendStateKey,
 		challengeKey,
-	}, code, challengeID, int((10 * time.Minute).Seconds()), int((10 * time.Minute).Seconds())).Result()
+	}, code, challengeID, lockTTLSecs, lockTTLSecs).Result()
 	if err != nil {
 		return err
 	}
-	value, ok := result.(int64)
-	if !ok {
+	parts, ok := result.([]interface{})
+	if !ok || len(parts) != 2 {
 		return errors.New("invalid manager verification result")
 	}
-	switch value {
+	statusVal, ok1 := redisInt64(parts[0])
+	retryVal, ok2 := redisInt64(parts[1])
+	if !ok1 || !ok2 {
+		return errors.New("invalid manager verification result")
+	}
+	retryAfter := int(retryVal)
+	if retryAfter < 1 {
+		retryAfter = 1
+	}
+	switch statusVal {
 	case 1:
 		return nil
 	case 2:
-		return ErrManagerCodeLocked
+		return &ManagerCodeLockedError{RetryAfter: retryAfter}
 	default:
 		return ErrManagerCodeInvalid
+	}
+}
+
+func redisInt64(value interface{}) (int64, bool) {
+	switch v := value.(type) {
+	case int64:
+		return v, true
+	case int:
+		return int64(v), true
+	case []byte:
+		var n int64
+		_, err := fmt.Sscanf(string(v), "%d", &n)
+		return n, err == nil
+	case string:
+		var n int64
+		_, err := fmt.Sscanf(v, "%d", &n)
+		return n, err == nil
+	default:
+		return 0, false
 	}
 }

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -656,8 +656,15 @@ func (m *Manager) verifyManagerMFACode(c *wkhttp.Context) {
 		managerMFAActiveKey(challenge.UID), managerMFASendStateKey(challenge.ID),
 		managerMFAChallengeKey(challenge.ID),
 	)
-	if errors.Is(err, commonbase.ErrManagerCodeLocked) {
-		managerMFAResponseError(c, errcode.ErrUserManagerMFARateLimited, nil)
+	var lockedErr *commonbase.ManagerCodeLockedError
+	if errors.As(err, &lockedErr) {
+		retryAfter := lockedErr.RetryAfter
+		if retryAfter < 1 {
+			retryAfter = 1
+		}
+		managerMFAResponseError(c, errcode.ErrUserManagerMFAVerifyLocked, octoi18n.Details{
+			"retry_after": retryAfter,
+		})
 		return
 	}
 	if errors.Is(err, commonbase.ErrManagerCodeInvalid) {

--- a/pkg/errcode/user.go
+++ b/pkg/errcode/user.go
@@ -612,6 +612,16 @@ var (
 		DefaultMessage: "The management-console verification code cannot be sent yet. Please try again later.",
 		SafeDetailKeys: []string{"retry_after"},
 	})
+	// ErrUserManagerMFAVerifyLocked fires when the operator has entered the
+	// wrong verification code three times and verification is locked for
+	// ten minutes. Distinct from the send cooldown (ErrUserManagerMFARateLimited)
+	// so the client can render a verification-specific countdown and message.
+	ErrUserManagerMFAVerifyLocked = register(codes.Code{
+		ID:             "err.server.user.manager_mfa_verify_locked",
+		HTTPStatus:     http.StatusTooManyRequests,
+		DefaultMessage: "Too many incorrect verification attempts. Verification is temporarily locked. Please try again later.",
+		SafeDetailKeys: []string{"retry_after"},
+	})
 	ErrUserManagerMFAEmailRequired = register(codes.Code{
 		ID:             "err.server.user.manager_email_mfa_enable_email_required",
 		HTTPStatus:     http.StatusBadRequest,

--- a/pkg/i18n/locales/active.en-US.toml
+++ b/pkg/i18n/locales/active.en-US.toml
@@ -25,5 +25,8 @@ other = "The management-console verification code is invalid."
 ["err.server.user.manager_mfa_rate_limited"]
 other = "The management-console verification code cannot be sent yet. Please try again later."
 
+["err.server.user.manager_mfa_verify_locked"]
+other = "Too many incorrect verification attempts. Verification is temporarily locked. Please try again later."
+
 ["err.server.user.manager_email_mfa_enable_email_required"]
 other = "The operator must have a valid email address before enabling management-console MFA."

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -402,6 +402,9 @@ other = "管理控制台验证码无效。"
 ["err.server.user.manager_mfa_rate_limited"]
 other = "管理控制台验证码发送过于频繁，请稍后再试。"
 
+["err.server.user.manager_mfa_verify_locked"]
+other = "验证码连续多次输入错误，验证已临时锁定，请稍后再试。"
+
 ["err.server.user.manager_email_mfa_enable_email_required"]
 other = "开启管理控制台 MFA 前，当前超管必须配置有效邮箱。"
 

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -1155,6 +1155,9 @@ other = "The management-console verification code cannot be sent yet. Please try
 ["err.server.user.manager_mfa_settings_unavailable"]
 other = "Management-console MFA settings are not ready."
 
+["err.server.user.manager_mfa_verify_locked"]
+other = "Too many incorrect verification attempts. Verification is temporarily locked. Please try again later."
+
 ["err.server.user.manager_permission_required"]
 other = "This account does not have management permission."
 


### PR DESCRIPTION
## Summary

When an operator enters the wrong MFA verification code three times, the manager console is locked for 10 minutes. Previously the server returned the same error code (`err.server.user.manager_mfa_rate_limited`) used for the send cooldown, with an empty `details` object and a misleading message about sending codes too frequently. The client could not tell the two states apart or display an accurate countdown.

This PR separates the verify lockout into its own error code with a correct message and a `retry_after` value reflecting the remaining lock TTL.

## Related Issue

Fixes #808

## Changes

- Added `ErrUserManagerMFAVerifyLocked` (`err.server.user.manager_mfa_verify_locked`) as a dedicated 429 code with `retry_after` in `SafeDetailKeys`, with an accurate default message about verification being locked
- Replaced the bare sentinel `ErrManagerCodeLocked` with a structured `*ManagerCodeLockedError{RetryAfter int}` that keeps `errors.Is(err, ErrManagerCodeLocked)` compatibility via an `Is()` method
- Updated the Redis Lua script in `VerifyManagerCodeAtomically` to return `{status, retry_after}` tuples: when a lock key exists, the script reads its remaining TTL via `TTL`; when a new lock is set (3rd wrong attempt), it returns the full 600s lock duration
- Changed `api_manager.go` verify endpoint to use `errors.As` to extract `RetryAfter` and return the new `ErrUserManagerMFAVerifyLocked` code with `retry_after` in details
- Added zh-CN and en-US i18n translations for the new error code

## Testing

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./pkg/errcode/... ./modules/base/common/...` passes
- [ ] Unit tests added/updated — the existing integration test in `modules/user/manager_mfa_integration_test.go` exercises the send cooldown path (unchanged); the verify lockout path requires Redis and was verified via code review of the Lua script return values and the `ManagerCodeLockedError` propagation

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?
   On the MFA verify endpoint (`POST /v1/manager/login/verify`), after three wrong codes the response changes from `err.server.user.manager_mfa_rate_limited` with empty details to `err.server.user.manager_mfa_verify_locked` with `details.retry_after` set to the remaining lock TTL in seconds. The lock mechanism itself (Redis key, 10-minute TTL, per-email keying) is unchanged; only the wire response changes.

2. **What could break** because of it (dependents + failure mode)?
   - The Lua script return shape changed from a single integer to a two-element array. The old single-int parse path is removed; any caller that bypassed `VerifyManagerCodeAtomically` and called the script directly would break, but the script is not exported and only called from one place.
   - `*ManagerCodeLockedError` implements `Is(error) bool` for `ErrManagerCodeLocked`, so any existing `errors.Is(err, ErrManagerCodeLocked)` checks continue to work. No other callers exist in the codebase besides the updated handler.
   - If a lock key exists with no TTL (edge case: `TTL` returns -1), the script sets a fresh EXPIRE of 600s and returns 600, which is a safe degradation.

3. **How do you know it works** (specific test/repro/trace)?
   - Build and vet pass cleanly across the entire module.
   - The Lua script logic was traced for all three lock paths: (a) pre-existing lock returns actual TTL, (b) newly-set lock returns 600s, (c) no-TTL edge case refreshes TTL and returns 600s.
   - The Go-side switch handles status 2 by constructing `*ManagerCodeLockedError{RetryAfter}` with a floor of 1 second, and the API handler maps it to the new error code with the retry value in details.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [ ] Added tests for my changes (integration test requires live Redis; existing test structure covers the unchanged send path)
- [x] Updated documentation (i18n entries added for both locales)
- [x] Followed commit message conventions (Conventional Commits)