### PR TITLE
feat(common): appconfig adds drive_search_on display flag

### DIFF
--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -400,6 +400,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 			DocsOn:                 cn.systemSettings.DocsEnabled(),
 			DocsSearchOn:           cn.systemSettings.DocsSearchEnabled(),
 			DriveOn:                cn.systemSettings.DriveEnabled(),
+			DriveSearchOn:          cn.systemSettings.DriveSearchEnabled(),
 			MailOn:                 cn.systemSettings.MailEnabled(),
 			DmloopOn:               cn.systemSettings.DmloopEnabled(),
 			DmpersonalOn:           cn.systemSettings.DmpersonalEnabled(),
@@ -456,6 +457,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 		DocsOn:                 cn.systemSettings.DocsEnabled(),
 		DocsSearchOn:           cn.systemSettings.DocsSearchEnabled(),
 		DriveOn:                cn.systemSettings.DriveEnabled(),
+		DriveSearchOn:          cn.systemSettings.DriveSearchEnabled(),
 		MailOn:                 cn.systemSettings.MailEnabled(),
 		DmloopOn:               cn.systemSettings.DmloopEnabled(),
 		DmpersonalOn:           cn.systemSettings.DmpersonalEnabled(),
@@ -886,6 +888,12 @@ type appConfigResp struct {
 	// 自身，本字段不承担任何鉴权。与 app_config.version 解耦的原因同 DocsOn：运维切展示
 	// 策略后老客户端命中 version 短路分支也必须拿到最新值，故两个分支都下发。
 	DriveOn bool `json:"drive_on"`
+
+	// DriveSearchOn 告知客户端是否展示全局搜索的"网盘"tab。值来源于 system_setting
+	// drive.search_enabled；默认 false —— 与 drive_on 解耦，搜索端点由 octo-drive-search
+	// 独立提供，可晚于 drive 模块本体上线，上线+索引就绪后才放量。仅表达展示策略，鉴权
+	// 在 octo-drive-search 自身，本字段不承担鉴权。与 app_config.version 解耦的原因同 DriveOn。
+	DriveSearchOn bool `json:"drive_search_on"`
 
 	// MailOn 告知客户端是否展示 Agent Mail 模块入口。值来源于 system_setting
 	// mail.enabled，默认 false。该字段只表达展示策略，不替代 octo-server 网关及

--- a/modules/common/api_test.go
+++ b/modules/common/api_test.go
@@ -130,6 +130,23 @@ func setDocsSearchEnabledSetting(t *testing.T, ctx *config.Context, enabled bool
 	require.NoError(t, EnsureSystemSettings(ctx).Reload())
 }
 
+// setDriveSearchEnabledSetting upserts system_setting drive.search_enabled and
+// reloads the shared snapshot. This is the appconfig-facing display toggle for
+// the global-search "网盘" tab, decoupled from drive.enabled (search endpoint
+// ships in octo-drive-search on its own timeline).
+func setDriveSearchEnabledSetting(t *testing.T, ctx *config.Context, enabled bool) {
+	t.Helper()
+	v := "0"
+	if enabled {
+		v = "1"
+	}
+	_, err := ctx.DB().InsertInto("system_setting").
+		Columns("category", "key_name", "value", "value_type").
+		Values("drive", "search_enabled", v, "bool").Exec()
+	require.NoError(t, err)
+	require.NoError(t, EnsureSystemSettings(ctx).Reload())
+}
+
 func TestAddVersion(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 	s, ctx := testutil.NewTestServer()
@@ -936,6 +953,56 @@ func TestGetAppConfig_DocsSearchOn_OnVersionShortCircuit(t *testing.T) {
 	s.GetRoute().ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), `"docs_search_on":true`)
+}
+
+// appconfig 必须下发 drive_search_on：值来源于 system_setting drive.search_enabled。
+// 默认 false，与 drive_on 解耦，客户端据此隐藏全局搜索的"网盘"tab（搜索端点就绪前）。
+func TestGetAppConfig_DriveSearchOn_DefaultFalse(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"drive_search_on":false`)
+}
+
+// system_setting drive.search_enabled=true → appconfig 下发 true。与 drive.enabled 解耦：
+// 只开 drive.search_enabled 不开 drive.enabled 时，drive_search_on=true 而 drive_on=false。
+func TestGetAppConfig_DriveSearchOn_True_Independent(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	setDriveSearchEnabledSetting(t, ctx, true)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"drive_search_on":true`)
+	assert.Contains(t, w.Body.String(), `"drive_on":false`)
+}
+
+// version 短路分支同样要下发 drive_search_on（展示开关与 app_config.version 解耦）。
+func TestGetAppConfig_DriveSearchOn_OnVersionShortCircuit(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	setDriveSearchEnabledSetting(t, ctx, true)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig?version=99999999", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"drive_search_on":true`)
 }
 
 // reloads the shared snapshot. Generic sibling of setDocsEnabledSetting for the

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -294,6 +294,15 @@ var systemSettingSchema = []settingDef{
 	{Category: "drive", Key: "enabled", Type: settingTypeBool, Description: "是否向客户端展示网盘(drive)模块入口（octo-drive 上线前默认关闭）",
 		Effective: func(s *SystemSettings) string { return boolToCanonical(s.DriveEnabled()) }},
 
+	// drive 全局搜索"网盘"tab 展示开关，与 drive.enabled 解耦：drive-search 后端
+	// 由独立的 octo-drive-search 服务提供，可晚于 drive 模块本体上线。默认关闭；
+	// 上线且索引灰度完成后由管理台切 drive.search_enabled 放量。仅表达展示策略，
+	// 不承担任何服务端鉴权（搜索鉴权在 octo-drive-search 自身：VisibleSpaces +
+	// VisibleDocs + baseFilters）。经 GET /v1/common/appconfig 的 drive_search_on
+	// 下发给客户端。
+	{Category: "drive", Key: "search_enabled", Type: settingTypeBool, Description: "是否向客户端展示全局搜索的\"网盘\"tab（与 drive.enabled 解耦；搜索端点上线+索引就绪前默认关闭）",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.DriveSearchEnabled()) }},
+
 	// Loop(回路)模块展示开关。loop 依赖后端服务 + fleet 代理 + daemon runtime 一整套,未就绪前
 	// 默认关闭;feature 分支合入 main 也不暴露,上线后由管理台切 dmloop.enabled 灰度放量。仅表达
 	// 展示策略,不承担服务端鉴权(/fleet 鉴权在后端)。经 GET /v1/common/appconfig 的 dmloop_on 下发给客户端。

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -1635,6 +1635,20 @@ func (s *SystemSettings) DriveEnabled() bool {
 	return s.getBool("drive", "enabled", false)
 }
 
+// DriveSearchEnabled reports whether clients should surface the "网盘" tab in
+// the global-search modal. Decoupled from DriveEnabled: the search endpoint is
+// provided independently by octo-drive-search and may land later than the
+// drive module itself, or roll out independently under its own gray-release
+// timeline. Display policy only — it neither grants nor enforces any
+// server-side authorization, which lives in octo-drive-search (VisibleSpaces
+// + VisibleDocs + baseFilters permission down-push). Default false so the tab
+// stays hidden until search is deployed, the index is populated, and the
+// admin flips drive.search_enabled for a controlled rollout. Value source:
+// system_setting drive.search_enabled (DB, hot-reloaded).
+func (s *SystemSettings) DriveSearchEnabled() bool {
+	return s.getBool("drive", "search_enabled", false)
+}
+
 // DmloopEnabled reports whether the Loop(回路)module entry should be shown to
 // clients. Default false — the loop feature (backend service + fleet proxy +
 // daemon runtimes) stays hidden until ops flips dmloop.enabled after those deps


### PR DESCRIPTION
# Summary

Add a `drive.search_enabled` system setting and surface it as `drive_search_on` on `GET /v1/common/appconfig`, mirroring the existing `docs_search_on` (#678) and `drive_on` (#676) pattern. It lets the client gate the global-search 网盘 tab on `driveOn && driveSearchOn`, decoupled from the drive module so drive-search can be rolled out independently.

Without this flag, the front-end (octo-web `feat/global-search-drive-tab` merged upstream as PR https://github.com/Mininglamp-OSS/octo-web/pull/1603) reads `drive_search_on` from remoteConfig and parses it via `parseRemoteBool` — but the field is absent from the server response, so it evaluates to `false` and the tab stays hidden even on deployments where `drive_on=true` and octo-drive-search is running. This is the missing server-side half of that flag.

## Related

- Upstream host-side PR: https://github.com/Mininglamp-OSS/octo-web/pull/1603 (merged; consumes `drive_search_on`)
- Pattern reference: #678 (`docs_search_on`), #676 (`drive_on`)

## Changes

- `system_setting_schema.go`: add `{Category: "drive", Key: "search_enabled", Type: settingTypeBool}` with an `Effective` accessor, alongside the existing `drive.enabled`.
- `system_settings.go`: add `DriveSearchEnabled()` accessor (`getBool("drive", "search_enabled", false)`), documented as display-policy-only.
- `api.go`: add `DriveSearchOn bool `json:"drive_search_on"`` to `appConfigResp`; populate it from `DriveSearchEnabled()` on **both** the normal branch and the `app_config.version` short-circuit branch (same as `drive_on` / `docs_search_on`, so an admin toggle reaches clients that hit the version cache).
- `api_test.go`: add `setDriveSearchEnabledSetting` helper + three tests mirroring the `docs_search_on` suite (default false; enabled independently of `drive_on`; delivered on the version short-circuit branch).

## Testing

- `go build ./modules/common/` — pass
- `go vet ./modules/common/` — pass
- New tests: `TestGetAppConfig_DriveSearchOn_DefaultFalse`, `TestGetAppConfig_DriveSearchOn_True_Independent`, `TestGetAppConfig_DriveSearchOn_OnVersionShortCircuit` — will run against a MySQL + Redis fixture in CI, structurally identical to the passing `docs_search_on` suite.

## Blast radius

Display-only: this flag can only show/hide the client's global-search 网盘 tab. It grants no access — every drive-search request is still authorized in octo-drive-search itself (`VisibleSpaces` DB check + `VisibleDocs` DB check + `baseFilters` OS query). A wrong `true` at worst shows a tab that 404s until the backend is live; a wrong `false` hides a working tab. No data exposure either way.

## Rollout order

1. Merge this MR → ship `octo-server` image
2. octo-web PR #1603 (already merged) ship in the coordinated web release
3. Deploy octo-drive-search backend + index producer
4. Admin flips `drive.search_enabled=true` via `/v1/manager/common/system_setting` when the search index is populated

## Checklist

- Conventional commit
- Mirrors the established `drive_on` / `docs_search_on` pattern
- Default false (safe dark-launch)
- Tests added (parallel to the merged `docs_search_on` suite)
- No server-side authorization added or changed
- No unrelated changes
