### PR TITLE
feat(bot-api): validate Space-qualified principals

### DIFF
--- a/.octospec/tasks/bot-space-principal-lookup/brief.md
+++ b/.octospec/tasks/bot-space-principal-lookup/brief.md
@@ -1,0 +1,53 @@
+---
+type: Task
+title: "Task: bot-space-principal-lookup"
+description: Add an exact-Space, Bot-authenticated principal eligibility lookup for Docs.
+tags: [bot-api, space, auth, docs, principal]
+timestamp: 2026-08-27T23:08:00+08:00
+# --- octospec extension fields ---
+slug: bot-space-principal-lookup
+upstream: "approved Docs integration"
+source: user
+---
+
+# Task: bot-space-principal-lookup
+
+## Goal
+
+Add `GET /v1/bot/space/principals/:uid?space_id=...` so a Docs integration can resolve one principal only when the authenticated Bot and target are eligible in that exact active Space. Return only the stable principal UID and classification.
+
+## Load-bearing list
+
+- `/v1/bot` authentication and context identity (`robot_id`, `bot_kind`).
+- Exact-Space isolation: active Space, calling Bot authority for that Space, and active target `space_member` are mandatory.
+- User Bot eligibility: active, unambiguous `robot` identity whose active creator is an active member of the same Space.
+- App Bots are outside this endpoint's contract: reject an App Bot caller from
+  the authenticated `bot_kind` context before any principal DB lookup, and
+  reject an App Bot target through the same non-enumerating not-found response.
+- Human eligibility: active, non-terminally-destroyed user identity.
+- Ambiguous/conflicting Bot identities and database errors fail closed.
+- All absent/inactive/ineligible targets share one localized not-found response; infrastructure errors use an internal localized response.
+- Response contract is minimal: `uid` and `principal_type` (`human` or `user_bot`).
+
+## Out of scope
+
+- Principal search, prefix/fuzzy lookup, batches, profile/PII fields, or membership mutation.
+- Changes to Bot token issuance/authentication, Space membership, robot/app-bot schemas, or Docs persistence.
+- Platform- or Space-scoped App Bot compatibility, as either caller or target.
+- Granting a caller access based on request-provided identity or a non-exact/default Space.
+- Commit, push, PR creation, or deployment.
+
+## Acceptance
+
+- The endpoint is mounted only under the existing authenticated `/v1/bot` group and rejects missing `uid` or `space_id` through the localized invalid-request envelope.
+- Human target succeeds only with an active target membership in the exact active Space and returns exactly `uid` plus `principal_type=human`.
+- An App Bot caller is rejected before the database lookup. An App Bot target
+  returns the same not-found envelope as every absent/inactive/ineligible target.
+- Eligible active User Bot targets are classified as `user_bot`; conflicting identities fail closed.
+- Target absent, caller outside the Space, disabled Space/member/Bot, and User Bot creator absent/inactive/outside the Space all return the same not-found envelope without revealing which predicate failed.
+- Database errors return the localized internal query-failed envelope and never a raw error.
+- Focused route tests cover App Bot caller rejection before lookup, validation,
+  human success, App Bot target rejection, target absence, caller/target outside
+  Space, disabled caller/target/Space/member/Bot, missing Bot creator, and DB failure.
+- Database tests pin the exact-Space eligibility query and classification rules.
+- Edited Go files pass gofmt; focused tests, `go test`/build compilation, and `git diff --check` are run where infrastructure permits, with exact blockers reported.

--- a/.octospec/tasks/bot-space-principal-lookup/context.yaml
+++ b/.octospec/tasks/bot-space-principal-lookup/context.yaml
@@ -1,0 +1,21 @@
+injected:
+  - id: space-isolation
+    source: repo
+    reason: Exact active-Space membership and Bot authority are the endpoint's security boundary.
+  - id: error-handling
+    source: repo
+    reason: All denial and infrastructure failures must preserve the localized error envelope.
+  - id: rate-limit
+    source: repo
+    reason: The endpoint inherits the existing authenticated per-Bot business limiter.
+  - id: testing
+    source: repo
+    reason: Route and database authorization matrices require proportional regression tests.
+  - id: commit-style
+    source: repo
+    reason: Repository convention applies if this work is later committed.
+brief: .octospec/tasks/bot-space-principal-lookup/brief.md
+scope:
+  caller: user-bot-only
+  supported_targets: [human, user_bot]
+  app_bot: rejected-as-caller-and-target

--- a/modules/bot_api/api_i18n_test.go
+++ b/modules/bot_api/api_i18n_test.go
@@ -38,7 +38,7 @@ func TestBotAPINoLegacyResponseError(t *testing.T) {
 	files := []string{
 		"auth.go", "register.go", "commands.go", "events.go", "mention_pref.go",
 		"sync.go", "typing.go", "send.go", "threads.go", "file.go", "groups.go",
-		"voice_adapter.go", "obo_api.go", "resolve_targets.go", "incoming_webhook.go",
+		"voice_adapter.go", "obo_api.go", "resolve_targets.go", "space_principal.go", "incoming_webhook.go",
 		"card_revision.go",
 		"card_profile.go",
 	}

--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -172,6 +172,9 @@ type BotAPI struct {
 	// returns the error without logging identifiers; the permission observer owns
 	// the single desensitized terminal log.
 	spaceMemberQueryOverride func(uid, spaceID string) (bool, error)
+	// principalStoreOverride makes the exact-Space principal lookup testable
+	// without weakening its production DB-backed authorization query.
+	principalStoreOverride spacePrincipalStore
 	// groupMemberCountOverride lets focused permission tests distinguish an
 	// empty active membership from a query failure without a live MySQL session.
 	groupMemberCountOverride func(groupNo, robotID string) (int, error)
@@ -423,6 +426,7 @@ func (ba *BotAPI) Route(r *wkhttp.WKHttp) {
 		botAPI.GET("/groups/:group_no/md", ba.getGroupMd)
 		botAPI.PUT("/groups/:group_no/md", ba.updateGroupMd)
 		botAPI.GET("/space/members", ba.botSpaceMembers)
+		botAPI.GET("/space/principals/:uid", ba.botSpacePrincipal)
 		botAPI.POST("/createGroup", ba.botGroupCreate)
 		botAPI.PUT("/groups/:group_no/info", ba.botGroupUpdate)
 		botAPI.POST("/groups/:group_no/members/add", ba.botGroupMemberAdd)

--- a/modules/bot_api/db.go
+++ b/modules/bot_api/db.go
@@ -226,3 +226,102 @@ func (d *botAPIDB) queryAppBotByUID(uid string) (*appBotModel, error) {
 	_, err := d.session.Select("*").From("app_bot").Where("uid=?", uid).Load(&m)
 	return m, err
 }
+
+// lookupEligibleSpacePrincipal performs the complete exact-Space authorization
+// and target classification in one snapshot statement. Counts are intentional:
+// duplicate/conflicting robot identities are treated as ineligible rather than
+// selecting an arbitrary row.
+type spacePrincipalEligibilityRow struct {
+	SpaceActive int `db:"space_active"`
+
+	CallerMember          int `db:"caller_member"`
+	CallerUserBot         int `db:"caller_user_bot"`
+	CallerAppBot          int `db:"caller_app_bot"`
+	CallerCreatorEligible int `db:"caller_creator_eligible"`
+
+	CanonicalUID          string `db:"canonical_uid"`
+	TargetMember          int    `db:"target_member"`
+	TargetHuman           int    `db:"target_human"`
+	TargetRobotIdentity   int    `db:"target_robot_identity"`
+	TargetUserBot         int    `db:"target_user_bot"`
+	TargetAppBot          int    `db:"target_app_bot"`
+	TargetCreatorEligible int    `db:"target_creator_eligible"`
+}
+
+// The user.robot predicates are an additional fail-closed consistency filter;
+// robot remains the authoritative User Bot identity table.
+const spacePrincipalEligibilityQuery = `SELECT
+  (SELECT COUNT(*) FROM space s WHERE s.space_id=? AND s.status=1) AS space_active,
+  (SELECT COUNT(*) FROM space_member sm WHERE sm.space_id=? AND sm.uid=? AND sm.status=1) AS caller_member,
+  (SELECT COUNT(*) FROM robot r JOIN user u ON u.uid=r.robot_id AND u.status=1 AND COALESCE(u.is_destroy,0)<>2 AND u.robot=1 WHERE r.robot_id=? AND r.status=1) AS caller_user_bot,
+  (SELECT COUNT(*) FROM app_bot ab WHERE ab.uid=?) AS caller_app_bot,
+  (SELECT COUNT(*) FROM robot r JOIN user u ON u.uid=r.creator_uid AND u.status=1 AND COALESCE(u.is_destroy,0)<>2 AND u.robot=0 JOIN space_member sm ON sm.uid=r.creator_uid AND sm.space_id=? AND sm.status=1 WHERE r.robot_id=? AND r.status=1) AS caller_creator_eligible,
+  COALESCE((SELECT u.uid FROM user u WHERE u.uid=? LIMIT 1),'') AS canonical_uid,
+  (SELECT COUNT(*) FROM space_member sm WHERE sm.space_id=? AND sm.uid=? AND sm.status=1) AS target_member,
+  (SELECT COUNT(*) FROM user u WHERE u.uid=? AND u.status=1 AND COALESCE(u.is_destroy,0)<>2 AND u.robot=0) AS target_human,
+  (SELECT COUNT(*) FROM robot r WHERE r.robot_id=? AND r.status=1) AS target_robot_identity,
+  (SELECT COUNT(*) FROM robot r JOIN user u ON u.uid=r.robot_id AND u.status=1 AND COALESCE(u.is_destroy,0)<>2 AND u.robot=1 WHERE r.robot_id=? AND r.status=1) AS target_user_bot,
+  (SELECT COUNT(*) FROM app_bot ab WHERE ab.uid=?) AS target_app_bot,
+  (SELECT COUNT(*) FROM robot r JOIN user u ON u.uid=r.creator_uid AND u.status=1 AND COALESCE(u.is_destroy,0)<>2 AND u.robot=0 JOIN space_member sm ON sm.uid=r.creator_uid AND sm.space_id=? AND sm.status=1 WHERE r.robot_id=? AND r.status=1) AS target_creator_eligible`
+
+func (d *botAPIDB) lookupEligibleSpacePrincipal(callerUID, callerKind, spaceID, targetUID string) (*spacePrincipal, error) {
+	var row spacePrincipalEligibilityRow
+	err := d.session.QueryRow(spacePrincipalEligibilityQuery, spacePrincipalEligibilityArgs(callerUID, spaceID, targetUID)...).Scan(
+		&row.SpaceActive,
+		&row.CallerMember,
+		&row.CallerUserBot,
+		&row.CallerAppBot,
+		&row.CallerCreatorEligible,
+		&row.CanonicalUID,
+		&row.TargetMember,
+		&row.TargetHuman,
+		&row.TargetRobotIdentity,
+		&row.TargetUserBot,
+		&row.TargetAppBot,
+		&row.TargetCreatorEligible,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return classifyEligibleSpacePrincipal(callerKind, row)
+}
+
+func spacePrincipalEligibilityArgs(callerUID, spaceID, targetUID string) []interface{} {
+	return []interface{}{
+		spaceID,
+		spaceID, callerUID,
+		callerUID,
+		callerUID,
+		spaceID, callerUID,
+		targetUID,
+		spaceID, targetUID,
+		targetUID,
+		targetUID,
+		targetUID,
+		targetUID,
+		spaceID, targetUID,
+	}
+}
+
+func classifyEligibleSpacePrincipal(callerKind string, row spacePrincipalEligibilityRow) (*spacePrincipal, error) {
+	if row.SpaceActive != 1 {
+		return nil, errSpacePrincipalNotFound
+	}
+	if callerKind != BotKindUser || row.CallerMember != 1 || row.CallerUserBot != 1 || row.CallerAppBot != 0 || row.CallerCreatorEligible != 1 {
+		return nil, errSpacePrincipalNotFound
+	}
+	if row.CanonicalUID == "" || row.TargetMember != 1 {
+		return nil, errSpacePrincipalNotFound
+	}
+
+	botIdentities := row.TargetRobotIdentity + row.TargetAppBot
+	switch {
+	case row.TargetHuman == 1 && botIdentities == 0:
+		return &spacePrincipal{UID: row.CanonicalUID, PrincipalType: principalTypeHuman}, nil
+	case row.TargetHuman == 0 && row.TargetUserBot == 1 && row.TargetAppBot == 0 && row.TargetCreatorEligible == 1:
+		return &spacePrincipal{UID: row.CanonicalUID, PrincipalType: principalTypeUserBot}, nil
+	default:
+		return nil, errSpacePrincipalNotFound
+	}
+}

--- a/modules/bot_api/space_principal.go
+++ b/modules/bot_api/space_principal.go
@@ -1,0 +1,75 @@
+package bot_api
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"go.uber.org/zap"
+)
+
+const (
+	principalTypeHuman   = "human"
+	principalTypeUserBot = "user_bot"
+)
+
+var errSpacePrincipalNotFound = errors.New("space principal not found")
+
+type spacePrincipal struct {
+	UID           string `json:"uid"`
+	PrincipalType string `json:"principal_type"`
+}
+
+type spacePrincipalStore interface {
+	lookupEligibleSpacePrincipal(callerUID, callerKind, spaceID, targetUID string) (*spacePrincipal, error)
+}
+
+// botSpacePrincipal resolves one principal without exposing why an identity is
+// absent or ineligible. The exact Space is mandatory and is never inferred from
+// another membership or from a client-controlled default.
+func (ba *BotAPI) botSpacePrincipal(c *wkhttp.Context) {
+	callerUID := getRobotIDFromContext(c)
+	callerKind := getBotKindFromContext(c)
+	if callerKind == BotKindApp {
+		// This integration surface is deliberately User-Bot-only. Reject from the
+		// authenticated kind context before validation or any principal DB lookup.
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIAppBotUnsupported, nil, nil)
+		return
+	}
+	if callerUID == "" || callerKind != BotKindUser {
+		ba.respondBotAPIIdentityMissing(c)
+		return
+	}
+
+	spaceID := strings.TrimSpace(c.Query("space_id"))
+	targetUID := strings.TrimSpace(c.Param("uid"))
+	if spaceID == "" {
+		respondBotAPIRequestInvalid(c, "space_id")
+		return
+	}
+	if targetUID == "" {
+		respondBotAPIRequestInvalid(c, "uid")
+		return
+	}
+
+	store := ba.principalStoreOverride
+	if store == nil {
+		store = ba.db
+	}
+	principal, err := store.lookupEligibleSpacePrincipal(callerUID, callerKind, spaceID, targetUID)
+	if errors.Is(err, errSpacePrincipalNotFound) || (err == nil && principal == nil) {
+		// Every absent/inactive/unauthorized condition deliberately collapses to
+		// the same response so this exact lookup cannot enumerate identities,
+		// membership, bot state, ownership, or Space state.
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIUserNotFound, nil, nil)
+		return
+	}
+	if err != nil {
+		ba.Error("space principal eligibility query failed", zap.Error(err))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIQueryFailed, nil, nil)
+		return
+	}
+	c.Response(principal)
+}

--- a/modules/bot_api/space_principal_test.go
+++ b/modules/bot_api/space_principal_test.go
@@ -1,0 +1,259 @@
+package bot_api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeSpacePrincipalStore struct {
+	principal *spacePrincipal
+	err       error
+	calls     [][4]string
+}
+
+func (f *fakeSpacePrincipalStore) lookupEligibleSpacePrincipal(callerUID, callerKind, spaceID, targetUID string) (*spacePrincipal, error) {
+	f.calls = append(f.calls, [4]string{callerUID, callerKind, spaceID, targetUID})
+	return f.principal, f.err
+}
+
+func principalContext(t *testing.T, ba *BotAPI, callerUID, callerKind, targetUID, spaceID string) (*wkhttp.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(w)
+	gc.Request = httptest.NewRequest(http.MethodGet, "/v1/bot/space/principals/"+targetUID+"?space_id="+spaceID, nil)
+	gc.Params = gin.Params{{Key: "uid", Value: targetUID}}
+	c := &wkhttp.Context{Context: gc}
+	c.Set(CtxKeyRobotID, callerUID)
+	c.Set(CtxKeyBotKind, callerKind)
+	return c, w
+}
+
+func TestBotSpacePrincipalHumanSuccessMinimalResponse(t *testing.T) {
+	store := &fakeSpacePrincipalStore{principal: &spacePrincipal{UID: "human-1", PrincipalType: principalTypeHuman}}
+	ba := &BotAPI{Log: log.NewTLog("principal-test"), principalStoreOverride: store}
+	c, w := principalContext(t, ba, "bot-1", BotKindUser, "human-1", "space-1")
+
+	ba.botSpacePrincipal(c)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	require.Equal(t, map[string]any{"uid": "human-1", "principal_type": "human"}, got)
+	require.Equal(t, [][4]string{{"bot-1", BotKindUser, "space-1", "human-1"}}, store.calls)
+}
+
+func TestBotSpacePrincipalValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name, targetUID, spaceID string
+	}{
+		{name: "missing uid", spaceID: "space-1"},
+		{name: "missing space", targetUID: "human-1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeSpacePrincipalStore{}
+			ba := &BotAPI{Log: log.NewTLog("principal-test"), principalStoreOverride: store}
+			c, w := principalContext(t, ba, "bot-1", BotKindUser, tc.targetUID, tc.spaceID)
+			ba.botSpacePrincipal(c)
+			require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+			require.Empty(t, store.calls)
+		})
+	}
+}
+
+func TestBotSpacePrincipalRejectsAppBotCallerBeforeLookup(t *testing.T) {
+	store := &fakeSpacePrincipalStore{}
+	ba := &BotAPI{Log: log.NewTLog("principal-test"), principalStoreOverride: store}
+	c, w := principalContext(t, ba, "app-bot-1", BotKindApp, "human-1", "space-1")
+
+	ba.botSpacePrincipal(c)
+
+	require.Equal(t, http.StatusForbidden, w.Code, w.Body.String())
+	require.Contains(t, w.Body.String(), errcode.ErrBotAPIAppBotUnsupported.DefaultMessage)
+	require.Empty(t, store.calls, "App Bot caller must be rejected before DB lookup")
+}
+
+func TestBotSpacePrincipalDenialsAreIndistinguishable(t *testing.T) {
+	for _, name := range []string{
+		"target absent", "caller outside space", "disabled space", "disabled member",
+		"disabled bot", "bot creator absent",
+	} {
+		t.Run(name, func(t *testing.T) {
+			store := &fakeSpacePrincipalStore{err: errSpacePrincipalNotFound}
+			ba := &BotAPI{Log: log.NewTLog("principal-test"), principalStoreOverride: store}
+			c, w := principalContext(t, ba, "bot-1", BotKindUser, "target-1", "space-1")
+			ba.botSpacePrincipal(c)
+			require.Equal(t, http.StatusNotFound, w.Code, w.Body.String())
+		})
+	}
+}
+
+func TestBotSpacePrincipalDBErrorUsesInternalEnvelope(t *testing.T) {
+	store := &fakeSpacePrincipalStore{err: errors.New("database unavailable")}
+	ba := &BotAPI{Log: log.NewTLog("principal-test"), principalStoreOverride: store}
+	c, w := principalContext(t, ba, "bot-1", BotKindUser, "target-1", "space-1")
+	ba.botSpacePrincipal(c)
+	require.Equal(t, http.StatusInternalServerError, w.Code, w.Body.String())
+	var env struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	require.NotContains(t, w.Body.String(), "database unavailable")
+}
+
+func TestBotSpacePrincipalRouteRegistered(t *testing.T) {
+	source, err := os.ReadFile("bot_api.go")
+	require.NoError(t, err)
+	require.Contains(t, string(source), `botAPI.GET("/space/principals/:uid", ba.botSpacePrincipal)`)
+}
+
+func eligibleHumanRow() spacePrincipalEligibilityRow {
+	return spacePrincipalEligibilityRow{
+		SpaceActive: 1, CallerMember: 1, CallerUserBot: 1, CallerCreatorEligible: 1,
+		CanonicalUID: "target-1", TargetMember: 1, TargetHuman: 1,
+	}
+}
+
+func TestClassifyEligibleSpacePrincipal(t *testing.T) {
+	userBot := eligibleHumanRow()
+	userBot.TargetHuman, userBot.TargetRobotIdentity, userBot.TargetUserBot, userBot.TargetCreatorEligible = 0, 1, 1, 1
+	appBot := eligibleHumanRow()
+	appBot.TargetHuman, appBot.TargetAppBot, appBot.TargetCreatorEligible = 0, 1, 1
+
+	for _, tc := range []struct {
+		name, kind, want string
+		row              spacePrincipalEligibilityRow
+		ok               bool
+	}{
+		{name: "human", kind: BotKindUser, row: eligibleHumanRow(), want: principalTypeHuman, ok: true},
+		{name: "human-looking App Bot rejected", kind: BotKindUser, row: func() spacePrincipalEligibilityRow { r := eligibleHumanRow(); r.TargetAppBot = 1; return r }()},
+		{name: "user bot", kind: BotKindUser, row: userBot, want: principalTypeUserBot, ok: true},
+		{name: "app bot target rejected", kind: BotKindUser, row: appBot},
+		{name: "app bot caller rejected", kind: BotKindApp, row: eligibleHumanRow()},
+		{name: "target absent", kind: BotKindUser, row: func() spacePrincipalEligibilityRow { r := eligibleHumanRow(); r.TargetHuman = 0; return r }()},
+		{name: "caller outside exact space", kind: BotKindUser, row: func() spacePrincipalEligibilityRow { r := eligibleHumanRow(); r.CallerMember = 0; return r }()},
+		{name: "caller user missing", kind: BotKindUser, row: func() spacePrincipalEligibilityRow { r := eligibleHumanRow(); r.CallerUserBot = 0; return r }()},
+		{name: "caller user disabled", kind: BotKindUser, row: func() spacePrincipalEligibilityRow { r := eligibleHumanRow(); r.CallerUserBot = 0; return r }()},
+		{name: "caller user destroyed", kind: BotKindUser, row: func() spacePrincipalEligibilityRow { r := eligibleHumanRow(); r.CallerUserBot = 0; return r }()},
+		{name: "caller user robot flag false", kind: BotKindUser, row: func() spacePrincipalEligibilityRow { r := eligibleHumanRow(); r.CallerUserBot = 0; return r }()},
+		{name: "caller creator is robot", kind: BotKindUser, row: func() spacePrincipalEligibilityRow { r := eligibleHumanRow(); r.CallerCreatorEligible = 0; return r }()},
+		{name: "disabled space", kind: BotKindUser, row: func() spacePrincipalEligibilityRow { r := eligibleHumanRow(); r.SpaceActive = 0; return r }()},
+		{name: "target outside exact space or disabled membership", kind: BotKindUser, row: func() spacePrincipalEligibilityRow { r := eligibleHumanRow(); r.TargetMember = 0; return r }()},
+		{name: "target human disabled", kind: BotKindUser, row: func() spacePrincipalEligibilityRow { r := eligibleHumanRow(); r.TargetHuman = 0; return r }()},
+		{name: "target user bot disabled", kind: BotKindUser, row: func() spacePrincipalEligibilityRow { r := userBot; r.TargetUserBot = 0; return r }()},
+		{name: "bot creator absent", kind: BotKindUser, row: func() spacePrincipalEligibilityRow { r := userBot; r.TargetCreatorEligible = 0; return r }()},
+		{name: "target creator is robot", kind: BotKindUser, row: func() spacePrincipalEligibilityRow { r := userBot; r.TargetCreatorEligible = 0; return r }()},
+		{name: "caller creator absent", kind: BotKindUser, row: func() spacePrincipalEligibilityRow { r := eligibleHumanRow(); r.CallerCreatorEligible = 0; return r }()},
+		{name: "conflicting bot identity", kind: BotKindUser, row: func() spacePrincipalEligibilityRow { r := userBot; r.TargetAppBot = 1; return r }()},
+		{name: "human with robot identity", kind: BotKindUser, row: func() spacePrincipalEligibilityRow { r := eligibleHumanRow(); r.TargetRobotIdentity = 1; return r }()},
+		{name: "ambiguous duplicate bot", kind: BotKindUser, row: func() spacePrincipalEligibilityRow { r := userBot; r.TargetUserBot = 2; return r }()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := classifyEligibleSpacePrincipal(tc.kind, tc.row)
+			if !tc.ok {
+				require.ErrorIs(t, err, errSpacePrincipalNotFound)
+				require.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got.PrincipalType)
+			require.Equal(t, tc.row.CanonicalUID, got.UID)
+		})
+	}
+}
+
+func TestLookupEligibleSpacePrincipalDatabase(t *testing.T) {
+	db, mock, closeDB := newSqlmockBotAPIDB(t)
+	defer closeDB()
+
+	columns := []string{
+		"space_active", "caller_member", "caller_user_bot", "caller_app_bot",
+		"caller_creator_eligible", "canonical_uid", "target_member",
+		"target_human", "target_robot_identity", "target_user_bot", "target_app_bot", "target_creator_eligible",
+	}
+	mock.ExpectQuery(regexp.QuoteMeta(spacePrincipalEligibilityQuery)).
+		WithArgs(
+			"space-1", "space-1", "caller-bot", "caller-bot", "caller-bot", "space-1", "caller-bot",
+			"HUMAN-1", "space-1", "HUMAN-1", "HUMAN-1", "HUMAN-1", "HUMAN-1", "HUMAN-1", "space-1", "HUMAN-1",
+		).
+		WillReturnRows(sqlmock.NewRows(columns).AddRow(1, 1, 1, 0, 1, "Human-1", 1, 1, 0, 0, 0, 0))
+
+	got, err := db.lookupEligibleSpacePrincipal("caller-bot", BotKindUser, "space-1", "HUMAN-1")
+	require.NoError(t, err)
+	require.Equal(t, &spacePrincipal{UID: "Human-1", PrincipalType: principalTypeHuman}, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSpacePrincipalEligibilitySQLArgsAreExactSpaceScoped(t *testing.T) {
+	want := []interface{}{
+		"space-1",
+		"space-1", "caller-bot",
+		"caller-bot",
+		"caller-bot",
+		"space-1", "caller-bot",
+		"target-1",
+		"space-1", "target-1",
+		"target-1",
+		"target-1",
+		"target-1",
+		"target-1",
+		"space-1", "target-1",
+	}
+	require.Equal(t, want, spacePrincipalEligibilityArgs("caller-bot", "space-1", "target-1"))
+	require.Equal(t, len(want), strings.Count(spacePrincipalEligibilityQuery, "?"))
+	require.NotContains(t, spacePrincipalEligibilityQuery, "scope='platform'")
+	require.NotContains(t, spacePrincipalEligibilityQuery, "COLLATE")
+	require.Contains(t, spacePrincipalEligibilityQuery, "SELECT u.uid FROM user u WHERE u.uid=? LIMIT 1")
+	require.Contains(t, spacePrincipalEligibilityQuery, "FROM app_bot ab WHERE ab.uid=?) AS target_app_bot")
+}
+
+func TestSpacePrincipalEligibilitySQLRequiresCompleteUserBotIdentitiesAndHumanCreators(t *testing.T) {
+	for _, tc := range []struct {
+		name, fragment string
+	}{
+		{name: "caller user missing", fragment: "FROM robot r JOIN user u ON u.uid=r.robot_id"},
+		{name: "caller user disabled", fragment: "u.uid=r.robot_id AND u.status=1"},
+		{name: "caller user destroyed", fragment: "u.status=1 AND COALESCE(u.is_destroy,0)<>2"},
+		{name: "caller user robot flag false", fragment: "COALESCE(u.is_destroy,0)<>2 AND u.robot=1 WHERE r.robot_id=? AND r.status=1) AS caller_user_bot"},
+		{name: "target User Bot symmetric identity", fragment: "COALESCE(u.is_destroy,0)<>2 AND u.robot=1 WHERE r.robot_id=? AND r.status=1) AS target_user_bot"},
+		{name: "caller creator is robot", fragment: "COALESCE(u.is_destroy,0)<>2 AND u.robot=0 JOIN space_member sm ON sm.uid=r.creator_uid AND sm.space_id=? AND sm.status=1 WHERE r.robot_id=? AND r.status=1) AS caller_creator_eligible"},
+		{name: "target creator is robot", fragment: "COALESCE(u.is_destroy,0)<>2 AND u.robot=0 JOIN space_member sm ON sm.uid=r.creator_uid AND sm.space_id=? AND sm.status=1 WHERE r.robot_id=? AND r.status=1) AS target_creator_eligible"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Contains(t, spacePrincipalEligibilityQuery, tc.fragment)
+		})
+	}
+}
+
+func TestLookupEligibleSpacePrincipalDatabaseError(t *testing.T) {
+	db, mock, closeDB := newSqlmockBotAPIDB(t)
+	defer closeDB()
+
+	wantErr := errors.New("query failed")
+	mock.ExpectQuery(regexp.QuoteMeta(spacePrincipalEligibilityQuery)).
+		WithArgs(
+			"space-1", "space-1", "caller-bot", "caller-bot", "caller-bot", "space-1", "caller-bot",
+			"human-1", "space-1", "human-1", "human-1", "human-1", "human-1", "human-1", "space-1", "human-1",
+		).
+		WillReturnError(wantErr)
+
+	got, err := db.lookupEligibleSpacePrincipal("caller-bot", BotKindUser, "space-1", "human-1")
+	require.ErrorIs(t, err, wantErr)
+	require.Nil(t, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
## Summary

- add a User-Bot-only exact Space-principal lookup under the authenticated Bot API;
- require an active Space, active exact-Space membership, complete User Bot identity, and an active Human creator in the same Space;
- accept active Human and User Bot targets, reject App Bot callers/targets, and collapse ineligible principals to a non-enumerating 404;
- fail closed on database errors.

## Linked Spec

- Fixes #818
- `.octospec/tasks/bot-space-principal-lookup/brief.md`
- Companion Docs Backend: dmwork/octo-docs-backend#13

## How verified

- focused Bot API route/classification/SQL contract tests;
- `go vet ./modules/bot_api/...`;
- `go build ./...`;
- `make i18n-extract-check`;
- `make i18n-lint`;
- `git diff --check`.

The full `modules/bot_api` integration suite requires local MySQL at `127.0.0.1:3306`, which is not available on this host; focused offline tests and compile/build gates pass.

## COMPREHENSION

### What does this change actually do?

Before, a Docs User Bot could only prove that a UID existed globally or depend on a service credential to enumerate a Space roster. After, Octo Server can authoritatively validate one exact `(uid, Space)` using the caller's User Bot bearer without exposing the full roster.

### What could break?

The new endpoint is additive. Its security boundary is intentionally narrow: App Bot callers and targets are rejected, and inactive/destroyed/ambiguous User Bot identities or non-Human creators are ineligible. The companion Docs change must be deployed only after this endpoint is available.

### How do you know it works?

Tests cover Human/User Bot success, App Bot rejection, exact-Space isolation, disabled/destroyed/malformed identities, Human creator requirements, database failures, stable status/body contracts, and SQL argument ordering. Build, vet, i18n, and diff checks pass.
