### PR TITLE
fix(notify): skip bots for docs comment cards

### DIFF
--- a/.octospec/tasks/card-message-internal-dispatch/docs-notify-contract.md
+++ b/.octospec/tasks/card-message-internal-dispatch/docs-notify-contract.md
@@ -44,10 +44,14 @@
 3. **禁止客户端手搓 type-17 map**:Decision 14 仍生效 —— `payload` 若被
    `cardmsg.IsCardPayload` 判为卡片(`type=17`)一律 400
    `err.server.notify.card_not_allowed`,无论走 `Card` 还是 `DocsCard`。
-4. **响应契约不变**:仍返回 `NotifyResp{delivered:[], filtered:{uid:reason}}`。
-   reason 词表与 summary 一致(`not_space_member` / `target_denied`
-   / `dispatch_failed` / `busy` / `send_failed`) —— docs-backend 可**照抄**
-   smart-summary 的 dedup / retry / sweep 状态机。
+4. **响应结构不变**:仍返回 `NotifyResp{delivered:[], filtered:{uid:reason}}`。
+   通用 reason 词表与 summary 一致(`not_space_member` / `target_denied`
+   / `dispatch_failed` / `busy` / `send_failed`)。`commented` 另有终态 reason
+   `bot_recipient`:普通 Bot 和系统 Bot 不接收普通评论通知,调用方不得重试;
+   该过滤先于 Space 成员校验,因此非成员 Bot 也返回 `bot_recipient`,而不是
+   `not_space_member`;Bot 身份查询失败时整次请求失败且零投递。过滤不依赖
+   `doc_comment_mention` 的 feature gate 或 allowlist:专用事件未启用或文档未
+   命中 allowlist 时,对 Bot 保持静默是有意行为。其他 docs card kind 不受影响。
 5. **模板/文案/链接归属 octo-server**:docs-backend **只发原始字段**;卡片布局、
    按钮文案(查看详情)、FactSet 标签(操作人 / 时间)、attribution
    (「Alice 分享了文档」)、`/d/{doc_id}` deep-link、
@@ -151,7 +155,7 @@ X-Internal-Token: <OCTO_DOCS_NOTIFY_TOKEN>
    - per-recipient dedup(避免同一评论触发多次通知);
    - 消费 `NotifyResp{delivered,filtered}` —— 只认 `delivered[]` 判真送达,
      `filtered` 内标记为 `not_space_member` / `busy` / `dispatch_failed` 的
-     可延时重试;
+     可按业务延时重试;`bot_recipient` 是终态过滤,不得重试;
    - **不实现自身文本降级路径** —— server 侧已负责;发失败即上报错误让
      调用方按业务重试(与 smart-summary 侧的 `Sweep` 一致)。
 

--- a/docs/docs-notify-card.md
+++ b/docs/docs-notify-card.md
@@ -221,8 +221,18 @@ Docs 链接不携带 `?sp=`。octo-web 的 standalone `/d/:docId` 打开链路�
 
 ## 7. 降级与错误分类
 
-与 summary 完全一致，见 `docs/summary-notify-card.md` §7。reason 词表：
+与 summary 完全一致，见 `docs/summary-notify-card.md` §7。通用 reason 词表：
 `not_space_member` / `target_denied` / `dispatch_failed` / `busy` / `send_failed`。
+
+`commented` 额外在投递前排除普通 Bot 和系统 Bot，并在 `filtered` 中标记
+`bot_recipient`。这是终态过滤，不应重试；其他 docs card kind 不做该过滤。
+该过滤先于 Space 成员校验，因此非成员 Bot 也返回 `bot_recipient`，而不是可重试的
+`not_space_member`。
+如果 Bot 身份查询失败，请求整体失败且零投递，避免把普通评论通知误发给 Bot。
+
+该过滤不依赖 `doc_comment_mention` 的 feature gate 或 allowlist。若专用事件未启用
+或文档不在 allowlist 中，Bot 仍不会回退收到普通评论通知；此时对 Bot 保持静默是
+有意行为。
 
 ## 8. 已知调优候选
 

--- a/modules/notify/card.go
+++ b/modules/notify/card.go
@@ -19,6 +19,7 @@ import (
 	summarycompleted "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/summary_completed"
 	summaryfailed "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/summary_failed"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"go.uber.org/zap"
 )
 
@@ -464,9 +465,32 @@ func (n *Notify) deliverDocsCardNotification(ctx context.Context, req *NotifyReq
 		targets = tmp
 	}
 
-	members, filteredMap, err := n.memberCache.verify(n.db, req.SpaceID, targets)
+	filteredMap := make(map[string]string)
+	if card.Kind == DocsCardKindCommented {
+		// Ordinary "commented" cards are human-recipient notifications. Bot
+		// recipients are filtered independently of whether the separate
+		// doc_comment_mention event is enabled for this document.
+		botUIDs, err := spacepkg.GetBotUIDs(n.db, targets)
+		if err != nil {
+			return nil, fmt.Errorf("bot recipient lookup failed: %w", err)
+		}
+		humanTargets := make([]string, 0, len(targets))
+		for _, uid := range targets {
+			if botUIDs[uid] || spacepkg.IsSystemBot(uid) {
+				filteredMap[uid] = "bot_recipient"
+				continue
+			}
+			humanTargets = append(humanTargets, uid)
+		}
+		targets = humanTargets
+	}
+
+	members, memberFiltered, err := n.memberCache.verify(n.db, req.SpaceID, targets)
 	if err != nil {
 		return nil, fmt.Errorf("member verification failed: %w", err)
+	}
+	for uid, reason := range memberFiltered {
+		filteredMap[uid] = reason
 	}
 	if len(members) == 0 {
 		return &NotifyResp{Delivered: []string{}, Filtered: filteredMap}, nil

--- a/modules/notify/card_test.go
+++ b/modules/notify/card_test.go
@@ -3,11 +3,13 @@ package notify
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"sync"
 	"sync/atomic"
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/stretchr/testify/assert"
@@ -377,6 +379,102 @@ func TestDeliverDocsCardNotification_NonMemberExcluded(t *testing.T) {
 	assert.Equal(t, "not_space_member", resp.Filtered["uid_stranger"])
 	assert.NotContains(t, resp.Delivered, "uid_stranger")
 	assert.Equal(t, int32(1), atomic.LoadInt32(&wk.messageCount), "only the member gets a DM")
+}
+
+func TestDeliverDocsCardNotification_CommentedSkipsBotRecipients(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	db, mock, closeDB := newMockedDBSession(t)
+	defer closeDB()
+
+	mock.ExpectQuery(`SELECT uid FROM .*user.*robot=1`).
+		WillReturnRows(sqlmock.NewRows([]string{"uid"}).
+			AddRow("uid_bot").
+			AddRow("uid_bot_nonmember"))
+	n := newTestNotify(ctx, db, newStubUserService(), &stubAppService{}, "tk")
+	n.docsSender = nil
+	n.botOK.Store(true)
+	primeMemberCache(n, "spc_1", "uid_human", "uid_bot")
+	card := validDocsCard()
+	card.Kind = DocsCardKindCommented
+
+	resp, err := n.deliverDocsCardNotification(context.Background(), &NotifyReq{
+		SpaceID: "spc_1", Service: "docs-service", Targets: []string{"uid_human", "uid_bot", "uid_bot_nonmember", "uid_stranger"}, DocsCard: card,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"uid_human"}, resp.Delivered)
+	assert.Equal(t, "bot_recipient", resp.Filtered["uid_bot"])
+	assert.Equal(t, "bot_recipient", resp.Filtered["uid_bot_nonmember"], "bot classification takes precedence over membership")
+	assert.Equal(t, "not_space_member", resp.Filtered["uid_stranger"])
+	assert.Equal(t, int32(1), atomic.LoadInt32(&wk.messageCount), "only the human gets the comment notification")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDeliverDocsCardNotification_CommentedSkipsSystemBotRecipient(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	n := newTestNotify(ctx, nil, nil, nil, "tk")
+	n.docsSender = nil
+	n.botOK.Store(true)
+	primeMemberCache(n, "spc_1", "notification")
+	card := validDocsCard()
+	card.Kind = DocsCardKindCommented
+
+	resp, err := n.deliverDocsCardNotification(context.Background(), &NotifyReq{
+		SpaceID: "spc_1", Service: "docs-service", Targets: []string{"notification"}, DocsCard: card,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Delivered)
+	assert.Equal(t, "bot_recipient", resp.Filtered["notification"])
+	assert.Zero(t, atomic.LoadInt32(&wk.messageCount), "system bots must not receive comment notifications")
+}
+
+func TestDeliverDocsCardNotification_SharedStillReachesBotRecipient(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	db, mock, closeDB := newMockedDBSession(t)
+	defer closeDB()
+	n := newTestNotify(ctx, db, newStubUserService(), &stubAppService{}, "tk")
+	n.docsSender = nil
+	n.botOK.Store(true)
+	primeMemberCache(n, "spc_1", "uid_bot")
+
+	resp, err := n.deliverDocsCardNotification(context.Background(), &NotifyReq{
+		SpaceID: "spc_1", Service: "docs-service", Targets: []string{"uid_bot"}, DocsCard: validDocsCard(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"uid_bot"}, resp.Delivered)
+	assert.Empty(t, resp.Filtered)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&wk.messageCount), "non-comment docs notifications keep their existing behavior")
+	assert.NoError(t, mock.ExpectationsWereMet(), "shared notifications must not query recipient robot status")
+}
+
+func TestDeliverDocsCardNotification_CommentedBotLookupFailureFailsClosed(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	db, mock, closeDB := newMockedDBSession(t)
+	defer closeDB()
+
+	mock.ExpectQuery(`SELECT uid FROM .*user.*robot=1`).WillReturnError(errors.New("db unavailable"))
+	n := newTestNotify(ctx, db, newStubUserService(), &stubAppService{}, "tk")
+	n.docsSender = nil
+	n.botOK.Store(true)
+	primeMemberCache(n, "spc_1", "uid_human")
+	card := validDocsCard()
+	card.Kind = DocsCardKindCommented
+
+	resp, err := n.deliverDocsCardNotification(context.Background(), &NotifyReq{
+		SpaceID: "spc_1", Service: "docs-service", Targets: []string{"uid_human"}, DocsCard: card,
+	})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "bot recipient lookup failed")
+	assert.Zero(t, atomic.LoadInt32(&wk.messageCount), "classification failure must not leak a comment notification")
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 // A newline embedded in a caller field must not inject a spoofed line into the


### PR DESCRIPTION
## Summary

- Treat ordinary Docs `commented` notifications as human-only.
- Filter Bot and system-Bot recipients with the explicit reason `bot_recipient`.
- Keep dedicated `doc_comment_mention` task events and non-comment Docs notifications unchanged.
- Fail closed if Bot-recipient classification cannot be completed.

## Linked Spec

- `.octospec/tasks/card-message-internal-dispatch/docs-notify-contract.md`

## How verified

- `go test ./modules/notify -run 'TestDeliverDocsCardNotification_(CommentedSkipsBotRecipients|CommentedSkipsSystemBotRecipient|SharedStillReachesBotRecipient|CommentedBotLookupFailureFailsClosed)$' -count=1`
- `go vet ./modules/notify/...`
- `git diff --check upstream/main...HEAD`
- Real local UI E2E against Docker-backed Docs and the patched server: `@test22` produced dedicated event `1001002`; Agent input contained `doc_id=d_733e169c3db2ce2060e163fd`, `comment_id=199`, and `thread_id=199`; the Agent reply POST returned 201 and OpenClaw recorded `workLanded=true`.
- Runtime mixed-recipient probe returned the human UID in `delivered` and the Bot UID in `filtered` with `bot_recipient`.

## COMPREHENSION

1. Load-bearing behavior: filtering occurs before member verification and fan-out, so an ordinary comment notification cannot reach a Bot through either card or text fallback.
2. Dependencies and failure mode: classification relies on the authoritative robot flag plus the system-Bot predicate. Lookup failure aborts the request instead of leaking a notification.
3. Regression boundary: only `DocsCardKindCommented` changes. Dedicated mention events still reach OpenClaw, while `shared` and other Docs card kinds keep their existing behavior.
