### PR TITLE
feat(opanalytics): include community-topic (subarea) messages in channel facts

### DIFF
--- a/modules/opanalytics/db.go
+++ b/modules/opanalytics/db.go
@@ -87,7 +87,9 @@ func (d *opanalyticsDB) overviewMsgAndGroups(start, end string, spaceIDs []strin
 		"IFNULL(SUM(human_msg_count),0) AS human_msg",
 		"IFNULL(SUM(agent_msg_count),0) AS agent_msg",
 		"COUNT(DISTINCT CASE WHEN channel_type=2 THEN channel_id END) AS active_groups",
-	).From("octo_fact_channel_daily").Where("stat_date BETWEEN ? AND ?", start, end)
+	).From("octo_fact_channel_daily").
+		Where("stat_date BETWEEN ? AND ?", start, end).
+		Where("channel_type IN (1,2)") // 排除子区(channel_type=5)：其 SUM 会撑大总量(YUJ-375)
 	stmt = applySpaceFilter(stmt, spaceIDs)
 	_, err = stmt.Load(&res)
 	return res.HumanMsg, res.AgentMsg, res.ActiveGroups, err
@@ -117,7 +119,9 @@ func (d *opanalyticsDB) overviewActiveMembers(start, end string, spaceIDs []stri
 		sql += " JOIN space_member sm ON sm.uid = f.sender_uid AND sm.status=1 AND " + smClause
 		args = append(args, smArgs...)
 	}
-	sql += " WHERE f.stat_date BETWEEN ? AND ? AND m.is_excluded=0"
+	// channel_type IN (1,2) 始终生效：排除子区(=5)，使全局与选中 space 两条口径都不含子区
+	// (YUJ-375)。选中 space 时下方另加 f.channel_type=2，与此 AND 后收敛为 =2，私聊排除语义不变。
+	sql += " WHERE f.stat_date BETWEEN ? AND ? AND m.is_excluded=0 AND f.channel_type IN (1,2)"
 	args = append(args, start, end)
 	if len(spaceIDs) > 0 {
 		spaceClause, spaceArgs := inClause("f.space_id", spaceIDs)
@@ -149,6 +153,7 @@ func (d *opanalyticsDB) queryMessageComposition(start, end string, spaceIDs []st
 	).From("octo_fact_channel_daily").
 		Where("stat_date BETWEEN ? AND ?", start, end).
 		Where("conv_type BETWEEN 1 AND 4").
+		Where("channel_type IN (1,2)"). // 子区继承父群 conv_type(1/2)，不加此过滤会被误计入 HH群/HA群桶(YUJ-375)
 		GroupBy("conv_type")
 	stmt = applySpaceFilter(stmt, spaceIDs)
 	_, err := stmt.Load(&rows)
@@ -191,7 +196,7 @@ func (d *opanalyticsDB) queryTrendChannelTotals(start, end, granularity string, 
 		"IFNULL(SUM(agent_msg_count),0) AS agent_msg, " +
 		"COUNT(DISTINCT CASE WHEN channel_type=2 THEN channel_id END) AS active_groups, " +
 		"COUNT(DISTINCT CASE WHEN channel_type=1 THEN channel_id END) AS private_active " +
-		"FROM octo_fact_channel_daily WHERE stat_date BETWEEN ? AND ?"
+		"FROM octo_fact_channel_daily WHERE stat_date BETWEEN ? AND ? AND channel_type IN (1,2)" // 排除子区撑大 SUM(YUJ-375)
 	args := []interface{}{start, end}
 	if len(spaceIDs) > 0 {
 		spaceClause, spaceArgs := inClause("space_id", spaceIDs)
@@ -225,7 +230,7 @@ func (d *opanalyticsDB) queryTrendConvTypeMsg(start, end, granularity string, sp
 	sql := "SELECT " + bucketExpr + " AS bucket, conv_type, " +
 		"IFNULL(SUM(human_msg_count),0) AS human_msg, " +
 		"IFNULL(SUM(agent_msg_count),0) AS agent_msg " +
-		"FROM octo_fact_channel_daily WHERE stat_date BETWEEN ? AND ? AND conv_type BETWEEN 1 AND 4"
+		"FROM octo_fact_channel_daily WHERE stat_date BETWEEN ? AND ? AND conv_type BETWEEN 1 AND 4 AND channel_type IN (1,2)" // 排除子区(继承父群conv)误计入群桶(YUJ-375)
 	args := []interface{}{start, end}
 	if len(spaceIDs) > 0 {
 		spaceClause, spaceArgs := inClause("space_id", spaceIDs)
@@ -265,7 +270,7 @@ func (d *opanalyticsDB) queryTrendActiveMembers(start, end, granularity string, 
 		sql += " JOIN space_member sm ON sm.uid = f.sender_uid AND sm.status=1 AND " + smClause
 		args = append(args, smArgs...)
 	}
-	sql += " WHERE f.stat_date BETWEEN ? AND ? AND m.is_excluded=0"
+	sql += " WHERE f.stat_date BETWEEN ? AND ? AND m.is_excluded=0 AND f.channel_type IN (1,2)" // 排除子区(=5)，全局/选中space口径一致(YUJ-375)
 	args = append(args, start, end)
 	if len(spaceIDs) > 0 {
 		spaceClause, spaceArgs := inClause("f.space_id", spaceIDs)

--- a/modules/opanalytics/etl.go
+++ b/modules/opanalytics/etl.go
@@ -242,7 +242,11 @@ func aggregateChunk(rows []*srcMessageRow, memberType map[string]uint8, excluded
 			continue
 		}
 		dirtySet[ca.day] = struct{}{}
-		res.activityRows = append(res.activityRows, []interface{}{ca.channelID, ca.channelType, ca.dayMaxTs})
+		// 子区不登记 dim_channel 活跃行：该维表仅服务群/私聊看板，子区无展示；写入只会
+		// 积累永不被 refreshDimChannelGroups enrich 的裸 channel_type=5 行(YUJ-375 review)。
+		if cm.channelType != channelTypeCommunityTopic {
+			res.activityRows = append(res.activityRows, []interface{}{ca.channelID, ca.channelType, ca.dayMaxTs})
+		}
 		if cm.channelType == channelTypePerson {
 			a, b, _ := normalizePrivatePair(ca.channelID) // skip=false 保证可解析
 			human, agent := 0, 0
@@ -313,10 +317,11 @@ func resolveChannelMeta(channelID string, channelType uint8, memberType map[stri
 	// 子区(话题)：channel_id = "<父群no>____<短ID>"。劈出父群段，归属父群的 space/conv。
 	// 子区自有 channel_id → 事实表按子区独立成行；parentChannelID 记父群便于上卷。
 	if channelType == channelTypeCommunityTopic {
-		parts := strings.SplitN(channelID, threadChannelIDSeparator, 2)
-		if len(parts) != 2 || parts[0] == "" {
-			// 畸形子区 channel_id(无分隔符/父群段空)→ fail-closed 丢弃(与 bot_api
-			// obo_fanout / message disband guard 的处理一致)。
+		parts := strings.Split(channelID, threadChannelIDSeparator)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			// 畸形子区 channel_id → fail-closed 丢弃：要求恰两段且父群段/topic段均非空
+			// (与 canonical thread.ParseChannelID 一致；堵住 "g1____" 空 topic 段与
+			// "a____b____c" 多段)。与 bot_api obo_fanout / message disband guard 同口径。
 			return &channelMeta{channelType: channelTypeCommunityTopic, skip: true}
 		}
 		parentNo := parts[0]

--- a/modules/opanalytics/etl.go
+++ b/modules/opanalytics/etl.go
@@ -19,12 +19,18 @@ const (
 	convTypeHHPrivate uint8 = 3
 	convTypeHAPrivate uint8 = 4
 
-	channelTypePerson uint8 = 1 // = octo-lib common.ChannelTypePerson
-	channelTypeGroup  uint8 = 2 // = octo-lib common.ChannelTypeGroup
+	channelTypePerson         uint8 = 1 // = octo-lib common.ChannelTypePerson
+	channelTypeGroup          uint8 = 2 // = octo-lib common.ChannelTypeGroup
+	channelTypeCommunityTopic uint8 = 5 // = octo-lib common.ChannelTypeCommunityTopic (群下子区/话题)
 
 	dimStatusNormal   uint8 = 1
 	dimStatusDisband  uint8 = 2
 	privateMemberSize       = 2
+
+	// threadChannelIDSeparator 子区 channel_id = "<父群no>____<短ID>"(与 bot_api
+	// threadChannelIDSeparator 同值)。父群段即父群 channel_id(= group_no)，据此
+	// 归属父群的 space_id/conv_type，无需额外数据源。
+	threadChannelIDSeparator = "____"
 )
 
 // ETL 看板预聚合任务(增量水位，幂等)。
@@ -170,10 +176,11 @@ type senderDayAgg struct {
 
 // channelMeta 会话的归属/分类(ETL 当日打标)。
 type channelMeta struct {
-	spaceID     string
-	convType    uint8
-	channelType uint8
-	skip        bool // 不可解析的私聊(uid 含 @)或任一方为系统/测试账号 → 丢弃其事实行
+	spaceID         string
+	convType        uint8
+	channelType     uint8
+	parentChannelID string // 子区(channelType=5)所属父群 channel_id；非子区为 ""
+	skip            bool   // 不可解析的私聊(uid 含 @)或任一方为系统/测试账号 → 丢弃其事实行
 }
 
 // aggregateChunk 把一个 chunk 的消息按(日,会话,成员)聚合成待写数据(纯函数)。
@@ -265,16 +272,17 @@ func aggregateChunk(rows []*srcMessageRow, memberType map[string]uint8, excluded
 			st = memberTypeHuman
 		}
 		res.fact3 = append(res.fact3, &factMemberChannelDailyModel{
-			StatDate:    sa.day,
-			ChannelID:   sa.channelID,
-			ChannelType: cm.channelType,
-			SpaceID:     cm.spaceID,
-			ConvType:    cm.convType,
-			ContentType: 0,
-			SenderUID:   sa.senderUID,
-			SenderType:  st,
-			MsgCount:    sa.msgCount,
-			LastMsgAt:   sa.lastMsgAt,
+			StatDate:        sa.day,
+			ChannelID:       sa.channelID,
+			ChannelType:     cm.channelType,
+			SpaceID:         cm.spaceID,
+			ConvType:        cm.convType,
+			ParentChannelID: cm.parentChannelID,
+			ContentType:     0,
+			SenderUID:       sa.senderUID,
+			SenderType:      st,
+			MsgCount:        sa.msgCount,
+			LastMsgAt:       sa.lastMsgAt,
 		})
 	}
 
@@ -293,7 +301,7 @@ func channelTypeFromChannels(channels map[string]*chanDayAgg, day, channelID str
 	return 0
 }
 
-// resolveChannelMeta 解析会话归属/分类(群查 group 维表；私聊反解 fakeChannelID)。
+// resolveChannelMeta 解析会话归属/分类(群查 group 维表；子区劈父群段继承；私聊反解 fakeChannelID)。
 func resolveChannelMeta(channelID string, channelType uint8, memberType map[string]uint8, excludedUID func(string) bool, groupMeta map[string]groupMetaInfo) *channelMeta {
 	if channelType == channelTypeGroup {
 		if gm, ok := groupMeta[channelID]; ok {
@@ -301,6 +309,22 @@ func resolveChannelMeta(channelID string, channelType uint8, memberType map[stri
 		}
 		// 已从 group 表消失的孤儿群：仍计消息，但不归 space、类型未知。
 		return &channelMeta{spaceID: "", convType: 0, channelType: channelTypeGroup}
+	}
+	// 子区(话题)：channel_id = "<父群no>____<短ID>"。劈出父群段，归属父群的 space/conv。
+	// 子区自有 channel_id → 事实表按子区独立成行；parentChannelID 记父群便于上卷。
+	if channelType == channelTypeCommunityTopic {
+		parts := strings.SplitN(channelID, threadChannelIDSeparator, 2)
+		if len(parts) != 2 || parts[0] == "" {
+			// 畸形子区 channel_id(无分隔符/父群段空)→ fail-closed 丢弃(与 bot_api
+			// obo_fanout / message disband guard 的处理一致)。
+			return &channelMeta{channelType: channelTypeCommunityTopic, skip: true}
+		}
+		parentNo := parts[0]
+		if gm, ok := groupMeta[parentNo]; ok {
+			return &channelMeta{spaceID: gm.spaceID, convType: gm.convType, channelType: channelTypeCommunityTopic, parentChannelID: parentNo}
+		}
+		// 父群已消失的孤儿子区：仍计消息，不归 space、conv 未知，但保留父群归属。
+		return &channelMeta{spaceID: "", convType: 0, channelType: channelTypeCommunityTopic, parentChannelID: parentNo}
 	}
 	// 私聊(person)
 	a, b, ok := normalizePrivatePair(channelID)

--- a/modules/opanalytics/etl_db.go
+++ b/modules/opanalytics/etl_db.go
@@ -141,21 +141,21 @@ func (d *etlDB) accumulateFact3(tx *dbr.Tx, fact3 []*factMemberChannelDailyModel
 	if len(fact3) == 0 {
 		return nil
 	}
-	const cols = "(`stat_date`,`channel_id`,`channel_type`,`space_id`,`conv_type`,`content_type`," +
+	const cols = "(`stat_date`,`channel_id`,`channel_type`,`space_id`,`conv_type`,`parent_channel_id`,`content_type`," +
 		"`sender_uid`,`sender_type`,`msg_count`,`last_msg_at`)"
 	const suffix = " ON DUPLICATE KEY UPDATE " +
 		"`channel_type`=VALUES(`channel_type`),`space_id`=VALUES(`space_id`),`conv_type`=VALUES(`conv_type`)," +
-		"`sender_type`=VALUES(`sender_type`)," +
+		"`parent_channel_id`=VALUES(`parent_channel_id`),`sender_type`=VALUES(`sender_type`)," +
 		"`msg_count`=`msg_count`+VALUES(`msg_count`)," +
 		"`last_msg_at`=GREATEST(`last_msg_at`,VALUES(`last_msg_at`))"
 	rows := make([][]interface{}, 0, len(fact3))
 	for _, f := range fact3 {
 		rows = append(rows, []interface{}{
-			f.StatDate, f.ChannelID, f.ChannelType, f.SpaceID, f.ConvType, f.ContentType,
+			f.StatDate, f.ChannelID, f.ChannelType, f.SpaceID, f.ConvType, f.ParentChannelID, f.ContentType,
 			f.SenderUID, f.SenderType, f.MsgCount, f.LastMsgAt,
 		})
 	}
-	return execValuesUpsert(tx, "octo_fact_member_channel_daily", cols, 10, suffix, rows)
+	return execValuesUpsert(tx, "octo_fact_member_channel_daily", cols, 11, suffix, rows)
 }
 
 // markDirtyDays 把本 chunk 触达的统计日入队(待全部 chunk 后由 ③ 重算 ④)。
@@ -203,9 +203,9 @@ func (d *etlDB) recomputeChannelDay(day string) error {
 	}
 	if _, err = tx.InsertBySql(
 		"INSERT INTO octo_fact_channel_daily "+
-			"(stat_date,channel_id,channel_type,space_id,conv_type,human_msg_count,agent_msg_count,"+
+			"(stat_date,channel_id,channel_type,space_id,conv_type,parent_channel_id,human_msg_count,agent_msg_count,"+
 			"active_human_members,active_agent_members,last_msg_at) "+
-			"SELECT stat_date, channel_id, MAX(channel_type), MAX(space_id), MAX(conv_type), "+
+			"SELECT stat_date, channel_id, MAX(channel_type), MAX(space_id), MAX(conv_type), MAX(parent_channel_id), "+
 			"SUM(CASE WHEN sender_type=1 THEN msg_count ELSE 0 END), "+
 			"SUM(CASE WHEN sender_type=2 THEN msg_count ELSE 0 END), "+
 			"COUNT(DISTINCT CASE WHEN sender_type=1 THEN sender_uid END), "+

--- a/modules/opanalytics/etl_test.go
+++ b/modules/opanalytics/etl_test.go
@@ -193,3 +193,83 @@ func TestAggregateChunk(t *testing.T) {
 		t.Fatalf("dirtyDays = %v, want [%s]", res.dirtyDays, day)
 	}
 }
+
+// TestResolveChannelMetaSubarea 覆盖子区(channel_type=5)归属解析（YUJ-375）：
+// 正常子区继承父群 space/conv 并记 parentChannelID；父群缺失(孤儿)仍计但不归 space；
+// 畸形 channel_id(无分隔符/父群段空)fail-closed 丢弃。
+func TestResolveChannelMetaSubarea(t *testing.T) {
+	groupMeta := map[string]groupMetaInfo{
+		"g1": {spaceID: "s1", convType: convTypeHAGroup},
+	}
+	noExclude := func(string) bool { return false }
+	noMember := map[string]uint8{}
+
+	// 正常子区：g1____topicA → 继承 g1 的 space/conv，父群 = g1
+	cm := resolveChannelMeta("g1____topicA", channelTypeCommunityTopic, noMember, noExclude, groupMeta)
+	if cm.skip {
+		t.Fatal("正常子区不应被丢弃")
+	}
+	if cm.channelType != channelTypeCommunityTopic {
+		t.Fatalf("channelType = %d, want %d", cm.channelType, channelTypeCommunityTopic)
+	}
+	if cm.parentChannelID != "g1" || cm.spaceID != "s1" || cm.convType != convTypeHAGroup {
+		t.Fatalf("子区归属错误: parent=%q space=%q conv=%d, want g1/s1/%d",
+			cm.parentChannelID, cm.spaceID, cm.convType, convTypeHAGroup)
+	}
+
+	// 孤儿子区：父群 gX 不在维表 → 仍计消息、保留父群归属、不归 space、conv 未知
+	orphan := resolveChannelMeta("gX____topicB", channelTypeCommunityTopic, noMember, noExclude, groupMeta)
+	if orphan.skip {
+		t.Fatal("孤儿子区应仍计入(与孤儿群一致)")
+	}
+	if orphan.parentChannelID != "gX" || orphan.spaceID != "" || orphan.convType != 0 {
+		t.Fatalf("孤儿子区: parent=%q space=%q conv=%d, want gX/\"\"/0",
+			orphan.parentChannelID, orphan.spaceID, orphan.convType)
+	}
+
+	// 畸形子区 channel_id → fail-closed 丢弃
+	for _, bad := range []string{"noseparator", "____topicC", ""} {
+		if cm := resolveChannelMeta(bad, channelTypeCommunityTopic, noMember, noExclude, groupMeta); !cm.skip {
+			t.Fatalf("畸形子区 channel_id %q 应被丢弃(skip)", bad)
+		}
+	}
+}
+
+// TestAggregateChunkSubarea 端到端：子区消息经 aggregateChunk 后 fact3 带 parent 且人/AI 分开。
+func TestAggregateChunkSubarea(t *testing.T) {
+	const ts = int64(1_780_000_000)
+	memberType := map[string]uint8{"alice": memberTypeHuman, "agentX": memberTypeAgent}
+	noExclude := func(uid string) bool { return false }
+	groupMeta := map[string]groupMetaInfo{"g1": {spaceID: "s1", convType: convTypeHAGroup}}
+
+	rows := []*srcMessageRow{
+		{ID: 1, FromUID: "alice", ChannelID: "g1____topicA", ChannelType: channelTypeCommunityTopic, Timestamp: ts},
+		{ID: 2, FromUID: "agentX", ChannelID: "g1____topicA", ChannelType: channelTypeCommunityTopic, Timestamp: ts + 1},
+		{ID: 3, FromUID: "alice", ChannelID: "bad_no_sep", ChannelType: channelTypeCommunityTopic, Timestamp: ts + 2}, // 畸形→丢弃
+	}
+	res := aggregateChunk(rows, memberType, noExclude, groupMeta)
+
+	var human, agent *factMemberChannelDailyModel
+	for _, f := range res.fact3 {
+		if f.ChannelID == "bad_no_sep" {
+			t.Fatal("畸形子区消息不应进 fact3")
+		}
+		switch f.SenderUID {
+		case "alice":
+			human = f
+		case "agentX":
+			agent = f
+		}
+	}
+	if human == nil || agent == nil {
+		t.Fatalf("子区 human/agent 行缺失: %+v", res.fact3)
+	}
+	for _, f := range []*factMemberChannelDailyModel{human, agent} {
+		if f.ChannelType != channelTypeCommunityTopic || f.ParentChannelID != "g1" || f.SpaceID != "s1" || f.ConvType != convTypeHAGroup {
+			t.Fatalf("子区 fact3 归属错误: %+v", f)
+		}
+	}
+	if human.SenderType != memberTypeHuman || agent.SenderType != memberTypeAgent {
+		t.Fatalf("sender_type 人/AI 区分错误: human=%d agent=%d", human.SenderType, agent.SenderType)
+	}
+}

--- a/modules/opanalytics/etl_test.go
+++ b/modules/opanalytics/etl_test.go
@@ -227,8 +227,9 @@ func TestResolveChannelMetaSubarea(t *testing.T) {
 			orphan.parentChannelID, orphan.spaceID, orphan.convType)
 	}
 
-	// 畸形子区 channel_id → fail-closed 丢弃
-	for _, bad := range []string{"noseparator", "____topicC", ""} {
+	// 畸形子区 channel_id → fail-closed 丢弃：无分隔符 / 父群段空 / topic段空(g1____) /
+	// 多段(a____b____c) / 全空。要求恰两段且两段均非空，与 thread.ParseChannelID 一致。
+	for _, bad := range []string{"noseparator", "____topicC", "g1____", "a____b____c", ""} {
 		if cm := resolveChannelMeta(bad, channelTypeCommunityTopic, noMember, noExclude, groupMeta); !cm.skip {
 			t.Fatalf("畸形子区 channel_id %q 应被丢弃(skip)", bad)
 		}

--- a/modules/opanalytics/model.go
+++ b/modules/opanalytics/model.go
@@ -4,16 +4,17 @@ package opanalytics
 
 // factMemberChannelDailyModel 对应 octo_fact_member_channel_daily 的一行(③)。
 type factMemberChannelDailyModel struct {
-	StatDate    string // YYYY-MM-DD (报告时区自然日)
-	ChannelID   string
-	ChannelType uint8
-	SpaceID     string
-	ConvType    uint8
-	ContentType uint8
-	SenderUID   string
-	SenderType  uint8
-	MsgCount    int
-	LastMsgAt   int64
+	StatDate        string // YYYY-MM-DD (报告时区自然日)
+	ChannelID       string
+	ChannelType     uint8
+	SpaceID         string
+	ConvType        uint8
+	ParentChannelID string // 子区(channel_type=5)所属父群 channel_id；非子区为 ""
+	ContentType     uint8
+	SenderUID       string
+	SenderType      uint8
+	MsgCount        int
+	LastMsgAt       int64
 }
 
 // factChannelDailyModel 对应 octo_fact_channel_daily 的一行(④)。
@@ -23,6 +24,7 @@ type factChannelDailyModel struct {
 	ChannelType        uint8
 	SpaceID            string
 	ConvType           uint8
+	ParentChannelID    string // 子区(channel_type=5)所属父群 channel_id；非子区为 ""
 	HumanMsgCount      int
 	AgentMsgCount      int
 	ActiveHumanMembers int

--- a/modules/opanalytics/sql/20260830000001_opanalytics_add_thread_parent.sql
+++ b/modules/opanalytics/sql/20260830000001_opanalytics_add_thread_parent.sql
@@ -3,25 +3,35 @@
 -- 被当作私聊反解失败而整段丢弃，事实表本就无子区行(非"没算浓度"，是"无数据源")。
 -- 现放开子区：channel_id="<父群no>____<短ID>"，劈父群段继承父群 space/conv，子区自有
 -- channel_id 独立成事实行。为让下游(octo-dap)按父群归属上卷子区，两张事实表补
--- parent_channel_id 冗余列(非子区行为 '')。
+-- parent_channel_id 冗余列(NOT NULL DEFAULT ''，非子区行为 '')。
 --
 -- ③ octo_fact_member_channel_daily：写入侧(accumulateFact3)带列；重算 ④ 时按会话取 MAX。
 -- ④ octo_fact_channel_daily：recomputeChannelDay 由 ③ MAX(parent_channel_id) 上卷得到；
 --    加 idx_parent_date 支撑下游按父群×日聚合子区。
 --
--- 列可空默认 ''，历史行(全部为非子区)天然回填空串，语义正确。加列走 INSTANT/INPLACE，
--- 在线安全。注意：历史子区消息此前被丢弃，本迁移只补 schema——要有历史子区数据须在
--- 部署新 ETL 后走 truncateForRebuild 全量重扫 message 分片重建。
+-- 在线性：列位置对事实表纯装饰(读写全按列名)，故不用 AFTER，让 ADD COLUMN 在 8.0.12+
+-- 走真正的 INSTANT(AFTER <非末列> 需 8.0.29+ 才 instant，否则静默退化为表重建)。索引单独
+-- 一条 ALTER(ADD INDEX 至多 INPLACE，与 INSTANT 加列合并会令整条语句无法 INSTANT)。两条均
+-- 显式钉 ALGORITHM/LOCK：一旦某 MySQL 版本无法满足，直接报错而非静默退化为 COPY 锁表。
+-- 注意：历史子区消息此前被丢弃，本迁移只补 schema——要有历史子区数据须在部署新 ETL 后走
+-- Rebuild()/truncateForRebuild 全量重扫 message 分片重建。
 ALTER TABLE `octo_fact_member_channel_daily`
-  ADD COLUMN `parent_channel_id` VARCHAR(100) NOT NULL DEFAULT '' COMMENT '子区(channel_type=5)所属父群channel_id; 非子区为空' AFTER `conv_type`;
+  ADD COLUMN `parent_channel_id` VARCHAR(100) NOT NULL DEFAULT '' COMMENT '子区(channel_type=5)所属父群channel_id; 非子区为空',
+  ALGORITHM=INSTANT;
 
 ALTER TABLE `octo_fact_channel_daily`
-  ADD COLUMN `parent_channel_id` VARCHAR(100) NOT NULL DEFAULT '' COMMENT '子区(channel_type=5)所属父群channel_id; 非子区为空' AFTER `conv_type`,
-  ADD KEY `idx_parent_date` (`parent_channel_id`,`stat_date`);
+  ADD COLUMN `parent_channel_id` VARCHAR(100) NOT NULL DEFAULT '' COMMENT '子区(channel_type=5)所属父群channel_id; 非子区为空',
+  ALGORITHM=INSTANT;
+
+ALTER TABLE `octo_fact_channel_daily`
+  ADD KEY `idx_parent_date` (`parent_channel_id`,`stat_date`),
+  ALGORITHM=INPLACE, LOCK=NONE;
 
 -- +migrate Down
 ALTER TABLE `octo_fact_channel_daily`
-  DROP KEY `idx_parent_date`,
+  DROP KEY `idx_parent_date`;
+
+ALTER TABLE `octo_fact_channel_daily`
   DROP COLUMN `parent_channel_id`;
 
 ALTER TABLE `octo_fact_member_channel_daily`

--- a/modules/opanalytics/sql/20260830000001_opanalytics_add_thread_parent.sql
+++ b/modules/opanalytics/sql/20260830000001_opanalytics_add_thread_parent.sql
@@ -1,0 +1,28 @@
+-- +migrate Up
+-- YUJ-375：开放群下子区(channel_type=5)AI浓度。子区消息此前在 ETL resolveChannelMeta
+-- 被当作私聊反解失败而整段丢弃，事实表本就无子区行(非"没算浓度"，是"无数据源")。
+-- 现放开子区：channel_id="<父群no>____<短ID>"，劈父群段继承父群 space/conv，子区自有
+-- channel_id 独立成事实行。为让下游(octo-dap)按父群归属上卷子区，两张事实表补
+-- parent_channel_id 冗余列(非子区行为 '')。
+--
+-- ③ octo_fact_member_channel_daily：写入侧(accumulateFact3)带列；重算 ④ 时按会话取 MAX。
+-- ④ octo_fact_channel_daily：recomputeChannelDay 由 ③ MAX(parent_channel_id) 上卷得到；
+--    加 idx_parent_date 支撑下游按父群×日聚合子区。
+--
+-- 列可空默认 ''，历史行(全部为非子区)天然回填空串，语义正确。加列走 INSTANT/INPLACE，
+-- 在线安全。注意：历史子区消息此前被丢弃，本迁移只补 schema——要有历史子区数据须在
+-- 部署新 ETL 后走 truncateForRebuild 全量重扫 message 分片重建。
+ALTER TABLE `octo_fact_member_channel_daily`
+  ADD COLUMN `parent_channel_id` VARCHAR(100) NOT NULL DEFAULT '' COMMENT '子区(channel_type=5)所属父群channel_id; 非子区为空' AFTER `conv_type`;
+
+ALTER TABLE `octo_fact_channel_daily`
+  ADD COLUMN `parent_channel_id` VARCHAR(100) NOT NULL DEFAULT '' COMMENT '子区(channel_type=5)所属父群channel_id; 非子区为空' AFTER `conv_type`,
+  ADD KEY `idx_parent_date` (`parent_channel_id`,`stat_date`);
+
+-- +migrate Down
+ALTER TABLE `octo_fact_channel_daily`
+  DROP KEY `idx_parent_date`,
+  DROP COLUMN `parent_channel_id`;
+
+ALTER TABLE `octo_fact_member_channel_daily`
+  DROP COLUMN `parent_channel_id`;


### PR DESCRIPTION
## What

Include group-subarea (community-topic, `channel_type=5`) messages in the
opanalytics channel fact tables. Previously these messages were silently dropped
by the ETL, so `octo_fact_channel_daily` had no subarea rows and downstream
consumers had no data source for subarea metrics.

## Why

`resolveChannelMeta` treated any non-group channel as a private chat;
`normalizePrivatePair` failed on a subarea `channel_id` and the row was skipped.
So subarea AI-density had no source (not merely "uncomputed").

## How

A subarea `channel_id` is `<parent_group_no>____<short_id>`. Split the parent
segment and inherit the parent group's `space_id`/`conv_type` from the group dim
(no new data source). The subarea keeps its own `channel_id`, so it forms its own
fact rows; `parent_channel_id` is recorded on both fact tables for parent rollup.
Malformed subarea ids fail closed (dropped); orphan parents are still counted
without space attribution, mirroring orphan-group handling.

- `etl.go`: `channelTypeCommunityTopic` / `threadChannelIDSeparator` consts,
  `channelMeta.parentChannelID`, subarea branch in `resolveChannelMeta`, carry parent into fact3
- `model.go`: `ParentChannelID` on both fact models
- `etl_db.go`: `parent_channel_id` in the fact3 upsert and the fact4 recompute (`MAX` rollup)
- migration `20260830000001_opanalytics_add_thread_parent.sql`: add
  `parent_channel_id VARCHAR(100) NOT NULL DEFAULT ''` to both fact tables
  (INSTANT add, `AFTER conv_type`) + `idx_parent_date` on the rolled-up table
- tests: `TestResolveChannelMetaSubarea`, `TestAggregateChunkSubarea`

## Scope / compatibility

- **Read-side dashboard untouched**: queries stay filtered to `channel_type IN
  (1,2)`, so existing metrics are unaffected by the new subarea rows.
- **Historical backfill**: this only adds the schema + write path. To populate
  historical subarea data (previously dropped), run a full rebuild
  (`ETL.Rebuild()` / truncate facts + cursor + dirty-day) after deploy.

## Testing

- `go build ./modules/opanalytics/...` and `go vet` clean.
- Pure-function tests pass, including the two new subarea cases (parent
  inheritance, human/AI split, malformed drop, orphan-parent still counted).
- The DB-backed integration test (`TestOpanalyticsETLAndDB`) was not run locally:
  the test harness applies all historical migrations and fails on an unrelated
  legacy migration under this machine's MySQL version — it never reaches this
  change.


Fixes #821
