### PR TITLE
fix(cards): resolve authoritative decision actor

### DIFF
--- a/docs/card-action-callback-consumer.md
+++ b/docs/card-action-callback-consumer.md
@@ -130,6 +130,7 @@ Example request body:
   "action_id": "approval-execute",
   "decision": "execute",
   "operator_uid": "user-b",
+  "operator_space_id": "space-2",
   "inputs": {},
   "data": {
     "owner": "tasks",
@@ -144,6 +145,17 @@ Example request body:
   "acted_at": 1784073600
 }
 ```
+
+`space_id` is the card/resource origin Space. `operator_space_id` is the
+operator's current Space verified by octo-server at click time. They are
+separate assertions and may differ for a valid cross-Space decision. Consumers
+must authorize `operator_uid` in `operator_space_id` and against their own
+request ACL; they must not require membership in the card-origin `space_id`
+unless that is an independent consumer-domain rule.
+
+Routes using the `octo-card-v1` envelope receive the same operator Space as
+`actor.space_id`, alongside `actor.uid`; the flat field is not duplicated in
+that envelope.
 
 `channel_id` names the channel from the **card sender's** point of view, exactly
 as the sender addressed it when it sent the card. For a DM (`channel_type: 1`)
@@ -192,6 +204,11 @@ the single UTF-8 line shown below with no trailing newline. Its field values are
 arbitrary filler pinned to these exact bytes — do not "correct" them to match the
 example above, or the published digest and signature stop matching.
 
+This vector intentionally remains frozen without `operator_space_id`. It tests
+HMAC canonicalization over one exact historical body, not the latest request
+schema. Adding the field would change the body hash and signature without
+adding request-shape coverage.
+
 ```text
 secret:    0123456789abcdef0123456789abcdef
 method:    POST
@@ -225,6 +242,7 @@ type DecisionRequest = {
   action_id: string;
   decision: string;
   operator_uid: string;
+  operator_space_id?: string;
   doc_id?: string;
   request_id?: string;
   inputs: Record<string, unknown>;
@@ -240,6 +258,9 @@ type DecisionResult = {
   disposition: "applied" | "replayed" | "forbidden" | "conflict" | "not_found";
   state: "pending" | "approved" | "denied" | "cancelled";
   requester_uid?: string;
+  decider_uid?: string;
+  decider_space_id?: string;
+  decided_at?: number;
   display?: Record<string, string>;
 };
 
@@ -287,7 +308,12 @@ function parseDecisionRequest(value: unknown): DecisionRequest {
   ) {
     throw new Error("invalid action data");
   }
-  for (const key of ["doc_id", "request_id", "space_id"]) {
+  for (const key of [
+    "doc_id",
+    "request_id",
+    "space_id",
+    "operator_space_id",
+  ]) {
     if (value[key] !== undefined && typeof value[key] !== "string") {
       throw new Error(`invalid ${key}`);
     }
@@ -407,6 +433,9 @@ type DecisionResult = {
   disposition: "applied" | "replayed" | "forbidden" | "conflict" | "not_found";
   state: "pending" | "approved" | "denied" | "cancelled";
   requester_uid?: string;
+  decider_uid?: string;
+  decider_space_id?: string;
+  decided_at?: number;
   display?: Record<string, string>;
 };
 ```
@@ -418,9 +447,21 @@ Applied action example:
   "disposition": "applied",
   "state": "approved",
   "requester_uid": "user-a",
+  "decider_uid": "user-b",
+  "decider_space_id": "space-2",
+  "decided_at": 1784073600,
   "display": { "title": "Execute task" }
 }
 ```
+
+For consumers such as Docs that persist a first-writer decision, these decider
+fields identify the stored winner, not necessarily the click currently being
+replayed. octo-server resolves actor and Space display names internally.
+`decider_space_id` is accepted for display only when that exact decider is an
+active member of that exact active Space. It is not checked against the
+card-origin Space because legitimate cross-Space decisions exist. The IDs come
+from the trusted decision consumer, but are not a general anti-forgery proof;
+callback-supplied display strings do not override their resolved display.
 
 An idempotent replay must return the exact stored result for the same
 `event_id`. If the original result was the applied action above, repeat that
@@ -464,11 +505,29 @@ is `approved` or `denied`. Generic standard approval finalizers consume it to
 send a requester outcome; the Docs specialized finalizer ignores it and sends
 no second applicant terminal IM card. It must be the consumer-authoritative
 request initiator, not the operator or an unverified callback field. Responses
-are limited to 64 KiB and the current decoder rejects unknown top-level fields.
-`display` accepts at most 32 string fields; keys are non-empty and at most 64
-bytes, and values are at most 500 Unicode code points. The standard finalizer
+are limited to 64 KiB. The exact validation is:
+
+- unknown top-level fields, trailing JSON values, malformed types, and unknown
+  `disposition`/`state` enum values are rejected;
+- `requester_uid`, `decider_uid`, and `decider_space_id` have no leading or
+  trailing Unicode whitespace and are at most 128 **UTF-8 bytes** each (Go
+  `len(string)` semantics); empty values are otherwise allowed;
+- `decider_space_id` requires a non-empty `decider_uid`;
+- `decided_at` is an optional non-negative integer Unix timestamp in seconds
+  (`0` means absent/unknown);
+- `requester_uid` is non-empty when state is `approved` or `denied`;
+- `display` has at most 32 entries; keys are non-empty and at most 64 bytes, and
+  values are at most 500 Unicode code points.
+
+The standard finalizer
 currently consumes only `display.title`. Coordinate schema additions with an
 octo-server release.
+
+Because decoding is strict, deploy octo-server versions that accept these new
+response fields **before** deploying a Docs consumer that emits them. Old
+consumers may omit all three fields during a rolling upgrade. Reversing the
+order makes old servers classify a successful response as invalid, retry it,
+and eventually send it to the DLQ.
 
 For standard approval routes, the originating card must carry an authoritative
 `space_id`; terminal requester notification fails closed without it.
@@ -497,5 +556,16 @@ Do not return HTTP 403/404 for normal domain outcomes; use the typed
 - an unknown `decision` is rejected without a domain transition;
 - concurrent decisions produce one domain winner;
 - operator removed from ACL before click returns `forbidden`;
+- flat callbacks carry `operator_space_id`; `octo-card-v1` callbacks carry the
+  same value as `actor.space_id`;
+- cross-Space authorization uses the verified operator Space and does not
+  incorrectly require membership in the card-origin Space;
 - terminal `approved`/`denied` always includes `requester_uid`; Docs accepts but does not consume it;
+- first-writer/replay results return the stored `decider_uid`,
+  `decider_space_id`, and `decided_at`, including when the current clicker differs;
+- decider IDs reject leading/trailing whitespace, 129-byte values, and a Space
+  without a UID; 128-byte values are accepted;
+- unknown result fields, negative/string `decided_at`, trailing JSON, and a body
+  larger than 64 KiB are rejected;
+- rollout rehearsal proves servers accept the fields before Docs emits them;
 - transient `5xx` can be retried safely.

--- a/internal/cardactiondispatch/contract.go
+++ b/internal/cardactiondispatch/contract.go
@@ -32,21 +32,28 @@ const (
 )
 
 type Event struct {
-	EventID     int64                  `json:"event_id"`
-	SenderUID   string                 `json:"sender_uid"`
-	Owner       string                 `json:"owner"`
-	ActionType  string                 `json:"action_type"`
-	MessageID   string                 `json:"message_id"`
-	ChannelID   string                 `json:"channel_id"`
-	ChannelType uint8                  `json:"channel_type"`
-	SpaceID     string                 `json:"space_id,omitempty"`
-	ActionID    string                 `json:"action_id"`
-	OperatorUID string                 `json:"operator_uid"`
-	ClientToken string                 `json:"client_token,omitempty"`
-	ActedAt     int64                  `json:"acted_at"`
-	Inputs      map[string]interface{} `json:"inputs"`
-	Data        map[string]interface{} `json:"data,omitempty"`
-	Card        CardContext            `json:"card,omitempty"`
+	EventID     int64  `json:"event_id"`
+	SenderUID   string `json:"sender_uid"`
+	Owner       string `json:"owner"`
+	ActionType  string `json:"action_type"`
+	MessageID   string `json:"message_id"`
+	ChannelID   string `json:"channel_id"`
+	ChannelType uint8  `json:"channel_type"`
+	SpaceID     string `json:"space_id,omitempty"`
+	ActionID    string `json:"action_id"`
+	OperatorUID string `json:"operator_uid"`
+	// OperatorSpaceID is the operator's TRUSTED current Space at click time —
+	// the value SpaceMiddleware validated and pinned in the request context. It
+	// is captured separately from SpaceID (the card/document authoritative origin
+	// Space) and never relabels it: the two answer different questions and can
+	// differ when the operator acts on a card that originates in another of their
+	// Spaces. Empty when the click carried no server-verified Space.
+	OperatorSpaceID string                 `json:"operator_space_id,omitempty"`
+	ClientToken     string                 `json:"client_token,omitempty"`
+	ActedAt         int64                  `json:"acted_at"`
+	Inputs          map[string]interface{} `json:"inputs"`
+	Data            map[string]interface{} `json:"data,omitempty"`
+	Card            CardContext            `json:"card,omitempty"`
 }
 
 // CardContext is derived from the effective server-authored card frame before
@@ -86,15 +93,46 @@ type DecisionRequest struct {
 	ChannelID   string                 `json:"channel_id"`
 	ChannelType uint8                  `json:"channel_type"`
 	SpaceID     string                 `json:"space_id,omitempty"`
-	ActedAt     int64                  `json:"acted_at"`
-	event       *Event
+	// OperatorSpaceID carries the operator's trusted current Space to the
+	// decision consumer alongside SpaceID (the card's origin Space), so the
+	// consumer can attribute the click without conflating the two.
+	OperatorSpaceID string `json:"operator_space_id,omitempty"`
+	ActedAt         int64  `json:"acted_at"`
+	event           *Event
 }
 
 type DecisionResult struct {
-	Disposition  Disposition       `json:"disposition"`
-	State        State             `json:"state"`
-	RequesterUID string            `json:"requester_uid,omitempty"`
-	Display      map[string]string `json:"display,omitempty"`
+	Disposition  Disposition `json:"disposition"`
+	State        State       `json:"state"`
+	RequesterUID string      `json:"requester_uid,omitempty"`
+	// Authoritative decider identity. Docs is the source of truth for WHO
+	// decided; for a duplicate/concurrent click that is the FIRST decider, not
+	// the current clicker, so these win over the clicker for display. octo-server
+	// resolves the decider's display name and operator Space name from these ids
+	// internally (user service + active-membership check) — a caller never sends
+	// display copy that overrides them. DecidedAt is the authoritative decision
+	// timestamp/label produced by Docs.
+	DeciderUID     string            `json:"decider_uid,omitempty"`
+	DeciderSpaceID string            `json:"decider_space_id,omitempty"`
+	DecidedAt      int64             `json:"decided_at,omitempty"`
+	Display        map[string]string `json:"display,omitempty"`
+}
+
+// ValidateAuthoritativeDeciderIDs validates the optional identity pair returned
+// by a decision consumer. IDs use byte-length bounds, matching Go's len(string)
+// semantics elsewhere in this wire contract. Empty values are allowed for
+// rolling compatibility, but a Space cannot be attributed without a decider.
+func ValidateAuthoritativeDeciderIDs(deciderUID, deciderSpaceID string) error {
+	if len(deciderUID) > 128 || strings.TrimSpace(deciderUID) != deciderUID {
+		return errors.New("cardactiondispatch: invalid decider_uid")
+	}
+	if len(deciderSpaceID) > 128 || strings.TrimSpace(deciderSpaceID) != deciderSpaceID {
+		return errors.New("cardactiondispatch: invalid decider_space_id")
+	}
+	if deciderSpaceID != "" && deciderUID == "" {
+		return errors.New("cardactiondispatch: decider_space_id requires decider_uid")
+	}
+	return nil
 }
 
 func DecisionRequestFromEvent(event Event) DecisionRequest {
@@ -103,19 +141,20 @@ func DecisionRequestFromEvent(event Event) DecisionRequest {
 		inputs = map[string]interface{}{}
 	}
 	request := DecisionRequest{
-		EventID:     event.EventID,
-		ActionID:    event.ActionID,
-		Decision:    stringField(event.Data, "decision"),
-		OperatorUID: event.OperatorUID,
-		DocID:       stringField(event.Data, "doc_id"),
-		RequestID:   stringField(event.Data, "request_id"),
-		Inputs:      inputs,
-		Data:        event.Data,
-		MessageID:   event.MessageID,
-		ChannelID:   event.ChannelID,
-		ChannelType: event.ChannelType,
-		SpaceID:     event.SpaceID,
-		ActedAt:     event.ActedAt,
+		EventID:         event.EventID,
+		ActionID:        event.ActionID,
+		Decision:        stringField(event.Data, "decision"),
+		OperatorUID:     event.OperatorUID,
+		DocID:           stringField(event.Data, "doc_id"),
+		RequestID:       stringField(event.Data, "request_id"),
+		Inputs:          inputs,
+		Data:            event.Data,
+		MessageID:       event.MessageID,
+		ChannelID:       event.ChannelID,
+		ChannelType:     event.ChannelType,
+		SpaceID:         event.SpaceID,
+		OperatorSpaceID: event.OperatorSpaceID,
+		ActedAt:         event.ActedAt,
 	}
 	request.event = &event
 	return request
@@ -146,7 +185,8 @@ type callbackCard struct {
 }
 
 type callbackActor struct {
-	UID string `json:"uid"`
+	UID     string `json:"uid"`
+	SpaceID string `json:"space_id,omitempty"`
 }
 
 // MarshalCallbackRequest encodes either the frozen flat request or the
@@ -176,7 +216,7 @@ func MarshalCallbackRequest(event Event, format CallbackFormat) ([]byte, error) 
 			TemplateID: event.Card.TemplateID, TemplateVersion: event.Card.TemplateVersion, View: event.Card.View,
 			MessageID: event.MessageID, ChannelID: event.ChannelID, ChannelType: event.ChannelType,
 		},
-		Actor:     callbackActor{UID: event.OperatorUID},
+		Actor:     callbackActor{UID: event.OperatorUID, SpaceID: event.OperatorSpaceID},
 		TriggerID: fmt.Sprintf("%d", event.EventID),
 	})
 }
@@ -227,6 +267,15 @@ func DecodeDecisionResult(reader io.Reader) (DecisionResult, error) {
 	}
 	if (result.State == StateApproved || result.State == StateDenied) && result.RequesterUID == "" {
 		return DecisionResult{}, errors.New("cardactiondispatch: terminal decision requires requester_uid")
+	}
+	// Authoritative decider identity is optional (legacy callbacks omit it) but,
+	// when present, is typed and bounded: it feeds an internal user/Space lookup,
+	// never raw display. decider_space_id without decider_uid is meaningless.
+	if err := ValidateAuthoritativeDeciderIDs(result.DeciderUID, result.DeciderSpaceID); err != nil {
+		return DecisionResult{}, err
+	}
+	if result.DecidedAt < 0 {
+		return DecisionResult{}, errors.New("cardactiondispatch: invalid decided_at")
 	}
 	if len(result.Display) > 32 {
 		return DecisionResult{}, errors.New("cardactiondispatch: too many display fields")

--- a/internal/cardactiondispatch/decider_contract_test.go
+++ b/internal/cardactiondispatch/decider_contract_test.go
@@ -1,0 +1,108 @@
+package cardactiondispatch
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// The operator's trusted current Space rides the callback as operator_space_id,
+// kept distinct from space_id (the card's authoritative origin Space).
+func TestDecisionRequestCarriesOperatorSpaceIDDistinctFromCardSpace(t *testing.T) {
+	body, err := json.Marshal(DecisionRequestFromEvent(Event{
+		EventID: 7, SpaceID: "card-origin-space", OperatorSpaceID: "operator-current-space",
+	}))
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if got := string(fields["space_id"]); got != `"card-origin-space"` {
+		t.Fatalf("space_id JSON = %s, want the card origin Space", got)
+	}
+	if got := string(fields["operator_space_id"]); got != `"operator-current-space"` {
+		t.Fatalf("operator_space_id JSON = %s, want the operator's current Space", got)
+	}
+}
+
+// An empty operator Space is omitted rather than sent as "".
+func TestDecisionRequestOmitsEmptyOperatorSpaceID(t *testing.T) {
+	body, err := json.Marshal(DecisionRequestFromEvent(Event{EventID: 1}))
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if strings.Contains(string(body), "operator_space_id") {
+		t.Fatalf("empty operator_space_id was emitted: %s", body)
+	}
+}
+
+// The octo-card-v1 envelope carries the same trusted operator Space inside the
+// authenticated actor object; it must not be lost when a route opts into the
+// structured callback format.
+func TestOctoCardEnvelopeCarriesOperatorSpaceID(t *testing.T) {
+	body, err := MarshalCallbackRequest(Event{
+		EventID: 9, OperatorUID: "operator-1", OperatorSpaceID: "operator-space",
+		ActionID: "approve", Card: CardContext{TemplateID: "t", TemplateVersion: "1", View: "pending"},
+	}, CallbackFormatOctoCardV1)
+	if err != nil {
+		t.Fatalf("MarshalCallbackRequest() error = %v", err)
+	}
+	var envelope struct {
+		Actor struct {
+			UID     string `json:"uid"`
+			SpaceID string `json:"space_id"`
+		} `json:"actor"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if envelope.Actor.UID != "operator-1" || envelope.Actor.SpaceID != "operator-space" {
+		t.Fatalf("actor = %+v", envelope.Actor)
+	}
+}
+
+func TestDecodeDecisionResultAcceptsAuthoritativeDeciderFields(t *testing.T) {
+	valid := `{"disposition":"applied","state":"approved","requester_uid":"user-a",` +
+		`"decider_uid":"decider-1","decider_space_id":"space-op","decided_at":1787223660}`
+	result, err := DecodeDecisionResult(strings.NewReader(valid))
+	if err != nil {
+		t.Fatalf("DecodeDecisionResult(valid) error = %v", err)
+	}
+	if result.DeciderUID != "decider-1" || result.DeciderSpaceID != "space-op" || result.DecidedAt != 1787223660 {
+		t.Fatalf("DecodeDecisionResult authoritative fields = %+v", result)
+	}
+}
+
+func TestDecodeDecisionResultRejectsMalformedDeciderFields(t *testing.T) {
+	invalid := map[string]string{
+		"oversized decider_uid": `{"disposition":"applied","state":"approved","requester_uid":"u",` +
+			`"decider_uid":"` + strings.Repeat("x", 129) + `"}`,
+		"untrimmed decider_uid": `{"disposition":"applied","state":"approved","requester_uid":"u",` +
+			`"decider_uid":" decider "}`,
+		"oversized decider_space_id": `{"disposition":"applied","state":"approved","requester_uid":"u",` +
+			`"decider_uid":"d","decider_space_id":"` + strings.Repeat("s", 129) + `"}`,
+		"space without decider": `{"disposition":"applied","state":"approved","requester_uid":"u",` +
+			`"decider_space_id":"space-op"}`,
+		"string decided_at":   `{"disposition":"applied","state":"approved","requester_uid":"u","decided_at":"2026"}`,
+		"negative decided_at": `{"disposition":"applied","state":"approved","requester_uid":"u","decided_at":-1}`,
+	}
+	for name, body := range invalid {
+		if _, err := DecodeDecisionResult(strings.NewReader(body)); err == nil {
+			t.Errorf("DecodeDecisionResult(%s) error = nil, want rejection", name)
+		}
+	}
+}
+
+func TestValidateAuthoritativeDeciderIDsUsesByteBounds(t *testing.T) {
+	// 42 three-byte runes plus two ASCII bytes are exactly 128 bytes and
+	// accepted; adding another three-byte rune exceeds the contract even though
+	// both strings are well under 128 characters.
+	if err := ValidateAuthoritativeDeciderIDs(strings.Repeat("界", 42)+"ab", "space"); err != nil {
+		t.Fatalf("128-byte decider_uid rejected: %v", err)
+	}
+	if err := ValidateAuthoritativeDeciderIDs(strings.Repeat("界", 43), "space"); err == nil {
+		t.Fatal("129-byte decider_uid accepted")
+	}
+}

--- a/modules/message/api_card_action.go
+++ b/modules/message/api_card_action.go
@@ -42,6 +42,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"go.uber.org/zap"
 )
 
@@ -245,6 +246,14 @@ func (m *Message) cardAction(c *wkhttp.Context) {
 		return
 	}
 	cardSpaceID, cardSpaceKnown := m.resolveCardOriginSpaceID(msgM)
+	// The operator's TRUSTED current Space is the SpaceMiddleware-validated
+	// context value (the /v1/message group mounts SpaceMiddleware, which pins the
+	// membership-checked space_id via SetSpaceID). It is captured SEPARATELY from
+	// cardSpaceID (the card's authoritative origin Space) and never relabels it:
+	// the two differ when the operator acts, via X-Space-ID: B, on a card whose
+	// origin is Space A. Read only the server-set context key here — never request
+	// JSON or a raw unvalidated header. Empty when the click declared no Space.
+	operatorSpaceID := spacepkg.GetSpaceID(c)
 	// PR-C D3：principal 从生效帧的 stored provenance 恢复并校验（sender/
 	// producer 绑定/Space 一致性都在 resolveRegistryCardContext 内 fail-close）；
 	// 无标记的 legacy 帧沿用 sender 派生的 bot principal（static 兼容）。
@@ -319,13 +328,17 @@ func (m *Message) cardAction(c *wkhttp.Context) {
 		ChannelID:   eventChannelID,
 		ChannelType: req.ChannelType,
 		SpaceID:     stringEventField(eventData, "space_id"),
-		ActionID:    req.ActionID,
-		OperatorUID: loginUID,
-		ClientToken: req.ClientToken,
-		ActedAt:     eventData["acted_at"].(int64),
-		Inputs:      req.Inputs,
-		Data:        actionData,
-		Card:        cardContext,
+		// OperatorSpaceID is the operator's trusted current Space, kept distinct
+		// from SpaceID (card origin). It never enters the conditional event_data
+		// space_id key above — that one is the card's authoritative origin Space.
+		OperatorSpaceID: operatorSpaceID,
+		ActionID:        req.ActionID,
+		OperatorUID:     loginUID,
+		ClientToken:     req.ClientToken,
+		ActedAt:         eventData["acted_at"].(int64),
+		Inputs:          req.Inputs,
+		Data:            actionData,
+		Card:            cardContext,
 	})
 	if err != nil {
 		m.releaseCardClaim(idemKey)

--- a/modules/notify/action_finalizer.go
+++ b/modules/notify/action_finalizer.go
@@ -9,12 +9,15 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
 	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"go.uber.org/zap"
 )
 
 type cardActionMutator interface {
@@ -25,6 +28,12 @@ type DocsActionFinalizer struct {
 	ctx     *config.Context
 	mutator cardActionMutator
 	updater cardtmpl.CardUpdater
+	// users/spaces resolve the AUTHORITATIVE decider display internally from the
+	// ids Docs returns (result.DeciderUID / DeciderSpaceID). They are optional:
+	// when nil (or when a callback carries no decider ids) the finalizer keeps the
+	// bounded compatibility fallback to result.Display.
+	users  deciderUserResolver
+	spaces deciderSpaceResolver
 }
 
 type actionFinalizeError struct {
@@ -56,7 +65,16 @@ func NewDocsActionFinalizerFromContext(ctx *config.Context) (*DocsActionFinalize
 	if err != nil {
 		return nil, err
 	}
-	return NewDocsActionFinalizerWithUpdater(ctx, updater, mutator)
+	finalizer, err := NewDocsActionFinalizerWithUpdater(ctx, updater, mutator)
+	if err != nil {
+		return nil, err
+	}
+	// Production wiring for authoritative decider display resolution: names come
+	// from the user service, operator Space names from an active-membership check
+	// against the server DB. Both stay best-effort inside Finalize.
+	finalizer.users = user.NewService(ctx)
+	finalizer.spaces = spaceMemberNameResolver{session: ctx.DB()}
+	return finalizer, nil
 }
 
 func (f *DocsActionFinalizer) Finalize(ctx context.Context, event cardactiondispatch.Event, result cardactiondispatch.DecisionResult) error {
@@ -98,6 +116,16 @@ func (f *DocsActionFinalizer) Finalize(ctx context.Context, event cardactiondisp
 	if v, ok := event.Inputs[cardtmpl.DocsDenyReasonInputID].(string); ok {
 		denyReason = strings.TrimSpace(v)
 	}
+	// Authoritative decider resolution (decision-actor-server-resolution). When
+	// Docs returns the decider's ids, octo-server — the identity authority —
+	// resolves the display name and operator Space name internally and those win
+	// over any caller-supplied display copy (anti-forgery: a callback could name
+	// any operator/Space it liked). Only approved/denied cards carry a decision
+	// block, so only they need it. Every lookup failure degrades the optional
+	// display field to empty (the render then shows the generic placeholder); it
+	// must never fail this already-committed decision. Legacy callbacks with no
+	// decider ids keep the bounded compatibility fallback to result.Display.
+	result = f.resolveAuthoritativeDeciderDisplay(ctx, result)
 	// Every state renders through the Registry when an updater is present, not
 	// just the decided ones. The pending card is a Registry render and so
 	// carries the server-authored catalog markers; the fallback below rebuilds
@@ -134,6 +162,46 @@ func (f *DocsActionFinalizer) Finalize(ctx context.Context, event cardactiondisp
 	// The original request card is the sole terminal surface. Do not send a
 	// second "access granted/denied" card to the requester.
 	return nil
+}
+
+// resolveAuthoritativeDeciderDisplay overwrites the operator display fields with
+// octo-server's internal resolution of the authoritative decider ids for
+// approved/denied results. When result.DeciderUID is set, caller-supplied
+// display.operator_name/operator_space_name are discarded (they must never win
+// over the authoritative ids) and decided_at is taken from result.DecidedAt.
+// When no decider id is present, the result is returned unchanged so legacy
+// callbacks keep their bounded compatibility fallback. The returned copy owns a
+// fresh Display map, so the shared result value is never mutated.
+func (f *DocsActionFinalizer) resolveAuthoritativeDeciderDisplay(_ context.Context, result cardactiondispatch.DecisionResult) cardactiondispatch.DecisionResult {
+	if strings.TrimSpace(result.DeciderUID) == "" {
+		return result
+	}
+	if result.State != cardactiondispatch.StateApproved && result.State != cardactiondispatch.StateDenied {
+		return result
+	}
+	resolved := resolveDeciderDisplay(f.users, f.spaces, result.DeciderUID, result.DeciderSpaceID, func(msg string, err error) {
+		log.NewTLog("DocsActionFinalizer").Warn("docs action "+msg+" failed (display degraded)",
+			zap.Error(err), zap.String("decider_uid", result.DeciderUID), zap.String("decider_space_id", result.DeciderSpaceID))
+	})
+	display := make(map[string]string, len(result.Display)+3)
+	for k, v := range result.Display {
+		display[k] = v
+	}
+	// Authoritative ids present → the resolved values win, even when a lookup
+	// returned empty (degrade to placeholder rather than trust caller copy).
+	// Clear ALL three legacy display fields first: if the authoritative time is
+	// absent, retaining display.decided_at would pair a trusted decider with an
+	// untrusted / potentially late-clicker timestamp.
+	delete(display, "operator_name")
+	delete(display, "operator_space_name")
+	delete(display, "decided_at")
+	display["operator_name"] = resolved.OperatorName
+	display["operator_space_name"] = resolved.OperatorSpaceName
+	if decidedAt := formatDecisionTime(result.DecidedAt); decidedAt != "" {
+		display["decided_at"] = decidedAt
+	}
+	result.Display = display
+	return result
 }
 
 // 0.3.0 result view schema 的各字段 rune 上限(见
@@ -174,14 +242,15 @@ func (f *DocsActionFinalizer) replaceWithRegistryResult(ctx context.Context, eve
 		return err
 	}
 	fields, state, err := buildDocsAccessResultFields(lang, version, docsResultRenderInput{
-		Data:              event.Data,
-		Title:             title,
-		OperatorName:      result.Display["operator_name"],
-		OperatorSpaceName: result.Display["operator_space_name"],
-		DecidedAtDisplay:  result.Display["decided_at"],
-		DenyReason:        denyReason,
-		Denied:            result.State == cardactiondispatch.StateDenied,
-		Cancelled:         result.State == cardactiondispatch.StateCancelled,
+		Data:                  event.Data,
+		Title:                 title,
+		OperatorName:          result.Display["operator_name"],
+		OperatorSpaceName:     result.Display["operator_space_name"],
+		DecidedAtDisplay:      result.Display["decided_at"],
+		AuthoritativeDecision: strings.TrimSpace(result.DeciderUID) != "",
+		DenyReason:            denyReason,
+		Denied:                result.State == cardactiondispatch.StateDenied,
+		Cancelled:             result.State == cardactiondispatch.StateCancelled,
 		// Anything that is not a decision and not an explicit cancellation —
 		// `pending` today, whatever a later contract adds — renders as
 		// unavailable, which is what the pre-Registry fallback already showed
@@ -212,15 +281,16 @@ func (f *DocsActionFinalizer) replaceWithRegistryResult(ctx context.Context, eve
 // from the stored server-authored Action.Submit payload, never caller display
 // JSON, so request/document identity cannot be rewritten during a mutation.
 type docsResultRenderInput struct {
-	Data              map[string]interface{}
-	Title             string
-	OperatorName      string
-	OperatorSpaceName string
-	DecidedAtDisplay  string
-	DenyReason        string
-	Denied            bool
-	Cancelled         bool
-	Unavailable       bool
+	Data                  map[string]interface{}
+	Title                 string
+	OperatorName          string
+	OperatorSpaceName     string
+	DecidedAtDisplay      string
+	AuthoritativeDecision bool
+	DenyReason            string
+	Denied                bool
+	Cancelled             bool
+	Unavailable           bool
 }
 
 func buildDocsAccessResultFields(lang, version string, input docsResultRenderInput) (json.RawMessage, cardtmpl.State, error) {
@@ -303,6 +373,13 @@ func buildDocsAccessResultFields(lang, version string, input docsResultRenderInp
 		"requestReason": "request_reason", "requestedAtDisplay": "requested_at_display",
 		"messageTimeDisplay": "message_time_display",
 	} {
+		// V3 historically falls back from an empty decision time to the request
+		// message time. Keep that for legacy callbacks, but never fabricate a
+		// decision timestamp after Docs has supplied an authoritative decider.
+		if destination == "messageTimeDisplay" && input.AuthoritativeDecision &&
+			strings.TrimSpace(input.DecidedAtDisplay) == "" {
+			continue
+		}
 		if value := strings.TrimSpace(stringEventData(input.Data, source)); value != "" {
 			fields[destination] = truncRunes(value, dataCaps[destination])
 		}

--- a/modules/notify/action_finalizer_v3_test.go
+++ b/modules/notify/action_finalizer_v3_test.go
@@ -120,6 +120,83 @@ func TestDocsActionFinalizerUsesV3RegistryResultForTerminalStates(t *testing.T) 
 	_ = carddispatch.CardMutationResult{}
 }
 
+func TestDocsActionFinalizerAuthoritativeDeciderWithoutTimeDoesNotUseRequestTime(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+	updater := &captureViewUpdater{}
+	finalizer := &DocsActionFinalizer{ctx: ctx, updater: updater}
+	event := cardactiondispatch.Event{
+		EventID: 42, SenderUID: NotifyBotUIDValue, MessageID: "1001", ChannelID: NotifyBotUIDValue,
+		ChannelType: 1, SpaceID: "card-space-a",
+		Data: map[string]any{
+			"doc_id": "doc-1", "request_id": "request-1", "doc_title": "Roadmap", "actor": "Alice",
+			"message_time_display": "REQUEST-TIME-MUST-NOT-BECOME-DECISION-TIME",
+		},
+	}
+	result := cardactiondispatch.DecisionResult{
+		State: cardactiondispatch.StateApproved, DeciderUID: "authoritative-decider",
+		Display: map[string]string{"operator_name": "Reviewer"},
+	}
+
+	if err := finalizer.replaceWithRegistryResult(context.Background(), event, result,
+		NotifyBotUIDValue, "en", "Roadmap", ""); err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(updater.fields, &fields); err != nil {
+		t.Fatal(err)
+	}
+	if _, found := fields["messageTimeDisplay"]; found {
+		t.Fatalf("authoritative result retained request-time fallback: %+v", fields)
+	}
+	registry := cardtmpl.NewRegistry()
+	registry.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	registry.Freeze()
+	rendered, err := registry.Render(context.Background(), updater.id, updater.version, updater.state, updater.fields, updater.env)
+	if err != nil {
+		t.Fatalf("render terminal fields: %v", err)
+	}
+	raw, err := json.Marshal(rendered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "REQUEST-TIME-MUST-NOT-BECOME-DECISION-TIME") {
+		t.Fatalf("terminal card rendered request time as decision time: %s", raw)
+	}
+}
+
+func TestDocsActionFinalizerLegacyResultKeepsRequestTimeFallback(t *testing.T) {
+	input := docsResultRenderInput{
+		Data: map[string]any{
+			"doc_id": "doc-1", "request_id": "request-1", "doc_title": "Roadmap", "actor": "Alice",
+			"message_time_display": "LEGACY-REQUEST-TIME",
+		},
+		Title: "Roadmap", OperatorName: "Reviewer",
+	}
+	fields, state, err := buildDocsAccessResultFields("en", docsaccessrequest.TemplateVersionV3, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry := cardtmpl.NewRegistry()
+	registry.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	registry.Freeze()
+	rendered, err := registry.Render(context.Background(), docsaccessrequest.TemplateID,
+		docsaccessrequest.TemplateVersionV3, state, fields,
+		cardtmpl.BuildEnv{Lang: "en", SpaceID: "space-1", WebLoginURL: "https://im.example.com/login"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(rendered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), "LEGACY-REQUEST-TIME") {
+		t.Fatalf("legacy result lost request-time compatibility fallback: %s", raw)
+	}
+}
+
 func TestDocsActionFinalizerUsesConsumerResolvedOperatorDisplay(t *testing.T) {
 	wk := newWuKongServer()
 	defer wk.close()

--- a/modules/notify/api.go
+++ b/modules/notify/api.go
@@ -65,10 +65,16 @@ var (
 
 // Notify 通知模块
 type Notify struct {
-	ctx           *config.Context
-	userService   user.IService
-	appService    app.IService
-	db            *dbr.Session
+	ctx         *config.Context
+	userService user.IService
+	appService  app.IService
+	db          *dbr.Session
+	// deciderUsers / deciderSpaces resolve the authoritative operator display for
+	// /v1/internal/cards/mutate (name from the user service, Space name from an
+	// active-membership check). Both are injectable so tests can supply fakes
+	// without a live DB; New wires them to the real services.
+	deciderUsers  deciderUserResolver
+	deciderSpaces deciderSpaceResolver
 	memberCache   *memberCache
 	botMu         sync.Mutex
 	botOK         atomic.Bool
@@ -103,12 +109,15 @@ func New(ctx *config.Context) *Notify {
 		userService:   user.NewService(ctx),
 		appService:    app.NewService(ctx),
 		db:            ctx.DB(),
+		deciderSpaces: spaceMemberNameResolver{session: ctx.DB()},
 		memberCache:   newMemberCache(),
 		internalToken: token,
 		docsToken:     docsToken,
 		Log:           log.NewTLog("Notify"),
 		actionSenders: make(map[cardactiondispatch.NotifyCapability]carddispatch.Sender),
 	}
+	// The mutate endpoint's decider name lookups reuse the same user service.
+	n.deciderUsers = n.userService
 
 	// Obtain the producer-bound card Senders from the single registry composed at
 	// bootstrap (main.installCardDispatch, before module construction). A missing

--- a/modules/notify/card_mutate_api.go
+++ b/modules/notify/card_mutate_api.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
 	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
@@ -36,6 +38,8 @@ const docsCardMutateSeqKey = "messageExtra:docs-card-mutate"
 // "docs.access_requested" / "docs.access_granted") is the authoritative
 // docs-domain discriminator; only cards in this family may be touched.
 const docsAccessVariantPrefix = "docs.access_"
+
+const cardMutateMaxBodyBytes = 64 << 10
 
 var errDocsSiblingContextInvalid = errors.New("notify: invalid stored docs sibling context")
 
@@ -85,19 +89,36 @@ type CardMutateReq struct {
 	DocID       string `json:"doc_id"`
 	Title       string `json:"title"`
 	DenyReason  string `json:"deny_reason"` // surfaced on the denied terminal card; empty on approve
-	// Operator display fields are optional and are resolved once by the trusted
-	// Docs decision service. IDs are retained as bounded audit context only;
-	// octo-server never uses unbound caller-supplied IDs for display lookup.
+	// Older callers may provide operator display context directly. It remains for
+	// wire compatibility only and is not authoritative when decider_uid is set.
+	//
+	// decider_uid/decider_space_id are the AUTHORITATIVE actor ids (mirroring the
+	// DecisionResult contract). When present, octo-server resolves the operator
+	// name + Space name internally from them and ignores operator_name/
+	// operator_space_name below. operator_uid/operator_space_id are older display
+	// context fields; they are retained for wire compatibility but are not aliases
+	// for, and never substitute for, the authoritative decider identity.
+	DeciderUID        string `json:"decider_uid"`
+	DeciderSpaceID    string `json:"decider_space_id"`
 	OperatorUID       string `json:"operator_uid"`
 	OperatorName      string `json:"operator_name"`
 	OperatorSpaceID   string `json:"operator_space_id"`
 	OperatorSpaceName string `json:"operator_space_name"`
+	DecidedAt         int64  `json:"decided_at"`
 	DecidedAtDisplay  string `json:"decided_at_display"`
 }
 
 // CardMutateResp reports whether the card is now terminal.
 type CardMutateResp struct {
 	Mutated bool `json:"mutated"`
+}
+
+func validateCardMutateReq(req CardMutateReq) error {
+	if req.SpaceID == "" || req.ChannelID == "" || req.MessageID == "" || req.DocID == "" ||
+		(req.Kind != DocsCardKindAccessGranted && req.Kind != DocsCardKindAccessDenied) {
+		return errors.New("notify: invalid card mutate request")
+	}
+	return cardactiondispatch.ValidateAuthoritativeDeciderIDs(req.DeciderUID, req.DeciderSpaceID)
 }
 
 // mutateCard handles POST /v1/internal/cards/mutate. It drives one already-
@@ -112,13 +133,13 @@ func (n *Notify) mutateCard(c *wkhttp.Context) {
 		return
 	}
 
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, cardMutateMaxBodyBytes)
 	var req CardMutateReq
 	if err := c.BindJSON(&req); err != nil {
 		httperr.ResponseErrorL(c, errcode.ErrNotifyCardMutateInvalid, nil, nil)
 		return
 	}
-	if req.SpaceID == "" || req.ChannelID == "" || req.MessageID == "" || req.DocID == "" ||
-		(req.Kind != DocsCardKindAccessGranted && req.Kind != DocsCardKindAccessDenied) {
+	if validateCardMutateReq(req) != nil {
 		httperr.ResponseErrorL(c, errcode.ErrNotifyCardMutateInvalid, nil, nil)
 		return
 	}
@@ -191,6 +212,7 @@ func (n *Notify) mutateCard(c *wkhttp.Context) {
 		return
 	}
 	req.ChannelType = channelType
+	n.resolveMutateOperatorDisplay(&req)
 	if err = replaceSiblingWithRegistryResult(
 		ctx, updater, req, snap, cardSeq, cardtmpl.BuildEnv{
 			WebLoginURL: n.ctx.GetConfig().External.WebLoginURL,
@@ -254,13 +276,14 @@ func replaceSiblingWithRegistryResult(ctx context.Context, updater cardtmpl.Card
 	}
 	denied := req.Kind == DocsCardKindAccessDenied
 	fields, state, err := buildDocsAccessResultFields(env.Lang, version, docsResultRenderInput{
-		Data:              data,
-		Title:             req.Title,
-		OperatorName:      req.OperatorName,
-		OperatorSpaceName: req.OperatorSpaceName,
-		DecidedAtDisplay:  req.DecidedAtDisplay,
-		DenyReason:        req.DenyReason,
-		Denied:            denied,
+		Data:                  data,
+		Title:                 req.Title,
+		OperatorName:          req.OperatorName,
+		OperatorSpaceName:     req.OperatorSpaceName,
+		DecidedAtDisplay:      req.DecidedAtDisplay,
+		AuthoritativeDecision: strings.TrimSpace(req.DeciderUID) != "",
+		DenyReason:            req.DenyReason,
+		Denied:                denied,
 	})
 	if err != nil {
 		return fmt.Errorf("%w: %v", errDocsSiblingContextInvalid, err)
@@ -271,4 +294,34 @@ func replaceSiblingWithRegistryResult(ctx context.Context, updater cardtmpl.Card
 		},
 		SenderUID: NotifyBotUIDValue, MessageID: req.MessageID, CardSeq: cardSeq,
 	}, docsaccessrequest.TemplateID, version, state, fields, env)
+}
+
+// resolveMutateOperatorDisplay implements the authoritative decider display
+// resolution for /v1/internal/cards/mutate (decision-actor-server-resolution).
+// When the caller supplies the decider's ids (decider_uid/decider_space_id), octo-server
+// resolves the operator name + Space name internally (user service +
+// active-membership check) and OVERWRITES req.OperatorName/OperatorSpaceName — a
+// docs token must not be able to stamp an arbitrary display identity onto a
+// committed decision. Every lookup failure degrades to empty (the render then
+// shows the generic placeholder) and never blocks the mutation. A caller that
+// supplies no decider id keeps its display strings (bounded compatibility).
+func (n *Notify) resolveMutateOperatorDisplay(req *CardMutateReq) {
+	deciderUID := strings.TrimSpace(req.DeciderUID)
+	if deciderUID == "" {
+		return
+	}
+	deciderSpaceID := strings.TrimSpace(req.DeciderSpaceID)
+	// The authoritative contract makes callback-authored time display untrusted.
+	// Name fields are overwritten below, so clearing them first would be dead work.
+	req.DecidedAtDisplay = ""
+	resolved := resolveDeciderDisplay(n.deciderUsers, n.deciderSpaces, deciderUID, deciderSpaceID,
+		func(msg string, rerr error) {
+			n.Warn("card mutate "+msg+" failed (display degraded)", zap.Error(rerr),
+				zap.String("decider_uid", deciderUID), zap.String("message_id", req.MessageID))
+		})
+	req.OperatorName = resolved.OperatorName
+	req.OperatorSpaceName = resolved.OperatorSpaceName
+	if req.DecidedAt > 0 {
+		req.DecidedAtDisplay = formatDecisionTime(req.DecidedAt)
+	}
 }

--- a/modules/notify/card_mutate_api_test.go
+++ b/modules/notify/card_mutate_api_test.go
@@ -3,6 +3,7 @@ package notify
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
@@ -14,6 +15,31 @@ func TestDocsCardMutateSeqKeyCompatibility(t *testing.T) {
 	const want = "messageExtra:docs-card-mutate"
 	if docsCardMutateSeqKey != want {
 		t.Fatalf("docsCardMutateSeqKey=%q want persisted compatibility key %q", docsCardMutateSeqKey, want)
+	}
+}
+
+func TestValidateCardMutateReqAuthoritativeDeciderIDs(t *testing.T) {
+	valid := CardMutateReq{
+		SpaceID: "delivery-space", ChannelID: "reviewer", MessageID: "1",
+		Kind: DocsCardKindAccessGranted, DocID: "doc", DeciderUID: "decider",
+		DeciderSpaceID: "operator-space",
+	}
+	if err := validateCardMutateReq(valid); err != nil {
+		t.Fatalf("valid request rejected: %v", err)
+	}
+	invalid := map[string]CardMutateReq{
+		"untrimmed uid":       func() CardMutateReq { r := valid; r.DeciderUID = " decider"; return r }(),
+		"oversized uid":       func() CardMutateReq { r := valid; r.DeciderUID = strings.Repeat("x", 129); return r }(),
+		"untrimmed space":     func() CardMutateReq { r := valid; r.DeciderSpaceID = "space "; return r }(),
+		"oversized space":     func() CardMutateReq { r := valid; r.DeciderSpaceID = strings.Repeat("s", 129); return r }(),
+		"space without actor": func() CardMutateReq { r := valid; r.DeciderUID = ""; return r }(),
+	}
+	for name, req := range invalid {
+		t.Run(name, func(t *testing.T) {
+			if err := validateCardMutateReq(req); err == nil {
+				t.Fatal("invalid request accepted")
+			}
+		})
 	}
 }
 
@@ -215,6 +241,51 @@ func TestReplaceSiblingWithRegistryResultRejectsCallerIdentityMismatch(t *testin
 				t.Fatal("replaceSiblingWithRegistryResult error = nil")
 			}
 		})
+	}
+}
+
+func TestReplaceSiblingAuthoritativeDeciderWithoutTimeDoesNotUseRequestTime(t *testing.T) {
+	updater := &captureViewUpdater{}
+	snapshot := carddispatch.CardMutationSnapshot{Envelope: json.RawMessage(`{
+		"type":17,
+		"profile":"octo/v2",
+		"space_id":"space-1",
+		"card":{"metadata":{"octo":{"variant":"docs.access_requested"}},"actions":[{
+			"type":"Action.Submit","id":"docs-access-approve",
+			"data":{"doc_id":"doc-1","request_id":"request-1","doc_title":"Roadmap","actor":"Alice",
+				"message_time_display":"REQUEST-TIME-MUST-NOT-BECOME-DECISION-TIME"}
+		}]}
+	}`)}
+	req := CardMutateReq{
+		SpaceID: "space-1", ChannelID: "reviewer-b", ChannelType: 1,
+		MessageID: "1002", Kind: DocsCardKindAccessGranted, DocID: "doc-1",
+		DeciderUID: "authoritative-decider", OperatorName: "Reviewer",
+	}
+
+	if err := replaceSiblingWithRegistryResult(context.Background(), updater, req, snapshot, 100,
+		cardtmpl.BuildEnv{WebLoginURL: "https://im.example.com/login", Lang: "en", SpaceID: "space-1"}); err != nil {
+		t.Fatalf("replaceSiblingWithRegistryResult: %v", err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(updater.fields, &fields); err != nil {
+		t.Fatal(err)
+	}
+	if _, found := fields["messageTimeDisplay"]; found {
+		t.Fatalf("authoritative sibling retained request-time fallback: %+v", fields)
+	}
+	registry := cardtmpl.NewRegistry()
+	registry.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	registry.Freeze()
+	rendered, err := registry.Render(context.Background(), updater.id, updater.version, updater.state, updater.fields, updater.env)
+	if err != nil {
+		t.Fatalf("render terminal fields: %v", err)
+	}
+	raw, err := json.Marshal(rendered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "REQUEST-TIME-MUST-NOT-BECOME-DECISION-TIME") {
+		t.Fatalf("sibling terminal card rendered request time as decision time: %s", raw)
 	}
 }
 

--- a/modules/notify/decider_display.go
+++ b/modules/notify/decider_display.go
@@ -1,0 +1,98 @@
+package notify
+
+import (
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
+	"github.com/gocraft/dbr/v2"
+)
+
+var decisionDisplayLocation = func() *time.Location {
+	loc, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		return time.FixedZone("CST", 8*60*60)
+	}
+	return loc
+}()
+
+// deciderUserResolver resolves a decider's display name from their uid. The
+// package's user.IService satisfies it; a test may inject a fake.
+type deciderUserResolver interface {
+	GetUser(uid string) (*user.Resp, error)
+}
+
+// deciderSpaceResolver verifies (spaceID, uid) is an ACTIVE membership and, when
+// so, returns that Space's name (ok=true). ok=false means the pair is not an
+// active membership — the caller must not infer any other Space.
+type deciderSpaceResolver interface {
+	ResolveActiveMemberSpaceName(spaceID, uid string) (string, bool, error)
+}
+
+// spaceMemberNameResolver adapts pkg/space to deciderSpaceResolver over a live
+// DB session. It is the production implementation used by both the finalizer and
+// the /v1/internal/cards/mutate handler.
+type spaceMemberNameResolver struct{ session *dbr.Session }
+
+func (r spaceMemberNameResolver) ResolveActiveMemberSpaceName(spaceID, uid string) (string, bool, error) {
+	return spacepkg.ResolveActiveMemberSpaceName(r.session, spaceID, uid)
+}
+
+// resolvedDeciderDisplay is octo-server's server-authoritative resolution of a
+// decision actor's display. Both fields are best-effort: an empty value means
+// the lookup did not resolve, and the caller must degrade to a generic
+// placeholder (docsLabelsFor(lang).decisionActor for the name) — never to a
+// caller-supplied string, which is exactly what the authoritative ids replace.
+type resolvedDeciderDisplay struct {
+	OperatorName      string
+	OperatorSpaceName string
+}
+
+// resolveDeciderDisplay resolves the decider's display name and operator Space
+// name from the authoritative decider ids. The name comes from the user service;
+// the operator Space name is resolved ONLY when deciderSpaceID is an active
+// membership of that SAME uid — a card/document Space or a default Space is
+// never inferred. Every lookup failure (error, miss, or non-membership) degrades
+// the corresponding optional field to empty; this function never returns an
+// error, so it can never fail an already-committed decision. warn, if non-nil,
+// is invoked on a lookup ERROR (not on an ordinary miss) for observability.
+func resolveDeciderDisplay(users deciderUserResolver, spaces deciderSpaceResolver, deciderUID, deciderSpaceID string, warn func(string, error)) resolvedDeciderDisplay {
+	var out resolvedDeciderDisplay
+	deciderUID = strings.TrimSpace(deciderUID)
+	if deciderUID == "" {
+		return out
+	}
+	if users != nil {
+		if resp, err := users.GetUser(deciderUID); err != nil {
+			if warn != nil {
+				warn("resolve decider name", err)
+			}
+		} else if resp != nil {
+			out.OperatorName = strings.TrimSpace(resp.Name)
+		}
+	}
+	deciderSpaceID = strings.TrimSpace(deciderSpaceID)
+	if deciderSpaceID != "" && spaces != nil {
+		if name, ok, err := spaces.ResolveActiveMemberSpaceName(deciderSpaceID, deciderUID); err != nil {
+			if warn != nil {
+				warn("resolve decider space name", err)
+			}
+		} else if ok {
+			out.OperatorSpaceName = strings.TrimSpace(name)
+		}
+		// ok=false → the decider is not an active member of that Space (or it is
+		// inactive): leave OperatorSpaceName empty. Do NOT fall back to any other
+		// Space.
+	}
+	return out
+}
+
+// formatDecisionTime renders authoritative unix seconds for the zh-CN card in
+// an explicit product timezone. It never follows the container-local timezone.
+func formatDecisionTime(seconds int64) string {
+	if seconds <= 0 {
+		return ""
+	}
+	return time.Unix(seconds, 0).In(decisionDisplayLocation).Format("2006-01-02 15:04")
+}

--- a/modules/notify/decider_resolution_test.go
+++ b/modules/notify/decider_resolution_test.go
@@ -1,0 +1,319 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+)
+
+// stubDeciderUsers resolves names from a fixed table; an unknown uid mimics the
+// user service's "not found" error, and errFor forces a lookup error.
+type stubDeciderUsers struct {
+	names  map[string]string
+	err    error
+	calls  int
+	lastID string
+}
+
+func (s *stubDeciderUsers) GetUser(uid string) (*user.Resp, error) {
+	s.calls++
+	s.lastID = uid
+	if s.err != nil {
+		return nil, s.err
+	}
+	if name, ok := s.names[uid]; ok {
+		return &user.Resp{UID: uid, Name: name}, nil
+	}
+	return nil, errors.New("用户不存在！")
+}
+
+// stubDeciderSpaces answers active membership from spaceID -> uid -> name.
+type stubDeciderSpaces struct {
+	memberships map[string]map[string]string
+	err         error
+	calls       int
+}
+
+func (s *stubDeciderSpaces) ResolveActiveMemberSpaceName(spaceID, uid string) (string, bool, error) {
+	s.calls++
+	if s.err != nil {
+		return "", false, s.err
+	}
+	if members, ok := s.memberships[spaceID]; ok {
+		if name, ok := members[uid]; ok {
+			return name, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+func TestResolveDeciderDisplayResolvesNameAndActiveSpace(t *testing.T) {
+	users := &stubDeciderUsers{names: map[string]string{"decider-1": "林澈"}}
+	spaces := &stubDeciderSpaces{memberships: map[string]map[string]string{
+		"space-op": {"decider-1": "运营中心"},
+	}}
+	got := resolveDeciderDisplay(users, spaces, "decider-1", "space-op", nil)
+	if got.OperatorName != "林澈" || got.OperatorSpaceName != "运营中心" {
+		t.Fatalf("resolved = %+v", got)
+	}
+}
+
+// A user in several Spaces must resolve the Space name for the SPECIFIED
+// decider_space_id, never another of their memberships.
+func TestResolveDeciderDisplayMultiSpaceUsesSpecifiedSpace(t *testing.T) {
+	users := &stubDeciderUsers{names: map[string]string{"multi": "多空间用户"}}
+	spaces := &stubDeciderSpaces{memberships: map[string]map[string]string{
+		"space-a": {"multi": "Space A"},
+		"space-b": {"multi": "Space B"},
+	}}
+	got := resolveDeciderDisplay(users, spaces, "multi", "space-b", nil)
+	if got.OperatorSpaceName != "Space B" {
+		t.Fatalf("multi-space resolution = %q, want Space B", got.OperatorSpaceName)
+	}
+}
+
+// A decider_space_id the decider is not an active member of degrades the Space
+// name to empty — it must never fall back to another Space.
+func TestResolveDeciderDisplayInactiveMembershipDegradesSpace(t *testing.T) {
+	users := &stubDeciderUsers{names: map[string]string{"decider-1": "林澈"}}
+	spaces := &stubDeciderSpaces{memberships: map[string]map[string]string{
+		"space-other": {"decider-1": "别的空间"},
+	}}
+	got := resolveDeciderDisplay(users, spaces, "decider-1", "space-nonmember", nil)
+	if got.OperatorName != "林澈" {
+		t.Fatalf("name should still resolve: %+v", got)
+	}
+	if got.OperatorSpaceName != "" {
+		t.Fatalf("non-member Space resolved to %q, want empty", got.OperatorSpaceName)
+	}
+}
+
+// A missing user lookup degrades the name to empty (caller shows the generic
+// placeholder) without erroring.
+func TestResolveDeciderDisplayMissingUserDegradesName(t *testing.T) {
+	users := &stubDeciderUsers{names: map[string]string{}}
+	spaces := &stubDeciderSpaces{}
+	got := resolveDeciderDisplay(users, spaces, "ghost", "", nil)
+	if got.OperatorName != "" {
+		t.Fatalf("missing user name = %q, want empty", got.OperatorName)
+	}
+}
+
+// A lookup error degrades to empty and reports via warn; it never propagates.
+func TestResolveDeciderDisplayLookupErrorDegradesAndWarns(t *testing.T) {
+	users := &stubDeciderUsers{err: errors.New("db down")}
+	spaces := &stubDeciderSpaces{err: errors.New("db down")}
+	var warnings int
+	got := resolveDeciderDisplay(users, spaces, "decider-1", "space-op", func(string, error) { warnings++ })
+	if got.OperatorName != "" || got.OperatorSpaceName != "" {
+		t.Fatalf("errors should degrade to empty: %+v", got)
+	}
+	if warnings != 2 {
+		t.Fatalf("warn count = %d, want 2 (name + space)", warnings)
+	}
+}
+
+func TestResolveDeciderDisplayWithoutDeciderIsEmpty(t *testing.T) {
+	users := &stubDeciderUsers{names: map[string]string{"decider-1": "林澈"}}
+	got := resolveDeciderDisplay(users, &stubDeciderSpaces{}, "", "space-op", nil)
+	if got != (resolvedDeciderDisplay{}) {
+		t.Fatalf("no decider uid should resolve to zero: %+v", got)
+	}
+	if users.calls != 0 {
+		t.Fatalf("user service was called without a decider uid")
+	}
+}
+
+// ---- DocsActionFinalizer.resolveAuthoritativeDeciderDisplay ----
+
+func approvedResultWithForgedDisplay(deciderUID, deciderSpaceID string) cardactiondispatch.DecisionResult {
+	return cardactiondispatch.DecisionResult{
+		Disposition: cardactiondispatch.DispositionApplied, State: cardactiondispatch.StateApproved,
+		RequesterUID: "user-a", DeciderUID: deciderUID, DeciderSpaceID: deciderSpaceID,
+		DecidedAt: 1_787_223_660,
+		Display: map[string]string{
+			"title":               "Roadmap",
+			"operator_name":       "FORGED NAME",
+			"operator_space_name": "FORGED SPACE",
+			"decided_at":          "1970-01-01",
+		},
+	}
+}
+
+// The authoritative ids win over caller-supplied display copy: a forged
+// operator_name/operator_space_name is discarded and replaced with the
+// internally resolved values, and decided_at comes from the authoritative field.
+func TestResolveAuthoritativeDeciderDisplayDiscardsForgedNames(t *testing.T) {
+	f := &DocsActionFinalizer{
+		users:  &stubDeciderUsers{names: map[string]string{"decider-1": "林澈"}},
+		spaces: &stubDeciderSpaces{memberships: map[string]map[string]string{"space-op": {"decider-1": "运营中心"}}},
+	}
+	out := f.resolveAuthoritativeDeciderDisplay(context.Background(), approvedResultWithForgedDisplay("decider-1", "space-op"))
+	if out.Display["operator_name"] != "林澈" {
+		t.Fatalf("operator_name = %q, want resolved 林澈 (forged discarded)", out.Display["operator_name"])
+	}
+	if out.Display["operator_space_name"] != "运营中心" {
+		t.Fatalf("operator_space_name = %q, want resolved 运营中心", out.Display["operator_space_name"])
+	}
+	if out.Display["decided_at"] != "2026-08-20 19:01" {
+		t.Fatalf("decided_at = %q, want authoritative value", out.Display["decided_at"])
+	}
+	if out.Display["title"] != "Roadmap" {
+		t.Fatalf("unrelated display fields must be preserved: %+v", out.Display)
+	}
+}
+
+// Duplicate/concurrent click: Docs returns the FIRST decider's ids, not the late
+// clicker's. Resolution keys off result.DeciderUID, so the card shows the real
+// decider even though the forged display named someone else.
+// An authoritative decider without an authoritative timestamp must clear any
+// caller-supplied legacy time rather than pairing it with the trusted actor.
+func TestResolveAuthoritativeDeciderDisplayClearsForgedTimeWhenMissingAuthoritativeTime(t *testing.T) {
+	f := &DocsActionFinalizer{
+		users:  &stubDeciderUsers{names: map[string]string{"decider-1": "林澈"}},
+		spaces: &stubDeciderSpaces{},
+	}
+	result := approvedResultWithForgedDisplay("decider-1", "")
+	result.DecidedAt = 0
+	out := f.resolveAuthoritativeDeciderDisplay(context.Background(), result)
+	if _, exists := out.Display["decided_at"]; exists {
+		t.Fatalf("forged decided_at survived without authoritative time: %+v", out.Display)
+	}
+}
+
+func TestResolveAuthoritativeDeciderDisplayHonorsDeciderNotClicker(t *testing.T) {
+	f := &DocsActionFinalizer{
+		users: &stubDeciderUsers{names: map[string]string{
+			"first-decider": "原审批人", "late-clicker": "迟到点击者",
+		}},
+		spaces: &stubDeciderSpaces{memberships: map[string]map[string]string{
+			"space-first": {"first-decider": "首审空间"},
+		}},
+	}
+	result := approvedResultWithForgedDisplay("first-decider", "space-first")
+	result.Display["operator_name"] = "迟到点击者" // as if a late clicker's name leaked in
+	out := f.resolveAuthoritativeDeciderDisplay(context.Background(), result)
+	if out.Display["operator_name"] != "原审批人" {
+		t.Fatalf("operator_name = %q, want the authoritative decider 原审批人", out.Display["operator_name"])
+	}
+	if out.Display["operator_space_name"] != "首审空间" {
+		t.Fatalf("operator_space_name = %q, want 首审空间", out.Display["operator_space_name"])
+	}
+}
+
+// A failed internal lookup must NOT fail the committed decision: the display just
+// degrades (empty → generic placeholder downstream) and the caller-supplied
+// forged value is still discarded.
+func TestResolveAuthoritativeDeciderDisplayFailureDegradesNotFails(t *testing.T) {
+	f := &DocsActionFinalizer{
+		users:  &stubDeciderUsers{err: errors.New("db down")},
+		spaces: &stubDeciderSpaces{err: errors.New("db down")},
+	}
+	out := f.resolveAuthoritativeDeciderDisplay(context.Background(), approvedResultWithForgedDisplay("decider-1", "space-op"))
+	if out.Display["operator_name"] != "" || out.Display["operator_space_name"] != "" {
+		t.Fatalf("lookup failure should degrade display to empty: %+v", out.Display)
+	}
+}
+
+// Legacy callbacks with no decider ids keep their supplied display untouched
+// (bounded compatibility fallback) and never touch the resolvers.
+func TestResolveAuthoritativeDeciderDisplayLegacyFallback(t *testing.T) {
+	users := &stubDeciderUsers{}
+	spaces := &stubDeciderSpaces{}
+	f := &DocsActionFinalizer{users: users, spaces: spaces}
+	legacy := cardactiondispatch.DecisionResult{
+		Disposition: cardactiondispatch.DispositionApplied, State: cardactiondispatch.StateApproved,
+		RequesterUID: "user-a",
+		Display:      map[string]string{"operator_name": "Caller Name", "operator_space_name": "Caller Space"},
+	}
+	out := f.resolveAuthoritativeDeciderDisplay(context.Background(), legacy)
+	if out.Display["operator_name"] != "Caller Name" || out.Display["operator_space_name"] != "Caller Space" {
+		t.Fatalf("legacy display must be preserved: %+v", out.Display)
+	}
+	if users.calls != 0 || spaces.calls != 0 {
+		t.Fatalf("legacy path must not call resolvers: users=%d spaces=%d", users.calls, spaces.calls)
+	}
+}
+
+// A non-terminal state carries no decision block, so resolution is skipped even
+// when decider ids are present.
+func TestResolveAuthoritativeDeciderDisplaySkipsNonTerminal(t *testing.T) {
+	users := &stubDeciderUsers{names: map[string]string{"decider-1": "林澈"}}
+	f := &DocsActionFinalizer{users: users, spaces: &stubDeciderSpaces{}}
+	cancelled := cardactiondispatch.DecisionResult{
+		State: cardactiondispatch.StateCancelled, DeciderUID: "decider-1",
+		Display: map[string]string{"operator_name": "unchanged"},
+	}
+	out := f.resolveAuthoritativeDeciderDisplay(context.Background(), cancelled)
+	if out.Display["operator_name"] != "unchanged" {
+		t.Fatalf("non-terminal display must be untouched: %+v", out.Display)
+	}
+	if users.calls != 0 {
+		t.Fatalf("non-terminal must not resolve: users=%d", users.calls)
+	}
+}
+
+// ---- /v1/internal/cards/mutate authoritative resolution ----
+
+func TestMutateResolvesDeciderDisplayAndIgnoresCallerNames(t *testing.T) {
+	users := &stubDeciderUsers{names: map[string]string{"decider-1": "Reviewer B"}}
+	spaces := &stubDeciderSpaces{memberships: map[string]map[string]string{"operator-space-b": {"decider-1": "Operator Space B"}}}
+	n := &Notify{deciderUsers: users, deciderSpaces: spaces, Log: log.NewTLog("test")}
+	req := CardMutateReq{
+		DeciderUID: "decider-1", DeciderSpaceID: "operator-space-b",
+		OperatorName: "FORGED", OperatorSpaceName: "FORGED SPACE",
+	}
+	n.resolveMutateOperatorDisplay(&req)
+	if req.OperatorName != "Reviewer B" || req.OperatorSpaceName != "Operator Space B" {
+		t.Fatalf("mutate resolution = name:%q space:%q (forged must be discarded)", req.OperatorName, req.OperatorSpaceName)
+	}
+}
+
+// New decider_uid with no authoritative time clears a forged legacy display
+// timestamp instead of carrying it onto the terminal sibling card.
+func TestMutateClearsForgedTimeWhenAuthoritativeTimeMissing(t *testing.T) {
+	users := &stubDeciderUsers{names: map[string]string{"decider-1": "Reviewer B"}}
+	n := &Notify{deciderUsers: users, deciderSpaces: &stubDeciderSpaces{}, Log: log.NewTLog("test")}
+	req := CardMutateReq{
+		DeciderUID: "decider-1", OperatorName: "FORGED", OperatorSpaceName: "FORGED SPACE",
+		DecidedAtDisplay: "2099-01-01 00:00",
+	}
+	n.resolveMutateOperatorDisplay(&req)
+	if req.DecidedAtDisplay != "" {
+		t.Fatalf("forged decided_at_display survived: %q", req.DecidedAtDisplay)
+	}
+}
+
+// The older operator fields are display context, not aliases for authoritative
+// decider identity. Without decider_uid, this compatibility path does no lookup.
+func TestMutateDoesNotTreatLegacyOperatorFieldsAsDeciderAliases(t *testing.T) {
+	users := &stubDeciderUsers{names: map[string]string{"decider-1": "Reviewer B"}}
+	spaces := &stubDeciderSpaces{memberships: map[string]map[string]string{"space-op": {"decider-1": "Ops"}}}
+	n := &Notify{deciderUsers: users, deciderSpaces: spaces, Log: log.NewTLog("test")}
+	req := CardMutateReq{OperatorUID: "decider-1", OperatorSpaceID: "space-op", OperatorName: "Legacy Name", OperatorSpaceName: "Legacy Space", DecidedAtDisplay: "legacy-time"}
+	n.resolveMutateOperatorDisplay(&req)
+	if req.OperatorName != "Legacy Name" || req.OperatorSpaceName != "Legacy Space" || req.DecidedAtDisplay != "legacy-time" {
+		t.Fatalf("legacy display context changed = name:%q space:%q time:%q", req.OperatorName, req.OperatorSpaceName, req.DecidedAtDisplay)
+	}
+	if users.calls != 0 || spaces.calls != 0 {
+		t.Fatalf("legacy fields triggered authoritative lookup: users=%d spaces=%d", users.calls, spaces.calls)
+	}
+}
+
+// No decider id → the caller's display strings are left intact (bounded compat).
+func TestMutateKeepsCallerDisplayWhenNoDeciderID(t *testing.T) {
+	users := &stubDeciderUsers{}
+	n := &Notify{deciderUsers: users, deciderSpaces: &stubDeciderSpaces{}, Log: log.NewTLog("test")}
+	req := CardMutateReq{OperatorName: "Trusted Caller", OperatorSpaceName: "Trusted Space"}
+	n.resolveMutateOperatorDisplay(&req)
+	if req.OperatorName != "Trusted Caller" || req.OperatorSpaceName != "Trusted Space" {
+		t.Fatalf("legacy display must survive: name:%q space:%q", req.OperatorName, req.OperatorSpaceName)
+	}
+	if users.calls != 0 {
+		t.Fatalf("no decider id must not call the user service")
+	}
+}

--- a/pkg/space/membership.go
+++ b/pkg/space/membership.go
@@ -65,8 +65,35 @@ func CheckMembershipForCleanup(session *dbr.Session, spaceID string, uid string)
 	return count > 0, nil
 }
 
-// HaveCommonSpace checks if uid1 and uid2 share at least one active Space membership.
-// Used to prevent cross-Space existence probing in user search.
+// ResolveActiveMemberSpaceName verifies uid is an active member of the given
+// active Space (space.status=1 AND space_member.status=1) and, when so, returns
+// that Space's name. ok=false means uid is NOT an active member of that Space
+// (or the Space is inactive) — callers MUST treat that as "no authoritative
+// operator Space" and never fall back to a default/card/document Space. A DB
+// error is returned as-is with ok=false. name may be empty for a valid Space
+// with no name set; ok=true still distinguishes that from a non-member.
+func ResolveActiveMemberSpaceName(session *dbr.Session, spaceID string, uid string) (string, bool, error) {
+	if spaceID == "" || uid == "" {
+		return "", false, nil
+	}
+	var name string
+	rows, err := session.SelectBySql(
+		"SELECT s.name FROM space_member sm "+
+			"INNER JOIN space s ON s.space_id = sm.space_id AND s.status = 1 "+
+			"WHERE sm.uid = ? AND sm.space_id = ? AND sm.status = 1 LIMIT 1",
+		uid, spaceID,
+	).Load(&name)
+	if err != nil {
+		return "", false, err
+	}
+	if rows == 0 {
+		return "", false, nil
+	}
+	return name, true, nil
+}
+
+// HaveCommonSpace reports whether uid1 and uid2 share at least one active Space
+// membership. It is used to prevent cross-Space existence probing in user search.
 func HaveCommonSpace(session *dbr.Session, uid1, uid2 string) (bool, error) {
 	if uid1 == "" || uid2 == "" {
 		return false, nil


### PR DESCRIPTION
## Summary
- propagate the operator’s verified current Space independently from the card origin Space
- accept authoritative decision actor IDs/time returned by Docs
- resolve approver and active Space names with internal Octo services
- discard caller-provided name, Space, and time when authoritative IDs are present
- retain bounded compatibility for legacy callbacks without `decider_uid`

## Linked Issue
Fixes #814

## How verified
- focused `internal/cardactiondispatch` decision-contract tests pass
- focused `modules/notify` actor-resolution/finalizer/mutate tests pass
- `modules/message` compiles through `go test ... -run '^$'`
- `git diff --check` passes
- broader package tests remain blocked only by local MySQL `127.0.0.1:3306` being unavailable

## COMPREHENSION
### What does this change actually do?
Before, callback-provided display strings could determine the terminal approval-card actor display. After, Octo Server propagates a verified operator Space, consumes Docs’ persisted winning actor IDs/time, resolves names internally, and treats callback display strings as legacy-only fallback.

### What could break?
Approval-card callback decoding, cross-Space attribution, terminal-card rendering, and sibling-card mutation. Legacy callbacks remain supported when authoritative actor IDs are absent; lookup failures degrade optional display fields without undoing a committed decision.

### How do you know it works?
Contract tests cover distinct card/operator Spaces, malformed actor fields, authoritative-over-forged display behavior, missing authoritative time, active-membership Space resolution, lookup failure degradation, and legacy fallback.
