### PR TITLE
feat(message): add manual unread state for groups and topics

### DIFF
--- a/.octospec/tasks/clear-manual-unread/brief.md
+++ b/.octospec/tasks/clear-manual-unread/brief.md
@@ -20,12 +20,16 @@ CommunityTopic conversations:
   manual-unread marker;
 - `PUT /v1/conversation/clearManualUnread` clears that marker as a dedicated
   fallback in the frontend's conversation-open flow;
-- the existing `PUT /v1/conversation/clearUnread` clears the marker whenever it
-  successfully updates a Group or CommunityTopic unread state;
+- the existing `PUT /v1/conversation/clearUnread` preserves its real-unread
+  clear and broadcast contract, then best-effort clears the marker for Group
+  and CommunityTopic conversations;
 - conversation synchronization and Sidebar responses expose the marker to
   clients;
-- every persisted marker change advances the conversation-extra version and
-  notifies the user's online clients with `CMDSyncConversationExtra`.
+- persisted marker changes advance the conversation-extra version and attempt
+  to notify the user's online clients with `CMDSyncConversationExtra`.
+- every production path that writes `conversation_extra` participates in one
+  UID-scoped Redis lease so the user's shared extension cursor advances in
+  commit order.
 
 The marker is stored in `conversation_extra.manual_unread` under the current
 user's exact `(uid, channel_id, channel_type)` row. It is a display state that
@@ -48,8 +52,10 @@ The frontend may enter a conversation whose initial message sync returns no
 messages and consequently may not use its existing `clearUnread` path. In that
 case, `clearManualUnread` completes the conversation-open flow by clearing the
 display marker while preserving the real unread state. When the existing
-`clearUnread` path is used, that endpoint performs both updates and the
-frontend avoids a second clear request.
+`clearUnread` path is used, that endpoint first completes the real-unread clear
+and legacy broadcast, then best-effort clears the marker so conversation-extra
+availability cannot regress the existing contract. The frontend avoids a
+second clear request when that path is used.
 
 Conversation-extra versioning is the multi-device synchronization source of
 truth. The CMD is a transient change notification; clients fetch the updated
@@ -82,12 +88,26 @@ multi-client compatibility decision, not a bug.
   maintain independent markers without parent aggregation, and the same row
   remains available for stale-state cleanup after the user leaves a group or
   topic.
-- Every successful Group or CommunityTopic `clearUnread` request clears an
-  existing manual marker for both `unread=0` and `unread>0`. Person
+- After WuKongIM accepts a `clearUnread` request, the handler sends the legacy
+  `CMDConversationUnreadClear` broadcast before accessing conversation-extra.
+  Group and CommunityTopic marker cleanup for both `unread=0` and `unread>0`
+  is best-effort after that broadcast; query, version, store, and extension-CMD
+  failures are logged and cannot change the completed core response. Person
   `clearUnread` retains its existing real-unread behavior.
 - A marker write and its new conversation-extra version are committed before
-  `CMDSyncConversationExtra` is sent to the user's Person channel with
-  `NoPersist=true`.
+  the service attempts `CMDSyncConversationExtra` on the user's Person channel
+  with `NoPersist=true`. Notification delivery is best-effort: a failure is
+  logged and does not replace the committed success result with an HTTP error.
+- The ordinary extension update, dedicated set/clear endpoints, and
+  `clearUnread` marker cleanup all acquire the same UID-scoped Redis lock. Each
+  lease has a request-unique UUID owner and a 10-second TTL; ownership is
+  compare-renewed immediately before the database write and compare-deleted on
+  release. CMD delivery occurs only after release.
+- Version allocation under the lease compares the existing per-user database
+  high-water mark with `GenSeq`, and every database update accepts only a
+  strictly newer version. Conditional UPSERT/UPDATE results determine whether
+  a state transition actually occurred, so an expired stale owner cannot move
+  an existing row's version backwards.
 - Ordinary conversation-extra updates atomically preserve
   `manual_unread`; the dedicated endpoints and the Group/CommunityTopic
   `clearUnread` integration own marker state transitions.
@@ -140,9 +160,11 @@ multi-client compatibility decision, not a bug.
 - `setManualUnread` and `clearManualUnread` update only the authenticated
   user's exact row, including when the caller is no longer a member of the
   requested group or topic.
-- Group and CommunityTopic `clearUnread` clears manual-unread for both
-  `unread=0` and `unread>0`; Person `clearUnread` leaves legacy manual rows
-  untouched.
+- Group and CommunityTopic `clearUnread` attempts to clear manual-unread for
+  both `unread=0` and `unread>0` after the real-unread clear and legacy CMD;
+  any supplementary cleanup failure is logged without suppressing the legacy
+  broadcast or changing the core success response. Person `clearUnread` leaves
+  legacy manual rows untouched.
 - Ordinary draft and read-position extension updates preserve a concurrently
   stored manual marker.
 - Manual markers annotate eligible Sidebar entries but do not independently
@@ -150,7 +172,17 @@ multi-client compatibility decision, not a bug.
   configured Recent window. An out-of-window manually unread conversation
   remaining hidden during a mixed Web/Android/iOS rollout is expected behavior,
   not a defect.
-- Every successful marker change is visible through extension-version sync and
-  sends `CMDSyncConversationExtra` to the user's online clients.
+- Dedicated marker changes remain visible through extension-version sync and
+  attempt `CMDSyncConversationExtra` as a best-effort notification. A CMD
+  failure after commit is logged while the endpoint still returns the changed
+  state and version. The `clearUnread` integration applies the same policy to
+  its supplementary marker notification after the legacy broadcast.
+- Two concurrent first-time `setManualUnread` requests are serialized: exactly
+  one returns `changed=true`; the other observes the committed marker and
+  returns the idempotent `changed=false` result.
+- Redis lock tests prove the owner is a UUID, the lease has a positive TTL,
+  compare-renew rejects a replaced owner, and an expired owner cannot delete a
+  successor's lock. Database tests prove stale set, clear, and ordinary-extra
+  writes cannot replace a newer stored version.
 - Formatting, package compilation, focused regression tests, and
   `git diff --check` pass.

--- a/.octospec/tasks/clear-manual-unread/brief.md
+++ b/.octospec/tasks/clear-manual-unread/brief.md
@@ -1,0 +1,96 @@
+---
+type: Task
+title: "Task: conversation-manual-unread"
+description: Add and maintain the conversation manual-unread state, including set, dedicated clear, WuKongIM compatibility, and clearUnread integration.
+tags: ["message", "conversation", "manual-unread", "wukongim", "compatibility", "testing"]
+timestamp: 2026-08-27T00:00:00+08:00
+slug: clear-manual-unread
+upstream: none
+source: self
+---
+
+# Task: conversation-manual-unread
+
+## Goal
+
+Implement the complete application-level manual-unread flow for conversations:
+
+- `setManualUnread` marks a conversation as manually unread only when WuKongIM
+  reports that its normal unread count is zero;
+- `clearManualUnread` provides a dedicated endpoint for the frontend's
+  conversation-open flow and clears only the application-level marker;
+- `clearUnread` continues to update WuKongIM's real unread state and also
+  clears the manual marker for every valid explicit unread operation.
+
+The manual marker is stored in `conversation_extra` and is independent of
+WuKongIM's real unread cursor or browse position.
+
+## Background
+
+The pinned WuKongIM version removed the legacy recent-conversations endpoint
+used by `setManualUnread`. The target conversation must therefore be located through
+the supported `IMSyncUserConversation` call using an unfiltered current-state
+query (`version=0`, `msgCount=1`, and an empty `lastMsgSeqs` value). This avoids
+the client's cursor filtering from hiding the conversation whose unread state
+is being checked.
+
+The frontend may enter a conversation whose initial message sync returns no
+messages and consequently may not call `clearUnread`. The dedicated
+`clearManualUnread` endpoint lets it clear the manual marker after opening the
+conversation without changing WuKongIM's real unread count. The endpoint is
+idempotent, so the frontend can call it after the initial conversation-open
+sync without needing to inspect the message count on the server.
+
+## Load-bearing list
+
+- `PUT /v1/conversation/setManualUnread` must locate the current user's target
+  conversation with the supported WuKongIM conversation-sync API and must
+  distinguish normal unread from manual unread.
+- The `setManualUnread` WuKongIM query uses `IMSyncUserConversation(loginUID, 0, 1,
+  "", nil)` or an equivalent target-preserving query. It must not reintroduce
+  the removed `IMGetConversations` endpoint.
+- The manual state is keyed by the authenticated user's exact
+  `(channel_id, channel_type)` pair. Parent groups and community topics keep
+  independent manual-unread states; there is no implicit parent aggregation.
+- The new endpoint must only clear the authenticated user's exact
+  `(channel_id, channel_type)` manual-unread row.
+- The new endpoint must update the conversation-extra sync version and notify
+  other logged-in clients with `CMDSyncConversationExtra`.
+- Existing `clearUnread` calls with any valid `unread` value must clear the
+  target conversation's manual-unread marker as well as update WuKongIM.
+- Manual state operations are scoped to the authenticated user's exact
+  `(uid, channel_id, channel_type)` row. They intentionally do not require
+  current group or parent-group membership, so users can clear stale state
+  after leaving a group or topic.
+- The database write for a manual-state change must happen before the sync
+  command is sent, so clients never receive a stale `manual_unread` value.
+- Ordinary conversation-extra updates that omit `manual_unread` must preserve
+  the existing value for compatibility with older clients; an explicit field
+  is required to change it through that update path.
+- The `conversation_extra.manual_unread` migration must be registered through
+  the existing message-module SQL migration mechanism.
+
+## Out of scope
+
+- Frontend changes to decide when `clearManualUnread` is called.
+- Parent-group aggregation for community-topic manual-unread state.
+- Changes to WuKongIM or the real unread cursor semantics.
+- Changes to octo-lib's removed/legacy conversation endpoint or unrelated
+  callers.
+
+## Acceptance
+
+- `PUT /v1/conversation/setManualUnread` uses the supported conversation-sync API
+  and no longer calls `IMGetConversations`.
+- `setManualUnread` writes `manual_unread=true` only for a target conversation whose
+  WuKongIM normal unread count is zero, and not when the marker is already set.
+- `PUT /v1/conversation/clearManualUnread` is authenticated and space-scoped.
+- The endpoint is idempotent when the row is absent or already clear.
+- It does not call `IMClearConversationUnread` or `CMDConversationUnreadClear`.
+- `setManualUnread` and `clearManualUnread` never modify another user's row,
+  even when the caller is no longer a member of the requested group or topic.
+- `clearUnread` clears manual-unread for both `unread=0` and `unread>0`.
+- A successful state change updates the conversation-extra version and sends
+  `CMDSyncConversationExtra` to the user's logged-in clients.
+- Formatting, package compilation, focused regression tests, and
+  `git diff --check` pass.

--- a/.octospec/tasks/clear-manual-unread/brief.md
+++ b/.octospec/tasks/clear-manual-unread/brief.md
@@ -92,9 +92,12 @@ from the Recent activity window in both `/v1/sidebar/sync` and the opt-in
   `CMDConversationUnreadClear` broadcast before accessing conversation-extra.
   Group and CommunityTopic marker cleanup is attempted only for `unread=0`
   and is best-effort after that broadcast; `unread>0` leaves the marker
-  unchanged. Query, version, store, and extension-CMD failures are logged and
-  cannot change the completed core response. Person `clearUnread` retains its
-  existing real-unread behavior.
+  unchanged. Once the core clear and broadcast complete, the supplementary
+  cleanup runs on a request-value-preserving context that ignores client
+  disconnect cancellation and has its own five-second timeout. Query, version,
+  store, and extension-CMD failures are logged and cannot change the completed
+  core response. Person `clearUnread` retains its existing real-unread
+  behavior.
 - A marker write and its new conversation-extra version are committed before
   the service attempts `CMDSyncConversationExtra` on the user's Person channel
   with `NoPersist=true`. Its `param` carries the exact `channel_id`,
@@ -172,7 +175,9 @@ from the Recent activity window in both `/v1/sidebar/sync` and the opt-in
   manual-unread after the real-unread clear and legacy CMD; `unread>0` leaves
   manual-unread unchanged. Any supplementary cleanup failure is logged without
   suppressing the legacy broadcast or changing the core success response.
-  Person `clearUnread` leaves legacy manual rows untouched.
+  Client disconnect after the legacy broadcast does not cancel that cleanup;
+  its independent context remains bounded to five seconds. Person
+  `clearUnread` leaves legacy manual rows untouched.
 - Ordinary draft and read-position extension updates preserve a concurrently
   stored manual marker.
 - Manual markers annotate eligible Sidebar entries but do not independently

--- a/.octospec/tasks/clear-manual-unread/brief.md
+++ b/.octospec/tasks/clear-manual-unread/brief.md
@@ -17,24 +17,29 @@ Deliver the complete application-level manual-unread flow for Group and
 CommunityTopic conversations:
 
 - `PUT /v1/conversation/setManualUnread` stores the authenticated user's
-  manual-unread marker;
-- `PUT /v1/conversation/clearManualUnread` clears that marker as a dedicated
-  fallback in the frontend's conversation-open flow;
+  manual-unread marker without querying WuKongIM conversation existence or
+  real unread state;
+- `PUT /v1/conversation/clearManualUnread` is the frontend's explicit marker
+  clear whenever it re-enters a conversation that was manually unread before
+  navigation;
 - the existing `PUT /v1/conversation/clearUnread` preserves its real-unread
-  clear and broadcast contract, then best-effort clears the marker for Group
-  and CommunityTopic conversations;
+  clear and broadcast contract, and only `unread=0` best-effort clears the
+  marker for Group and CommunityTopic conversations;
 - conversation synchronization and Sidebar responses expose the marker to
   clients;
 - persisted marker changes advance the conversation-extra version and attempt
-  to notify the user's online clients with `CMDSyncConversationExtra`.
+  to notify the user's online clients with `CMDSyncConversationExtra`, whose
+  payload directly identifies the channel, final marker state, and version.
 - every production path that writes `conversation_extra` participates in one
   UID-scoped Redis lease so the user's shared extension cursor advances in
   commit order.
 
 The marker is stored in `conversation_extra.manual_unread` under the current
 user's exact `(uid, channel_id, channel_type)` row. It is a display state that
-can coexist with the conversation's real unread count and leaves the current
-message read position intact.
+leaves the current message read position intact and is independent of
+WuKongIM conversation existence and real unread state. If real messages and a
+marker coexist, the frontend renders the real count without adding the marker
+as an extra message.
 
 The shipped scope is Group and CommunityTopic. Person conversations remain on
 their existing real-unread behavior because one Person channel is shared
@@ -48,35 +53,30 @@ marked as unread. It is stored separately from the real unread count so the
 client can render both states with OR semantics without inventing an unread
 message or moving the message read position.
 
-The frontend may enter a conversation whose initial message sync returns no
-messages and consequently may not use its existing `clearUnread` path. In that
-case, `clearManualUnread` completes the conversation-open flow by clearing the
-display marker while preserving the real unread state. When the existing
-`clearUnread` path is used, that endpoint first completes the real-unread clear
-and legacy broadcast, then best-effort clears the marker so conversation-extra
-availability cannot regress the existing contract. The frontend avoids a
-second clear request when that path is used.
+When the frontend re-enters a conversation that was manually unread before the
+navigation, it calls `clearManualUnread` to clear the display marker regardless
+of whether the message pull is empty. The existing `clearUnread` path remains
+compatible only for a full real-unread clear: after its core clear and legacy
+broadcast, `unread=0` best-effort clears the marker. A positive `unread` update
+must leave the marker unchanged.
 
 Conversation-extra versioning is the multi-device synchronization source of
-truth. The CMD is a transient change notification; clients fetch the updated
-extension rows and refresh Sidebar after receiving it.
+truth. The CMD is a transient change notification whose `param` directly
+carries `channel_id`, `channel_type`, `manual_unread`, and `version`; clients
+may update that channel immediately and still use extension sync for recovery.
 
-Recent-window behavior is deliberately rollout-safe across Web, Android, and
-iOS. Web may learn to render `manual_unread` before the Android and iOS clients
-are upgraded. If the server used a manual marker to exempt an old conversation
-from the Recent activity window during that mixed-version period, an older
-mobile client would receive and display the out-of-window conversation but
-would not render its manual-unread dot. The resulting "old conversation shown
-without a red dot" experience is avoided by keeping the existing Recent
-window unchanged. A manually unread conversation outside that window therefore
-remains hidden in the current implementation; this is an intentional
-multi-client compatibility decision, not a bug.
+Manual unread is an explicit user request to keep a conversation visible as
+unread. Group and CommunityTopic markers therefore exempt matching entries
+from the Recent activity window in both `/v1/sidebar/sync` and the opt-in
+`/v1/conversation/sync` Recent projection.
 
 ## Load-bearing list
 
 - `setManualUnread` accepts Group and CommunityTopic targets, writes
   `manual_unread=true`, and returns `changed=true` with the new extension
-  version. An already-set marker returns the idempotent
+  version without calling `IMGetConversations` or otherwise querying WuKongIM
+  conversation existence or real unread state. An already-set marker returns
+  the idempotent
   `changed=false, reason=already_manual_unread` result.
 - `clearManualUnread` accepts the same channel types, writes
   `manual_unread=false`, and returns the new extension version. A missing or
@@ -90,14 +90,17 @@ multi-client compatibility decision, not a bug.
   topic.
 - After WuKongIM accepts a `clearUnread` request, the handler sends the legacy
   `CMDConversationUnreadClear` broadcast before accessing conversation-extra.
-  Group and CommunityTopic marker cleanup for both `unread=0` and `unread>0`
-  is best-effort after that broadcast; query, version, store, and extension-CMD
-  failures are logged and cannot change the completed core response. Person
-  `clearUnread` retains its existing real-unread behavior.
+  Group and CommunityTopic marker cleanup is attempted only for `unread=0`
+  and is best-effort after that broadcast; `unread>0` leaves the marker
+  unchanged. Query, version, store, and extension-CMD failures are logged and
+  cannot change the completed core response. Person `clearUnread` retains its
+  existing real-unread behavior.
 - A marker write and its new conversation-extra version are committed before
   the service attempts `CMDSyncConversationExtra` on the user's Person channel
-  with `NoPersist=true`. Notification delivery is best-effort: a failure is
-  logged and does not replace the committed success result with an HTTP error.
+  with `NoPersist=true`. Its `param` carries the exact `channel_id`,
+  `channel_type`, final `manual_unread`, and `version`. Notification delivery
+  is best-effort: a failure is logged and does not replace the committed
+  success result with an HTTP error.
 - The ordinary extension update, dedicated set/clear endpoints, and
   `clearUnread` marker cleanup all acquire the same UID-scoped Redis lock. Each
   lease has a request-unique UUID owner and a 10-second TTL; ownership is
@@ -117,11 +120,16 @@ multi-client compatibility decision, not a bug.
 - Sidebar first builds entries from its existing IM, follow, and thread data
   sources—including the existing DB-only CommunityTopic merge—and then
   overlays manual-unread state on the resulting items.
-- Recent visibility continues to use the configured activity window and its
-  existing real-unread, pinned, and system-bot exemptions. A surviving item
-  carries its manual marker, while the marker itself does not extend that
-  window. This preserves consistent rendering while Web, Android, and iOS may
-  run different manual-unread feature versions.
+- The Sidebar Follow lookup runs after its final item set is known. The Recent
+  lookup runs before the time window against only the bounded, visible IM
+  candidate keys so manual unread can act as an exemption. Both queries select
+  only `channel_id` / `channel_type`; neither scans the user's full extension
+  row set. A Recent marker-query failure skips the time window for that poll so
+  incomplete auxiliary state cannot hide a manually unread conversation.
+- Recent visibility uses the configured activity window with real-unread,
+  manual-unread, pinned, and system-bot exemptions. Group and CommunityTopic
+  markers retain matching conversations beyond the configured window in both
+  Recent response paths.
 - Legacy Person markers are projected as `manual_unread=false` by conversation
   and Sidebar synchronization.
 - The `conversation_extra.manual_unread` column is installed through the
@@ -132,10 +140,7 @@ multi-client compatibility decision, not a bug.
 - Frontend changes to decide when `clearManualUnread` is called.
 - Parent-group aggregation for community-topic manual-unread state.
 - Space-scoped Person manual-unread state.
-- Manual-unread-driven creation of new Sidebar entries or exemption from the
-  Recent activity window.
-- A coordinated future rollout that makes manual unread a Recent-window
-  exemption after every supported client can render the marker.
+- Manual-unread-driven creation of new Sidebar entries.
 - Changes to the existing real-unread cursor semantics.
 
 ## Acceptance
@@ -143,6 +148,9 @@ multi-client compatibility decision, not a bug.
 - A first Group or CommunityTopic `setManualUnread` call persists `true`,
   returns `changed=true` and a version, and emits
   `CMDSyncConversationExtra`.
+- A Group or CommunityTopic can be marked manually unread whether its
+  WuKongIM conversation is missing, has `unread=0`, or has real `unread>0`;
+  `setManualUnread` performs no WuKongIM conversation lookup.
 - Repeating `setManualUnread` returns `changed=false` with
   `reason=already_manual_unread` and leaves the stored version unchanged.
 - A first `clearManualUnread` call against a set marker persists `false`,
@@ -160,18 +168,16 @@ multi-client compatibility decision, not a bug.
 - `setManualUnread` and `clearManualUnread` update only the authenticated
   user's exact row, including when the caller is no longer a member of the
   requested group or topic.
-- Group and CommunityTopic `clearUnread` attempts to clear manual-unread for
-  both `unread=0` and `unread>0` after the real-unread clear and legacy CMD;
-  any supplementary cleanup failure is logged without suppressing the legacy
-  broadcast or changing the core success response. Person `clearUnread` leaves
-  legacy manual rows untouched.
+- Group and CommunityTopic `clearUnread(unread=0)` attempts to clear
+  manual-unread after the real-unread clear and legacy CMD; `unread>0` leaves
+  manual-unread unchanged. Any supplementary cleanup failure is logged without
+  suppressing the legacy broadcast or changing the core success response.
+  Person `clearUnread` leaves legacy manual rows untouched.
 - Ordinary draft and read-position extension updates preserve a concurrently
   stored manual marker.
 - Manual markers annotate eligible Sidebar entries but do not independently
-  create Group or CommunityTopic entries and do not retain an item beyond the
-  configured Recent window. An out-of-window manually unread conversation
-  remaining hidden during a mixed Web/Android/iOS rollout is expected behavior,
-  not a defect.
+  create Group or CommunityTopic entries. Existing manually unread entries are
+  retained beyond the configured Recent window in both response paths.
 - Dedicated marker changes remain visible through extension-version sync and
   attempt `CMDSyncConversationExtra` as a best-effort notification. A CMD
   failure after commit is logged while the endpoint still returns the changed
@@ -184,5 +190,9 @@ multi-client compatibility decision, not a bug.
   compare-renew rejects a replaced owner, and an expired owner cannot delete a
   successor's lock. Database tests prove stale set, clear, and ordinary-extra
   writes cannot replace a newer stored version.
+- The manual-unread database, concurrent-transition, version-high-water,
+  notification-failure, and `clearUnread` ordering regressions run in the
+  default `modules/message` test lane. They do not depend on the optional
+  `integration` build tag and remain executable under CI `-race -shuffle`.
 - Formatting, package compilation, focused regression tests, and
   `git diff --check` pass.

--- a/.octospec/tasks/clear-manual-unread/brief.md
+++ b/.octospec/tasks/clear-manual-unread/brief.md
@@ -1,8 +1,8 @@
 ---
 type: Task
 title: "Task: conversation-manual-unread"
-description: Add and maintain the conversation manual-unread state, including set, dedicated clear, WuKongIM compatibility, and clearUnread integration.
-tags: ["message", "conversation", "manual-unread", "wukongim", "compatibility", "testing"]
+description: Add Group and CommunityTopic manual-unread state, dedicated set and clear APIs, conversation-extra synchronization, and clearUnread integration.
+tags: ["message", "conversation", "manual-unread", "sidebar", "sync", "testing"]
 timestamp: 2026-08-27T00:00:00+08:00
 slug: clear-manual-unread
 upstream: none
@@ -13,84 +13,144 @@ source: self
 
 ## Goal
 
-Implement the complete application-level manual-unread flow for conversations:
+Deliver the complete application-level manual-unread flow for Group and
+CommunityTopic conversations:
 
-- `setManualUnread` marks a conversation as manually unread only when WuKongIM
-  reports that its normal unread count is zero;
-- `clearManualUnread` provides a dedicated endpoint for the frontend's
-  conversation-open flow and clears only the application-level marker;
-- `clearUnread` continues to update WuKongIM's real unread state and also
-  clears the manual marker for every valid explicit unread operation.
+- `PUT /v1/conversation/setManualUnread` stores the authenticated user's
+  manual-unread marker;
+- `PUT /v1/conversation/clearManualUnread` clears that marker as a dedicated
+  fallback in the frontend's conversation-open flow;
+- the existing `PUT /v1/conversation/clearUnread` clears the marker whenever it
+  successfully updates a Group or CommunityTopic unread state;
+- conversation synchronization and Sidebar responses expose the marker to
+  clients;
+- every persisted marker change advances the conversation-extra version and
+  notifies the user's online clients with `CMDSyncConversationExtra`.
 
-The manual marker is stored in `conversation_extra` and is independent of
-WuKongIM's real unread cursor or browse position.
+The marker is stored in `conversation_extra.manual_unread` under the current
+user's exact `(uid, channel_id, channel_type)` row. It is a display state that
+can coexist with the conversation's real unread count and leaves the current
+message read position intact.
+
+The shipped scope is Group and CommunityTopic. Person conversations remain on
+their existing real-unread behavior because one Person channel is shared
+across Spaces while the current `conversation_extra` key has no Space
+dimension.
 
 ## Background
 
-The pinned WuKongIM version removed the legacy recent-conversations endpoint
-used by `setManualUnread`. The target conversation must therefore be located through
-the supported `IMSyncUserConversation` call using an unfiltered current-state
-query (`version=0`, `msgCount=1`, and an empty `lastMsgSeqs` value). This avoids
-the client's cursor filtering from hiding the conversation whose unread state
-is being checked.
+Manual unread represents a user's request to keep a conversation visually
+marked as unread. It is stored separately from the real unread count so the
+client can render both states with OR semantics without inventing an unread
+message or moving the message read position.
 
 The frontend may enter a conversation whose initial message sync returns no
-messages and consequently may not call `clearUnread`. The dedicated
-`clearManualUnread` endpoint lets it clear the manual marker after opening the
-conversation without changing WuKongIM's real unread count. The endpoint is
-idempotent, so the frontend can call it after the initial conversation-open
-sync without needing to inspect the message count on the server.
+messages and consequently may not use its existing `clearUnread` path. In that
+case, `clearManualUnread` completes the conversation-open flow by clearing the
+display marker while preserving the real unread state. When the existing
+`clearUnread` path is used, that endpoint performs both updates and the
+frontend avoids a second clear request.
+
+Conversation-extra versioning is the multi-device synchronization source of
+truth. The CMD is a transient change notification; clients fetch the updated
+extension rows and refresh Sidebar after receiving it.
+
+Recent-window behavior is deliberately rollout-safe across Web, Android, and
+iOS. Web may learn to render `manual_unread` before the Android and iOS clients
+are upgraded. If the server used a manual marker to exempt an old conversation
+from the Recent activity window during that mixed-version period, an older
+mobile client would receive and display the out-of-window conversation but
+would not render its manual-unread dot. The resulting "old conversation shown
+without a red dot" experience is avoided by keeping the existing Recent
+window unchanged. A manually unread conversation outside that window therefore
+remains hidden in the current implementation; this is an intentional
+multi-client compatibility decision, not a bug.
 
 ## Load-bearing list
 
-- `PUT /v1/conversation/setManualUnread` must locate the current user's target
-  conversation with the supported WuKongIM conversation-sync API and must
-  distinguish normal unread from manual unread.
-- The `setManualUnread` WuKongIM query uses `IMSyncUserConversation(loginUID, 0, 1,
-  "", nil)` or an equivalent target-preserving query. It must not reintroduce
-  the removed `IMGetConversations` endpoint.
+- `setManualUnread` accepts Group and CommunityTopic targets, writes
+  `manual_unread=true`, and returns `changed=true` with the new extension
+  version. An already-set marker returns the idempotent
+  `changed=false, reason=already_manual_unread` result.
+- `clearManualUnread` accepts the same channel types, writes
+  `manual_unread=false`, and returns the new extension version. A missing or
+  already-clear marker returns `changed=false` as an idempotent success.
+- Person and unknown channel types return the localized request-invalid
+  envelope before any manual-state write or synchronization CMD.
 - The manual state is keyed by the authenticated user's exact
-  `(channel_id, channel_type)` pair. Parent groups and community topics keep
-  independent manual-unread states; there is no implicit parent aggregation.
-- The new endpoint must only clear the authenticated user's exact
-  `(channel_id, channel_type)` manual-unread row.
-- The new endpoint must update the conversation-extra sync version and notify
-  other logged-in clients with `CMDSyncConversationExtra`.
-- Existing `clearUnread` calls with any valid `unread` value must clear the
-  target conversation's manual-unread marker as well as update WuKongIM.
-- Manual state operations are scoped to the authenticated user's exact
-  `(uid, channel_id, channel_type)` row. They intentionally do not require
-  current group or parent-group membership, so users can clear stale state
-  after leaving a group or topic.
-- The database write for a manual-state change must happen before the sync
-  command is sent, so clients never receive a stale `manual_unread` value.
-- Ordinary conversation-extra updates that omit `manual_unread` must preserve
-  the existing value for compatibility with older clients; an explicit field
-  is required to change it through that update path.
-- The `conversation_extra.manual_unread` migration must be registered through
-  the existing message-module SQL migration mechanism.
+  `(uid, channel_id, channel_type)` row. Parent groups and community topics
+  maintain independent markers without parent aggregation, and the same row
+  remains available for stale-state cleanup after the user leaves a group or
+  topic.
+- Every successful Group or CommunityTopic `clearUnread` request clears an
+  existing manual marker for both `unread=0` and `unread>0`. Person
+  `clearUnread` retains its existing real-unread behavior.
+- A marker write and its new conversation-extra version are committed before
+  `CMDSyncConversationExtra` is sent to the user's Person channel with
+  `NoPersist=true`.
+- Ordinary conversation-extra updates atomically preserve
+  `manual_unread`; the dedicated endpoints and the Group/CommunityTopic
+  `clearUnread` integration own marker state transitions.
+- `/v1/conversation/sync` exposes the marker in `conversation.extra`,
+  `/v1/conversation/extra/sync` exposes it in each top-level extension row,
+  and `/v1/sidebar/sync` exposes it as an item-level `manual_unread` field.
+- Sidebar first builds entries from its existing IM, follow, and thread data
+  sources—including the existing DB-only CommunityTopic merge—and then
+  overlays manual-unread state on the resulting items.
+- Recent visibility continues to use the configured activity window and its
+  existing real-unread, pinned, and system-bot exemptions. A surviving item
+  carries its manual marker, while the marker itself does not extend that
+  window. This preserves consistent rendering while Web, Android, and iOS may
+  run different manual-unread feature versions.
+- Legacy Person markers are projected as `manual_unread=false` by conversation
+  and Sidebar synchronization.
+- The `conversation_extra.manual_unread` column is installed through the
+  message module's embedded SQL migration mechanism.
 
 ## Out of scope
 
 - Frontend changes to decide when `clearManualUnread` is called.
 - Parent-group aggregation for community-topic manual-unread state.
-- Changes to WuKongIM or the real unread cursor semantics.
-- Changes to octo-lib's removed/legacy conversation endpoint or unrelated
-  callers.
+- Space-scoped Person manual-unread state.
+- Manual-unread-driven creation of new Sidebar entries or exemption from the
+  Recent activity window.
+- A coordinated future rollout that makes manual unread a Recent-window
+  exemption after every supported client can render the marker.
+- Changes to the existing real-unread cursor semantics.
 
 ## Acceptance
 
-- `PUT /v1/conversation/setManualUnread` uses the supported conversation-sync API
-  and no longer calls `IMGetConversations`.
-- `setManualUnread` writes `manual_unread=true` only for a target conversation whose
-  WuKongIM normal unread count is zero, and not when the marker is already set.
+- A first Group or CommunityTopic `setManualUnread` call persists `true`,
+  returns `changed=true` and a version, and emits
+  `CMDSyncConversationExtra`.
+- Repeating `setManualUnread` returns `changed=false` with
+  `reason=already_manual_unread` and leaves the stored version unchanged.
+- A first `clearManualUnread` call against a set marker persists `false`,
+  returns `changed=true` and a version, and emits
+  `CMDSyncConversationExtra`.
+- Clearing an absent or already-clear marker returns `changed=false` without
+  creating a new version.
+- Group and CommunityTopic requests can set and clear independent markers.
+- Person requests to `setManualUnread` and `clearManualUnread` return the
+  localized request-invalid response before a write or synchronization CMD.
+- Conversation, conversation-extra, and Sidebar synchronization expose Group
+  and CommunityTopic markers with the JSON field name `manual_unread` and
+  project legacy Person markers as false.
 - `PUT /v1/conversation/clearManualUnread` is authenticated and space-scoped.
-- The endpoint is idempotent when the row is absent or already clear.
-- It does not call `IMClearConversationUnread` or `CMDConversationUnreadClear`.
-- `setManualUnread` and `clearManualUnread` never modify another user's row,
-  even when the caller is no longer a member of the requested group or topic.
-- `clearUnread` clears manual-unread for both `unread=0` and `unread>0`.
-- A successful state change updates the conversation-extra version and sends
-  `CMDSyncConversationExtra` to the user's logged-in clients.
+- `setManualUnread` and `clearManualUnread` update only the authenticated
+  user's exact row, including when the caller is no longer a member of the
+  requested group or topic.
+- Group and CommunityTopic `clearUnread` clears manual-unread for both
+  `unread=0` and `unread>0`; Person `clearUnread` leaves legacy manual rows
+  untouched.
+- Ordinary draft and read-position extension updates preserve a concurrently
+  stored manual marker.
+- Manual markers annotate eligible Sidebar entries but do not independently
+  create Group or CommunityTopic entries and do not retain an item beyond the
+  configured Recent window. An out-of-window manually unread conversation
+  remaining hidden during a mixed Web/Android/iOS rollout is expected behavior,
+  not a defect.
+- Every successful marker change is visible through extension-version sync and
+  sends `CMDSyncConversationExtra` to the user's online clients.
 - Formatting, package compilation, focused regression tests, and
   `git diff --check` pass.

--- a/modules/message/api_conversation.go
+++ b/modules/message/api_conversation.go
@@ -1336,7 +1336,13 @@ func (co *Conversation) clearConversationUnread(c *wkhttp.Context) {
 	// state the dedicated manual marker must not be cleared implicitly; the
 	// frontend clears it explicitly when the user re-enters the conversation.
 	if req.Unread == 0 {
-		co.clearManualUnreadAfterClearBestEffort(c.Request.Context(), loginUID, req.ChannelID, req.ChannelType)
+		// WuKongIM has already committed the real-unread clear and the legacy
+		// broadcast has already succeeded. Keep the supplementary cleanup alive
+		// if the HTTP client disconnects in this narrow window, but bound it with
+		// its own deadline so Redis or database trouble cannot hold the handler.
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), 5*time.Second)
+		defer cancel()
+		co.clearManualUnreadAfterClearBestEffort(cleanupCtx, loginUID, req.ChannelID, req.ChannelType)
 	}
 	c.ResponseOK()
 }

--- a/modules/message/api_conversation.go
+++ b/modules/message/api_conversation.go
@@ -1283,30 +1283,33 @@ func (co *Conversation) clearConversationUnread(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
 		return
 	}
-	// 任何有效的 clearUnread 操作都会清除当前会话的手动未读标识。
+	// 群聊和子区的任何有效 clearUnread 操作都会清除当前会话的手动未读标识。
 	// 这里不仅包括 unread=0 的真实未读清零，也包括前端用 unread>0
 	// 设置/保留真实未读数量的显式操作；后者同样代表用户重新定义了该会话的
-	// 未读状态，不应继续保留旧的 manual_unread 标识。
-	extra, queryErr := co.conversationExtraDB.queryOne(loginUID, req.ChannelID, req.ChannelType)
-	if queryErr != nil {
-		co.Error("查询会话手动未读状态失败！", zap.Error(queryErr))
-		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
-		return
-	}
+	// 未读状态，不应继续保留旧的 manual_unread 标识。私聊暂不支持手动未读，
+	// 因此只处理 WuKongIM 的真实未读，不读写 conversation_extra.manual_unread。
 	manualUnreadCleared := false
-	if extra != nil && extra.ManualUnread {
-		version, seqErr := co.ctx.GenSeq(common.SyncConversationExtraKey)
-		if seqErr != nil {
-			co.Error("生成会话扩展序列号失败！", zap.Error(seqErr))
-			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
+	if supportsManualUnreadChannelType(req.ChannelType) {
+		extra, queryErr := co.conversationExtraDB.queryOne(loginUID, req.ChannelID, req.ChannelType)
+		if queryErr != nil {
+			co.Error("查询会话手动未读状态失败！", zap.Error(queryErr))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
-		if storeErr := co.conversationExtraDB.clearManualUnread(loginUID, req.ChannelID, req.ChannelType, version); storeErr != nil {
-			co.Error("清除会话手动未读状态失败！", zap.Error(storeErr))
-			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
-			return
+		if extra != nil && extra.ManualUnread {
+			version, seqErr := co.ctx.GenSeq(common.SyncConversationExtraKey)
+			if seqErr != nil {
+				co.Error("生成会话扩展序列号失败！", zap.Error(seqErr))
+				httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
+				return
+			}
+			if storeErr := co.conversationExtraDB.clearManualUnread(loginUID, req.ChannelID, req.ChannelType, version); storeErr != nil {
+				co.Error("清除会话手动未读状态失败！", zap.Error(storeErr))
+				httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
+				return
+			}
+			manualUnreadCleared = true
 		}
-		manualUnreadCleared = true
 	}
 
 	// manual_unread 由数据库更新后，必须单独通知客户端同步会话扩展。
@@ -1453,7 +1456,7 @@ func newConversationExtraResp(m *conversationExtraModel) *conversationExtraResp 
 		KeepOffsetY:    m.KeepOffsetY,
 		Draft:          m.Draft,
 		Version:        m.Version,
-		ManualUnread:   m.ManualUnread,
+		ManualUnread:   supportsManualUnreadChannelType(m.ChannelType) && m.ManualUnread,
 	}
 }
 
@@ -1880,6 +1883,12 @@ func (co *Conversation) enrichConversationExternalMarkers(resps []*SyncUserConve
 		applyExternalMarkers(resp.Recents, markers)
 	}
 }
+
+func supportsManualUnreadChannelType(channelType uint8) bool {
+	return channelType == common.ChannelTypeGroup.Uint8() ||
+		channelType == common.ChannelTypeCommunityTopic.Uint8()
+}
+
 func (co *Conversation) setManualUnread(c *wkhttp.Context) {
 	loginUID := c.MustGet("uid").(string)
 	var req setManualUnreadReq
@@ -1892,48 +1901,14 @@ func (co *Conversation) setManualUnread(c *wkhttp.Context) {
 		respondMessageRequestInvalid(c, "channel_id")
 		return
 	}
-	// Manual state is scoped to the authenticated user's exact
-	// (uid, channel_id, channel_type) row. Membership is intentionally not
-	// checked, so stale state can be cleared after leaving a group or topic.
-	switch req.ChannelType {
-	case common.ChannelTypePerson.Uint8():
-	case common.ChannelTypeGroup.Uint8():
-	case common.ChannelTypeCommunityTopic.Uint8():
-	default:
+	// 手动未读当前只支持群聊和子区。私聊的物理会话跨 Space 共享，在完成
+	// Space 级状态建模前不能安全复用全局 conversation_extra 标志。
+	if !supportsManualUnreadChannelType(req.ChannelType) {
 		respondMessageRequestInvalid(c, "channel_type")
 		return
 	}
-
-	// WuKongIM v2.2.4 已移除 GET /conversations，要求使用
-	// POST /conversation/sync。这里不是普通的客户端增量同步，而是为了
-	// 判断目标会话当前是否已经存在正常未读，因此必须使用一次不带游标的
-	// 当前状态查询：
-	//   - version=0：避免客户端游标把目标会话过滤掉；
-	//   - msgCount=1：让 WuKongIM 构造会话返回并计算 Unread；
-	//   - lastMsgSeqs=""：避免客户端已保存的频道序号过滤掉目标会话。
-	// 该参数组合也与项目中其它需要读取完整最近会话的调用保持一致。
-	conversations, err := co.ctx.IMSyncUserConversation(loginUID, 0, 1, "", nil)
-	if err != nil {
-		co.Error("获取当前用户会话失败！", zap.Error(err))
-		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
-		return
-	}
-
-	var currentConversation *config.SyncUserConversationResp
-	for _, conversation := range conversations {
-		if conversation == nil {
-			continue
-		}
-		if conversation.ChannelID == req.ChannelID && conversation.ChannelType == req.ChannelType {
-			currentConversation = conversation
-			break
-		}
-	}
-	if currentConversation == nil {
-		co.Error("当前用户没有目标会话", zap.String("uid", loginUID), zap.String("channelID", req.ChannelID), zap.Uint8("channelType", req.ChannelType))
-		httperr.ResponseErrorL(c, errcode.ErrMessageConversationForbidden, nil, nil)
-		return
-	}
+	// 状态仍只属于当前登录用户的精确频道行；沿用既定产品语义，不要求
+	// 当前仍是群或父群成员，以便用户离开频道后也能清理遗留标志。
 
 	extra, err := co.conversationExtraDB.queryOne(loginUID, req.ChannelID, req.ChannelType)
 	if err != nil {
@@ -1942,18 +1917,13 @@ func (co *Conversation) setManualUnread(c *wkhttp.Context) {
 		return
 	}
 
-	manualUnread := extra != nil && extra.ManualUnread
-	if currentConversation.Unread > 0 || manualUnread {
-		reason := "already_unread"
-		if manualUnread {
-			reason = "already_manual_unread"
-		}
+	if extra != nil && extra.ManualUnread {
 		c.Response(setManualUnreadResp{
 			ChannelID:    req.ChannelID,
 			ChannelType:  req.ChannelType,
-			ManualUnread: manualUnread,
+			ManualUnread: true,
 			Changed:      false,
-			Reason:       reason,
+			Reason:       "already_manual_unread",
 		})
 		return
 	}
@@ -2006,15 +1976,12 @@ func (co *Conversation) clearManualUnread(c *wkhttp.Context) {
 		return
 	}
 
-	switch req.ChannelType {
-	case common.ChannelTypePerson.Uint8(), common.ChannelTypeGroup.Uint8(), common.ChannelTypeCommunityTopic.Uint8():
-		// Manual state is scoped to the authenticated user's exact
-		// (uid, channel_id, channel_type) row. Membership is intentionally not
-		// checked so stale state can be cleared after leaving a channel.
-	default:
+	// 与 setManualUnread 保持同一协议边界：只允许群聊和子区。
+	if !supportsManualUnreadChannelType(req.ChannelType) {
 		respondMessageRequestInvalid(c, "channel_type")
 		return
 	}
+	// 不做当前成员校验，避免用户离开群或子区后无法清理自己的遗留状态。
 
 	extra, err := co.conversationExtraDB.queryOne(loginUID, req.ChannelID, req.ChannelType)
 	if err != nil {

--- a/modules/message/api_conversation.go
+++ b/modules/message/api_conversation.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -37,21 +38,22 @@ import (
 type Conversation struct {
 	ctx *config.Context
 	log.Log
-	userDB              *user.DB
-	groupDB             *group.DB
-	messageExtraDB      *messageExtraDB
-	messageReactionDB   *messageReactionDB
-	messageUserExtraDB  *messageUserExtraDB
-	channelOffsetDB     *channelOffsetDB
-	deviceOffsetDB      *deviceOffsetDB
-	userLastOffsetDB    *userLastOffsetDB
-	groupCategoryDB     *groupCategoryDB
-	userService         user.IService
-	groupService        group.IService
-	service             IService
-	channelService      chservice.IService
-	conversationExtraDB *conversationExtraDB
-	threadDB            *thread.DB
+	userDB                *user.DB
+	groupDB               *group.DB
+	messageExtraDB        *messageExtraDB
+	messageReactionDB     *messageReactionDB
+	messageUserExtraDB    *messageUserExtraDB
+	channelOffsetDB       *channelOffsetDB
+	deviceOffsetDB        *deviceOffsetDB
+	userLastOffsetDB      *userLastOffsetDB
+	groupCategoryDB       *groupCategoryDB
+	userService           user.IService
+	groupService          group.IService
+	service               IService
+	channelService        chservice.IService
+	conversationExtraDB   *conversationExtraDB
+	conversationExtraLock *conversationExtraLock
+	threadDB              *thread.DB
 
 	syncConversationResultCacheMap  map[string][]string
 	syncConversationVersionMap      map[string]int64
@@ -73,6 +75,7 @@ func NewConversation(ctx *config.Context) *Conversation {
 		userLastOffsetDB:               newUserLastOffsetDB(ctx),
 		groupCategoryDB:                newGroupCategoryDB(ctx),
 		conversationExtraDB:            newConversationExtraDB(ctx),
+		conversationExtraLock:          newConversationExtraLock(ctx),
 		threadDB:                       thread.NewDB(ctx),
 		userService:                    user.NewService(ctx),
 		groupService:                   group.NewService(ctx),
@@ -193,26 +196,48 @@ func (co *Conversation) conversationExtraUpdate(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 
 	channelTypeI64, _ := strconv.ParseInt(channelTypeStr, 10, 64)
+	channelType := uint8(channelTypeI64)
 
-	version, err := co.ctx.GenSeq(common.SyncConversationExtraKey)
+	var version int64
+	err := co.withConversationExtraLease(
+		c.Request.Context(),
+		loginUID,
+		channelID,
+		channelType,
+		func(lease *conversationExtraLease) error {
+			var versionErr error
+			version, versionErr = co.nextConversationExtraVersionLocked(loginUID)
+			if versionErr != nil {
+				return versionErr
+			}
+			if renewErr := lease.Renew(c.Request.Context()); renewErr != nil {
+				return renewErr
+			}
+			changed, storeErr := co.conversationExtraDB.insertOrUpdate(&conversationExtraModel{
+				UID:            loginUID,
+				ChannelID:      channelID,
+				ChannelType:    channelType,
+				BrowseTo:       req.BrowseTo,
+				KeepMessageSeq: req.KeepMessageSeq,
+				KeepOffsetY:    req.KeepOffsetY,
+				Draft:          req.Draft,
+				Version:        version,
+			})
+			if storeErr != nil {
+				return storeErr
+			}
+			if !changed {
+				return errConversationExtraVersion
+			}
+			return nil
+		},
+	)
 	if err != nil {
-		co.Error("生成会话扩展序列号失败", zap.Error(err))
-		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
-		return
-	}
-
-	err = co.conversationExtraDB.insertOrUpdate(&conversationExtraModel{
-		UID:            loginUID,
-		ChannelID:      channelID,
-		ChannelType:    uint8(channelTypeI64),
-		BrowseTo:       req.BrowseTo,
-		KeepMessageSeq: req.KeepMessageSeq,
-		KeepOffsetY:    req.KeepOffsetY,
-		Draft:          req.Draft,
-		Version:        version,
-	})
-	if err != nil {
-		co.Error("添加或更新最近会话扩展失败！", zap.Error(err))
+		co.Error("添加或更新最近会话扩展失败！",
+			zap.Error(err),
+			zap.String("channel_id", channelID),
+			zap.Uint8("channel_type", channelType),
+		)
 		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
@@ -1283,53 +1308,11 @@ func (co *Conversation) clearConversationUnread(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
 		return
 	}
-	// 群聊和子区的任何有效 clearUnread 操作都会清除当前会话的手动未读标识。
-	// 这里不仅包括 unread=0 的真实未读清零，也包括前端用 unread>0
-	// 设置/保留真实未读数量的显式操作；后者同样代表用户重新定义了该会话的
-	// 未读状态，不应继续保留旧的 manual_unread 标识。私聊暂不支持手动未读，
-	// 因此只处理 WuKongIM 的真实未读，不读写 conversation_extra.manual_unread。
-	manualUnreadCleared := false
-	if supportsManualUnreadChannelType(req.ChannelType) {
-		extra, queryErr := co.conversationExtraDB.queryOne(loginUID, req.ChannelID, req.ChannelType)
-		if queryErr != nil {
-			co.Error("查询会话手动未读状态失败！", zap.Error(queryErr))
-			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
-			return
-		}
-		if extra != nil && extra.ManualUnread {
-			version, seqErr := co.ctx.GenSeq(common.SyncConversationExtraKey)
-			if seqErr != nil {
-				co.Error("生成会话扩展序列号失败！", zap.Error(seqErr))
-				httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
-				return
-			}
-			if storeErr := co.conversationExtraDB.clearManualUnread(loginUID, req.ChannelID, req.ChannelType, version); storeErr != nil {
-				co.Error("清除会话手动未读状态失败！", zap.Error(storeErr))
-				httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
-				return
-			}
-			manualUnreadCleared = true
-		}
-	}
 
-	// manual_unread 由数据库更新后，必须单独通知客户端同步会话扩展。
-	// CMDConversationUnreadClear 只负责 WuKongIM 的真实未读状态，不会刷新
-	// conversation_extra，因此不能依赖它同步 manual_unread。
-	if manualUnreadCleared {
-		err = co.ctx.SendCMD(config.MsgCMDReq{
-			NoPersist:   true,
-			ChannelID:   loginUID,
-			ChannelType: common.ChannelTypePerson.Uint8(),
-			CMD:         common.CMDSyncConversationExtra,
-		})
-		if err != nil {
-			co.Error("发送同步会话扩展命令失败！", zap.Error(err))
-			httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
-			return
-		}
-	}
-
-	// 发送清空红点的命令。
+	// Preserve the pre-existing clearUnread contract before attempting the
+	// application-level manual marker cleanup. Once WuKongIM has committed the
+	// real unread change, every online client must receive this legacy broadcast
+	// even if conversation_extra is temporarily unavailable.
 	err = co.ctx.SendCMD(config.MsgCMDReq{
 		NoPersist:   true,
 		ChannelID:   loginUID,
@@ -1346,7 +1329,79 @@ func (co *Conversation) clearConversationUnread(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
 		return
 	}
+
+	co.clearManualUnreadAfterClearBestEffort(c.Request.Context(), loginUID, req.ChannelID, req.ChannelType)
 	c.ResponseOK()
+}
+
+// clearManualUnreadAfterClearBestEffort clears the application-level marker
+// only after clearConversationUnread has completed its real unread clear and
+// legacy broadcast. The marker is supplementary state: query, version, store,
+// or extension-notification failures are logged but must not turn the already
+// completed core operation into a partial-success error response.
+func (co *Conversation) clearManualUnreadAfterClearBestEffort(ctx context.Context, loginUID, channelID string, channelType uint8) {
+	if !supportsManualUnreadChannelType(channelType) {
+		return
+	}
+
+	manualUnreadCleared := false
+	err := co.withConversationExtraLease(ctx, loginUID, channelID, channelType, func(lease *conversationExtraLease) error {
+		// 群聊和子区的任何有效 clearUnread 操作都会清除当前会话的手动未读标识。
+		// 这里不仅包括 unread=0 的真实未读清零，也包括前端用 unread>0
+		// 设置/保留真实未读数量的显式操作；后者同样代表用户重新定义了该会话的
+		// 未读状态，不应继续保留旧的 manual_unread 标识。
+		extra, queryErr := co.conversationExtraDB.queryOne(loginUID, channelID, channelType)
+		if queryErr != nil {
+			return queryErr
+		}
+		if extra == nil || !extra.ManualUnread {
+			return nil
+		}
+
+		version, versionErr := co.nextConversationExtraVersionLocked(loginUID)
+		if versionErr != nil {
+			return versionErr
+		}
+		if renewErr := lease.Renew(ctx); renewErr != nil {
+			return renewErr
+		}
+		changed, storeErr := co.conversationExtraDB.clearManualUnread(loginUID, channelID, channelType, version)
+		if storeErr != nil {
+			return storeErr
+		}
+		if !changed {
+			return errConversationExtraVersion
+		}
+		manualUnreadCleared = true
+		return nil
+	})
+	if err != nil {
+		co.Error("清除会话手动未读状态失败！",
+			zap.Error(err),
+			zap.String("channel_id", channelID),
+			zap.Uint8("channel_type", channelType),
+		)
+		return
+	}
+	if !manualUnreadCleared {
+		return
+	}
+
+	// CMDConversationUnreadClear only refreshes WuKongIM's real unread state.
+	// Notify clients separately after the marker write, but keep this transient
+	// notification best-effort so it cannot break the core clearUnread contract.
+	if err = co.ctx.SendCMD(config.MsgCMDReq{
+		NoPersist:   true,
+		ChannelID:   loginUID,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		CMD:         common.CMDSyncConversationExtra,
+	}); err != nil {
+		co.Error("发送同步会话扩展命令失败！",
+			zap.Error(err),
+			zap.String("channel_id", channelID),
+			zap.Uint8("channel_type", channelType),
+		)
+	}
 }
 
 // ---------- vo ----------
@@ -1910,14 +1965,67 @@ func (co *Conversation) setManualUnread(c *wkhttp.Context) {
 	// 状态仍只属于当前登录用户的精确频道行；沿用既定产品语义，不要求
 	// 当前仍是群或父群成员，以便用户离开频道后也能清理遗留标志。
 
-	extra, err := co.conversationExtraDB.queryOne(loginUID, req.ChannelID, req.ChannelType)
+	var (
+		extra       *conversationExtraModel
+		version     int64
+		changed     bool
+		queryFailed bool
+	)
+	err := co.withConversationExtraLease(
+		c.Request.Context(),
+		loginUID,
+		req.ChannelID,
+		req.ChannelType,
+		func(lease *conversationExtraLease) error {
+			var queryErr error
+			extra, queryErr = co.conversationExtraDB.queryOne(loginUID, req.ChannelID, req.ChannelType)
+			if queryErr != nil {
+				queryFailed = true
+				return queryErr
+			}
+			if extra != nil && extra.ManualUnread {
+				return nil
+			}
+
+			var versionErr error
+			version, versionErr = co.nextConversationExtraVersionLocked(loginUID)
+			if versionErr != nil {
+				return versionErr
+			}
+			if renewErr := lease.Renew(c.Request.Context()); renewErr != nil {
+				return renewErr
+			}
+			var storeErr error
+			changed, storeErr = co.conversationExtraDB.setManualUnread(
+				loginUID,
+				req.ChannelID,
+				req.ChannelType,
+				version,
+			)
+			if storeErr != nil {
+				return storeErr
+			}
+			if !changed {
+				return errConversationExtraVersion
+			}
+			return nil
+		},
+	)
 	if err != nil {
-		co.Error("查询会话扩展失败！", zap.Error(err))
-		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		co.Error("设置会话手动未读状态失败！",
+			zap.Error(err),
+			zap.String("channel_id", req.ChannelID),
+			zap.Uint8("channel_type", req.ChannelType),
+		)
+		if queryFailed {
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		} else {
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
+		}
 		return
 	}
 
-	if extra != nil && extra.ManualUnread {
+	if !changed {
 		c.Response(setManualUnreadResp{
 			ChannelID:    req.ChannelID,
 			ChannelType:  req.ChannelType,
@@ -1928,27 +2036,20 @@ func (co *Conversation) setManualUnread(c *wkhttp.Context) {
 		return
 	}
 
-	version, err := co.ctx.GenSeq(common.SyncConversationExtraKey)
-	if err != nil {
-		co.Error("生成会话扩展序列号失败！", zap.Error(err))
-		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
-		return
-	}
-	if err := co.conversationExtraDB.setManualUnread(loginUID, req.ChannelID, req.ChannelType, version); err != nil {
-		co.Error("设置会话手动未读状态失败！", zap.Error(err))
-		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
-		return
-	}
-
 	if err := co.ctx.SendCMD(config.MsgCMDReq{
 		NoPersist:   true,
 		ChannelID:   loginUID,
 		ChannelType: common.ChannelTypePerson.Uint8(),
 		CMD:         common.CMDSyncConversationExtra,
 	}); err != nil {
-		co.Error("发送同步会话扩展命令失败！", zap.Error(err))
-		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
-		return
+		// The marker and version are already committed. This CMD is only a
+		// transient notification, so a delivery failure must not turn the
+		// successful state transition into a retryable HTTP error.
+		co.Error("发送同步会话扩展命令失败！",
+			zap.Error(err),
+			zap.String("channel_id", req.ChannelID),
+			zap.Uint8("channel_type", req.ChannelType),
+		)
 	}
 
 	c.Response(setManualUnreadResp{
@@ -1983,13 +2084,66 @@ func (co *Conversation) clearManualUnread(c *wkhttp.Context) {
 	}
 	// 不做当前成员校验，避免用户离开群或子区后无法清理自己的遗留状态。
 
-	extra, err := co.conversationExtraDB.queryOne(loginUID, req.ChannelID, req.ChannelType)
+	var (
+		extra       *conversationExtraModel
+		version     int64
+		changed     bool
+		queryFailed bool
+	)
+	err := co.withConversationExtraLease(
+		c.Request.Context(),
+		loginUID,
+		req.ChannelID,
+		req.ChannelType,
+		func(lease *conversationExtraLease) error {
+			var queryErr error
+			extra, queryErr = co.conversationExtraDB.queryOne(loginUID, req.ChannelID, req.ChannelType)
+			if queryErr != nil {
+				queryFailed = true
+				return queryErr
+			}
+			if extra == nil || !extra.ManualUnread {
+				return nil
+			}
+
+			var versionErr error
+			version, versionErr = co.nextConversationExtraVersionLocked(loginUID)
+			if versionErr != nil {
+				return versionErr
+			}
+			if renewErr := lease.Renew(c.Request.Context()); renewErr != nil {
+				return renewErr
+			}
+			var storeErr error
+			changed, storeErr = co.conversationExtraDB.clearManualUnread(
+				loginUID,
+				req.ChannelID,
+				req.ChannelType,
+				version,
+			)
+			if storeErr != nil {
+				return storeErr
+			}
+			if !changed {
+				return errConversationExtraVersion
+			}
+			return nil
+		},
+	)
 	if err != nil {
-		co.Error("查询会话手动未读状态失败！", zap.Error(err))
-		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		co.Error("清除会话手动未读状态失败！",
+			zap.Error(err),
+			zap.String("channel_id", req.ChannelID),
+			zap.Uint8("channel_type", req.ChannelType),
+		)
+		if queryFailed {
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		} else {
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
+		}
 		return
 	}
-	if extra == nil || !extra.ManualUnread {
+	if !changed {
 		c.Response(clearManualUnreadResp{
 			ChannelID:    req.ChannelID,
 			ChannelType:  req.ChannelType,
@@ -1999,27 +2153,19 @@ func (co *Conversation) clearManualUnread(c *wkhttp.Context) {
 		return
 	}
 
-	version, err := co.ctx.GenSeq(common.SyncConversationExtraKey)
-	if err != nil {
-		co.Error("生成会话扩展序列号失败！", zap.Error(err))
-		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
-		return
-	}
-	if err := co.conversationExtraDB.clearManualUnread(loginUID, req.ChannelID, req.ChannelType, version); err != nil {
-		co.Error("清除会话手动未读状态失败！", zap.Error(err))
-		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
-		return
-	}
-
 	if err := co.ctx.SendCMD(config.MsgCMDReq{
 		NoPersist:   true,
 		ChannelID:   loginUID,
 		ChannelType: common.ChannelTypePerson.Uint8(),
 		CMD:         common.CMDSyncConversationExtra,
 	}); err != nil {
-		co.Error("发送同步会话扩展命令失败！", zap.Error(err))
-		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
-		return
+		// The marker and version are already committed. Keep notification
+		// delivery best-effort for the same reason as setManualUnread.
+		co.Error("发送同步会话扩展命令失败！",
+			zap.Error(err),
+			zap.String("channel_id", req.ChannelID),
+			zap.Uint8("channel_type", req.ChannelType),
+		)
 	}
 
 	c.Response(clearManualUnreadResp{

--- a/modules/message/api_conversation.go
+++ b/modules/message/api_conversation.go
@@ -115,6 +115,8 @@ func (co *Conversation) Route(r *wkhttp.WKHttp) {
 		conversation.POST("/syncack", co.syncUserConversationAck)
 		conversation.POST("/extra/sync", co.conversationExtraSync)   // 同步最近会话扩展
 		conversation.PUT("/clearUnread", co.clearConversationUnread) // 清除未读（正确拼写路径）
+		conversation.PUT("/setManualUnread", co.setManualUnread)     // 手动设置未读状态
+		conversation.PUT("/clearManualUnread", co.clearManualUnread) // 清除手动未读状态
 	}
 	conversations := r.Group("/v1/conversations", co.ctx.AuthMiddleware(r), uidLimit)
 	{
@@ -938,9 +940,12 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 
 // filterRecentConversations drops conversations whose per-channel-type activity
 // window has elapsed, mirroring the sidebar recent tab (buildRecentItems): a
-// conversation is hidden iff its type's cutoff is non-zero AND its Timestamp is
-// at or before that cutoff. A cutoff of 0 means "no filter" for that type, and
-// unknown channel types are kept unconditionally (recentCutoffs.cutoffFor).
+// conversation is hidden iff it is not exempted (for example, by unread,
+// pinned, or system-bot state) and its type's cutoff is non-zero AND its
+// Timestamp is at or before that cutoff. A cutoff of 0 means "no filter" for
+// that type, and unknown channel types are kept unconditionally
+// (recentCutoffs.cutoffFor). Manual-unread state is returned to the client but
+// does not exempt a conversation from this activity window.
 //
 // Returns a new slice — the input is not mutated, so the caller's raw-based
 // cursor/unread computations stay intact (issue #294).
@@ -955,8 +960,9 @@ func filterRecentConversations(
 		if pinnedSet != nil {
 			_, pinned = pinnedSet[channelKey(r.ChannelID, r.ChannelType)]
 		}
-		// 未读 / 置顶 / 系统 Bot 豁免与 sidebar recent tab 共用同一个谓词
-		// （keepDespiteRecentWindow），两个端点的窗口语义因此逐字一致。
+		// 未读 / 置顶 / 系统 Bot 豁免与 sidebar recent tab 共用同一套窗口语义。
+		// manual_unread 只是会话的展示标识，不改变真实未读数，也不再绕过
+		// Recent 活跃时间窗口。
 		//
 		// 这里读的是跨 Space 的 r.Unread —— per-Space 未读由 fillPersonSpaceUnread
 		// 在本步之后才算出。于是「在别的 Space 有未读的 DM」会在当前 Space 也被豁免。
@@ -1277,7 +1283,50 @@ func (co *Conversation) clearConversationUnread(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
 		return
 	}
-	// 发送清空红点的命令
+	// 任何有效的 clearUnread 操作都会清除当前会话的手动未读标识。
+	// 这里不仅包括 unread=0 的真实未读清零，也包括前端用 unread>0
+	// 设置/保留真实未读数量的显式操作；后者同样代表用户重新定义了该会话的
+	// 未读状态，不应继续保留旧的 manual_unread 标识。
+	extra, queryErr := co.conversationExtraDB.queryOne(loginUID, req.ChannelID, req.ChannelType)
+	if queryErr != nil {
+		co.Error("查询会话手动未读状态失败！", zap.Error(queryErr))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		return
+	}
+	manualUnreadCleared := false
+	if extra != nil && extra.ManualUnread {
+		version, seqErr := co.ctx.GenSeq(common.SyncConversationExtraKey)
+		if seqErr != nil {
+			co.Error("生成会话扩展序列号失败！", zap.Error(seqErr))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
+			return
+		}
+		if storeErr := co.conversationExtraDB.clearManualUnread(loginUID, req.ChannelID, req.ChannelType, version); storeErr != nil {
+			co.Error("清除会话手动未读状态失败！", zap.Error(storeErr))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
+			return
+		}
+		manualUnreadCleared = true
+	}
+
+	// manual_unread 由数据库更新后，必须单独通知客户端同步会话扩展。
+	// CMDConversationUnreadClear 只负责 WuKongIM 的真实未读状态，不会刷新
+	// conversation_extra，因此不能依赖它同步 manual_unread。
+	if manualUnreadCleared {
+		err = co.ctx.SendCMD(config.MsgCMDReq{
+			NoPersist:   true,
+			ChannelID:   loginUID,
+			ChannelType: common.ChannelTypePerson.Uint8(),
+			CMD:         common.CMDSyncConversationExtra,
+		})
+		if err != nil {
+			co.Error("发送同步会话扩展命令失败！", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
+			return
+		}
+	}
+
+	// 发送清空红点的命令。
 	err = co.ctx.SendCMD(config.MsgCMDReq{
 		NoPersist:   true,
 		ChannelID:   loginUID,
@@ -1326,6 +1375,33 @@ type clearConversationUnreadReq struct {
 	MessageSeq  uint32 `json:"message_seq"`
 }
 
+type clearManualUnreadReq struct {
+	ChannelID   string `json:"channel_id"`
+	ChannelType uint8  `json:"channel_type"`
+}
+
+type clearManualUnreadResp struct {
+	ChannelID    string `json:"channel_id"`
+	ChannelType  uint8  `json:"channel_type"`
+	ManualUnread bool   `json:"manual_unread"`
+	Changed      bool   `json:"changed"`
+	Version      int64  `json:"version,omitempty"`
+}
+
+type setManualUnreadReq struct {
+	ChannelID   string `json:"channel_id"`
+	ChannelType uint8  `json:"channel_type"`
+}
+
+type setManualUnreadResp struct {
+	ChannelID    string `json:"channel_id"`
+	ChannelType  uint8  `json:"channel_type"`
+	ManualUnread bool   `json:"manual_unread"`
+	Changed      bool   `json:"changed"`
+	Version      int64  `json:"version,omitempty"`
+	Reason       string `json:"reason,omitempty"`
+}
+
 type ChannelState struct {
 	ChannelID   string `json:"channel_id"`
 	ChannelType uint8  `json:"channel_type"`
@@ -1364,6 +1440,7 @@ type conversationExtraResp struct {
 	KeepOffsetY    int    `json:"keep_offset_y"`
 	Draft          string `json:"draft"` // 草稿
 	Version        int64  `json:"version"`
+	ManualUnread   bool   `json:"manual_unread"`
 }
 
 func newConversationExtraResp(m *conversationExtraModel) *conversationExtraResp {
@@ -1376,6 +1453,7 @@ func newConversationExtraResp(m *conversationExtraModel) *conversationExtraResp 
 		KeepOffsetY:    m.KeepOffsetY,
 		Draft:          m.Draft,
 		Version:        m.Version,
+		ManualUnread:   m.ManualUnread,
 	}
 }
 
@@ -1801,4 +1879,187 @@ func (co *Conversation) enrichConversationExternalMarkers(resps []*SyncUserConve
 		}
 		applyExternalMarkers(resp.Recents, markers)
 	}
+}
+func (co *Conversation) setManualUnread(c *wkhttp.Context) {
+	loginUID := c.MustGet("uid").(string)
+	var req setManualUnreadReq
+	if err := c.BindJSON(&req); err != nil {
+		co.Error("数据格式有误！", zap.Error(err))
+		respondMessageRequestInvalid(c, "")
+		return
+	}
+	if strings.TrimSpace(req.ChannelID) == "" {
+		respondMessageRequestInvalid(c, "channel_id")
+		return
+	}
+	// Manual state is scoped to the authenticated user's exact
+	// (uid, channel_id, channel_type) row. Membership is intentionally not
+	// checked, so stale state can be cleared after leaving a group or topic.
+	switch req.ChannelType {
+	case common.ChannelTypePerson.Uint8():
+	case common.ChannelTypeGroup.Uint8():
+	case common.ChannelTypeCommunityTopic.Uint8():
+	default:
+		respondMessageRequestInvalid(c, "channel_type")
+		return
+	}
+
+	// WuKongIM v2.2.4 已移除 GET /conversations，要求使用
+	// POST /conversation/sync。这里不是普通的客户端增量同步，而是为了
+	// 判断目标会话当前是否已经存在正常未读，因此必须使用一次不带游标的
+	// 当前状态查询：
+	//   - version=0：避免客户端游标把目标会话过滤掉；
+	//   - msgCount=1：让 WuKongIM 构造会话返回并计算 Unread；
+	//   - lastMsgSeqs=""：避免客户端已保存的频道序号过滤掉目标会话。
+	// 该参数组合也与项目中其它需要读取完整最近会话的调用保持一致。
+	conversations, err := co.ctx.IMSyncUserConversation(loginUID, 0, 1, "", nil)
+	if err != nil {
+		co.Error("获取当前用户会话失败！", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		return
+	}
+
+	var currentConversation *config.SyncUserConversationResp
+	for _, conversation := range conversations {
+		if conversation == nil {
+			continue
+		}
+		if conversation.ChannelID == req.ChannelID && conversation.ChannelType == req.ChannelType {
+			currentConversation = conversation
+			break
+		}
+	}
+	if currentConversation == nil {
+		co.Error("当前用户没有目标会话", zap.String("uid", loginUID), zap.String("channelID", req.ChannelID), zap.Uint8("channelType", req.ChannelType))
+		httperr.ResponseErrorL(c, errcode.ErrMessageConversationForbidden, nil, nil)
+		return
+	}
+
+	extra, err := co.conversationExtraDB.queryOne(loginUID, req.ChannelID, req.ChannelType)
+	if err != nil {
+		co.Error("查询会话扩展失败！", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		return
+	}
+
+	manualUnread := extra != nil && extra.ManualUnread
+	if currentConversation.Unread > 0 || manualUnread {
+		reason := "already_unread"
+		if manualUnread {
+			reason = "already_manual_unread"
+		}
+		c.Response(setManualUnreadResp{
+			ChannelID:    req.ChannelID,
+			ChannelType:  req.ChannelType,
+			ManualUnread: manualUnread,
+			Changed:      false,
+			Reason:       reason,
+		})
+		return
+	}
+
+	version, err := co.ctx.GenSeq(common.SyncConversationExtraKey)
+	if err != nil {
+		co.Error("生成会话扩展序列号失败！", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
+		return
+	}
+	if err := co.conversationExtraDB.setManualUnread(loginUID, req.ChannelID, req.ChannelType, version); err != nil {
+		co.Error("设置会话手动未读状态失败！", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
+		return
+	}
+
+	if err := co.ctx.SendCMD(config.MsgCMDReq{
+		NoPersist:   true,
+		ChannelID:   loginUID,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		CMD:         common.CMDSyncConversationExtra,
+	}); err != nil {
+		co.Error("发送同步会话扩展命令失败！", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
+		return
+	}
+
+	c.Response(setManualUnreadResp{
+		ChannelID:    req.ChannelID,
+		ChannelType:  req.ChannelType,
+		ManualUnread: true,
+		Changed:      true,
+		Version:      version,
+	})
+}
+
+// clearManualUnread clears only the application-level manual-unread marker.
+// It intentionally does not touch WuKongIM's real unread cursor; that remains
+// the responsibility of clearConversationUnread.
+func (co *Conversation) clearManualUnread(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+	var req clearManualUnreadReq
+	if err := c.BindJSON(&req); err != nil {
+		co.Error("数据格式有误！", zap.Error(err))
+		respondMessageRequestInvalid(c, "")
+		return
+	}
+	if strings.TrimSpace(req.ChannelID) == "" {
+		respondMessageRequestInvalid(c, "channel_id")
+		return
+	}
+
+	switch req.ChannelType {
+	case common.ChannelTypePerson.Uint8(), common.ChannelTypeGroup.Uint8(), common.ChannelTypeCommunityTopic.Uint8():
+		// Manual state is scoped to the authenticated user's exact
+		// (uid, channel_id, channel_type) row. Membership is intentionally not
+		// checked so stale state can be cleared after leaving a channel.
+	default:
+		respondMessageRequestInvalid(c, "channel_type")
+		return
+	}
+
+	extra, err := co.conversationExtraDB.queryOne(loginUID, req.ChannelID, req.ChannelType)
+	if err != nil {
+		co.Error("查询会话手动未读状态失败！", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		return
+	}
+	if extra == nil || !extra.ManualUnread {
+		c.Response(clearManualUnreadResp{
+			ChannelID:    req.ChannelID,
+			ChannelType:  req.ChannelType,
+			ManualUnread: false,
+			Changed:      false,
+		})
+		return
+	}
+
+	version, err := co.ctx.GenSeq(common.SyncConversationExtraKey)
+	if err != nil {
+		co.Error("生成会话扩展序列号失败！", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
+		return
+	}
+	if err := co.conversationExtraDB.clearManualUnread(loginUID, req.ChannelID, req.ChannelType, version); err != nil {
+		co.Error("清除会话手动未读状态失败！", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
+		return
+	}
+
+	if err := co.ctx.SendCMD(config.MsgCMDReq{
+		NoPersist:   true,
+		ChannelID:   loginUID,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		CMD:         common.CMDSyncConversationExtra,
+	}); err != nil {
+		co.Error("发送同步会话扩展命令失败！", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
+		return
+	}
+
+	c.Response(clearManualUnreadResp{
+		ChannelID:    req.ChannelID,
+		ChannelType:  req.ChannelType,
+		ManualUnread: false,
+		Changed:      true,
+		Version:      version,
+	})
 }

--- a/modules/message/api_conversation.go
+++ b/modules/message/api_conversation.go
@@ -965,12 +965,11 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 
 // filterRecentConversations drops conversations whose per-channel-type activity
 // window has elapsed, mirroring the sidebar recent tab (buildRecentItems): a
-// conversation is hidden iff it is not exempted (for example, by unread,
-// pinned, or system-bot state) and its type's cutoff is non-zero AND its
-// Timestamp is at or before that cutoff. A cutoff of 0 means "no filter" for
-// that type, and unknown channel types are kept unconditionally
-// (recentCutoffs.cutoffFor). Manual-unread state is returned to the client but
-// does not exempt a conversation from this activity window.
+// conversation is hidden iff it is not exempted (for example, by real unread,
+// Group/CommunityTopic manual unread, pinned, or system-bot state) and its
+// type's cutoff is non-zero AND its Timestamp is at or before that cutoff. A
+// cutoff of 0 means "no filter" for that type, and unknown channel types are
+// kept unconditionally (recentCutoffs.cutoffFor).
 //
 // Returns a new slice — the input is not mutated, so the caller's raw-based
 // cursor/unread computations stay intact (issue #294).
@@ -985,9 +984,9 @@ func filterRecentConversations(
 		if pinnedSet != nil {
 			_, pinned = pinnedSet[channelKey(r.ChannelID, r.ChannelType)]
 		}
-		// 未读 / 置顶 / 系统 Bot 豁免与 sidebar recent tab 共用同一套窗口语义。
-		// manual_unread 只是会话的展示标识，不改变真实未读数，也不再绕过
-		// Recent 活跃时间窗口。
+		// 未读 / 人工未读 / 置顶 / 系统 Bot 豁免与 sidebar recent tab 共用
+		// 同一套窗口语义。manual_unread 是用户显式保留未读展示的请求，
+		// 因此群聊和子区必须穿透 Recent 活跃时间窗口。
 		//
 		// 这里读的是跨 Space 的 r.Unread —— per-Space 未读由 fillPersonSpaceUnread
 		// 在本步之后才算出。于是「在别的 Space 有未读的 DM」会在当前 Space 也被豁免。
@@ -997,7 +996,10 @@ func filterRecentConversations(
 		// 置顶只认 user_pinned_channel（与 sidebar 同源）。响应里的 Stick 是另一套
 		// 旧的 userDetail.Top / group.Top 标记，两个端点历史上都未据它豁免，此处
 		// 保持一致而非单侧引入差异。
-		if keepDespiteRecentWindow(r.ChannelID, r.ChannelType, r.Unread, pinned) {
+		manualUnread := r.Extra != nil &&
+			supportsManualUnreadChannelType(r.ChannelType) &&
+			r.Extra.ManualUnread
+		if manualUnread || keepDespiteRecentWindow(r.ChannelID, r.ChannelType, r.Unread, pinned) {
 			filtered = append(filtered, r)
 			continue
 		}
@@ -1330,7 +1332,12 @@ func (co *Conversation) clearConversationUnread(c *wkhttp.Context) {
 		return
 	}
 
-	co.clearManualUnreadAfterClearBestEffort(c.Request.Context(), loginUID, req.ChannelID, req.ChannelType)
+	// unread>0 means the caller is retaining a real unread count. In that
+	// state the dedicated manual marker must not be cleared implicitly; the
+	// frontend clears it explicitly when the user re-enters the conversation.
+	if req.Unread == 0 {
+		co.clearManualUnreadAfterClearBestEffort(c.Request.Context(), loginUID, req.ChannelID, req.ChannelType)
+	}
 	c.ResponseOK()
 }
 
@@ -1345,11 +1352,11 @@ func (co *Conversation) clearManualUnreadAfterClearBestEffort(ctx context.Contex
 	}
 
 	manualUnreadCleared := false
+	var version int64
 	err := co.withConversationExtraLease(ctx, loginUID, channelID, channelType, func(lease *conversationExtraLease) error {
-		// 群聊和子区的任何有效 clearUnread 操作都会清除当前会话的手动未读标识。
-		// 这里不仅包括 unread=0 的真实未读清零，也包括前端用 unread>0
-		// 设置/保留真实未读数量的显式操作；后者同样代表用户重新定义了该会话的
-		// 未读状态，不应继续保留旧的 manual_unread 标识。
+		// Only clearUnread(unread=0) calls this helper. Positive unread updates
+		// retain the explicit marker and the frontend clears it through the
+		// dedicated endpoint when the conversation is re-entered.
 		extra, queryErr := co.conversationExtraDB.queryOne(loginUID, channelID, channelType)
 		if queryErr != nil {
 			return queryErr
@@ -1358,7 +1365,8 @@ func (co *Conversation) clearManualUnreadAfterClearBestEffort(ctx context.Contex
 			return nil
 		}
 
-		version, versionErr := co.nextConversationExtraVersionLocked(loginUID)
+		var versionErr error
+		version, versionErr = co.nextConversationExtraVersionLocked(loginUID)
 		if versionErr != nil {
 			return versionErr
 		}
@@ -1395,6 +1403,12 @@ func (co *Conversation) clearManualUnreadAfterClearBestEffort(ctx context.Contex
 		ChannelID:   loginUID,
 		ChannelType: common.ChannelTypePerson.Uint8(),
 		CMD:         common.CMDSyncConversationExtra,
+		Param: map[string]interface{}{
+			"channel_id":    channelID,
+			"channel_type":  channelType,
+			"manual_unread": false,
+			"version":       version,
+		},
 	}); err != nil {
 		co.Error("发送同步会话扩展命令失败！",
 			zap.Error(err),
@@ -1962,8 +1976,9 @@ func (co *Conversation) setManualUnread(c *wkhttp.Context) {
 		respondMessageRequestInvalid(c, "channel_type")
 		return
 	}
+
 	// 状态仍只属于当前登录用户的精确频道行；沿用既定产品语义，不要求
-	// 当前仍是群或父群成员，以便用户离开频道后也能清理遗留标志。
+	// 当前仍是群或父群成员，也不依赖 WuKongIM Conversation 存在。
 
 	var (
 		extra       *conversationExtraModel
@@ -2041,6 +2056,12 @@ func (co *Conversation) setManualUnread(c *wkhttp.Context) {
 		ChannelID:   loginUID,
 		ChannelType: common.ChannelTypePerson.Uint8(),
 		CMD:         common.CMDSyncConversationExtra,
+		Param: map[string]interface{}{
+			"channel_id":    req.ChannelID,
+			"channel_type":  req.ChannelType,
+			"manual_unread": true,
+			"version":       version,
+		},
 	}); err != nil {
 		// The marker and version are already committed. This CMD is only a
 		// transient notification, so a delivery failure must not turn the
@@ -2158,6 +2179,12 @@ func (co *Conversation) clearManualUnread(c *wkhttp.Context) {
 		ChannelID:   loginUID,
 		ChannelType: common.ChannelTypePerson.Uint8(),
 		CMD:         common.CMDSyncConversationExtra,
+		Param: map[string]interface{}{
+			"channel_id":    req.ChannelID,
+			"channel_type":  req.ChannelType,
+			"manual_unread": false,
+			"version":       version,
+		},
 	}); err != nil {
 		// The marker and version are already committed. Keep notification
 		// delivery best-effort for the same reason as setManualUnread.

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -493,20 +493,8 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 	defaultSpaceID := space.GetUserDefaultSpaceID(sb.ctx, loginUID)
 
 	// 3. Build tab-specific items
-	// 查询所有手动未读的会话
-	unreadItems, err := sb.conversationExtraDB.queryManualUnread(loginUID)
-	if err != nil {
-		sb.Error("sidebar sync: manual unread query failed", zap.Error(err))
-		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
-		return
-	}
-	unreadMap := make(map[string]bool, len(unreadItems))
-	for _, it := range unreadItems {
-		if supportsManualUnreadChannelType(it.ChannelType) {
-			unreadMap[channelKey(it.ChannelID, it.ChannelType)] = true
-		}
-	}
 	var items []*SidebarItem
+	var manualUnreadItems []*conversationExtraModel
 	switch req.Tab {
 	case "follow":
 		items = buildFollowItems(conversations, categorySetting, unfollowedGroups, followedDMs, threadExtMap, groupExts, dmCategorySorts, groupSpaceMap, externalGroupMap, defaultSpaceID)
@@ -598,11 +586,6 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 					zap.Error(mErr), zap.Int("count", len(defaultFollowedGroups)))
 			}
 		}
-		// 构建完 items 后统一回填
-		for _, item := range items {
-			item.ManualUnread = supportsManualUnreadChannelType(item.ChannelType) &&
-				unreadMap[channelKey(item.ChannelID, item.ChannelType)]
-		}
 	case "recent":
 		cutoffs := loadRecentCutoffs(sb.ctx, time.Now())
 		if pinnedLoadFailed {
@@ -612,7 +595,22 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 			cutoffs = recentCutoffs{}
 			sb.Warn("sidebar sync: skipping recent window this response (pinned set unavailable)")
 		}
-		items = buildRecentItems(conversations, cutoffs, pinnedSet, groupSpaceMap, externalGroupMap, defaultSpaceID, unreadMap)
+
+		// Manual unread is a Recent-window exemption, so it must be loaded from
+		// the bounded IM candidate set before the window is applied. The query
+		// still selects only channel identity columns and never scans all rows
+		// owned by the user.
+		groupChannelIDs, topicChannelIDs := collectManualUnreadConversationIDs(conversations)
+		manualUnreadItems, err = sb.conversationExtraDB.queryManualUnread(loginUID, groupChannelIDs, topicChannelIDs)
+		if err != nil {
+			// The marker set is incomplete, so applying the window could hide a
+			// manually unread conversation. Fail open by skipping this response's
+			// window, then retry the marker overlay on the next poll.
+			sb.Warn("sidebar sync: manual unread query failed (non-fatal, recent window skipped)", zap.Error(err))
+			manualUnreadItems = nil
+			cutoffs = recentCutoffs{}
+		}
+		items = buildRecentItems(conversations, cutoffs, pinnedSet, manualUnreadChannelSet(manualUnreadItems), groupSpaceMap, externalGroupMap, defaultSpaceID)
 		// GH octo-server#310：recent tab 也要带 thread 生命周期状态。一次性批量
 		// 查询所有 thread 条目的 status（无 N+1），再 backfill。
 		// FAIL-OPEN：查询失败只记 warn 并把 Status 留空（omitempty -> 字段缺省），
@@ -660,6 +658,19 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 			item.IsPinned = true
 		}
 	}
+
+	// 4a. Follow has no activity window, so it can keep the narrower final-item
+	// lookup (including DB-only threads). Recent already loaded its bounded IM
+	// candidates before filtering because the marker affects membership there.
+	if req.Tab == "follow" {
+		groupChannelIDs, topicChannelIDs := collectManualUnreadChannelIDs(items)
+		manualUnreadItems, err = sb.conversationExtraDB.queryManualUnread(loginUID, groupChannelIDs, topicChannelIDs)
+		if err != nil {
+			sb.Warn("sidebar sync: manual unread query failed (non-fatal, markers omitted)", zap.Error(err))
+			manualUnreadItems = nil
+		}
+	}
+	backfillManualUnread(items, manualUnreadItems)
 
 	// 5. Sort
 	switch req.Tab {
@@ -1292,9 +1303,11 @@ func buildFollowItems(
 // Rules:
 //   - Each conversation is filtered against the cutoff for its channel type
 //     (cutoffs.cutoffFor): kept iff cutoff == 0 (window disabled) OR
-//     timestamp > cutoff. With the default cutoffs (groups/threads = 3-day
-//     window, DMs = 0) this reproduces the historical behaviour where DMs are
-//     always shown and groups/threads obey a 72h window — but every type is
+//     timestamp > cutoff, unless real unread, Group/CommunityTopic manual
+//     unread, pinned, or system-bot state exempts it. With the default cutoffs
+//     (groups/threads = 3-day window, DMs = 0) this reproduces the historical
+//     behaviour where DMs are always shown and groups/threads obey a 72h
+//     window, while respecting explicit unread visibility — but every type is
 //     now operator-tunable via system_settings (issue #289).
 //   - The returned slice is not yet sorted.
 //
@@ -1308,10 +1321,10 @@ func buildRecentItems(
 	convs []*config.SyncUserConversationResp,
 	cutoffs recentCutoffs,
 	pinnedSet map[string]struct{},
+	manualUnreadSet map[string]struct{},
 	groupSpaceMap map[string]string,
 	externalGroupMap map[string]string,
 	defaultSpaceID string,
-	unreadMap map[string]bool,
 ) []*SidebarItem {
 	items := make([]*SidebarItem, 0, len(convs))
 	for _, conv := range convs {
@@ -1319,11 +1332,12 @@ func buildRecentItems(
 		if pinnedSet != nil {
 			_, pinned = pinnedSet[channelKey(conv.ChannelID, conv.ChannelType)]
 		}
-		manualUnread := supportsManualUnreadChannelType(conv.ChannelType) &&
-			unreadMap[channelKey(conv.ChannelID, conv.ChannelType)]
+		manualUnread := false
+		if manualUnreadSet != nil && supportsManualUnreadChannelType(conv.ChannelType) {
+			_, manualUnread = manualUnreadSet[channelKey(conv.ChannelID, conv.ChannelType)]
+		}
 		// 窗口判定必须在算完 pinned 之后 —— 见 keepDespiteRecentWindow。
-		// manual_unread 仍会返回给客户端，但不再作为 Recent 活跃窗口的豁免条件。
-		if !keepDespiteRecentWindow(conv.ChannelID, conv.ChannelType, conv.Unread, pinned) {
+		if !manualUnread && !keepDespiteRecentWindow(conv.ChannelID, conv.ChannelType, conv.Unread, pinned) {
 			if cutoff := cutoffs.cutoffFor(conv.ChannelType); cutoff != 0 && conv.Timestamp <= cutoff {
 				continue
 			}
@@ -1358,12 +1372,78 @@ func buildRecentItems(
 			MySourceSpaceID: mySourceSpaceID,
 			Timestamp:       conv.Timestamp,
 			Unread:          conv.Unread,
+			ManualUnread:    manualUnread,
 			IsPinned:        pinned,
 			ParentChannelID: parentID,
-			ManualUnread:    manualUnread,
 		})
 	}
 	return items
+}
+
+func collectManualUnreadConversationIDs(conversations []*config.SyncUserConversationResp) (groupChannelIDs, topicChannelIDs []string) {
+	seen := make(map[string]struct{}, len(conversations))
+	for _, conversation := range conversations {
+		if conversation == nil || !supportsManualUnreadChannelType(conversation.ChannelType) {
+			continue
+		}
+		key := channelKey(conversation.ChannelID, conversation.ChannelType)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		switch conversation.ChannelType {
+		case common.ChannelTypeGroup.Uint8():
+			groupChannelIDs = append(groupChannelIDs, conversation.ChannelID)
+		case common.ChannelTypeCommunityTopic.Uint8():
+			topicChannelIDs = append(topicChannelIDs, conversation.ChannelID)
+		}
+	}
+	return groupChannelIDs, topicChannelIDs
+}
+
+func collectManualUnreadChannelIDs(items []*SidebarItem) (groupChannelIDs, topicChannelIDs []string) {
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		if item == nil || !supportsManualUnreadChannelType(item.ChannelType) {
+			continue
+		}
+		key := channelKey(item.ChannelID, item.ChannelType)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		switch item.ChannelType {
+		case common.ChannelTypeGroup.Uint8():
+			groupChannelIDs = append(groupChannelIDs, item.ChannelID)
+		case common.ChannelTypeCommunityTopic.Uint8():
+			topicChannelIDs = append(topicChannelIDs, item.ChannelID)
+		}
+	}
+	return groupChannelIDs, topicChannelIDs
+}
+
+func backfillManualUnread(items []*SidebarItem, unreadItems []*conversationExtraModel) {
+	unreadMap := manualUnreadChannelSet(unreadItems)
+	for _, item := range items {
+		if item == nil {
+			continue
+		}
+		item.ManualUnread = false
+		if !supportsManualUnreadChannelType(item.ChannelType) {
+			continue
+		}
+		_, item.ManualUnread = unreadMap[channelKey(item.ChannelID, item.ChannelType)]
+	}
+}
+
+func manualUnreadChannelSet(unreadItems []*conversationExtraModel) map[string]struct{} {
+	unreadMap := make(map[string]struct{}, len(unreadItems))
+	for _, item := range unreadItems {
+		if item != nil && supportsManualUnreadChannelType(item.ChannelType) {
+			unreadMap[channelKey(item.ChannelID, item.ChannelType)] = struct{}{}
+		}
+	}
+	return unreadMap
 }
 
 // mergeThreadEntries appends thread ext entries (from user_conversation_ext)

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -502,7 +502,9 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 	}
 	unreadMap := make(map[string]bool, len(unreadItems))
 	for _, it := range unreadItems {
-		unreadMap[channelKey(it.ChannelID, it.ChannelType)] = true
+		if supportsManualUnreadChannelType(it.ChannelType) {
+			unreadMap[channelKey(it.ChannelID, it.ChannelType)] = true
+		}
 	}
 	var items []*SidebarItem
 	switch req.Tab {
@@ -598,7 +600,8 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 		}
 		// 构建完 items 后统一回填
 		for _, item := range items {
-			item.ManualUnread = unreadMap[channelKey(item.ChannelID, item.ChannelType)]
+			item.ManualUnread = supportsManualUnreadChannelType(item.ChannelType) &&
+				unreadMap[channelKey(item.ChannelID, item.ChannelType)]
 		}
 	case "recent":
 		cutoffs := loadRecentCutoffs(sb.ctx, time.Now())
@@ -1316,7 +1319,8 @@ func buildRecentItems(
 		if pinnedSet != nil {
 			_, pinned = pinnedSet[channelKey(conv.ChannelID, conv.ChannelType)]
 		}
-		manualUnread := unreadMap[channelKey(conv.ChannelID, conv.ChannelType)]
+		manualUnread := supportsManualUnreadChannelType(conv.ChannelType) &&
+			unreadMap[channelKey(conv.ChannelID, conv.ChannelType)]
 		// 窗口判定必须在算完 pinned 之后 —— 见 keepDespiteRecentWindow。
 		// manual_unread 仍会返回给客户端，但不再作为 Recent 活跃窗口的豁免条件。
 		if !keepDespiteRecentWindow(conv.ChannelID, conv.ChannelType, conv.Unread, pinned) {

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -76,19 +76,21 @@ type Sidebar struct {
 	// external-group mapping。
 	groupDB *group.DB
 	log.Log
+	conversationExtraDB *conversationExtraDB
 }
 
 // NewSidebar creates a Sidebar handler.
 func NewSidebar(ctx *config.Context) *Sidebar {
 	return &Sidebar{
-		ctx:             ctx,
-		groupCategoryDB: newGroupCategoryDB(ctx),
-		convExtDB:       convext.NewDB(ctx),
-		threadDB:        thread.NewDB(ctx),
-		followVersionDB: convext.NewFollowVersionDB(ctx),
-		groupService:    group.NewService(ctx),
-		groupDB:         group.NewDB(ctx),
-		Log:             log.NewTLog("Sidebar"),
+		ctx:                 ctx,
+		groupCategoryDB:     newGroupCategoryDB(ctx),
+		convExtDB:           convext.NewDB(ctx),
+		threadDB:            thread.NewDB(ctx),
+		followVersionDB:     convext.NewFollowVersionDB(ctx),
+		groupService:        group.NewService(ctx),
+		groupDB:             group.NewDB(ctx),
+		Log:                 log.NewTLog("Sidebar"),
+		conversationExtraDB: &conversationExtraDB{ctx: ctx, session: ctx.DB()},
 	}
 }
 
@@ -142,7 +144,8 @@ type SidebarItem struct {
 	// 3=deleted，语义与 modules/thread/const.go 的 ThreadStatus* 枚举一致
 	// （GH octo-server#310）。客户端据此同步过滤已归档子区，无需等待 channelInfo。
 	// omitempty 让 DM / 群条目不带该字段，保持线上协议向后兼容。
-	Status int `json:"status,omitempty"`
+	Status       int  `json:"status,omitempty"`
+	ManualUnread bool `json:"manual_unread"`
 }
 
 // sidebarSyncResp is the JSON response for POST /v1/sidebar/sync.
@@ -490,10 +493,22 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 	defaultSpaceID := space.GetUserDefaultSpaceID(sb.ctx, loginUID)
 
 	// 3. Build tab-specific items
+	// 查询所有手动未读的会话
+	unreadItems, err := sb.conversationExtraDB.queryManualUnread(loginUID)
+	if err != nil {
+		sb.Error("sidebar sync: manual unread query failed", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		return
+	}
+	unreadMap := make(map[string]bool, len(unreadItems))
+	for _, it := range unreadItems {
+		unreadMap[channelKey(it.ChannelID, it.ChannelType)] = true
+	}
 	var items []*SidebarItem
 	switch req.Tab {
 	case "follow":
 		items = buildFollowItems(conversations, categorySetting, unfollowedGroups, followedDMs, threadExtMap, groupExts, dmCategorySorts, groupSpaceMap, externalGroupMap, defaultSpaceID)
+
 		// Append standalone thread ext entries not present in IM result.
 		// Pass categorySetting + unfollowedGroups so parent-follow filter applies
 		// to DB-only thread entries as well (PR review Round-3 Blocking #4).
@@ -581,6 +596,10 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 					zap.Error(mErr), zap.Int("count", len(defaultFollowedGroups)))
 			}
 		}
+		// 构建完 items 后统一回填
+		for _, item := range items {
+			item.ManualUnread = unreadMap[channelKey(item.ChannelID, item.ChannelType)]
+		}
 	case "recent":
 		cutoffs := loadRecentCutoffs(sb.ctx, time.Now())
 		if pinnedLoadFailed {
@@ -590,7 +609,7 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 			cutoffs = recentCutoffs{}
 			sb.Warn("sidebar sync: skipping recent window this response (pinned set unavailable)")
 		}
-		items = buildRecentItems(conversations, cutoffs, pinnedSet, groupSpaceMap, externalGroupMap, defaultSpaceID)
+		items = buildRecentItems(conversations, cutoffs, pinnedSet, groupSpaceMap, externalGroupMap, defaultSpaceID, unreadMap)
 		// GH octo-server#310：recent tab 也要带 thread 生命周期状态。一次性批量
 		// 查询所有 thread 条目的 status（无 N+1），再 backfill。
 		// FAIL-OPEN：查询失败只记 warn 并把 Status 留空（omitempty -> 字段缺省），
@@ -1289,6 +1308,7 @@ func buildRecentItems(
 	groupSpaceMap map[string]string,
 	externalGroupMap map[string]string,
 	defaultSpaceID string,
+	unreadMap map[string]bool,
 ) []*SidebarItem {
 	items := make([]*SidebarItem, 0, len(convs))
 	for _, conv := range convs {
@@ -1296,7 +1316,9 @@ func buildRecentItems(
 		if pinnedSet != nil {
 			_, pinned = pinnedSet[channelKey(conv.ChannelID, conv.ChannelType)]
 		}
+		manualUnread := unreadMap[channelKey(conv.ChannelID, conv.ChannelType)]
 		// 窗口判定必须在算完 pinned 之后 —— 见 keepDespiteRecentWindow。
+		// manual_unread 仍会返回给客户端，但不再作为 Recent 活跃窗口的豁免条件。
 		if !keepDespiteRecentWindow(conv.ChannelID, conv.ChannelType, conv.Unread, pinned) {
 			if cutoff := cutoffs.cutoffFor(conv.ChannelType); cutoff != 0 && conv.Timestamp <= cutoff {
 				continue
@@ -1334,6 +1356,7 @@ func buildRecentItems(
 			Unread:          conv.Unread,
 			IsPinned:        pinned,
 			ParentChannelID: parentID,
+			ManualUnread:    manualUnread,
 		})
 	}
 	return items

--- a/modules/message/api_sidebar_recent_filter_e2e_test.go
+++ b/modules/message/api_sidebar_recent_filter_e2e_test.go
@@ -68,7 +68,7 @@ func TestE2E_RecentFilter_DefaultsReproduceLegacyBehaviour(t *testing.T) {
 		makeIMConv("g-old", common.ChannelTypeGroup.Uint8(), now.Add(-73*time.Hour).Unix()),
 		makeIMConv("dm-old", common.ChannelTypePerson.Uint8(), now.Add(-1000*time.Hour).Unix()),
 	}
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "", map[string]bool{})
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, nil, "")
 	ids := idSet(items)
 	assert.True(t, ids["g-new"])
 	assert.False(t, ids["g-old"], "默认 3 天窗口剔除超期群")
@@ -121,7 +121,7 @@ func TestE2E_RecentFilter_AdminOverrideTakesEffect(t *testing.T) {
 		makeIMConv("dm-6d", common.ChannelTypePerson.Uint8(), now.Add(-6*24*time.Hour).Unix()),
 		makeIMConv("dm-8d", common.ChannelTypePerson.Uint8(), now.Add(-8*24*time.Hour).Unix()),
 	}
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "", map[string]bool{})
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, nil, "")
 	ids := idSet(items)
 	assert.True(t, ids["g-ancient"], "群窗口关闭 → 远古群也返回")
 	assert.False(t, ids["g1____t-old"], "话题 3 天窗口 → 剔除超期话题")

--- a/modules/message/api_sidebar_recent_filter_e2e_test.go
+++ b/modules/message/api_sidebar_recent_filter_e2e_test.go
@@ -68,7 +68,7 @@ func TestE2E_RecentFilter_DefaultsReproduceLegacyBehaviour(t *testing.T) {
 		makeIMConv("g-old", common.ChannelTypeGroup.Uint8(), now.Add(-73*time.Hour).Unix()),
 		makeIMConv("dm-old", common.ChannelTypePerson.Uint8(), now.Add(-1000*time.Hour).Unix()),
 	}
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "")
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "", map[string]bool{})
 	ids := idSet(items)
 	assert.True(t, ids["g-new"])
 	assert.False(t, ids["g-old"], "默认 3 天窗口剔除超期群")
@@ -121,7 +121,7 @@ func TestE2E_RecentFilter_AdminOverrideTakesEffect(t *testing.T) {
 		makeIMConv("dm-6d", common.ChannelTypePerson.Uint8(), now.Add(-6*24*time.Hour).Unix()),
 		makeIMConv("dm-8d", common.ChannelTypePerson.Uint8(), now.Add(-8*24*time.Hour).Unix()),
 	}
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "")
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "", map[string]bool{})
 	ids := idSet(items)
 	assert.True(t, ids["g-ancient"], "群窗口关闭 → 远古群也返回")
 	assert.False(t, ids["g1____t-old"], "话题 3 天窗口 → 剔除超期话题")

--- a/modules/message/api_sidebar_status_test.go
+++ b/modules/message/api_sidebar_status_test.go
@@ -226,7 +226,7 @@ func TestSidebar_RecentTab_BackfillsStatus(t *testing.T) {
 	}
 
 	sb := NewSidebar(ctx)
-	items := buildRecentItems(stubConvs, cutoffs, nil, nil, nil, "")
+	items := buildRecentItems(stubConvs, cutoffs, nil, nil, nil, "", map[string]bool{})
 	statusMap, err := sb.loadThreadStatuses(items)
 	require.NoError(t, err)
 	backfillThreadStatus(items, statusMap)
@@ -268,7 +268,7 @@ func TestSidebar_RecentTab_FailOpenOnStatusError(t *testing.T) {
 	stubConvs := []*config.SyncUserConversationResp{
 		{ChannelID: "g310e____thr", ChannelType: common.ChannelTypeCommunityTopic.Uint8(), Timestamp: 100},
 	}
-	items := buildRecentItems(stubConvs, cutoffs, nil, nil, nil, "")
+	items := buildRecentItems(stubConvs, cutoffs, nil, nil, nil, "", map[string]bool{})
 
 	// Mirror the handler's recent branch: query may fail → fail open.
 	statusMap, qerr := sb.loadThreadStatuses(items)

--- a/modules/message/api_sidebar_status_test.go
+++ b/modules/message/api_sidebar_status_test.go
@@ -226,7 +226,7 @@ func TestSidebar_RecentTab_BackfillsStatus(t *testing.T) {
 	}
 
 	sb := NewSidebar(ctx)
-	items := buildRecentItems(stubConvs, cutoffs, nil, nil, nil, "", map[string]bool{})
+	items := buildRecentItems(stubConvs, cutoffs, nil, nil, nil, nil, "")
 	statusMap, err := sb.loadThreadStatuses(items)
 	require.NoError(t, err)
 	backfillThreadStatus(items, statusMap)
@@ -268,7 +268,7 @@ func TestSidebar_RecentTab_FailOpenOnStatusError(t *testing.T) {
 	stubConvs := []*config.SyncUserConversationResp{
 		{ChannelID: "g310e____thr", ChannelType: common.ChannelTypeCommunityTopic.Uint8(), Timestamp: 100},
 	}
-	items := buildRecentItems(stubConvs, cutoffs, nil, nil, nil, "", map[string]bool{})
+	items := buildRecentItems(stubConvs, cutoffs, nil, nil, nil, nil, "")
 
 	// Mirror the handler's recent branch: query may fail → fail open.
 	statusMap, qerr := sb.loadThreadStatuses(items)

--- a/modules/message/api_sidebar_test.go
+++ b/modules/message/api_sidebar_test.go
@@ -250,7 +250,7 @@ func TestBuildRecentItems_GroupWithinWindow_Included(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), nowRecent()),
 	}
-	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "", map[string]bool{})
+	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, "g1", items[0].TargetID)
 }
@@ -259,7 +259,7 @@ func TestBuildRecentItems_GroupOutsideWindow_Excluded(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), now3DaysAgo()),
 	}
-	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "", map[string]bool{})
+	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 
@@ -268,7 +268,7 @@ func TestBuildRecentItems_DMAlwaysIncluded(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("peer1", common.ChannelTypePerson.Uint8(), now3DaysAgo()),
 	}
-	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "", map[string]bool{})
+	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, "peer1", items[0].TargetID)
 }
@@ -277,7 +277,7 @@ func TestBuildRecentItems_ThreadWithinWindow_Included(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1____th1", common.ChannelTypeCommunityTopic.Uint8(), nowRecent()),
 	}
-	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "", map[string]bool{})
+	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, "g1____th1", items[0].TargetID)
 }
@@ -286,11 +286,11 @@ func TestBuildRecentItems_ThreadOutsideWindow_Excluded(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1____th1", common.ChannelTypeCommunityTopic.Uint8(), now3DaysAgo()),
 	}
-	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "", map[string]bool{})
+	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 
-func TestBuildRecentItems_ManualUnreadDoesNotSurviveWindow(t *testing.T) {
+func TestBuildRecentItems_ManualUnreadSurvivesWindow(t *testing.T) {
 	tests := []struct {
 		name        string
 		channelID   string
@@ -313,22 +313,22 @@ func TestBuildRecentItems_ManualUnreadDoesNotSurviveWindow(t *testing.T) {
 			convs := []*config.SyncUserConversationResp{
 				makeIMConv(tc.channelID, tc.channelType, now3DaysAgo()),
 			}
-			manualUnread := map[string]bool{
-				channelKey(tc.channelID, tc.channelType): true,
+			manualUnreadSet := map[string]struct{}{
+				channelKey(tc.channelID, tc.channelType): {},
 			}
-
 			items := buildRecentItems(
 				convs,
 				legacyRecentCutoffs(),
 				nil,
+				manualUnreadSet,
 				nil,
 				nil,
 				"",
-				manualUnread,
 			)
 
-			assert.Empty(t, items,
-				"manual_unread 不应让超出活跃时间窗口的会话继续出现在 Recent")
+			require.Len(t, items, 1,
+				"manual_unread 必须让超出活跃时间窗口的会话继续出现在 Recent")
+			assert.True(t, items[0].ManualUnread)
 		})
 	}
 }
@@ -340,18 +340,14 @@ func TestBuildRecentItems_ManualUnreadFalseDoesNotSurviveWindow(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv(channelID, channelType.Uint8(), now3DaysAgo()),
 	}
-	manualUnread := map[string]bool{
-		channelKey(channelID, channelType.Uint8()): false,
-	}
-
 	items := buildRecentItems(
 		convs,
 		legacyRecentCutoffs(),
 		nil,
 		nil,
 		nil,
+		nil,
 		"",
-		manualUnread,
 	)
 
 	assert.Empty(t, items,
@@ -366,17 +362,17 @@ func TestBuildRecentItems_ManualUnreadIsScopedByChannelType(t *testing.T) {
 		makeIMConv(channelID, common.ChannelTypePerson.Uint8(), nowRecent()),
 		makeIMConv(channelID, common.ChannelTypeCommunityTopic.Uint8(), nowRecent()),
 	}
-	manualUnread := map[string]bool{
-		channelKey(channelID, common.ChannelTypePerson.Uint8()):         true,
-		channelKey(channelID, common.ChannelTypeCommunityTopic.Uint8()): true,
-	}
 	cutoffs := recentCutoffs{
 		group:  daysCutoff(time.Now(), 3),
 		thread: daysCutoff(time.Now(), 3),
 		person: daysCutoff(time.Now(), 3),
 	}
 
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "", manualUnread)
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, nil, "")
+	backfillManualUnread(items, []*conversationExtraModel{
+		{ChannelID: channelID, ChannelType: common.ChannelTypePerson.Uint8()},
+		{ChannelID: channelID, ChannelType: common.ChannelTypeCommunityTopic.Uint8()},
+	})
 
 	require.Len(t, items, 3)
 	manualUnreadByType := make(map[uint8]bool, len(items))
@@ -390,6 +386,36 @@ func TestBuildRecentItems_ManualUnreadIsScopedByChannelType(t *testing.T) {
 		"群聊与子区的 manual_unread 必须按 channel_type 区分")
 }
 
+func TestCollectManualUnreadChannelIDs_UsesOnlyFinalSupportedItems(t *testing.T) {
+	const channelID = "same-channel-id"
+	items := []*SidebarItem{
+		{ChannelID: channelID, ChannelType: common.ChannelTypeGroup.Uint8()},
+		{ChannelID: channelID, ChannelType: common.ChannelTypeGroup.Uint8()},
+		{ChannelID: channelID, ChannelType: common.ChannelTypeCommunityTopic.Uint8()},
+		{ChannelID: "person-id", ChannelType: common.ChannelTypePerson.Uint8()},
+		nil,
+	}
+
+	groupIDs, topicIDs := collectManualUnreadChannelIDs(items)
+
+	assert.Equal(t, []string{channelID}, groupIDs)
+	assert.Equal(t, []string{channelID}, topicIDs)
+}
+
+func TestBackfillManualUnread_EmptyRowsFailOpenToFalse(t *testing.T) {
+	items := []*SidebarItem{
+		{ChannelID: "group-id", ChannelType: common.ChannelTypeGroup.Uint8(), ManualUnread: true},
+		{ChannelID: "topic-id", ChannelType: common.ChannelTypeCommunityTopic.Uint8(), ManualUnread: true},
+		{ChannelID: "person-id", ChannelType: common.ChannelTypePerson.Uint8(), ManualUnread: true},
+	}
+
+	backfillManualUnread(items, nil)
+
+	for _, item := range items {
+		assert.False(t, item.ManualUnread)
+	}
+}
+
 func TestBuildRecentItems_PinnedFirst(t *testing.T) {
 	pinnedSet := map[string]struct{}{
 		channelKey("g2", common.ChannelTypeGroup.Uint8()): {},
@@ -398,7 +424,7 @@ func TestBuildRecentItems_PinnedFirst(t *testing.T) {
 		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), nowRecent()),
 		makeIMConv("g2", common.ChannelTypeGroup.Uint8(), nowRecent()-10),
 	}
-	items := buildRecentItems(convs, legacyRecentCutoffs(), pinnedSet, nil, nil, "", map[string]bool{})
+	items := buildRecentItems(convs, legacyRecentCutoffs(), pinnedSet, nil, nil, nil, "")
 	require.Len(t, items, 2)
 
 	// buildRecentItems sets IsPinned flag; sorting is done separately
@@ -438,7 +464,7 @@ func TestBuildRecentItems_GroupCutoffZero_AllGroupsKept(t *testing.T) {
 		makeIMConv("g-old", common.ChannelTypeGroup.Uint8(), now3DaysAgo()),
 		makeIMConv("g-new", common.ChannelTypeGroup.Uint8(), nowRecent()),
 	}
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "", map[string]bool{})
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, nil, "")
 	assert.Len(t, items, 2, "group 窗口关闭时，超期群也保留")
 }
 
@@ -451,7 +477,7 @@ func TestBuildRecentItems_PerTypeWindowsIndependent(t *testing.T) {
 		makeIMConv("g1____t-old", common.ChannelTypeCommunityTopic.Uint8(), now3DaysAgo()), // dropped (thread window on)
 		makeIMConv("g1____t-new", common.ChannelTypeCommunityTopic.Uint8(), nowRecent()),   // kept
 	}
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "", map[string]bool{})
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, nil, "")
 	ids := map[string]bool{}
 	for _, it := range items {
 		ids[it.TargetID] = true
@@ -470,7 +496,7 @@ func TestBuildRecentItems_PersonWindowFiltersDMs(t *testing.T) {
 		makeIMConv("dm-old", common.ChannelTypePerson.Uint8(), now3DaysAgo()),
 		makeIMConv("dm-new", common.ChannelTypePerson.Uint8(), nowRecent()),
 	}
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "", map[string]bool{})
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, nil, "")
 	require.Len(t, items, 1, "person 窗口=3天时，超期 DM 被剔除")
 	assert.Equal(t, "dm-new", items[0].TargetID)
 }
@@ -491,7 +517,7 @@ func TestBuildRecentItems_UnknownChannelType_KeptUnconditionally(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("x-ancient", unknownChannelType, time.Now().Add(-10000*time.Hour).Unix()),
 	}
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "", map[string]bool{})
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, nil, "")
 	require.Len(t, items, 1, "未知频道类型不应被时间窗口过滤（cutoffFor 默认 0=不过滤）")
 	assert.Equal(t, "x-ancient", items[0].TargetID)
 }
@@ -503,7 +529,7 @@ func TestBuildRecentItems_PersonCutoffZero_AllDMsKept(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("dm-ancient", common.ChannelTypePerson.Uint8(), time.Now().Add(-1000*time.Hour).Unix()),
 	}
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "", map[string]bool{})
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, nil, "")
 	require.Len(t, items, 1, "person 默认 0 → DM 永远保留")
 }
 
@@ -1091,7 +1117,7 @@ func TestBuildFollowItems_EmptyConversations(t *testing.T) {
 }
 
 func TestBuildRecentItems_EmptyConversations(t *testing.T) {
-	items := buildRecentItems(nil, legacyRecentCutoffs(), nil, nil, nil, "", map[string]bool{})
+	items := buildRecentItems(nil, legacyRecentCutoffs(), nil, nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 

--- a/modules/message/api_sidebar_test.go
+++ b/modules/message/api_sidebar_test.go
@@ -364,9 +364,11 @@ func TestBuildRecentItems_ManualUnreadIsScopedByChannelType(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv(channelID, common.ChannelTypeGroup.Uint8(), nowRecent()),
 		makeIMConv(channelID, common.ChannelTypePerson.Uint8(), nowRecent()),
+		makeIMConv(channelID, common.ChannelTypeCommunityTopic.Uint8(), nowRecent()),
 	}
 	manualUnread := map[string]bool{
-		channelKey(channelID, common.ChannelTypePerson.Uint8()): true,
+		channelKey(channelID, common.ChannelTypePerson.Uint8()):         true,
+		channelKey(channelID, common.ChannelTypeCommunityTopic.Uint8()): true,
 	}
 	cutoffs := recentCutoffs{
 		group:  daysCutoff(time.Now(), 3),
@@ -376,14 +378,16 @@ func TestBuildRecentItems_ManualUnreadIsScopedByChannelType(t *testing.T) {
 
 	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "", manualUnread)
 
-	require.Len(t, items, 2)
+	require.Len(t, items, 3)
 	manualUnreadByType := make(map[uint8]bool, len(items))
 	for _, item := range items {
 		manualUnreadByType[item.ChannelType] = item.ManualUnread
 	}
 	assert.False(t, manualUnreadByType[common.ChannelTypeGroup.Uint8()])
-	assert.True(t, manualUnreadByType[common.ChannelTypePerson.Uint8()],
-		"manual_unread 必须按 channel_id + channel_type 区分")
+	assert.False(t, manualUnreadByType[common.ChannelTypePerson.Uint8()],
+		"私聊即使存在遗留标志也不应返回 manual_unread=true")
+	assert.True(t, manualUnreadByType[common.ChannelTypeCommunityTopic.Uint8()],
+		"群聊与子区的 manual_unread 必须按 channel_type 区分")
 }
 
 func TestBuildRecentItems_PinnedFirst(t *testing.T) {

--- a/modules/message/api_sidebar_test.go
+++ b/modules/message/api_sidebar_test.go
@@ -250,7 +250,7 @@ func TestBuildRecentItems_GroupWithinWindow_Included(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), nowRecent()),
 	}
-	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "")
+	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "", map[string]bool{})
 	require.Len(t, items, 1)
 	assert.Equal(t, "g1", items[0].TargetID)
 }
@@ -259,7 +259,7 @@ func TestBuildRecentItems_GroupOutsideWindow_Excluded(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), now3DaysAgo()),
 	}
-	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "")
+	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "", map[string]bool{})
 	assert.Len(t, items, 0)
 }
 
@@ -268,7 +268,7 @@ func TestBuildRecentItems_DMAlwaysIncluded(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("peer1", common.ChannelTypePerson.Uint8(), now3DaysAgo()),
 	}
-	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "")
+	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "", map[string]bool{})
 	require.Len(t, items, 1)
 	assert.Equal(t, "peer1", items[0].TargetID)
 }
@@ -277,7 +277,7 @@ func TestBuildRecentItems_ThreadWithinWindow_Included(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1____th1", common.ChannelTypeCommunityTopic.Uint8(), nowRecent()),
 	}
-	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "")
+	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "", map[string]bool{})
 	require.Len(t, items, 1)
 	assert.Equal(t, "g1____th1", items[0].TargetID)
 }
@@ -286,8 +286,104 @@ func TestBuildRecentItems_ThreadOutsideWindow_Excluded(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1____th1", common.ChannelTypeCommunityTopic.Uint8(), now3DaysAgo()),
 	}
-	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "")
+	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "", map[string]bool{})
 	assert.Len(t, items, 0)
+}
+
+func TestBuildRecentItems_ManualUnreadDoesNotSurviveWindow(t *testing.T) {
+	tests := []struct {
+		name        string
+		channelID   string
+		channelType uint8
+	}{
+		{
+			name:        "group",
+			channelID:   "g-manual-unread",
+			channelType: common.ChannelTypeGroup.Uint8(),
+		},
+		{
+			name:        "thread",
+			channelID:   "g-manual-unread____thread-1",
+			channelType: common.ChannelTypeCommunityTopic.Uint8(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			convs := []*config.SyncUserConversationResp{
+				makeIMConv(tc.channelID, tc.channelType, now3DaysAgo()),
+			}
+			manualUnread := map[string]bool{
+				channelKey(tc.channelID, tc.channelType): true,
+			}
+
+			items := buildRecentItems(
+				convs,
+				legacyRecentCutoffs(),
+				nil,
+				nil,
+				nil,
+				"",
+				manualUnread,
+			)
+
+			assert.Empty(t, items,
+				"manual_unread 不应让超出活跃时间窗口的会话继续出现在 Recent")
+		})
+	}
+}
+
+func TestBuildRecentItems_ManualUnreadFalseDoesNotSurviveWindow(t *testing.T) {
+	const channelID = "g-manual-read"
+	const channelType = common.ChannelTypeGroup
+
+	convs := []*config.SyncUserConversationResp{
+		makeIMConv(channelID, channelType.Uint8(), now3DaysAgo()),
+	}
+	manualUnread := map[string]bool{
+		channelKey(channelID, channelType.Uint8()): false,
+	}
+
+	items := buildRecentItems(
+		convs,
+		legacyRecentCutoffs(),
+		nil,
+		nil,
+		nil,
+		"",
+		manualUnread,
+	)
+
+	assert.Empty(t, items,
+		"manual_unread=false 不应关闭原有的 Recent 时间窗口过滤")
+}
+
+func TestBuildRecentItems_ManualUnreadIsScopedByChannelType(t *testing.T) {
+	const channelID = "same-channel-id"
+
+	convs := []*config.SyncUserConversationResp{
+		makeIMConv(channelID, common.ChannelTypeGroup.Uint8(), nowRecent()),
+		makeIMConv(channelID, common.ChannelTypePerson.Uint8(), nowRecent()),
+	}
+	manualUnread := map[string]bool{
+		channelKey(channelID, common.ChannelTypePerson.Uint8()): true,
+	}
+	cutoffs := recentCutoffs{
+		group:  daysCutoff(time.Now(), 3),
+		thread: daysCutoff(time.Now(), 3),
+		person: daysCutoff(time.Now(), 3),
+	}
+
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "", manualUnread)
+
+	require.Len(t, items, 2)
+	manualUnreadByType := make(map[uint8]bool, len(items))
+	for _, item := range items {
+		manualUnreadByType[item.ChannelType] = item.ManualUnread
+	}
+	assert.False(t, manualUnreadByType[common.ChannelTypeGroup.Uint8()])
+	assert.True(t, manualUnreadByType[common.ChannelTypePerson.Uint8()],
+		"manual_unread 必须按 channel_id + channel_type 区分")
 }
 
 func TestBuildRecentItems_PinnedFirst(t *testing.T) {
@@ -298,7 +394,7 @@ func TestBuildRecentItems_PinnedFirst(t *testing.T) {
 		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), nowRecent()),
 		makeIMConv("g2", common.ChannelTypeGroup.Uint8(), nowRecent()-10),
 	}
-	items := buildRecentItems(convs, legacyRecentCutoffs(), pinnedSet, nil, nil, "")
+	items := buildRecentItems(convs, legacyRecentCutoffs(), pinnedSet, nil, nil, "", map[string]bool{})
 	require.Len(t, items, 2)
 
 	// buildRecentItems sets IsPinned flag; sorting is done separately
@@ -338,7 +434,7 @@ func TestBuildRecentItems_GroupCutoffZero_AllGroupsKept(t *testing.T) {
 		makeIMConv("g-old", common.ChannelTypeGroup.Uint8(), now3DaysAgo()),
 		makeIMConv("g-new", common.ChannelTypeGroup.Uint8(), nowRecent()),
 	}
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "")
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "", map[string]bool{})
 	assert.Len(t, items, 2, "group 窗口关闭时，超期群也保留")
 }
 
@@ -351,7 +447,7 @@ func TestBuildRecentItems_PerTypeWindowsIndependent(t *testing.T) {
 		makeIMConv("g1____t-old", common.ChannelTypeCommunityTopic.Uint8(), now3DaysAgo()), // dropped (thread window on)
 		makeIMConv("g1____t-new", common.ChannelTypeCommunityTopic.Uint8(), nowRecent()),   // kept
 	}
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "")
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "", map[string]bool{})
 	ids := map[string]bool{}
 	for _, it := range items {
 		ids[it.TargetID] = true
@@ -370,7 +466,7 @@ func TestBuildRecentItems_PersonWindowFiltersDMs(t *testing.T) {
 		makeIMConv("dm-old", common.ChannelTypePerson.Uint8(), now3DaysAgo()),
 		makeIMConv("dm-new", common.ChannelTypePerson.Uint8(), nowRecent()),
 	}
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "")
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "", map[string]bool{})
 	require.Len(t, items, 1, "person 窗口=3天时，超期 DM 被剔除")
 	assert.Equal(t, "dm-new", items[0].TargetID)
 }
@@ -391,7 +487,7 @@ func TestBuildRecentItems_UnknownChannelType_KeptUnconditionally(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("x-ancient", unknownChannelType, time.Now().Add(-10000*time.Hour).Unix()),
 	}
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "")
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "", map[string]bool{})
 	require.Len(t, items, 1, "未知频道类型不应被时间窗口过滤（cutoffFor 默认 0=不过滤）")
 	assert.Equal(t, "x-ancient", items[0].TargetID)
 }
@@ -403,7 +499,7 @@ func TestBuildRecentItems_PersonCutoffZero_AllDMsKept(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("dm-ancient", common.ChannelTypePerson.Uint8(), time.Now().Add(-1000*time.Hour).Unix()),
 	}
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "")
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "", map[string]bool{})
 	require.Len(t, items, 1, "person 默认 0 → DM 永远保留")
 }
 
@@ -991,7 +1087,7 @@ func TestBuildFollowItems_EmptyConversations(t *testing.T) {
 }
 
 func TestBuildRecentItems_EmptyConversations(t *testing.T) {
-	items := buildRecentItems(nil, legacyRecentCutoffs(), nil, nil, nil, "")
+	items := buildRecentItems(nil, legacyRecentCutoffs(), nil, nil, nil, "", map[string]bool{})
 	assert.Len(t, items, 0)
 }
 
@@ -1318,6 +1414,19 @@ func TestSidebarItem_JSON_ThreadIncludesStatus(t *testing.T) {
 			assert.Contains(t, string(b), tc.want)
 		})
 	}
+}
+
+func TestSidebarItem_JSON_ManualUnreadUsesExpectedField(t *testing.T) {
+	item := &SidebarItem{
+		TargetType:   int(common.ChannelTypeGroup),
+		TargetID:     "g-manual-unread",
+		ManualUnread: true,
+	}
+
+	b, err := json.Marshal(item)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"manual_unread":true`)
+	assert.NotContains(t, string(b), `"manual_read"`)
 }
 
 // Status semantics must match the thread package enum exactly (GH octo-server#310).

--- a/modules/message/conversation_extra_lock.go
+++ b/modules/message/conversation_extra_lock.go
@@ -1,0 +1,201 @@
+package message
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+const (
+	conversationExtraLockKeyPrefix = "conversation_extra:lock:"
+	conversationExtraLockTTL       = 10 * time.Second
+	conversationExtraLockWait      = 2 * time.Second
+	conversationExtraLockRetry     = 40 * time.Millisecond
+)
+
+var (
+	errConversationExtraLockTimeout = errors.New("conversation extra lock acquisition timed out")
+	errConversationExtraLockLost    = errors.New("conversation extra lock ownership lost")
+	errConversationExtraVersion     = errors.New("conversation extra version was not advanced")
+
+	releaseConversationExtraLockScript = rd.NewScript(`
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+end
+return 0
+`)
+	renewConversationExtraLockScript = rd.NewScript(`
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("PEXPIRE", KEYS[1], ARGV[2])
+end
+return 0
+`)
+)
+
+// conversationExtraLock serializes every conversation-extra write for one
+// user. The synchronization cursor is user-scoped, so a per-channel lock would
+// still allow two channels for the same user to commit versions out of order.
+type conversationExtraLock struct {
+	client *rd.Client
+}
+
+type conversationExtraLease struct {
+	lock  *conversationExtraLock
+	key   string
+	owner string
+}
+
+func newConversationExtraLock(ctx *config.Context) *conversationExtraLock {
+	return &conversationExtraLock{
+		client: octoredis.NewInstrumentedClient(ctx.GetConfig(), func(o *rd.Options) {
+			o.MaxRetries = 3
+			o.ReadTimeout = 3 * time.Second
+			o.WriteTimeout = 3 * time.Second
+			o.DialTimeout = 3 * time.Second
+		}),
+	}
+}
+
+func conversationExtraLockKey(uid string) string {
+	return conversationExtraLockKeyPrefix + uid
+}
+
+// Acquire waits for a bounded period and stores a request-unique UUID owner
+// together with the lease TTL. A crashed process therefore cannot leave a
+// permanent lock behind.
+func (l *conversationExtraLock) Acquire(ctx context.Context, uid string) (*conversationExtraLease, error) {
+	ownerUUID, err := uuid.NewRandom()
+	if err != nil {
+		return nil, fmt.Errorf("generate conversation extra lock owner: %w", err)
+	}
+	lease := &conversationExtraLease{
+		lock:  l,
+		key:   conversationExtraLockKey(uid),
+		owner: ownerUUID.String(),
+	}
+
+	acquireCtx, cancel := context.WithTimeout(ctx, conversationExtraLockWait)
+	defer cancel()
+	retry := time.NewTicker(conversationExtraLockRetry)
+	defer retry.Stop()
+
+	for {
+		acquired, err := l.client.WithContext(acquireCtx).
+			SetNX(lease.key, lease.owner, conversationExtraLockTTL).
+			Result()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil, fmt.Errorf("acquire conversation extra lock: %w", ctx.Err())
+			}
+			if acquireCtx.Err() != nil {
+				return nil, errConversationExtraLockTimeout
+			}
+			return nil, fmt.Errorf("acquire conversation extra lock: %w", err)
+		}
+		if acquired {
+			return lease, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("acquire conversation extra lock: %w", ctx.Err())
+		case <-acquireCtx.Done():
+			if ctx.Err() != nil {
+				return nil, fmt.Errorf("acquire conversation extra lock: %w", ctx.Err())
+			}
+			return nil, errConversationExtraLockTimeout
+		case <-retry.C:
+		}
+	}
+}
+
+// Renew atomically verifies the UUID owner and refreshes the 10-second lease.
+// Callers invoke it immediately before the protected database write.
+func (l *conversationExtraLease) Renew(ctx context.Context) error {
+	result, err := renewConversationExtraLockScript.Run(
+		l.lock.client.WithContext(ctx),
+		[]string{l.key},
+		l.owner,
+		conversationExtraLockTTL.Milliseconds(),
+	).Result()
+	if err != nil && !errors.Is(err, rd.Nil) {
+		return fmt.Errorf("renew conversation extra lock: %w", err)
+	}
+	if renewed, ok := result.(int64); !ok || renewed != 1 {
+		return errConversationExtraLockLost
+	}
+	return nil
+}
+
+// Release uses compare-and-delete so an expired owner can never delete a lock
+// subsequently acquired by another request.
+func (l *conversationExtraLease) Release(ctx context.Context) error {
+	_, err := releaseConversationExtraLockScript.Run(
+		l.lock.client.WithContext(ctx),
+		[]string{l.key},
+		l.owner,
+	).Result()
+	if err != nil && !errors.Is(err, rd.Nil) {
+		return fmt.Errorf("release conversation extra lock: %w", err)
+	}
+	return nil
+}
+
+// withConversationExtraLease keeps lock ownership and release policy in one
+// place. CMD delivery is deliberately performed by callers after this method
+// returns, so network notification latency never extends the critical section.
+func (co *Conversation) withConversationExtraLease(
+	ctx context.Context,
+	uid string,
+	channelID string,
+	channelType uint8,
+	fn func(*conversationExtraLease) error,
+) (err error) {
+	lease, err := co.conversationExtraLock.Acquire(ctx, uid)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		releaseCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if releaseErr := lease.Release(releaseCtx); releaseErr != nil {
+			co.Error("释放会话扩展分布式锁失败！",
+				zap.Error(releaseErr),
+				zap.String("channel_id", channelID),
+				zap.Uint8("channel_type", channelType),
+			)
+		}
+	}()
+	return fn(lease)
+}
+
+// nextConversationExtraVersionLocked combines the existing sequence source
+// with the persisted per-user high-water mark. GenSeq reserves process-local
+// blocks, so max+1 prevents a different process's older block from moving this
+// user's synchronization cursor backwards.
+func (co *Conversation) nextConversationExtraVersionLocked(uid string) (int64, error) {
+	maxVersion, err := co.conversationExtraDB.maxVersion(uid)
+	if err != nil {
+		return 0, err
+	}
+	generated, err := co.ctx.GenSeq(common.SyncConversationExtraKey)
+	if err != nil {
+		return 0, err
+	}
+	if generated > maxVersion {
+		return generated, nil
+	}
+	if maxVersion == math.MaxInt64 {
+		return 0, errors.New("conversation extra version exhausted")
+	}
+	return maxVersion + 1, nil
+}

--- a/modules/message/conversation_extra_lock_test.go
+++ b/modules/message/conversation_extra_lock_test.go
@@ -1,0 +1,74 @@
+package message
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConversationExtraLeaseUsesUUIDTTLAndOwnerCheckedScripts(t *testing.T) {
+	cfg := config.New()
+	ctx := config.NewContext(cfg)
+	lock := newConversationExtraLock(ctx)
+	t.Cleanup(func() { _ = lock.client.Close() })
+
+	uid := "lease-owner-" + uuid.NewString()
+	key := conversationExtraLockKey(uid)
+	require.NoError(t, lock.client.Del(key).Err())
+	t.Cleanup(func() { _ = lock.client.Del(key).Err() })
+
+	lease, err := lock.Acquire(context.Background(), uid)
+	require.NoError(t, err)
+	_, err = uuid.Parse(lease.owner)
+	require.NoError(t, err, "lock owner must be a UUID")
+
+	ttl, err := lock.client.PTTL(key).Result()
+	require.NoError(t, err)
+	require.Positive(t, ttl)
+	require.LessOrEqual(t, ttl, conversationExtraLockTTL)
+
+	require.NoError(t, lease.Renew(context.Background()))
+	renewedTTL, err := lock.client.PTTL(key).Result()
+	require.NoError(t, err)
+	require.Greater(t, renewedTTL, 9*time.Second)
+
+	// Simulate A expiring and B acquiring the same key. A's compare-delete must
+	// not remove B's lease, and A's compare-renew must report lost ownership.
+	newOwner := uuid.NewString()
+	require.NoError(t, lock.client.Set(key, newOwner, conversationExtraLockTTL).Err())
+	require.ErrorIs(t, lease.Renew(context.Background()), errConversationExtraLockLost)
+	require.NoError(t, lease.Release(context.Background()))
+	storedOwner, err := lock.client.Get(key).Result()
+	require.NoError(t, err)
+	require.Equal(t, newOwner, storedOwner)
+}
+
+func TestConversationExtraLockSerializesSameUID(t *testing.T) {
+	cfg := config.New()
+	ctx := config.NewContext(cfg)
+	lock := newConversationExtraLock(ctx)
+	t.Cleanup(func() { _ = lock.client.Close() })
+
+	uid := "lease-serial-" + uuid.NewString()
+	key := conversationExtraLockKey(uid)
+	require.NoError(t, lock.client.Del(key).Err())
+	t.Cleanup(func() { _ = lock.client.Del(key).Err() })
+
+	first, err := lock.Acquire(context.Background(), uid)
+	require.NoError(t, err)
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), 120*time.Millisecond)
+	defer cancel()
+	_, err = lock.Acquire(waitCtx, uid)
+	require.Error(t, err)
+
+	require.NoError(t, first.Release(context.Background()))
+	second, err := lock.Acquire(context.Background(), uid)
+	require.NoError(t, err)
+	require.NotEqual(t, first.owner, second.owner)
+	require.NoError(t, second.Release(context.Background()))
+}

--- a/modules/message/conversation_recent_filter_e2e_test.go
+++ b/modules/message/conversation_recent_filter_e2e_test.go
@@ -56,6 +56,7 @@ var (
 	fakeIMOnce  sync.Once
 	fakeIMSrv   *httptest.Server
 	fakeIMConvs []*config.SyncUserConversationResp
+	fakeIMCMDs  []string
 )
 
 func sharedFakeIM() *httptest.Server {
@@ -64,6 +65,21 @@ func sharedFakeIM() *httptest.Server {
 			w.Header().Set("Content-Type", "application/json")
 			if strings.HasSuffix(r.URL.Path, "/conversation/sync") {
 				_, _ = w.Write([]byte(util.ToJson(fakeIMConvs)))
+				return
+			}
+			if strings.HasSuffix(r.URL.Path, "/message/send") {
+				var req struct {
+					Payload []byte `json:"payload"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
+					var payload struct {
+						CMD string `json:"cmd"`
+					}
+					if err := json.Unmarshal(req.Payload, &payload); err == nil && payload.CMD != "" {
+						fakeIMCMDs = append(fakeIMCMDs, payload.CMD)
+					}
+				}
+				_, _ = w.Write([]byte(`{"data":{}}`))
 				return
 			}
 			_, _ = w.Write([]byte("{}"))
@@ -112,6 +128,7 @@ func setupConvSyncE2E(t *testing.T, convs []*config.SyncUserConversationResp) (*
 	// Point the IM at the shared fake and load this test's conversation slice
 	// before any NewTestServer so the very first ctx already sees the live URL.
 	fakeIMConvs = convs
+	fakeIMCMDs = nil
 	imURL := sharedFakeIM().URL
 
 	s, ctx := testutil.NewTestServer()

--- a/modules/message/conversation_recent_filter_e2e_test.go
+++ b/modules/message/conversation_recent_filter_e2e_test.go
@@ -53,10 +53,11 @@ const masterKeyEnvConvE2E = "OCTO_MASTER_KEY"
 // with a mutable response slice keeps the URL stable and alive across all tests.
 // Tests run sequentially (no t.Parallel), so the shared slice needs no lock.
 var (
-	fakeIMOnce  sync.Once
-	fakeIMSrv   *httptest.Server
-	fakeIMConvs []*config.SyncUserConversationResp
-	fakeIMCMDs  []string
+	fakeIMOnce      sync.Once
+	fakeIMSrv       *httptest.Server
+	fakeIMConvs     []*config.SyncUserConversationResp
+	fakeIMCMDs      []string
+	fakeIMSyncCalls int
 )
 
 func sharedFakeIM() *httptest.Server {
@@ -64,6 +65,7 @@ func sharedFakeIM() *httptest.Server {
 		fakeIMSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			if strings.HasSuffix(r.URL.Path, "/conversation/sync") {
+				fakeIMSyncCalls++
 				_, _ = w.Write([]byte(util.ToJson(fakeIMConvs)))
 				return
 			}
@@ -129,6 +131,7 @@ func setupConvSyncE2E(t *testing.T, convs []*config.SyncUserConversationResp) (*
 	// before any NewTestServer so the very first ctx already sees the live URL.
 	fakeIMConvs = convs
 	fakeIMCMDs = nil
+	fakeIMSyncCalls = 0
 	imURL := sharedFakeIM().URL
 
 	s, ctx := testutil.NewTestServer()

--- a/modules/message/conversation_recent_filter_e2e_test.go
+++ b/modules/message/conversation_recent_filter_e2e_test.go
@@ -57,6 +57,7 @@ var (
 	fakeIMSrv       *httptest.Server
 	fakeIMConvs     []*config.SyncUserConversationResp
 	fakeIMCMDs      []string
+	fakeIMFailCMD   string
 	fakeIMSyncCalls int
 )
 
@@ -73,13 +74,19 @@ func sharedFakeIM() *httptest.Server {
 				var req struct {
 					Payload []byte `json:"payload"`
 				}
+				cmd := ""
 				if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
 					var payload struct {
 						CMD string `json:"cmd"`
 					}
 					if err := json.Unmarshal(req.Payload, &payload); err == nil && payload.CMD != "" {
+						cmd = payload.CMD
 						fakeIMCMDs = append(fakeIMCMDs, payload.CMD)
 					}
+				}
+				if cmd == fakeIMFailCMD {
+					http.Error(w, "injected command failure", http.StatusServiceUnavailable)
+					return
 				}
 				_, _ = w.Write([]byte(`{"data":{}}`))
 				return
@@ -131,6 +138,7 @@ func setupConvSyncE2E(t *testing.T, convs []*config.SyncUserConversationResp) (*
 	// before any NewTestServer so the very first ctx already sees the live URL.
 	fakeIMConvs = convs
 	fakeIMCMDs = nil
+	fakeIMFailCMD = ""
 	fakeIMSyncCalls = 0
 	imURL := sharedFakeIM().URL
 
@@ -152,6 +160,7 @@ func setupConvSyncE2E(t *testing.T, convs []*config.SyncUserConversationResp) (*
 	// not cleared by CleanAllTables).
 	_ = ctx.GetRedisConn().Del("ratelimit:uid:" + testutil.UID)
 	_ = ctx.GetRedisConn().Del("userMaxVersion:" + testutil.UID)
+	_ = ctx.GetRedisConn().Del(conversationExtraLockKey(testutil.UID))
 
 	// Start from a known settings snapshot (the singleton may hold sidebar.* rows
 	// from a prior test within the ~60s auto-reload TTL).

--- a/modules/message/conversation_recent_filter_e2e_test.go
+++ b/modules/message/conversation_recent_filter_e2e_test.go
@@ -29,73 +29,17 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
-	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
-	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-lib/server"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	commonapi "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-const masterKeyEnvConvE2E = "OCTO_MASTER_KEY"
-
-// One long-lived fake WuKongIM server for the whole file. Per-test httptest
-// servers proved fragile: testutil.NewTestServer binds the registered handler's
-// ctx to the FIRST server's config, so a per-test APIURL (whose server is then
-// closed) leaves later tests dialling a dead port. A single never-closed server
-// with a mutable response slice keeps the URL stable and alive across all tests.
-// Tests run sequentially (no t.Parallel), so the shared slice needs no lock.
-var (
-	fakeIMOnce      sync.Once
-	fakeIMSrv       *httptest.Server
-	fakeIMConvs     []*config.SyncUserConversationResp
-	fakeIMCMDs      []string
-	fakeIMFailCMD   string
-	fakeIMSyncCalls int
-)
-
-func sharedFakeIM() *httptest.Server {
-	fakeIMOnce.Do(func() {
-		fakeIMSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			if strings.HasSuffix(r.URL.Path, "/conversation/sync") {
-				fakeIMSyncCalls++
-				_, _ = w.Write([]byte(util.ToJson(fakeIMConvs)))
-				return
-			}
-			if strings.HasSuffix(r.URL.Path, "/message/send") {
-				var req struct {
-					Payload []byte `json:"payload"`
-				}
-				cmd := ""
-				if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
-					var payload struct {
-						CMD string `json:"cmd"`
-					}
-					if err := json.Unmarshal(req.Payload, &payload); err == nil && payload.CMD != "" {
-						cmd = payload.CMD
-						fakeIMCMDs = append(fakeIMCMDs, payload.CMD)
-					}
-				}
-				if cmd == fakeIMFailCMD {
-					http.Error(w, "injected command failure", http.StatusServiceUnavailable)
-					return
-				}
-				_, _ = w.Write([]byte(`{"data":{}}`))
-				return
-			}
-			_, _ = w.Write([]byte("{}"))
-		}))
-	})
-	return fakeIMSrv
-}
 
 // dmIMConv builds a DM conversation as IMSyncUserConversation would return it,
 // with a single non-deleted recent message so the handler keeps it (the build
@@ -122,51 +66,6 @@ func dmIMConv(channelID string, ts, version int64, seq uint32) *config.SyncUserC
 			},
 		},
 	}
-}
-
-// setupConvSyncE2E wires a test server whose IM is the shared fake (returning
-// the given conversation slice), with a SuperAdmin token (needed for the
-// system_setting write) that also authenticates the conversation/sync call. It
-// resets the per-uid rate-limit bucket and the cursor Redis keys so each test
-// starts clean, and pins MessageSaveAcrossDevice off so the syncack
-// cursor-persist path is exercised deterministically.
-func setupConvSyncE2E(t *testing.T, convs []*config.SyncUserConversationResp) (*server.Server, *config.Context) {
-	t.Helper()
-	t.Setenv(masterKeyEnvConvE2E, "0123456789abcdef0123456789abcdef")
-
-	// Point the IM at the shared fake and load this test's conversation slice
-	// before any NewTestServer so the very first ctx already sees the live URL.
-	fakeIMConvs = convs
-	fakeIMCMDs = nil
-	fakeIMFailCMD = ""
-	fakeIMSyncCalls = 0
-	imURL := sharedFakeIM().URL
-
-	s, ctx := testutil.NewTestServer()
-	require.NoError(t, testutil.CleanAllTables(ctx))
-
-	cfg := ctx.GetConfig()
-	cfg.MessageSaveAcrossDevice = false
-	cfg.WuKongIM.APIURL = imURL
-
-	// SuperAdmin token: authenticates /v1/conversation/sync AND authorizes the
-	// /v1/manager/common/system_setting write. Format uid@name@role (token_parser).
-	require.NoError(t, ctx.Cache().Set(
-		cfg.Cache.TokenCachePrefix+testutil.Token,
-		testutil.UID+"@test@"+string(wkhttp.SuperAdmin),
-	))
-
-	// Clean per-uid rate-limit bucket + cursor keys (persist in Redis across runs,
-	// not cleared by CleanAllTables).
-	_ = ctx.GetRedisConn().Del("ratelimit:uid:" + testutil.UID)
-	_ = ctx.GetRedisConn().Del("userMaxVersion:" + testutil.UID)
-	_ = ctx.GetRedisConn().Del(conversationExtraLockKey(testutil.UID))
-
-	// Start from a known settings snapshot (the singleton may hold sidebar.* rows
-	// from a prior test within the ~60s auto-reload TTL).
-	require.NoError(t, commonapi.EnsureSystemSettings(ctx).Reload())
-
-	return s, ctx
 }
 
 // writePersonWindowDays sets sidebar.recent_filter_person_days via the admin HTTP

--- a/modules/message/conversation_recent_filter_test.go
+++ b/modules/message/conversation_recent_filter_test.go
@@ -58,7 +58,7 @@ func TestFilterRecentConversations_StaleGroupDropped(t *testing.T) {
 	assert.Equal(t, []string{"g-fresh"}, channelIDs(got))
 }
 
-func TestFilterRecentConversations_ManualUnreadDoesNotSurviveWindow(t *testing.T) {
+func TestFilterRecentConversations_ManualUnreadSurvivesWindow(t *testing.T) {
 	tests := []struct {
 		name        string
 		channelID   string
@@ -83,8 +83,9 @@ func TestFilterRecentConversations_ManualUnreadDoesNotSurviveWindow(t *testing.T
 
 			got := filterRecentConversations([]*SyncUserConversationResp{resp}, defaultRecentCutoffs(), nil)
 
-			assert.Empty(t, got,
-				"recent_filter=true 时，manual_unread 不应绕过 Recent 活跃时间窗口")
+			require.Len(t, got, 1,
+				"recent_filter=true 时，manual_unread 必须绕过 Recent 活跃时间窗口")
+			assert.Equal(t, tc.channelID, got[0].ChannelID)
 		})
 	}
 }

--- a/modules/message/conversation_recent_filter_test.go
+++ b/modules/message/conversation_recent_filter_test.go
@@ -58,6 +58,47 @@ func TestFilterRecentConversations_StaleGroupDropped(t *testing.T) {
 	assert.Equal(t, []string{"g-fresh"}, channelIDs(got))
 }
 
+func TestFilterRecentConversations_ManualUnreadDoesNotSurviveWindow(t *testing.T) {
+	tests := []struct {
+		name        string
+		channelID   string
+		channelType uint8
+	}{
+		{
+			name:        "group",
+			channelID:   "g-manual-unread",
+			channelType: common.ChannelTypeGroup.Uint8(),
+		},
+		{
+			name:        "thread",
+			channelID:   "g-manual-unread____thread-1",
+			channelType: common.ChannelTypeCommunityTopic.Uint8(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := makeSyncResp(tc.channelID, tc.channelType, now3DaysAgo())
+			resp.Extra = &conversationExtraResp{ManualUnread: true}
+
+			got := filterRecentConversations([]*SyncUserConversationResp{resp}, defaultRecentCutoffs(), nil)
+
+			assert.Empty(t, got,
+				"recent_filter=true 时，manual_unread 不应绕过 Recent 活跃时间窗口")
+		})
+	}
+}
+
+func TestFilterRecentConversations_ManualUnreadFalseDoesNotSurviveWindow(t *testing.T) {
+	resp := makeSyncResp("g-manual-read", common.ChannelTypeGroup.Uint8(), now3DaysAgo())
+	resp.Extra = &conversationExtraResp{ManualUnread: false}
+
+	got := filterRecentConversations([]*SyncUserConversationResp{resp}, defaultRecentCutoffs(), nil)
+
+	assert.Empty(t, got,
+		"manual_unread=false 不应关闭原有的 Recent 时间窗口过滤")
+}
+
 func TestFilterRecentConversations_StaleThreadDropped(t *testing.T) {
 	resps := []*SyncUserConversationResp{
 		makeSyncResp("t-fresh", common.ChannelTypeCommunityTopic.Uint8(), nowRecent()),

--- a/modules/message/conversation_sync_e2e_fixture_test.go
+++ b/modules/message/conversation_sync_e2e_fixture_test.go
@@ -1,0 +1,156 @@
+package message
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/server"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	commonapi "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/stretchr/testify/require"
+)
+
+const masterKeyEnvConvE2E = "OCTO_MASTER_KEY"
+
+// One long-lived fake WuKongIM server is shared by the default-lane manual
+// unread tests and the integration-tagged conversation-filter tests. The
+// tests are intentionally sequential and never call t.Parallel.
+var (
+	fakeIMOnce              sync.Once
+	fakeIMMu                sync.Mutex
+	fakeIMSrv               *httptest.Server
+	fakeIMConvs             []*config.SyncUserConversationResp
+	fakeIMCMDs              []string
+	fakeIMCMDRecords        []fakeIMCMDRecord
+	fakeIMFailCMD           string
+	fakeIMSyncCalls         int
+	fakeIMConversationCalls int
+)
+
+type fakeIMCMDRecord struct {
+	CMD   string
+	Param map[string]interface{}
+}
+
+func sharedFakeIM() *httptest.Server {
+	fakeIMOnce.Do(func() {
+		fakeIMSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if strings.HasSuffix(r.URL.Path, "/conversations") {
+				fakeIMMu.Lock()
+				fakeIMConversationCalls++
+				imConversations := append([]*config.SyncUserConversationResp(nil), fakeIMConvs...)
+				fakeIMMu.Unlock()
+				conversations := make([]*config.ConversationResp, 0, len(imConversations))
+				for _, conversation := range imConversations {
+					if conversation == nil {
+						continue
+					}
+					conversations = append(conversations, &config.ConversationResp{
+						ChannelID:   conversation.ChannelID,
+						ChannelType: conversation.ChannelType,
+						Unread:      int64(conversation.Unread),
+						Timestamp:   conversation.Timestamp,
+					})
+				}
+				_, _ = w.Write([]byte(util.ToJson(conversations)))
+				return
+			}
+			if strings.HasSuffix(r.URL.Path, "/conversation/sync") {
+				fakeIMMu.Lock()
+				fakeIMSyncCalls++
+				imConversations := append([]*config.SyncUserConversationResp(nil), fakeIMConvs...)
+				fakeIMMu.Unlock()
+				_, _ = w.Write([]byte(util.ToJson(imConversations)))
+				return
+			}
+			if strings.HasSuffix(r.URL.Path, "/message/send") {
+				var req struct {
+					Payload []byte `json:"payload"`
+				}
+				cmd := ""
+				if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
+					var payload struct {
+						CMD   string                 `json:"cmd"`
+						Param map[string]interface{} `json:"param"`
+					}
+					if err := json.Unmarshal(req.Payload, &payload); err == nil && payload.CMD != "" {
+						cmd = payload.CMD
+						fakeIMMu.Lock()
+						fakeIMCMDs = append(fakeIMCMDs, payload.CMD)
+						fakeIMCMDRecords = append(fakeIMCMDRecords, fakeIMCMDRecord{
+							CMD:   payload.CMD,
+							Param: payload.Param,
+						})
+						fakeIMMu.Unlock()
+					}
+				}
+				fakeIMMu.Lock()
+				failCMD := fakeIMFailCMD
+				fakeIMMu.Unlock()
+				if cmd == failCMD {
+					http.Error(w, "injected command failure", http.StatusServiceUnavailable)
+					return
+				}
+				_, _ = w.Write([]byte(`{"data":{}}`))
+				return
+			}
+			_, _ = w.Write([]byte("{}"))
+		}))
+	})
+	return fakeIMSrv
+}
+
+// setupConvSyncE2E wires the real message routes to the shared fake IM and the
+// CI-provided MySQL/Redis services. It resets every persistent per-UID key used
+// by these tests so the default lane remains deterministic under -shuffle.
+func setupConvSyncE2E(t *testing.T, convs []*config.SyncUserConversationResp) (*server.Server, *config.Context) {
+	t.Helper()
+	t.Setenv(masterKeyEnvConvE2E, "0123456789abcdef0123456789abcdef")
+
+	fakeIMMu.Lock()
+	fakeIMConvs = convs
+	fakeIMCMDs = nil
+	fakeIMCMDRecords = nil
+	fakeIMFailCMD = ""
+	fakeIMSyncCalls = 0
+	fakeIMConversationCalls = 0
+	fakeIMMu.Unlock()
+	imURL := sharedFakeIM().URL
+
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	cfg := ctx.GetConfig()
+	cfg.MessageSaveAcrossDevice = false
+	cfg.WuKongIM.APIURL = imURL
+
+	require.NoError(t, ctx.Cache().Set(
+		cfg.Cache.TokenCachePrefix+testutil.Token,
+		testutil.UID+"@test@"+string(wkhttp.SuperAdmin),
+	))
+
+	_ = ctx.GetRedisConn().Del("ratelimit:uid:" + testutil.UID)
+	_ = ctx.GetRedisConn().Del("userMaxVersion:" + testutil.UID)
+	_ = ctx.GetRedisConn().Del(conversationExtraLockKey(testutil.UID))
+
+	require.NoError(t, commonapi.EnsureSystemSettings(ctx).Reload())
+
+	// register.GetModules is process-global and retains the Context from the
+	// first test server initialized in this package. Build a dedicated route
+	// with a Conversation bound to this test's Context so command assertions do
+	// not depend on package test order or accidentally call the real WuKongIM.
+	s := server.New(ctx)
+	s.GetRoute().UseGin(ctx.Tracer().GinMiddle())
+	ctx.SetHttpRoute(s.GetRoute())
+	NewConversation(ctx).Route(s.GetRoute())
+
+	return s, ctx
+}

--- a/modules/message/conversation_sync_e2e_fixture_test.go
+++ b/modules/message/conversation_sync_e2e_fixture_test.go
@@ -30,6 +30,7 @@ var (
 	fakeIMCMDs              []string
 	fakeIMCMDRecords        []fakeIMCMDRecord
 	fakeIMFailCMD           string
+	fakeIMAfterCMD          func(string)
 	fakeIMSyncCalls         int
 	fakeIMConversationCalls int
 )
@@ -94,7 +95,11 @@ func sharedFakeIM() *httptest.Server {
 				}
 				fakeIMMu.Lock()
 				failCMD := fakeIMFailCMD
+				afterCMD := fakeIMAfterCMD
 				fakeIMMu.Unlock()
+				if afterCMD != nil {
+					afterCMD(cmd)
+				}
 				if cmd == failCMD {
 					http.Error(w, "injected command failure", http.StatusServiceUnavailable)
 					return
@@ -120,6 +125,7 @@ func setupConvSyncE2E(t *testing.T, convs []*config.SyncUserConversationResp) (*
 	fakeIMCMDs = nil
 	fakeIMCMDRecords = nil
 	fakeIMFailCMD = ""
+	fakeIMAfterCMD = nil
 	fakeIMSyncCalls = 0
 	fakeIMConversationCalls = 0
 	fakeIMMu.Unlock()

--- a/modules/message/db_conversation_extra.go
+++ b/modules/message/db_conversation_extra.go
@@ -24,9 +24,40 @@ func newConversationExtraDB(ctx *config.Context) *conversationExtraDB {
 // upsert statement. manual_unread is deliberately omitted from both the
 // insert values and duplicate-key assignments: a new row gets the column's
 // default value, while an existing marker is preserved atomically.
-func (c *conversationExtraDB) insertOrUpdate(model *conversationExtraModel) error {
-	_, err := c.session.InsertBySql("INSERT INTO conversation_extra (uid,channel_id,channel_type,browse_to,keep_message_seq,keep_offset_y,draft,version) VALUES (?,?,?,?,?,?,?,?) ON DUPLICATE KEY UPDATE browse_to=IF(VALUES(browse_to)>browse_to,VALUES(browse_to),browse_to),`keep_message_seq`=VALUES(`keep_message_seq`),keep_offset_y=VALUES(keep_offset_y),draft=VALUES(draft),version=VALUES(version)", model.UID, model.ChannelID, model.ChannelType, model.BrowseTo, model.KeepMessageSeq, model.KeepOffsetY, model.Draft, model.Version).Exec()
-	return err
+func (c *conversationExtraDB) insertOrUpdate(model *conversationExtraModel) (bool, error) {
+	result, err := c.session.InsertBySql(`
+INSERT INTO conversation_extra
+    (uid,channel_id,channel_type,browse_to,keep_message_seq,keep_offset_y,draft,version)
+VALUES (?,?,?,?,?,?,?,?)
+ON DUPLICATE KEY UPDATE
+    browse_to=IF(VALUES(version)>version AND VALUES(browse_to)>browse_to,VALUES(browse_to),browse_to),
+    keep_message_seq=IF(VALUES(version)>version,VALUES(keep_message_seq),keep_message_seq),
+    keep_offset_y=IF(VALUES(version)>version,VALUES(keep_offset_y),keep_offset_y),
+    draft=IF(VALUES(version)>version,VALUES(draft),draft),
+    version=GREATEST(version,VALUES(version))`,
+		model.UID,
+		model.ChannelID,
+		model.ChannelType,
+		model.BrowseTo,
+		model.KeepMessageSeq,
+		model.KeepOffsetY,
+		model.Draft,
+		model.Version,
+	).Exec()
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	return affected > 0, err
+}
+
+func (c *conversationExtraDB) maxVersion(uid string) (int64, error) {
+	var version int64
+	err := c.session.SelectBySql(
+		"SELECT COALESCE(MAX(version),0) FROM conversation_extra WHERE uid=?",
+		uid,
+	).LoadOne(&version)
+	return version, err
 }
 
 func (c *conversationExtraDB) sync(uid string, version int64) ([]*conversationExtraModel, error) {
@@ -72,21 +103,39 @@ func (c *conversationExtraDB) queryOne(uid string, channelID string, channelType
 // It intentionally does not use insertOrUpdate, because that method also
 // writes draft/read-position fields and would overwrite them with zero values
 // when called by the dedicated manual-unread endpoint.
-func (c *conversationExtraDB) setManualUnread(uid string, channelID string, channelType uint8, version int64) error {
-	_, err := c.session.InsertBySql("INSERT INTO conversation_extra (uid,channel_id,channel_type,version,manual_unread) VALUES (?,?,?,?,1) ON DUPLICATE KEY UPDATE version=VALUES(version),manual_unread=VALUES(manual_unread)", uid, channelID, channelType, version).Exec()
-	return err
+func (c *conversationExtraDB) setManualUnread(uid string, channelID string, channelType uint8, version int64) (bool, error) {
+	result, err := c.session.InsertBySql(`
+INSERT INTO conversation_extra (uid,channel_id,channel_type,version,manual_unread)
+VALUES (?,?,?,?,1)
+ON DUPLICATE KEY UPDATE
+    manual_unread=IF(VALUES(version)>version,VALUES(manual_unread),manual_unread),
+    version=GREATEST(version,VALUES(version))`,
+		uid,
+		channelID,
+		channelType,
+		version,
+	).Exec()
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	return affected > 0, err
 }
 
 // clearManualUnread changes only the manual-unread state and its sync version.
 // The caller must verify that the row is currently marked unread before
 // generating the version and invoking this method.
-func (c *conversationExtraDB) clearManualUnread(uid string, channelID string, channelType uint8, version int64) error {
-	_, err := c.session.Update("conversation_extra").
+func (c *conversationExtraDB) clearManualUnread(uid string, channelID string, channelType uint8, version int64) (bool, error) {
+	result, err := c.session.Update("conversation_extra").
 		Set("manual_unread", false).
 		Set("version", version).
-		Where("uid=? and channel_id=? and channel_type=? and manual_unread=1", uid, channelID, channelType).
+		Where("uid=? and channel_id=? and channel_type=? and manual_unread=1 and version<?", uid, channelID, channelType, version).
 		Exec()
-	return err
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	return affected > 0, err
 }
 
 type conversationExtraModel struct {

--- a/modules/message/db_conversation_extra.go
+++ b/modules/message/db_conversation_extra.go
@@ -74,15 +74,32 @@ func (c *conversationExtraDB) queryWithChannelIDs(uid string, channelIDs []strin
 	_, err := c.session.Select("*").From("conversation_extra").Where("uid=? and channel_id in ?", uid, channelIDs).Load(&models)
 	return models, err
 }
-func (c *conversationExtraDB) queryManualUnread(uid string) ([]*conversationExtraModel, error) {
+
+func (c *conversationExtraDB) queryManualUnread(uid string, groupChannelIDs, topicChannelIDs []string) ([]*conversationExtraModel, error) {
+	conditions := make([]dbr.Builder, 0, 2)
+	if len(groupChannelIDs) > 0 {
+		conditions = append(conditions, dbr.And(
+			dbr.Eq("channel_type", common.ChannelTypeGroup.Uint8()),
+			dbr.Eq("channel_id", groupChannelIDs),
+		))
+	}
+	if len(topicChannelIDs) > 0 {
+		conditions = append(conditions, dbr.And(
+			dbr.Eq("channel_type", common.ChannelTypeCommunityTopic.Uint8()),
+			dbr.Eq("channel_id", topicChannelIDs),
+		))
+	}
+	if len(conditions) == 0 {
+		return nil, nil
+	}
+
 	var models []*conversationExtraModel
-	_, err := c.session.Select("*").From("conversation_extra").
-		Where("uid=? and manual_unread=? and channel_type in (?,?)",
-			uid,
-			1,
-			common.ChannelTypeGroup.Uint8(),
-			common.ChannelTypeCommunityTopic.Uint8(),
-		).
+	_, err := c.session.Select("channel_id", "channel_type").From("conversation_extra").
+		Where(dbr.And(
+			dbr.Eq("uid", uid),
+			dbr.Eq("manual_unread", 1),
+			dbr.Or(conditions...),
+		)).
 		Load(&models)
 	return models, err
 }

--- a/modules/message/db_conversation_extra.go
+++ b/modules/message/db_conversation_extra.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/db"
 	"github.com/gocraft/dbr/v2"
@@ -44,7 +45,14 @@ func (c *conversationExtraDB) queryWithChannelIDs(uid string, channelIDs []strin
 }
 func (c *conversationExtraDB) queryManualUnread(uid string) ([]*conversationExtraModel, error) {
 	var models []*conversationExtraModel
-	_, err := c.session.Select("*").From("conversation_extra").Where("uid=? and manual_unread = ?", uid, 1).Load(&models)
+	_, err := c.session.Select("*").From("conversation_extra").
+		Where("uid=? and manual_unread=? and channel_type in (?,?)",
+			uid,
+			1,
+			common.ChannelTypeGroup.Uint8(),
+			common.ChannelTypeCommunityTopic.Uint8(),
+		).
+		Load(&models)
 	return models, err
 }
 

--- a/modules/message/db_conversation_extra.go
+++ b/modules/message/db_conversation_extra.go
@@ -19,6 +19,10 @@ func newConversationExtraDB(ctx *config.Context) *conversationExtraDB {
 	}
 }
 
+// insertOrUpdate writes the original conversation extension fields in one
+// upsert statement. manual_unread is deliberately omitted from both the
+// insert values and duplicate-key assignments: a new row gets the column's
+// default value, while an existing marker is preserved atomically.
 func (c *conversationExtraDB) insertOrUpdate(model *conversationExtraModel) error {
 	_, err := c.session.InsertBySql("INSERT INTO conversation_extra (uid,channel_id,channel_type,browse_to,keep_message_seq,keep_offset_y,draft,version) VALUES (?,?,?,?,?,?,?,?) ON DUPLICATE KEY UPDATE browse_to=IF(VALUES(browse_to)>browse_to,VALUES(browse_to),browse_to),`keep_message_seq`=VALUES(`keep_message_seq`),keep_offset_y=VALUES(keep_offset_y),draft=VALUES(draft),version=VALUES(version)", model.UID, model.ChannelID, model.ChannelType, model.BrowseTo, model.KeepMessageSeq, model.KeepOffsetY, model.Draft, model.Version).Exec()
 	return err
@@ -38,6 +42,44 @@ func (c *conversationExtraDB) queryWithChannelIDs(uid string, channelIDs []strin
 	_, err := c.session.Select("*").From("conversation_extra").Where("uid=? and channel_id in ?", uid, channelIDs).Load(&models)
 	return models, err
 }
+func (c *conversationExtraDB) queryManualUnread(uid string) ([]*conversationExtraModel, error) {
+	var models []*conversationExtraModel
+	_, err := c.session.Select("*").From("conversation_extra").Where("uid=? and manual_unread = ?", uid, 1).Load(&models)
+	return models, err
+}
+
+func (c *conversationExtraDB) queryOne(uid string, channelID string, channelType uint8) (*conversationExtraModel, error) {
+	var models []*conversationExtraModel
+	_, err := c.session.Select("*").From("conversation_extra").Where("uid=? and channel_id=? and channel_type=?", uid, channelID, channelType).Load(&models)
+	if err != nil {
+		return nil, err
+	}
+	if len(models) == 0 {
+		return nil, nil
+	}
+	return models[0], nil
+}
+
+// setManualUnread changes only the manual-unread state and its sync version.
+// It intentionally does not use insertOrUpdate, because that method also
+// writes draft/read-position fields and would overwrite them with zero values
+// when called by the dedicated manual-unread endpoint.
+func (c *conversationExtraDB) setManualUnread(uid string, channelID string, channelType uint8, version int64) error {
+	_, err := c.session.InsertBySql("INSERT INTO conversation_extra (uid,channel_id,channel_type,version,manual_unread) VALUES (?,?,?,?,1) ON DUPLICATE KEY UPDATE version=VALUES(version),manual_unread=VALUES(manual_unread)", uid, channelID, channelType, version).Exec()
+	return err
+}
+
+// clearManualUnread changes only the manual-unread state and its sync version.
+// The caller must verify that the row is currently marked unread before
+// generating the version and invoking this method.
+func (c *conversationExtraDB) clearManualUnread(uid string, channelID string, channelType uint8, version int64) error {
+	_, err := c.session.Update("conversation_extra").
+		Set("manual_unread", false).
+		Set("version", version).
+		Where("uid=? and channel_id=? and channel_type=? and manual_unread=1", uid, channelID, channelType).
+		Exec()
+	return err
+}
 
 type conversationExtraModel struct {
 	UID            string
@@ -49,4 +91,5 @@ type conversationExtraModel struct {
 	Draft          string // 草稿
 	Version        int64
 	db.BaseModel
+	ManualUnread bool
 }

--- a/modules/message/db_conversation_extra_manual_unread_test.go
+++ b/modules/message/db_conversation_extra_manual_unread_test.go
@@ -1,0 +1,83 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryManualUnread_NoSidebarCandidatesSkipsDatabase(t *testing.T) {
+	rows, err := (&conversationExtraDB{}).queryManualUnread("uid", nil, nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
+func TestQueryManualUnread_ScopesToSidebarKeysAndLoadsOnlyIdentity(t *testing.T) {
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+	_, ctx := testutil.NewTestServer()
+	defer func() {
+		require.NoError(t, testutil.CleanAllTables(ctx))
+	}()
+
+	extraDB := newConversationExtraDB(ctx)
+	groupType := common.ChannelTypeGroup.Uint8()
+	topicType := common.ChannelTypeCommunityTopic.Uint8()
+	personType := common.ChannelTypePerson.Uint8()
+	const (
+		sharedChannelID = "manual-unread-shared-id"
+		topicTargetID   = "manual-unread-group____topic-target"
+		unrelatedID     = "manual-unread-unrelated-group"
+		otherUID        = "manual-unread-other-user"
+	)
+
+	seed := func(uid, channelID string, channelType uint8, version int64) {
+		t.Helper()
+		changed, err := extraDB.insertOrUpdate(&conversationExtraModel{
+			UID:         uid,
+			ChannelID:   channelID,
+			ChannelType: channelType,
+			BrowseTo:    42,
+			Draft:       "must-not-be-loaded",
+			Version:     version,
+		})
+		require.NoError(t, err)
+		require.True(t, changed)
+
+		changed, err = extraDB.setManualUnread(uid, channelID, channelType, version+1)
+		require.NoError(t, err)
+		require.True(t, changed)
+	}
+
+	seed(testutil.UID, sharedChannelID, groupType, 100)
+	seed(testutil.UID, sharedChannelID, topicType, 200)
+	seed(testutil.UID, sharedChannelID, personType, 300)
+	seed(testutil.UID, topicTargetID, topicType, 400)
+	seed(testutil.UID, unrelatedID, groupType, 500)
+	seed(otherUID, sharedChannelID, groupType, 600)
+
+	rows, err := extraDB.queryManualUnread(
+		testutil.UID,
+		[]string{sharedChannelID},
+		[]string{topicTargetID},
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+
+	byKey := make(map[string]*conversationExtraModel, len(rows))
+	for _, row := range rows {
+		byKey[channelKey(row.ChannelID, row.ChannelType)] = row
+		assert.Zero(t, row.BrowseTo)
+		assert.Empty(t, row.Draft)
+		assert.Zero(t, row.Version)
+		assert.False(t, row.ManualUnread)
+	}
+	assert.Contains(t, byKey, channelKey(sharedChannelID, groupType))
+	assert.Contains(t, byKey, channelKey(topicTargetID, topicType))
+	assert.NotContains(t, byKey, channelKey(sharedChannelID, topicType))
+	assert.NotContains(t, byKey, channelKey(sharedChannelID, personType))
+	assert.NotContains(t, byKey, channelKey(unrelatedID, groupType))
+}

--- a/modules/message/manual_unread_channel_type_test.go
+++ b/modules/message/manual_unread_channel_type_test.go
@@ -1,0 +1,50 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSupportsManualUnreadChannelType(t *testing.T) {
+	tests := []struct {
+		name        string
+		channelType uint8
+		want        bool
+	}{
+		{name: "person", channelType: common.ChannelTypePerson.Uint8(), want: false},
+		{name: "group", channelType: common.ChannelTypeGroup.Uint8(), want: true},
+		{name: "community topic", channelType: common.ChannelTypeCommunityTopic.Uint8(), want: true},
+		{name: "unknown", channelType: 255, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, supportsManualUnreadChannelType(tc.channelType))
+		})
+	}
+}
+
+func TestNewConversationExtraRespSuppressesUnsupportedPersonManualUnread(t *testing.T) {
+	tests := []struct {
+		name        string
+		channelType uint8
+		want        bool
+	}{
+		{name: "person", channelType: common.ChannelTypePerson.Uint8(), want: false},
+		{name: "group", channelType: common.ChannelTypeGroup.Uint8(), want: true},
+		{name: "community topic", channelType: common.ChannelTypeCommunityTopic.Uint8(), want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := newConversationExtraResp(&conversationExtraModel{
+				ChannelID:    "channel",
+				ChannelType:  tc.channelType,
+				ManualUnread: true,
+			})
+			assert.Equal(t, tc.want, resp.ManualUnread)
+		})
+	}
+}

--- a/modules/message/manual_unread_e2e_test.go
+++ b/modules/message/manual_unread_e2e_test.go
@@ -1,6 +1,9 @@
-//go:build integration
-
 package message
+
+// These tests intentionally run in the default modules/message E2E lane. That
+// lane provisions MySQL, Redis, and WuKongIM and executes the package with
+// -race and -shuffle; keeping the manual-unread correctness tests there makes
+// their concurrency, database, and notification assertions visible to CI.
 
 import (
 	"bytes"
@@ -16,12 +19,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestIntegration_SetManualUnreadSkipsConversationSync verifies that setting
-// the application-level marker neither queries nor depends on WuKongIM's real
-// unread state. The fake target deliberately has normal unread messages; the
-// marker must still be created without calling /conversation/sync.
-func TestIntegration_SetManualUnreadSkipsConversationSync(t *testing.T) {
-	channelID := "set-manual-unread-without-sync"
+func requireManualUnreadCMDParam(
+	t *testing.T,
+	record fakeIMCMDRecord,
+	channelID string,
+	channelType uint8,
+	manualUnread bool,
+	version int64,
+) {
+	t.Helper()
+	require.Equal(t, common.CMDSyncConversationExtra, record.CMD)
+	require.Equal(t, channelID, record.Param["channel_id"])
+	require.Equal(t, float64(channelType), record.Param["channel_type"])
+	require.Equal(t, manualUnread, record.Param["manual_unread"])
+	require.Equal(t, float64(version), record.Param["version"])
+}
+
+// TestIntegration_SetManualUnreadDoesNotQueryIMConversation verifies that the
+// dedicated marker is independent of WuKongIM conversation existence and real
+// unread state. Even if the fake IM would report unread messages, the endpoint
+// must not call /conversations before persisting the user's marker.
+func TestIntegration_SetManualUnreadDoesNotQueryIMConversation(t *testing.T) {
+	channelID := "set-manual-unread-without-im-query"
 	fakeIMConvs = []*config.SyncUserConversationResp{
 		{
 			ChannelID:   channelID,
@@ -31,7 +50,7 @@ func TestIntegration_SetManualUnreadSkipsConversationSync(t *testing.T) {
 		},
 	}
 
-	s, _ := setupConvSyncE2E(t, fakeIMConvs)
+	s, ctx := setupConvSyncE2E(t, fakeIMConvs)
 
 	call := func() *httptest.ResponseRecorder {
 		w := httptest.NewRecorder()
@@ -51,7 +70,26 @@ func TestIntegration_SetManualUnreadSkipsConversationSync(t *testing.T) {
 	require.True(t, result.ManualUnread)
 	require.True(t, result.Changed)
 	require.NotZero(t, result.Version)
-	require.Zero(t, fakeIMSyncCalls, "setManualUnread 不应查询 WuKongIM 会话或真实未读数")
+	require.Empty(t, result.Reason)
+	require.Zero(t, fakeIMConversationCalls, "setManualUnread 不得查询 WuKongIM Conversation")
+	require.Len(t, fakeIMCMDRecords, 1)
+	requireManualUnreadCMDParam(
+		t,
+		fakeIMCMDRecords[0],
+		channelID,
+		common.ChannelTypeGroup.Uint8(),
+		true,
+		result.Version,
+	)
+	extra, err := newConversationExtraDB(ctx).queryOne(
+		testutil.UID,
+		channelID,
+		common.ChannelTypeGroup.Uint8(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, extra)
+	require.True(t, extra.ManualUnread)
+	require.Equal(t, result.Version, extra.Version)
 
 	resp = call()
 	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
@@ -59,15 +97,15 @@ func TestIntegration_SetManualUnreadSkipsConversationSync(t *testing.T) {
 	require.True(t, result.ManualUnread)
 	require.False(t, result.Changed)
 	require.Equal(t, "already_manual_unread", result.Reason)
-	require.Zero(t, fakeIMSyncCalls, "幂等设置同样不应查询 WuKongIM")
+	require.Zero(t, fakeIMConversationCalls, "幂等设置也不得查询 WuKongIM Conversation")
+	require.Len(t, fakeIMCMDRecords, 1, "幂等设置不应重复通知")
 }
 
-// TestIntegration_ClearManualUnreadAndClearUnreadAlwaysClearManualState
-// verifies the two explicit ways a manual marker is cleared:
+// TestIntegration_ClearManualUnreadAndClearUnreadZeroClearManualState verifies
+// the two explicit ways a manual marker is cleared:
 //   - clearManualUnread changes only conversation_extra.manual_unread;
-//   - clearUnread also clears manual_unread when unread is non-zero, because
-//     the existing frontend uses that endpoint for explicit unread updates.
-func TestIntegration_ClearManualUnreadAndClearUnreadAlwaysClearManualState(t *testing.T) {
+//   - clearUnread clears it only when the requested real unread count is zero.
+func TestIntegration_ClearManualUnreadAndClearUnreadZeroClearManualState(t *testing.T) {
 	channelID := "clear-manual-unread-group____topic"
 	fakeIMConvs = []*config.SyncUserConversationResp{
 		{
@@ -75,7 +113,7 @@ func TestIntegration_ClearManualUnreadAndClearUnreadAlwaysClearManualState(t *te
 			ChannelType: common.ChannelTypeCommunityTopic.Uint8(),
 			Timestamp:   1_700_000_000,
 			LastMsgSeq:  100,
-			Unread:      11,
+			Unread:      0,
 		},
 	}
 
@@ -126,28 +164,56 @@ func TestIntegration_ClearManualUnreadAndClearUnreadAlwaysClearManualState(t *te
 	require.NotNil(t, extra)
 	require.False(t, extra.ManualUnread)
 
-	// Re-create the manual marker, then use the existing clearUnread endpoint
-	// with unread>0. That explicit real-unread update must clear the marker too.
+	// Re-create the manual marker, then retain a positive real unread count.
+	// This must not clear the explicit manual marker.
 	setResp = call(
 		"/v1/conversation/setManualUnread",
 		`{"channel_id":"`+channelID+`","channel_type":5}`,
 	)
 	require.Equal(t, http.StatusOK, setResp.Code, setResp.Body.String())
 
+	fakeIMCMDs = nil
+	fakeIMCMDRecords = nil
 	clearResp := call(
 		"/v1/conversation/clearUnread",
 		`{"channel_id":"`+channelID+`","channel_type":5,"unread":5}`,
 	)
 	require.Equal(t, http.StatusOK, clearResp.Code, clearResp.Body.String())
-	require.Contains(t, fakeIMCMDs, common.CMDSyncConversationExtra,
-		"clearUnread 清除手动未读后必须通知客户端同步会话扩展")
 	require.Contains(t, fakeIMCMDs, common.CMDConversationUnreadClear,
 		"clearUnread 仍然必须发送真实未读清除命令")
+	require.NotContains(t, fakeIMCMDs, common.CMDSyncConversationExtra,
+		"unread>0 时不得清除或同步手动未读状态")
 
 	extra, err = extraDB.queryOne(testutil.UID, channelID, common.ChannelTypeCommunityTopic.Uint8())
 	require.NoError(t, err)
 	require.NotNil(t, extra)
+	require.True(t, extra.ManualUnread)
+
+	// unread=0 is the only clearUnread mode that also clears the marker.
+	fakeIMCMDs = nil
+	fakeIMCMDRecords = nil
+	clearResp = call(
+		"/v1/conversation/clearUnread",
+		`{"channel_id":"`+channelID+`","channel_type":5,"unread":0}`,
+	)
+	require.Equal(t, http.StatusOK, clearResp.Code, clearResp.Body.String())
+	require.Equal(t, []string{
+		common.CMDConversationUnreadClear,
+		common.CMDSyncConversationExtra,
+	}, fakeIMCMDs)
+	extra, err = extraDB.queryOne(testutil.UID, channelID, common.ChannelTypeCommunityTopic.Uint8())
+	require.NoError(t, err)
+	require.NotNil(t, extra)
 	require.False(t, extra.ManualUnread)
+	require.Len(t, fakeIMCMDRecords, 2)
+	requireManualUnreadCMDParam(
+		t,
+		fakeIMCMDRecords[1],
+		channelID,
+		common.ChannelTypeCommunityTopic.Uint8(),
+		false,
+		extra.Version,
+	)
 }
 
 // TestIntegration_ClearUnreadBroadcastsCoreStateBeforeBestEffortManualSync
@@ -176,6 +242,7 @@ func TestIntegration_ClearUnreadBroadcastsCoreStateBeforeBestEffortManualSync(t 
 	require.Equal(t, http.StatusOK, setResp.Code, setResp.Body.String())
 
 	fakeIMCMDs = nil
+	fakeIMCMDRecords = nil
 	fakeIMFailCMD = common.CMDSyncConversationExtra
 	defer func() { fakeIMFailCMD = "" }()
 
@@ -197,6 +264,15 @@ func TestIntegration_ClearUnreadBroadcastsCoreStateBeforeBestEffortManualSync(t 
 	require.NoError(t, err)
 	require.NotNil(t, extra)
 	require.False(t, extra.ManualUnread)
+	require.Len(t, fakeIMCMDRecords, 2)
+	requireManualUnreadCMDParam(
+		t,
+		fakeIMCMDRecords[1],
+		channelID,
+		common.ChannelTypeCommunityTopic.Uint8(),
+		false,
+		extra.Version,
+	)
 }
 
 // TestIntegration_DedicatedManualUnreadNotificationsAreBestEffort verifies
@@ -253,6 +329,23 @@ func TestIntegration_DedicatedManualUnreadNotificationsAreBestEffort(t *testing.
 		common.CMDSyncConversationExtra,
 		common.CMDSyncConversationExtra,
 	}, fakeIMCMDs)
+	require.Len(t, fakeIMCMDRecords, 2)
+	requireManualUnreadCMDParam(
+		t,
+		fakeIMCMDRecords[0],
+		channelID,
+		common.ChannelTypeGroup.Uint8(),
+		true,
+		setResult.Version,
+	)
+	requireManualUnreadCMDParam(
+		t,
+		fakeIMCMDRecords[1],
+		channelID,
+		common.ChannelTypeGroup.Uint8(),
+		false,
+		clearResult.Version,
+	)
 }
 
 func TestIntegration_ConcurrentSetManualUnreadHasOneStateTransition(t *testing.T) {
@@ -537,7 +630,11 @@ func TestIntegration_QueryManualUnreadExcludesPerson(t *testing.T) {
 		require.True(t, changed)
 	}
 
-	rows, err := extraDB.queryManualUnread(testutil.UID)
+	rows, err := extraDB.queryManualUnread(
+		testutil.UID,
+		[]string{"manual-unread-group-visible"},
+		[]string{"manual-unread-topic-visible"},
+	)
 	require.NoError(t, err)
 	require.Len(t, rows, 2)
 	for _, row := range rows {

--- a/modules/message/manual_unread_e2e_test.go
+++ b/modules/message/manual_unread_e2e_test.go
@@ -7,6 +7,7 @@ package message
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -268,6 +269,86 @@ func TestIntegration_ClearUnreadBroadcastsCoreStateBeforeBestEffortManualSync(t 
 	requireManualUnreadCMDParam(
 		t,
 		fakeIMCMDRecords[1],
+		channelID,
+		common.ChannelTypeCommunityTopic.Uint8(),
+		false,
+		extra.Version,
+	)
+}
+
+// TestIntegration_ClearUnreadManualCleanupSurvivesClientDisconnect verifies
+// that the supplementary marker cleanup has its own bounded lifetime after
+// the real-unread clear and legacy broadcast have completed. A client
+// disconnect at that point must not leave a ghost manual-unread marker.
+func TestIntegration_ClearUnreadManualCleanupSurvivesClientDisconnect(t *testing.T) {
+	const channelID = "clear-unread-client-disconnect"
+
+	s, ctx := setupConvSyncE2E(t, nil)
+	setResp := httptest.NewRecorder()
+	setReq := httptest.NewRequest(
+		http.MethodPut,
+		"/v1/conversation/setManualUnread",
+		bytes.NewBufferString(`{"channel_id":"`+channelID+`","channel_type":5}`),
+	)
+	setReq.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(setResp, setReq)
+	require.Equal(t, http.StatusOK, setResp.Code, setResp.Body.String())
+
+	fakeIMMu.Lock()
+	fakeIMCMDs = nil
+	fakeIMCMDRecords = nil
+	fakeIMMu.Unlock()
+
+	clearResp := httptest.NewRecorder()
+	clearReq := httptest.NewRequest(
+		http.MethodPut,
+		"/v1/conversation/clearUnread",
+		bytes.NewBufferString(`{"channel_id":"`+channelID+`","channel_type":5,"unread":0}`),
+	)
+	clearReq.Header.Set("token", testutil.Token)
+	requestCtx, cancelRequest := context.WithCancel(clearReq.Context())
+	clearReq = clearReq.WithContext(requestCtx)
+	defer cancelRequest()
+
+	fakeIMMu.Lock()
+	fakeIMAfterCMD = func(cmd string) {
+		if cmd == common.CMDConversationUnreadClear {
+			cancelRequest()
+		}
+	}
+	fakeIMMu.Unlock()
+	defer func() {
+		fakeIMMu.Lock()
+		fakeIMAfterCMD = nil
+		fakeIMMu.Unlock()
+	}()
+
+	s.GetRoute().ServeHTTP(clearResp, clearReq)
+	require.Equal(t, http.StatusOK, clearResp.Code, clearResp.Body.String())
+	require.ErrorIs(t, requestCtx.Err(), context.Canceled)
+
+	extra, err := newConversationExtraDB(ctx).queryOne(
+		testutil.UID,
+		channelID,
+		common.ChannelTypeCommunityTopic.Uint8(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, extra)
+	require.False(t, extra.ManualUnread,
+		"客户端在核心广播后断开时，后置清理仍应移除手动未读标记")
+
+	fakeIMMu.Lock()
+	cmds := append([]string(nil), fakeIMCMDs...)
+	records := append([]fakeIMCMDRecord(nil), fakeIMCMDRecords...)
+	fakeIMMu.Unlock()
+	require.Equal(t, []string{
+		common.CMDConversationUnreadClear,
+		common.CMDSyncConversationExtra,
+	}, cmds)
+	require.Len(t, records, 2)
+	requireManualUnreadCMDParam(
+		t,
+		records[1],
 		channelID,
 		common.ChannelTypeCommunityTopic.Uint8(),
 		false,

--- a/modules/message/recent_window_exemption_test.go
+++ b/modules/message/recent_window_exemption_test.go
@@ -134,7 +134,7 @@ func TestBuildRecentItems_PinnedSurvivesWindow(t *testing.T) {
 	pinned := map[string]struct{}{
 		channelKey("g-stale-pinned", common.ChannelTypeGroup.Uint8()): {},
 	}
-	items := buildRecentItems(convs, defaultRecentCutoffs(), pinned, nil, nil, "")
+	items := buildRecentItems(convs, defaultRecentCutoffs(), pinned, nil, nil, "", map[string]bool{})
 
 	require.Len(t, items, 1, "置顶条目必须存活，未置顶的陈旧群应被过滤")
 	assert.Equal(t, "g-stale-pinned", items[0].TargetID)
@@ -147,7 +147,7 @@ func TestBuildRecentItems_UnreadSurvivesWindow(t *testing.T) {
 		makeRawConv("g-stale-unread", common.ChannelTypeGroup.Uint8(), now3DaysAgo(), 3),
 		makeRawConv("g-stale-read", common.ChannelTypeGroup.Uint8(), now3DaysAgo(), 0),
 	}
-	items := buildRecentItems(convs, defaultRecentCutoffs(), nil, nil, nil, "")
+	items := buildRecentItems(convs, defaultRecentCutoffs(), nil, nil, nil, "", map[string]bool{})
 
 	require.Len(t, items, 1)
 	assert.Equal(t, "g-stale-unread", items[0].TargetID)
@@ -175,7 +175,7 @@ func TestRecentWindow_BothEndpointsAgree(t *testing.T) {
 		makeSyncRespUnread(pinnedID, common.ChannelTypeGroup.Uint8(), now3DaysAgo(), 0),
 	}
 
-	items := buildRecentItems(rawConvs, cutoffs, pinned, nil, nil, "")
+	items := buildRecentItems(rawConvs, cutoffs, pinned, nil, nil, "", map[string]bool{})
 	sidebarIDs := make([]string, 0, len(items))
 	for _, it := range items {
 		sidebarIDs = append(sidebarIDs, it.TargetID)

--- a/modules/message/recent_window_exemption_test.go
+++ b/modules/message/recent_window_exemption_test.go
@@ -3,9 +3,9 @@ package message
 // =============================================================================
 // 不活跃窗口的豁免规则（task inactive-hiding-user-control / P2）
 //
-// 窗口是「这个会话安静了，从我眼前淡出」的每人视图投影。三类东西不得被它淡出：
-// 未读、置顶、系统 Bot。前两者是「把窗口交给用户自己设」（Batch 2）的安全前提 ——
-// 一个能吞掉未读的窗口不能交到用户手里；第三类保证系统 Bot 在每个 Space 可达。
+// 窗口是「这个会话安静了，从我眼前淡出」的每人视图投影。四类东西不得被它淡出：
+// 真实未读、人工未读、置顶、系统 Bot。前三者是「把窗口交给用户自己设」（Batch 2）的安全前提 ——
+// 一个能吞掉未读的窗口不能交到用户手里；第四类保证系统 Bot 在每个 Space 可达。
 //
 // 纯逻辑测试：keepDespiteRecentWindow 与两个端点的过滤函数，无需 DB / IM。
 // =============================================================================
@@ -85,6 +85,16 @@ func TestFilterRecentConversations_StaleButPinnedKept(t *testing.T) {
 	assert.Equal(t, []string{"g-stale-pinned"}, channelIDs(got))
 }
 
+func TestFilterRecentConversations_StaleButManualUnreadKept(t *testing.T) {
+	manual := makeSyncResp("g-stale-manual", common.ChannelTypeGroup.Uint8(), now3DaysAgo())
+	manual.Extra = &conversationExtraResp{ManualUnread: true}
+	plain := makeSyncResp("g-stale-plain", common.ChannelTypeGroup.Uint8(), now3DaysAgo())
+
+	got := filterRecentConversations([]*SyncUserConversationResp{manual, plain}, defaultRecentCutoffs(), nil)
+
+	assert.Equal(t, []string{"g-stale-manual"}, channelIDs(got))
+}
+
 // 置顶集合为空（例如置顶查询失败降级）时不得 panic，且未读豁免仍然生效 ——
 // 两个端点的降级方向必须一致。
 func TestFilterRecentConversations_NilPinnedSetStillHonoursUnread(t *testing.T) {
@@ -134,7 +144,7 @@ func TestBuildRecentItems_PinnedSurvivesWindow(t *testing.T) {
 	pinned := map[string]struct{}{
 		channelKey("g-stale-pinned", common.ChannelTypeGroup.Uint8()): {},
 	}
-	items := buildRecentItems(convs, defaultRecentCutoffs(), pinned, nil, nil, "", map[string]bool{})
+	items := buildRecentItems(convs, defaultRecentCutoffs(), pinned, nil, nil, nil, "")
 
 	require.Len(t, items, 1, "置顶条目必须存活，未置顶的陈旧群应被过滤")
 	assert.Equal(t, "g-stale-pinned", items[0].TargetID)
@@ -147,11 +157,27 @@ func TestBuildRecentItems_UnreadSurvivesWindow(t *testing.T) {
 		makeRawConv("g-stale-unread", common.ChannelTypeGroup.Uint8(), now3DaysAgo(), 3),
 		makeRawConv("g-stale-read", common.ChannelTypeGroup.Uint8(), now3DaysAgo(), 0),
 	}
-	items := buildRecentItems(convs, defaultRecentCutoffs(), nil, nil, nil, "", map[string]bool{})
+	items := buildRecentItems(convs, defaultRecentCutoffs(), nil, nil, nil, nil, "")
 
 	require.Len(t, items, 1)
 	assert.Equal(t, "g-stale-unread", items[0].TargetID)
 	assert.Equal(t, 3, items[0].Unread, "未读数必须原样透出，不能因豁免路径丢字段")
+}
+
+func TestRecentWindowBuildItems_ManualUnreadSurvivesWindow(t *testing.T) {
+	convs := []*config.SyncUserConversationResp{
+		makeRawConv("g-stale-manual", common.ChannelTypeGroup.Uint8(), now3DaysAgo(), 0),
+		makeRawConv("g-stale-plain", common.ChannelTypeGroup.Uint8(), now3DaysAgo(), 0),
+	}
+	manualUnreadSet := map[string]struct{}{
+		channelKey("g-stale-manual", common.ChannelTypeGroup.Uint8()): {},
+	}
+
+	items := buildRecentItems(convs, defaultRecentCutoffs(), nil, manualUnreadSet, nil, nil, "")
+
+	require.Len(t, items, 1)
+	assert.Equal(t, "g-stale-manual", items[0].TargetID)
+	assert.True(t, items[0].ManualUnread)
 }
 
 // 两个端点在同一输入上必须给出同一可见集合 —— 本 task 的核心不变量。
@@ -174,8 +200,16 @@ func TestRecentWindow_BothEndpointsAgree(t *testing.T) {
 		makeSyncRespUnread("g-stale-unread", common.ChannelTypeGroup.Uint8(), now3DaysAgo(), 2),
 		makeSyncRespUnread(pinnedID, common.ChannelTypeGroup.Uint8(), now3DaysAgo(), 0),
 	}
+	manualID := "g-stale-manual"
+	rawConvs = append(rawConvs, makeRawConv(manualID, common.ChannelTypeGroup.Uint8(), now3DaysAgo(), 0))
+	manualResp := makeSyncRespUnread(manualID, common.ChannelTypeGroup.Uint8(), now3DaysAgo(), 0)
+	manualResp.Extra = &conversationExtraResp{ManualUnread: true}
+	respConvs = append(respConvs, manualResp)
+	manualUnreadSet := map[string]struct{}{
+		channelKey(manualID, common.ChannelTypeGroup.Uint8()): {},
+	}
 
-	items := buildRecentItems(rawConvs, cutoffs, pinned, nil, nil, "", map[string]bool{})
+	items := buildRecentItems(rawConvs, cutoffs, pinned, manualUnreadSet, nil, nil, "")
 	sidebarIDs := make([]string, 0, len(items))
 	for _, it := range items {
 		sidebarIDs = append(sidebarIDs, it.TargetID)

--- a/modules/message/round2_findings_test.go
+++ b/modules/message/round2_findings_test.go
@@ -152,7 +152,7 @@ func TestSpaceID_Round2_Finding3_BuildRecentItems_ExternalGroupMySource(t *testi
 	groupSpaceMap := map[string]string{"g_external": "spaceB"}
 	externalGroupMap := map[string]string{"g_external": "spaceA"}
 
-	items := buildRecentItems(convs, recentCutoffs{}, nil, groupSpaceMap, externalGroupMap, "")
+	items := buildRecentItems(convs, recentCutoffs{}, nil, groupSpaceMap, externalGroupMap, "", map[string]bool{})
 
 	byID := map[string]*SidebarItem{}
 	for _, it := range items {

--- a/modules/message/round2_findings_test.go
+++ b/modules/message/round2_findings_test.go
@@ -152,7 +152,7 @@ func TestSpaceID_Round2_Finding3_BuildRecentItems_ExternalGroupMySource(t *testi
 	groupSpaceMap := map[string]string{"g_external": "spaceB"}
 	externalGroupMap := map[string]string{"g_external": "spaceA"}
 
-	items := buildRecentItems(convs, recentCutoffs{}, nil, groupSpaceMap, externalGroupMap, "", map[string]bool{})
+	items := buildRecentItems(convs, recentCutoffs{}, nil, nil, groupSpaceMap, externalGroupMap, "")
 
 	byID := map[string]*SidebarItem{}
 	for _, it := range items {

--- a/modules/message/round3_findings_test.go
+++ b/modules/message/round3_findings_test.go
@@ -192,7 +192,7 @@ func TestSpaceID_Round3_Finding2_Sidebar_EmptySourceFallback(t *testing.T) {
 	})
 
 	t.Run("buildRecentItems", func(t *testing.T) {
-		items := buildRecentItems(convs, recentCutoffs{}, nil, groupSpaceMap, externalGroupMap, defaultSpaceID, map[string]bool{})
+		items := buildRecentItems(convs, recentCutoffs{}, nil, nil, groupSpaceMap, externalGroupMap, defaultSpaceID)
 		byID := map[string]*SidebarItem{}
 		for _, it := range items {
 			byID[it.TargetID] = it

--- a/modules/message/round3_findings_test.go
+++ b/modules/message/round3_findings_test.go
@@ -192,7 +192,7 @@ func TestSpaceID_Round3_Finding2_Sidebar_EmptySourceFallback(t *testing.T) {
 	})
 
 	t.Run("buildRecentItems", func(t *testing.T) {
-		items := buildRecentItems(convs, recentCutoffs{}, nil, groupSpaceMap, externalGroupMap, defaultSpaceID)
+		items := buildRecentItems(convs, recentCutoffs{}, nil, groupSpaceMap, externalGroupMap, defaultSpaceID, map[string]bool{})
 		byID := map[string]*SidebarItem{}
 		for _, it := range items {
 			byID[it.TargetID] = it

--- a/modules/message/set_unread_conversation_sync_integration_test.go
+++ b/modules/message/set_unread_conversation_sync_integration_test.go
@@ -150,6 +150,266 @@ func TestIntegration_ClearManualUnreadAndClearUnreadAlwaysClearManualState(t *te
 	require.False(t, extra.ManualUnread)
 }
 
+// TestIntegration_ClearUnreadBroadcastsCoreStateBeforeBestEffortManualSync
+// guards the legacy clearUnread contract. Once WuKongIM has accepted the real
+// unread clear, CMDConversationUnreadClear must be broadcast before the
+// supplementary conversation-extra notification. A failure of that later
+// notification is logged but must not turn the completed core operation into
+// an error response.
+func TestIntegration_ClearUnreadBroadcastsCoreStateBeforeBestEffortManualSync(t *testing.T) {
+	const channelID = "clear-unread-core-before-manual-sync"
+
+	s, ctx := setupConvSyncE2E(t, nil)
+	call := func(path, body string) *httptest.ResponseRecorder {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPut, path, bytes.NewBufferString(body))
+		req.Header.Set("token", testutil.Token)
+		s.GetRoute().ServeHTTP(w, req)
+		return w
+	}
+
+	setResp := call(
+		"/v1/conversation/setManualUnread",
+		`{"channel_id":"`+channelID+`","channel_type":5}`,
+	)
+	require.Equal(t, http.StatusOK, setResp.Code, setResp.Body.String())
+
+	fakeIMCMDs = nil
+	fakeIMFailCMD = common.CMDSyncConversationExtra
+	defer func() { fakeIMFailCMD = "" }()
+
+	clearResp := call(
+		"/v1/conversation/clearUnread",
+		`{"channel_id":"`+channelID+`","channel_type":5,"unread":0}`,
+	)
+	require.Equal(t, http.StatusOK, clearResp.Code, clearResp.Body.String())
+	require.Equal(t, []string{
+		common.CMDConversationUnreadClear,
+		common.CMDSyncConversationExtra,
+	}, fakeIMCMDs, "核心真实未读通知必须先于 best-effort 会话扩展通知")
+
+	extra, err := newConversationExtraDB(ctx).queryOne(
+		testutil.UID,
+		channelID,
+		common.ChannelTypeCommunityTopic.Uint8(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, extra)
+	require.False(t, extra.ManualUnread)
+}
+
+// TestIntegration_DedicatedManualUnreadNotificationsAreBestEffort verifies
+// that both dedicated marker endpoints return their committed state even when
+// the transient conversation-extra notification cannot be delivered. A CMD
+// failure must not produce a retryable HTTP error after the database commit.
+func TestIntegration_DedicatedManualUnreadNotificationsAreBestEffort(t *testing.T) {
+	const channelID = "manual-unread-best-effort-notification"
+
+	s, ctx := setupConvSyncE2E(t, nil)
+	fakeIMFailCMD = common.CMDSyncConversationExtra
+	defer func() { fakeIMFailCMD = "" }()
+
+	call := func(path string) *httptest.ResponseRecorder {
+		t.Helper()
+		resp := httptest.NewRecorder()
+		req := httptest.NewRequest(
+			http.MethodPut,
+			path,
+			bytes.NewBufferString(`{"channel_id":"`+channelID+`","channel_type":2}`),
+		)
+		req.Header.Set("token", testutil.Token)
+		s.GetRoute().ServeHTTP(resp, req)
+		return resp
+	}
+
+	setResp := call("/v1/conversation/setManualUnread")
+	require.Equal(t, http.StatusOK, setResp.Code, setResp.Body.String())
+	var setResult setManualUnreadResp
+	require.NoError(t, json.Unmarshal(setResp.Body.Bytes(), &setResult))
+	require.True(t, setResult.Changed)
+	require.True(t, setResult.ManualUnread)
+	require.NotZero(t, setResult.Version)
+
+	extraDB := newConversationExtraDB(ctx)
+	extra, err := extraDB.queryOne(testutil.UID, channelID, common.ChannelTypeGroup.Uint8())
+	require.NoError(t, err)
+	require.NotNil(t, extra)
+	require.True(t, extra.ManualUnread)
+
+	clearResp := call("/v1/conversation/clearManualUnread")
+	require.Equal(t, http.StatusOK, clearResp.Code, clearResp.Body.String())
+	var clearResult clearManualUnreadResp
+	require.NoError(t, json.Unmarshal(clearResp.Body.Bytes(), &clearResult))
+	require.True(t, clearResult.Changed)
+	require.False(t, clearResult.ManualUnread)
+	require.NotZero(t, clearResult.Version)
+
+	extra, err = extraDB.queryOne(testutil.UID, channelID, common.ChannelTypeGroup.Uint8())
+	require.NoError(t, err)
+	require.NotNil(t, extra)
+	require.False(t, extra.ManualUnread)
+	require.Equal(t, []string{
+		common.CMDSyncConversationExtra,
+		common.CMDSyncConversationExtra,
+	}, fakeIMCMDs)
+}
+
+func TestIntegration_ConcurrentSetManualUnreadHasOneStateTransition(t *testing.T) {
+	const channelID = "manual-unread-concurrent-set"
+
+	s, ctx := setupConvSyncE2E(t, nil)
+	start := make(chan struct{})
+	responses := make(chan *httptest.ResponseRecorder, 2)
+	call := func() {
+		<-start
+		resp := httptest.NewRecorder()
+		req := httptest.NewRequest(
+			http.MethodPut,
+			"/v1/conversation/setManualUnread",
+			bytes.NewBufferString(`{"channel_id":"`+channelID+`","channel_type":2}`),
+		)
+		req.Header.Set("token", testutil.Token)
+		s.GetRoute().ServeHTTP(resp, req)
+		responses <- resp
+	}
+
+	go call()
+	go call()
+	close(start)
+
+	changedCount := 0
+	unchangedCount := 0
+	var changedVersion int64
+	for range 2 {
+		resp := <-responses
+		require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+		var result setManualUnreadResp
+		require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &result))
+		if result.Changed {
+			changedCount++
+			changedVersion = result.Version
+			continue
+		}
+		unchangedCount++
+		require.Equal(t, "already_manual_unread", result.Reason)
+		require.Zero(t, result.Version)
+	}
+
+	require.Equal(t, 1, changedCount)
+	require.Equal(t, 1, unchangedCount)
+	require.NotZero(t, changedVersion)
+	extra, err := newConversationExtraDB(ctx).queryOne(
+		testutil.UID,
+		channelID,
+		common.ChannelTypeGroup.Uint8(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, extra)
+	require.True(t, extra.ManualUnread)
+	require.Equal(t, changedVersion, extra.Version)
+}
+
+func TestIntegration_ConversationExtraDBRejectsVersionRollback(t *testing.T) {
+	const channelID = "manual-unread-version-guard"
+
+	_, ctx := setupConvSyncE2E(t, nil)
+	extraDB := newConversationExtraDB(ctx)
+	channelType := common.ChannelTypeGroup.Uint8()
+
+	changed, err := extraDB.setManualUnread(testutil.UID, channelID, channelType, 200)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	changed, err = extraDB.setManualUnread(testutil.UID, channelID, channelType, 100)
+	require.NoError(t, err)
+	require.False(t, changed, "a stale set must not overwrite a newer version")
+
+	changed, err = extraDB.clearManualUnread(testutil.UID, channelID, channelType, 150)
+	require.NoError(t, err)
+	require.False(t, changed, "a stale clear must not overwrite a newer version")
+
+	changed, err = extraDB.insertOrUpdate(&conversationExtraModel{
+		UID:            testutil.UID,
+		ChannelID:      channelID,
+		ChannelType:    channelType,
+		BrowseTo:       9,
+		KeepMessageSeq: 9,
+		Draft:          "stale",
+		Version:        180,
+	})
+	require.NoError(t, err)
+	require.False(t, changed, "a stale ordinary extra update must be rejected")
+
+	extra, err := extraDB.queryOne(testutil.UID, channelID, channelType)
+	require.NoError(t, err)
+	require.NotNil(t, extra)
+	require.True(t, extra.ManualUnread)
+	require.Equal(t, int64(200), extra.Version)
+	require.Empty(t, extra.Draft)
+
+	changed, err = extraDB.insertOrUpdate(&conversationExtraModel{
+		UID:            testutil.UID,
+		ChannelID:      channelID,
+		ChannelType:    channelType,
+		BrowseTo:       9,
+		KeepMessageSeq: 9,
+		Draft:          "fresh",
+		Version:        201,
+	})
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	changed, err = extraDB.clearManualUnread(testutil.UID, channelID, channelType, 202)
+	require.NoError(t, err)
+	require.True(t, changed)
+	extra, err = extraDB.queryOne(testutil.UID, channelID, channelType)
+	require.NoError(t, err)
+	require.NotNil(t, extra)
+	require.False(t, extra.ManualUnread)
+	require.Equal(t, int64(202), extra.Version)
+	require.Equal(t, "fresh", extra.Draft)
+}
+
+func TestIntegration_SetManualUnreadAdvancesPastPersistedUIDHighWater(t *testing.T) {
+	const (
+		seedChannelID = "manual-unread-high-water-seed"
+		targetChannel = "manual-unread-high-water-target"
+		highWater     = int64(9_000_000_000_000)
+	)
+
+	s, ctx := setupConvSyncE2E(t, nil)
+	extraDB := newConversationExtraDB(ctx)
+	changed, err := extraDB.setManualUnread(
+		testutil.UID,
+		seedChannelID,
+		common.ChannelTypeGroup.Uint8(),
+		highWater,
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/v1/conversation/setManualUnread",
+		bytes.NewBufferString(`{"channel_id":"`+targetChannel+`","channel_type":2}`),
+	)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+
+	var result setManualUnreadResp
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &result))
+	require.True(t, result.Changed)
+	require.Equal(t, highWater+1, result.Version)
+
+	extra, err := extraDB.queryOne(testutil.UID, targetChannel, common.ChannelTypeGroup.Uint8())
+	require.NoError(t, err)
+	require.NotNil(t, extra)
+	require.Equal(t, highWater+1, extra.Version)
+}
+
 // TestIntegration_ConversationExtraUpdatePreservesOmittedManualUnread verifies
 // that a legacy extra update, which does not include manual_unread, cannot
 // overwrite a marker set by the dedicated manual-unread endpoint.
@@ -169,12 +429,14 @@ func TestIntegration_ConversationExtraUpdatePreservesOmittedManualUnread(t *test
 	extraDB := newConversationExtraDB(ctx)
 	version, err := ctx.GenSeq(common.SyncConversationExtraKey)
 	require.NoError(t, err)
-	require.NoError(t, extraDB.setManualUnread(
+	changed, err := extraDB.setManualUnread(
 		testutil.UID,
 		channelID,
 		common.ChannelTypeGroup.Uint8(),
 		version,
-	))
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
 
 	body := bytes.NewBufferString(`{"browse_to":11,"keep_message_seq":11,"keep_offset_y":0,"draft":"draft"}`)
 	req := httptest.NewRequest(
@@ -205,12 +467,14 @@ func TestIntegration_ManualUnreadRejectsPerson(t *testing.T) {
 	extraDB := newConversationExtraDB(ctx)
 	version, err := ctx.GenSeq(common.SyncConversationExtraKey)
 	require.NoError(t, err)
-	require.NoError(t, extraDB.setManualUnread(
+	changed, err := extraDB.setManualUnread(
 		testutil.UID,
 		channelID,
 		common.ChannelTypePerson.Uint8(),
 		version,
-	))
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
 
 	for _, path := range []string{
 		"/v1/conversation/setManualUnread",
@@ -268,7 +532,9 @@ func TestIntegration_QueryManualUnreadExcludesPerson(t *testing.T) {
 	} {
 		version, err := ctx.GenSeq(common.SyncConversationExtraKey)
 		require.NoError(t, err)
-		require.NoError(t, extraDB.setManualUnread(testutil.UID, tc.channelID, tc.channelType, version))
+		changed, err := extraDB.setManualUnread(testutil.UID, tc.channelID, tc.channelType, version)
+		require.NoError(t, err)
+		require.True(t, changed)
 	}
 
 	rows, err := extraDB.queryManualUnread(testutil.UID)

--- a/modules/message/set_unread_conversation_sync_integration_test.go
+++ b/modules/message/set_unread_conversation_sync_integration_test.go
@@ -5,6 +5,7 @@ package message
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -15,31 +16,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestIntegration_SetManualUnreadUsesConversationSync verifies the
-// regression fixed here: setManualUnread must use WuKongIM's supported
-// POST /conversation/sync endpoint instead of the removed GET /conversations
-// endpoint. The shared fake IM server returns a valid conversation only for
-// the supported sync path and accepts the follow-up no-persist CMD.
-func TestIntegration_SetManualUnreadUsesConversationSync(t *testing.T) {
-	channelID := "set-manual-unread-sync-group"
+// TestIntegration_SetManualUnreadSkipsConversationSync verifies that setting
+// the application-level marker neither queries nor depends on WuKongIM's real
+// unread state. The fake target deliberately has normal unread messages; the
+// marker must still be created without calling /conversation/sync.
+func TestIntegration_SetManualUnreadSkipsConversationSync(t *testing.T) {
+	channelID := "set-manual-unread-without-sync"
 	fakeIMConvs = []*config.SyncUserConversationResp{
 		{
 			ChannelID:   channelID,
 			ChannelType: common.ChannelTypeGroup.Uint8(),
-			Unread:      0,
+			Unread:      7,
 			LastMsgSeq:  42,
 		},
 	}
 
 	s, _ := setupConvSyncE2E(t, fakeIMConvs)
 
-	body := bytes.NewBufferString(`{"channel_id":"` + channelID + `","channel_type":2}`)
-	req := httptest.NewRequest(http.MethodPut, "/v1/conversation/setManualUnread", body)
-	req.Header.Set("token", testutil.Token)
+	call := func() *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		body := bytes.NewBufferString(`{"channel_id":"` + channelID + `","channel_type":2}`)
+		req := httptest.NewRequest(http.MethodPut, "/v1/conversation/setManualUnread", body)
+		req.Header.Set("token", testutil.Token)
+		s.GetRoute().ServeHTTP(w, req)
+		return w
+	}
 
-	resp := httptest.NewRecorder()
-	s.GetRoute().ServeHTTP(resp, req)
-
+	resp := call()
 	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
 	var result setManualUnreadResp
 	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &result))
@@ -48,6 +51,15 @@ func TestIntegration_SetManualUnreadUsesConversationSync(t *testing.T) {
 	require.True(t, result.ManualUnread)
 	require.True(t, result.Changed)
 	require.NotZero(t, result.Version)
+	require.Zero(t, fakeIMSyncCalls, "setManualUnread 不应查询 WuKongIM 会话或真实未读数")
+
+	resp = call()
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &result))
+	require.True(t, result.ManualUnread)
+	require.False(t, result.Changed)
+	require.Equal(t, "already_manual_unread", result.Reason)
+	require.Zero(t, fakeIMSyncCalls, "幂等设置同样不应查询 WuKongIM")
 }
 
 // TestIntegration_ClearManualUnreadAndClearUnreadAlwaysClearManualState
@@ -56,9 +68,15 @@ func TestIntegration_SetManualUnreadUsesConversationSync(t *testing.T) {
 //   - clearUnread also clears manual_unread when unread is non-zero, because
 //     the existing frontend uses that endpoint for explicit unread updates.
 func TestIntegration_ClearManualUnreadAndClearUnreadAlwaysClearManualState(t *testing.T) {
-	channelID := "clear-manual-unread-dm"
+	channelID := "clear-manual-unread-group____topic"
 	fakeIMConvs = []*config.SyncUserConversationResp{
-		dmIMConv(channelID, 1_700_000_000, 100, 11),
+		{
+			ChannelID:   channelID,
+			ChannelType: common.ChannelTypeCommunityTopic.Uint8(),
+			Timestamp:   1_700_000_000,
+			LastMsgSeq:  100,
+			Unread:      11,
+		},
 	}
 
 	s, ctx := setupConvSyncE2E(t, fakeIMConvs)
@@ -74,13 +92,13 @@ func TestIntegration_ClearManualUnreadAndClearUnreadAlwaysClearManualState(t *te
 
 	setResp := call(
 		"/v1/conversation/setManualUnread",
-		`{"channel_id":"`+channelID+`","channel_type":1}`,
+		`{"channel_id":"`+channelID+`","channel_type":5}`,
 	)
 	require.Equal(t, http.StatusOK, setResp.Code, setResp.Body.String())
 
 	clearManualResp := call(
 		"/v1/conversation/clearManualUnread",
-		`{"channel_id":"`+channelID+`","channel_type":1}`,
+		`{"channel_id":"`+channelID+`","channel_type":5}`,
 	)
 	require.Equal(t, http.StatusOK, clearManualResp.Code, clearManualResp.Body.String())
 	var clearResult clearManualUnreadResp
@@ -93,7 +111,7 @@ func TestIntegration_ClearManualUnreadAndClearUnreadAlwaysClearManualState(t *te
 	// it must not create another conversation-extra version or notify clients.
 	clearAgainResp := call(
 		"/v1/conversation/clearManualUnread",
-		`{"channel_id":"`+channelID+`","channel_type":1}`,
+		`{"channel_id":"`+channelID+`","channel_type":5}`,
 	)
 	require.Equal(t, http.StatusOK, clearAgainResp.Code, clearAgainResp.Body.String())
 	var clearAgainResult clearManualUnreadResp
@@ -103,7 +121,7 @@ func TestIntegration_ClearManualUnreadAndClearUnreadAlwaysClearManualState(t *te
 	require.Zero(t, clearAgainResult.Version)
 
 	extraDB := newConversationExtraDB(ctx)
-	extra, err := extraDB.queryOne(testutil.UID, channelID, common.ChannelTypePerson.Uint8())
+	extra, err := extraDB.queryOne(testutil.UID, channelID, common.ChannelTypeCommunityTopic.Uint8())
 	require.NoError(t, err)
 	require.NotNil(t, extra)
 	require.False(t, extra.ManualUnread)
@@ -112,13 +130,13 @@ func TestIntegration_ClearManualUnreadAndClearUnreadAlwaysClearManualState(t *te
 	// with unread>0. That explicit real-unread update must clear the marker too.
 	setResp = call(
 		"/v1/conversation/setManualUnread",
-		`{"channel_id":"`+channelID+`","channel_type":1}`,
+		`{"channel_id":"`+channelID+`","channel_type":5}`,
 	)
 	require.Equal(t, http.StatusOK, setResp.Code, setResp.Body.String())
 
 	clearResp := call(
 		"/v1/conversation/clearUnread",
-		`{"channel_id":"`+channelID+`","channel_type":1,"unread":5}`,
+		`{"channel_id":"`+channelID+`","channel_type":5,"unread":5}`,
 	)
 	require.Equal(t, http.StatusOK, clearResp.Code, clearResp.Body.String())
 	require.Contains(t, fakeIMCMDs, common.CMDSyncConversationExtra,
@@ -126,7 +144,7 @@ func TestIntegration_ClearManualUnreadAndClearUnreadAlwaysClearManualState(t *te
 	require.Contains(t, fakeIMCMDs, common.CMDConversationUnreadClear,
 		"clearUnread 仍然必须发送真实未读清除命令")
 
-	extra, err = extraDB.queryOne(testutil.UID, channelID, common.ChannelTypePerson.Uint8())
+	extra, err = extraDB.queryOne(testutil.UID, channelID, common.ChannelTypeCommunityTopic.Uint8())
 	require.NoError(t, err)
 	require.NotNil(t, extra)
 	require.False(t, extra.ManualUnread)
@@ -138,10 +156,52 @@ func TestIntegration_ClearManualUnreadAndClearUnreadAlwaysClearManualState(t *te
 func TestIntegration_ConversationExtraUpdatePreservesOmittedManualUnread(t *testing.T) {
 	channelID := "conversation-extra-preserve-manual-unread"
 	fakeIMConvs = []*config.SyncUserConversationResp{
-		dmIMConv(channelID, 1_700_000_000, 100, 11),
+		{
+			ChannelID:   channelID,
+			ChannelType: common.ChannelTypeGroup.Uint8(),
+			Timestamp:   1_700_000_000,
+			LastMsgSeq:  100,
+			Unread:      11,
+		},
 	}
 
 	s, ctx := setupConvSyncE2E(t, fakeIMConvs)
+	extraDB := newConversationExtraDB(ctx)
+	version, err := ctx.GenSeq(common.SyncConversationExtraKey)
+	require.NoError(t, err)
+	require.NoError(t, extraDB.setManualUnread(
+		testutil.UID,
+		channelID,
+		common.ChannelTypeGroup.Uint8(),
+		version,
+	))
+
+	body := bytes.NewBufferString(`{"browse_to":11,"keep_message_seq":11,"keep_offset_y":0,"draft":"draft"}`)
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/conversations/"+channelID+"/2/extra",
+		body,
+	)
+	req.Header.Set("token", testutil.Token)
+	resp := httptest.NewRecorder()
+	s.GetRoute().ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+
+	extra, err := extraDB.queryOne(testutil.UID, channelID, common.ChannelTypeGroup.Uint8())
+	require.NoError(t, err)
+	require.NotNil(t, extra)
+	require.True(t, extra.ManualUnread,
+		"未携带 manual_unread 的旧扩展更新必须保留数据库中的手动未读状态")
+}
+
+// TestIntegration_ManualUnreadRejectsPerson verifies the temporary product
+// boundary: manual-unread is supported only for groups and community topics.
+// A stale Person marker must neither make the endpoints accept the request nor
+// be mutated as a side effect of the rejected request.
+func TestIntegration_ManualUnreadRejectsPerson(t *testing.T) {
+	const channelID = "manual-unread-person-unsupported"
+
+	s, ctx := setupConvSyncE2E(t, nil)
 	extraDB := newConversationExtraDB(ctx)
 	version, err := ctx.GenSeq(common.SyncConversationExtraKey)
 	require.NoError(t, err)
@@ -152,20 +212,115 @@ func TestIntegration_ConversationExtraUpdatePreservesOmittedManualUnread(t *test
 		version,
 	))
 
-	body := bytes.NewBufferString(`{"browse_to":11,"keep_message_seq":11,"keep_offset_y":0,"draft":"draft"}`)
-	req := httptest.NewRequest(
-		http.MethodPost,
-		"/v1/conversations/"+channelID+"/1/extra",
-		body,
+	for _, path := range []string{
+		"/v1/conversation/setManualUnread",
+		"/v1/conversation/clearManualUnread",
+	} {
+		t.Run(path, func(t *testing.T) {
+			resp := httptest.NewRecorder()
+			req := httptest.NewRequest(
+				http.MethodPut,
+				path,
+				bytes.NewBufferString(`{"channel_id":"`+channelID+`","channel_type":1}`),
+			)
+			req.Header.Set("token", testutil.Token)
+			s.GetRoute().ServeHTTP(resp, req)
+
+			require.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
+			var envelope struct {
+				Status int `json:"status"`
+			}
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &envelope))
+			require.Equal(t, http.StatusBadRequest, envelope.Status)
+		})
+	}
+
+	clearResp := httptest.NewRecorder()
+	clearReq := httptest.NewRequest(
+		http.MethodPut,
+		"/v1/conversation/clearUnread",
+		bytes.NewBufferString(`{"channel_id":"`+channelID+`","channel_type":1,"unread":0}`),
 	)
-	req.Header.Set("token", testutil.Token)
-	resp := httptest.NewRecorder()
-	s.GetRoute().ServeHTTP(resp, req)
-	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	clearReq.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(clearResp, clearReq)
+	require.Equal(t, http.StatusOK, clearResp.Code, clearResp.Body.String())
 
 	extra, err := extraDB.queryOne(testutil.UID, channelID, common.ChannelTypePerson.Uint8())
 	require.NoError(t, err)
 	require.NotNil(t, extra)
-	require.True(t, extra.ManualUnread,
-		"未携带 manual_unread 的旧扩展更新必须保留数据库中的手动未读状态")
+	require.True(t, extra.ManualUnread, "私聊专用请求和 clearUnread 都不能维护遗留手动未读状态")
+	require.NotContains(t, fakeIMCMDs, common.CMDSyncConversationExtra)
+	require.Contains(t, fakeIMCMDs, common.CMDConversationUnreadClear)
+	require.Zero(t, fakeIMSyncCalls)
+}
+
+func TestIntegration_QueryManualUnreadExcludesPerson(t *testing.T) {
+	_, ctx := setupConvSyncE2E(t, nil)
+	extraDB := newConversationExtraDB(ctx)
+
+	for _, tc := range []struct {
+		channelID   string
+		channelType uint8
+	}{
+		{channelID: "manual-unread-person-hidden", channelType: common.ChannelTypePerson.Uint8()},
+		{channelID: "manual-unread-group-visible", channelType: common.ChannelTypeGroup.Uint8()},
+		{channelID: "manual-unread-topic-visible", channelType: common.ChannelTypeCommunityTopic.Uint8()},
+	} {
+		version, err := ctx.GenSeq(common.SyncConversationExtraKey)
+		require.NoError(t, err)
+		require.NoError(t, extraDB.setManualUnread(testutil.UID, tc.channelID, tc.channelType, version))
+	}
+
+	rows, err := extraDB.queryManualUnread(testutil.UID)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	for _, row := range rows {
+		require.True(t, supportsManualUnreadChannelType(row.ChannelType))
+	}
+}
+
+func TestIntegration_ManualUnreadSupportsGroupAndCommunityTopic(t *testing.T) {
+	s, ctx := setupConvSyncE2E(t, nil)
+
+	for _, tc := range []struct {
+		name        string
+		channelID   string
+		channelType uint8
+	}{
+		{name: "group", channelID: "manual-unread-group", channelType: common.ChannelTypeGroup.Uint8()},
+		{name: "community topic", channelID: "manual-unread-group____topic", channelType: common.ChannelTypeCommunityTopic.Uint8()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			call := func(path string) *httptest.ResponseRecorder {
+				resp := httptest.NewRecorder()
+				req := httptest.NewRequest(
+					http.MethodPut,
+					path,
+					bytes.NewBufferString(fmt.Sprintf(
+						`{"channel_id":%q,"channel_type":%d}`,
+						tc.channelID,
+						tc.channelType,
+					)),
+				)
+				req.Header.Set("token", testutil.Token)
+				s.GetRoute().ServeHTTP(resp, req)
+				return resp
+			}
+
+			setResp := call("/v1/conversation/setManualUnread")
+			require.Equal(t, http.StatusOK, setResp.Code, setResp.Body.String())
+			extraDB := newConversationExtraDB(ctx)
+			extra, err := extraDB.queryOne(testutil.UID, tc.channelID, tc.channelType)
+			require.NoError(t, err)
+			require.NotNil(t, extra)
+			require.True(t, extra.ManualUnread)
+
+			clearResp := call("/v1/conversation/clearManualUnread")
+			require.Equal(t, http.StatusOK, clearResp.Code, clearResp.Body.String())
+			extra, err = extraDB.queryOne(testutil.UID, tc.channelID, tc.channelType)
+			require.NoError(t, err)
+			require.NotNil(t, extra)
+			require.False(t, extra.ManualUnread)
+		})
+	}
 }

--- a/modules/message/set_unread_conversation_sync_integration_test.go
+++ b/modules/message/set_unread_conversation_sync_integration_test.go
@@ -1,0 +1,171 @@
+//go:build integration
+
+package message
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntegration_SetManualUnreadUsesConversationSync verifies the
+// regression fixed here: setManualUnread must use WuKongIM's supported
+// POST /conversation/sync endpoint instead of the removed GET /conversations
+// endpoint. The shared fake IM server returns a valid conversation only for
+// the supported sync path and accepts the follow-up no-persist CMD.
+func TestIntegration_SetManualUnreadUsesConversationSync(t *testing.T) {
+	channelID := "set-manual-unread-sync-group"
+	fakeIMConvs = []*config.SyncUserConversationResp{
+		{
+			ChannelID:   channelID,
+			ChannelType: common.ChannelTypeGroup.Uint8(),
+			Unread:      0,
+			LastMsgSeq:  42,
+		},
+	}
+
+	s, _ := setupConvSyncE2E(t, fakeIMConvs)
+
+	body := bytes.NewBufferString(`{"channel_id":"` + channelID + `","channel_type":2}`)
+	req := httptest.NewRequest(http.MethodPut, "/v1/conversation/setManualUnread", body)
+	req.Header.Set("token", testutil.Token)
+
+	resp := httptest.NewRecorder()
+	s.GetRoute().ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	var result setManualUnreadResp
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &result))
+	require.Equal(t, channelID, result.ChannelID)
+	require.Equal(t, uint8(common.ChannelTypeGroup), result.ChannelType)
+	require.True(t, result.ManualUnread)
+	require.True(t, result.Changed)
+	require.NotZero(t, result.Version)
+}
+
+// TestIntegration_ClearManualUnreadAndClearUnreadAlwaysClearManualState
+// verifies the two explicit ways a manual marker is cleared:
+//   - clearManualUnread changes only conversation_extra.manual_unread;
+//   - clearUnread also clears manual_unread when unread is non-zero, because
+//     the existing frontend uses that endpoint for explicit unread updates.
+func TestIntegration_ClearManualUnreadAndClearUnreadAlwaysClearManualState(t *testing.T) {
+	channelID := "clear-manual-unread-dm"
+	fakeIMConvs = []*config.SyncUserConversationResp{
+		dmIMConv(channelID, 1_700_000_000, 100, 11),
+	}
+
+	s, ctx := setupConvSyncE2E(t, fakeIMConvs)
+
+	call := func(path, body string) *httptest.ResponseRecorder {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPut, path, bytes.NewBufferString(body))
+		req.Header.Set("token", testutil.Token)
+		s.GetRoute().ServeHTTP(w, req)
+		return w
+	}
+
+	setResp := call(
+		"/v1/conversation/setManualUnread",
+		`{"channel_id":"`+channelID+`","channel_type":1}`,
+	)
+	require.Equal(t, http.StatusOK, setResp.Code, setResp.Body.String())
+
+	clearManualResp := call(
+		"/v1/conversation/clearManualUnread",
+		`{"channel_id":"`+channelID+`","channel_type":1}`,
+	)
+	require.Equal(t, http.StatusOK, clearManualResp.Code, clearManualResp.Body.String())
+	var clearResult clearManualUnreadResp
+	require.NoError(t, json.Unmarshal(clearManualResp.Body.Bytes(), &clearResult))
+	require.False(t, clearResult.ManualUnread)
+	require.True(t, clearResult.Changed)
+	require.NotZero(t, clearResult.Version)
+
+	// Clearing an already-clear marker is a successful no-op. In particular,
+	// it must not create another conversation-extra version or notify clients.
+	clearAgainResp := call(
+		"/v1/conversation/clearManualUnread",
+		`{"channel_id":"`+channelID+`","channel_type":1}`,
+	)
+	require.Equal(t, http.StatusOK, clearAgainResp.Code, clearAgainResp.Body.String())
+	var clearAgainResult clearManualUnreadResp
+	require.NoError(t, json.Unmarshal(clearAgainResp.Body.Bytes(), &clearAgainResult))
+	require.False(t, clearAgainResult.ManualUnread)
+	require.False(t, clearAgainResult.Changed)
+	require.Zero(t, clearAgainResult.Version)
+
+	extraDB := newConversationExtraDB(ctx)
+	extra, err := extraDB.queryOne(testutil.UID, channelID, common.ChannelTypePerson.Uint8())
+	require.NoError(t, err)
+	require.NotNil(t, extra)
+	require.False(t, extra.ManualUnread)
+
+	// Re-create the manual marker, then use the existing clearUnread endpoint
+	// with unread>0. That explicit real-unread update must clear the marker too.
+	setResp = call(
+		"/v1/conversation/setManualUnread",
+		`{"channel_id":"`+channelID+`","channel_type":1}`,
+	)
+	require.Equal(t, http.StatusOK, setResp.Code, setResp.Body.String())
+
+	clearResp := call(
+		"/v1/conversation/clearUnread",
+		`{"channel_id":"`+channelID+`","channel_type":1,"unread":5}`,
+	)
+	require.Equal(t, http.StatusOK, clearResp.Code, clearResp.Body.String())
+	require.Contains(t, fakeIMCMDs, common.CMDSyncConversationExtra,
+		"clearUnread 清除手动未读后必须通知客户端同步会话扩展")
+	require.Contains(t, fakeIMCMDs, common.CMDConversationUnreadClear,
+		"clearUnread 仍然必须发送真实未读清除命令")
+
+	extra, err = extraDB.queryOne(testutil.UID, channelID, common.ChannelTypePerson.Uint8())
+	require.NoError(t, err)
+	require.NotNil(t, extra)
+	require.False(t, extra.ManualUnread)
+}
+
+// TestIntegration_ConversationExtraUpdatePreservesOmittedManualUnread verifies
+// that a legacy extra update, which does not include manual_unread, cannot
+// overwrite a marker set by the dedicated manual-unread endpoint.
+func TestIntegration_ConversationExtraUpdatePreservesOmittedManualUnread(t *testing.T) {
+	channelID := "conversation-extra-preserve-manual-unread"
+	fakeIMConvs = []*config.SyncUserConversationResp{
+		dmIMConv(channelID, 1_700_000_000, 100, 11),
+	}
+
+	s, ctx := setupConvSyncE2E(t, fakeIMConvs)
+	extraDB := newConversationExtraDB(ctx)
+	version, err := ctx.GenSeq(common.SyncConversationExtraKey)
+	require.NoError(t, err)
+	require.NoError(t, extraDB.setManualUnread(
+		testutil.UID,
+		channelID,
+		common.ChannelTypePerson.Uint8(),
+		version,
+	))
+
+	body := bytes.NewBufferString(`{"browse_to":11,"keep_message_seq":11,"keep_offset_y":0,"draft":"draft"}`)
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/conversations/"+channelID+"/1/extra",
+		body,
+	)
+	req.Header.Set("token", testutil.Token)
+	resp := httptest.NewRecorder()
+	s.GetRoute().ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+
+	extra, err := extraDB.queryOne(testutil.UID, channelID, common.ChannelTypePerson.Uint8())
+	require.NoError(t, err)
+	require.NotNil(t, extra)
+	require.True(t, extra.ManualUnread,
+		"未携带 manual_unread 的旧扩展更新必须保留数据库中的手动未读状态")
+}

--- a/modules/message/sidebar_space_id_test.go
+++ b/modules/message/sidebar_space_id_test.go
@@ -78,7 +78,7 @@ func TestSpaceID_BuildRecentItems_GroupAndThreadFilled(t *testing.T) {
 		"g1": "spaceB",
 	}
 
-	items := buildRecentItems(convs, recentCutoffs{}, nil, groupSpaceMap, nil, "")
+	items := buildRecentItems(convs, recentCutoffs{}, nil, groupSpaceMap, nil, "", map[string]bool{})
 
 	bySpace := map[string]string{}
 	for _, it := range items {

--- a/modules/message/sidebar_space_id_test.go
+++ b/modules/message/sidebar_space_id_test.go
@@ -78,7 +78,7 @@ func TestSpaceID_BuildRecentItems_GroupAndThreadFilled(t *testing.T) {
 		"g1": "spaceB",
 	}
 
-	items := buildRecentItems(convs, recentCutoffs{}, nil, groupSpaceMap, nil, "", map[string]bool{})
+	items := buildRecentItems(convs, recentCutoffs{}, nil, nil, groupSpaceMap, nil, "")
 
 	bySpace := map[string]string{}
 	for _, it := range items {

--- a/modules/message/sql/20260827000001_conversation_extra_manual_unread.sql
+++ b/modules/message/sql/20260827000001_conversation_extra_manual_unread.sql
@@ -1,0 +1,12 @@
+-- +migrate Up
+
+-- 为用户会话扩展增加独立的手动未读标识。
+-- 该字段只表达侧边栏展示状态，不改变 browse_to 等真实阅读位置。
+ALTER TABLE `conversation_extra`
+    ADD COLUMN `manual_unread` TINYINT NOT NULL DEFAULT 0
+    COMMENT '手动未读标识：0=正常，1=手动标为未读';
+
+-- +migrate Down
+
+ALTER TABLE `conversation_extra`
+    DROP COLUMN `manual_unread`;

--- a/modules/message/swagger/conversation.yaml
+++ b/modules/message/swagger/conversation.yaml
@@ -202,7 +202,7 @@ paths:
         最后一条消息或会话列表。客户端应在本地保存本次返回结果中的最大 `version`，
         下次请求时作为游标传回。返回空数组时保持原游标不变。
 
-        `manual_unread` 是独立于真实 `unread` 的手动展示标识：
+        `manual_unread` 是独立于真实 `unread` 的手动展示标识，目前只对群聊和社区子区有效：
         - `true`：用户手动将该会话标记为未读；
         - `false`：该会话当前没有手动未读标识；
         - 它不会改变 `browse_to`、`keep_message_seq` 或 WuKongIM 的真实阅读位置。
@@ -246,13 +246,15 @@ paths:
         - "conversation"
       summary: "设置会话手动未读"
       description: |
-        将当前登录用户指定的会话设置为手动未读。
+        将当前登录用户指定的群聊或社区子区设置为手动未读。私聊暂不支持该功能，
+        `channel_type=1` 会按请求参数错误返回。
 
         该标识只属于当前用户，不会修改其他用户的会话状态，也不会修改 WuKongIM 的真实
-        未读数或阅读游标。服务端会先查询 WuKongIM 中当前用户的目标会话：
-        - 目标会话已有真实未读消息时，不重复创建手动未读标识，返回 `changed=false`；
-        - 目标会话已经是手动未读时，接口幂等返回 `changed=false`；
-        - 只有真实未读为 0 且尚未手动未读时，才会写入 `manual_unread=true`。
+        未读数或阅读游标。服务端不会查询 WuKongIM 的会话或真实未读状态：即使目标会话
+        已有真实未读消息，也可以同时设置 `manual_unread=true`。
+
+        目标会话已经是手动未读时，接口幂等返回 `changed=false`；否则写入
+        `manual_unread=true` 并返回 `changed=true`。
 
         设置成功后，服务端会更新 `conversation_extra.version`，并向当前用户的个人频道
         发送 `CMDSyncConversationExtra`，通知其他在线设备调用 `/conversation/extra/sync`。
@@ -270,11 +272,11 @@ paths:
             $ref: "#/definitions/manualUnreadRequest"
       responses:
         200:
-          description: "设置结果；已是真实未读或手动未读时也返回 200，使用 changed/reason 判断是否发生变化"
+          description: "设置结果；已经是手动未读时也返回 200，使用 changed/reason 判断是否发生变化"
           schema:
             $ref: "#/definitions/setManualUnreadResponse"
         400:
-          description: "请求参数或会话查询错误"
+          description: "请求参数或会话扩展查询错误"
           schema:
             $ref: "#/definitions/response"
       security:
@@ -285,7 +287,8 @@ paths:
         - "conversation"
       summary: "清除会话手动未读"
       description: |
-        仅清除当前登录用户指定会话的 `manual_unread` 标识。
+        仅清除当前登录用户指定群聊或社区子区的 `manual_unread` 标识。私聊暂不支持
+        该功能，`channel_type=1` 会按请求参数错误返回。
 
         该接口不会调用 WuKongIM 的 `clearUnread`，因此不会修改真实未读数量、阅读游标或
         消息拉取位置。接口适用于用户进入会话后，前端确认当前页面不需要继续显示手动未读
@@ -324,10 +327,11 @@ paths:
       description: |
         清除或更新当前登录用户在 WuKongIM 中的真实未读状态。
 
-        当前服务端实现中，只要该请求本身有效并且目标会话存在手动未读标识，处理成功后
-        也会一并清除该用户的 `manual_unread`，然后发送会话扩展同步通知。因此：
+        当前服务端实现中，只要群聊或子区请求本身有效并且目标会话存在手动未读标识，
+        处理成功后也会一并清除该用户的 `manual_unread`，然后发送会话扩展同步通知。因此：
         - `unread=0`：清除真实未读，同时清除手动未读；
         - `unread>0`：按 WuKongIM 语义设置/保留真实未读，同时也清除手动未读；
+        - 私聊：只处理 WuKongIM 真实未读，不查询或修改手动未读标识；
         - 如果前端只想清除手动未读而保留真实未读，应调用 `/conversation/clearManualUnread`。
 
         该接口不会清除其他用户的状态。
@@ -494,7 +498,7 @@ definitions:
         description: "会话扩展全局同步版本"
       manual_unread:
         type: boolean
-        description: "是否被当前用户手动标记为未读；不代表 unread 消息数量"
+        description: "群聊或子区是否被当前用户手动标记为未读；私聊固定为 false，不代表 unread 消息数量"
   manualUnreadRequest:
     type: "object"
     required:
@@ -508,8 +512,8 @@ definitions:
       channel_type:
         type: integer
         format: uint8
-        enum: [1, 2, 5]
-        description: "频道类型：1=单聊，2=群聊，5=社区子区"
+        enum: [2, 5]
+        description: "频道类型：2=群聊，5=社区子区；暂不支持私聊"
   setManualUnreadResponse:
     type: "object"
     properties:
@@ -532,8 +536,8 @@ definitions:
         description: "状态发生变化时生成的会话扩展版本；未变化时省略"
       reason:
         type: string
-        enum: [already_unread, already_manual_unread]
-        description: "changed=false 时的原因；真实未读已存在或已经是手动未读"
+        enum: [already_manual_unread]
+        description: "changed=false 时的原因：会话已经是手动未读"
   clearManualUnreadResponse:
     type: "object"
     properties:

--- a/modules/message/swagger/conversation.yaml
+++ b/modules/message/swagger/conversation.yaml
@@ -27,6 +27,9 @@ paths:
           下一次 sync 会重新出现；前端"已归档列表"入口请使用
           `GET /v1/groups/{group_no}/threads?status=archived`。
         - 当前用户已退群的群会话不返回。
+        - `extra.manual_unread` 只表示用户手动设置的展示标识，不等价于 WuKongIM 的
+          `unread` 消息数量，也不会改变真实阅读位置。它不属于 recent 活跃时间窗口的
+          豁免条件；当 `recent_filter=true` 时，超过窗口的手动未读会话仍会被过滤。
 
         cursor 推进基于过滤前的 raw conversations，确保被过滤掉的会话不会让游标卡住
         导致客户端反复拉同一批数据。
@@ -103,6 +106,9 @@ paths:
                       items:
                         $ref: "#/definitions/syncMessage"
                         description: "最近N条消息"
+                    extra:
+                      $ref: "#/definitions/conversationExtra"
+                      description: "Octo 会话扩展信息，包括草稿、阅读位置和手动未读标识"
                     users:
                       type: array
                       items:
@@ -189,7 +195,20 @@ paths:
       tags:
         - "conversation"
       summary: "同步最近会话扩展"
-      description: "同步最近会话扩展"
+      description: |
+        按会话扩展版本增量同步当前登录用户的 `conversation_extra` 数据。
+
+        该接口只同步 Octo 维护的会话扩展信息，不负责同步 WuKongIM 的真实未读数、
+        最后一条消息或会话列表。客户端应在本地保存本次返回结果中的最大 `version`，
+        下次请求时作为游标传回。返回空数组时保持原游标不变。
+
+        `manual_unread` 是独立于真实 `unread` 的手动展示标识：
+        - `true`：用户手动将该会话标记为未读；
+        - `false`：该会话当前没有手动未读标识；
+        - 它不会改变 `browse_to`、`keep_message_seq` 或 WuKongIM 的真实阅读位置。
+
+        收到 WuKongIM 的 `CMDSyncConversationExtra` 命令后，客户端应调用本接口拉取
+        实际变更数据。该命令只起到变更通知作用，不携带完整的扩展记录。
       operationId: "sync conversation extra"
       consumes:
         - "application/json"
@@ -198,44 +217,139 @@ paths:
       parameters:
         - in: "body"
           name: "body"
-          description: "同步离线最近会话回执"
+          description: "会话扩展增量同步参数"
           required: true
           schema:
             type: object
             properties:
               version:
                 type: integer
-                description: "cmd版本"
+                format: int64
+                default: 0
+                description: "客户端已同步到的会话扩展全局版本；仅返回 version 大于该值的记录，不传时按 0 处理"
       responses:
         200:
           description: "返回"
           schema:
             type: array
             items:
-              properties:
-                channel_id:
-                  type: string
-                  description: "频道唯一ID"
-                channel_type:
-                  type: integer
-                  description: "频道类型"
-                browse_to:
-                  type: integer
-                  description: "预览到的位置，与会话保持位置不同的是 预览到的位置是用户读到的最大的messageSeq。跟未读消息数量有关系"
-                keep_message_seq:
-                  type: integer
-                  description: "会话保持的位置"
-                keep_offset_y:
-                  type: integer
-                  description: "会话保持的位置的偏移量"
-                draft:
-                  type: string
-                  description: "草稿"
-                version:
-                  type: integer
-                  description: "版本号"
+              $ref: "#/definitions/conversationExtra"
         400:
           description: "错误"
+          schema:
+            $ref: "#/definitions/response"
+      security:
+        - token: []
+  /conversation/setManualUnread:
+    put:
+      tags:
+        - "conversation"
+      summary: "设置会话手动未读"
+      description: |
+        将当前登录用户指定的会话设置为手动未读。
+
+        该标识只属于当前用户，不会修改其他用户的会话状态，也不会修改 WuKongIM 的真实
+        未读数或阅读游标。服务端会先查询 WuKongIM 中当前用户的目标会话：
+        - 目标会话已有真实未读消息时，不重复创建手动未读标识，返回 `changed=false`；
+        - 目标会话已经是手动未读时，接口幂等返回 `changed=false`；
+        - 只有真实未读为 0 且尚未手动未读时，才会写入 `manual_unread=true`。
+
+        设置成功后，服务端会更新 `conversation_extra.version`，并向当前用户的个人频道
+        发送 `CMDSyncConversationExtra`，通知其他在线设备调用 `/conversation/extra/sync`。
+      operationId: "set manual unread"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "body"
+          name: "body"
+          description: "要设置为手动未读的会话"
+          required: true
+          schema:
+            $ref: "#/definitions/manualUnreadRequest"
+      responses:
+        200:
+          description: "设置结果；已是真实未读或手动未读时也返回 200，使用 changed/reason 判断是否发生变化"
+          schema:
+            $ref: "#/definitions/setManualUnreadResponse"
+        400:
+          description: "请求参数或会话查询错误"
+          schema:
+            $ref: "#/definitions/response"
+      security:
+        - token: []
+  /conversation/clearManualUnread:
+    put:
+      tags:
+        - "conversation"
+      summary: "清除会话手动未读"
+      description: |
+        仅清除当前登录用户指定会话的 `manual_unread` 标识。
+
+        该接口不会调用 WuKongIM 的 `clearUnread`，因此不会修改真实未读数量、阅读游标或
+        消息拉取位置。接口适用于用户进入会话后，前端确认当前页面不需要继续显示手动未读
+        标识的场景，尤其是本次消息拉取为空时。
+
+        如果目标会话本来没有手动未读标识，接口按幂等成功处理并返回 `changed=false`。
+        状态发生变化后，服务端会更新扩展版本并通知当前用户的其他在线设备同步。
+      operationId: "clear manual unread"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "body"
+          name: "body"
+          description: "要清除手动未读的会话"
+          required: true
+          schema:
+            $ref: "#/definitions/manualUnreadRequest"
+      responses:
+        200:
+          description: "清除结果；没有手动未读标识时也返回 200"
+          schema:
+            $ref: "#/definitions/clearManualUnreadResponse"
+        400:
+          description: "请求参数或数据库查询错误"
+          schema:
+            $ref: "#/definitions/response"
+      security:
+        - token: []
+  /conversation/clearUnread:
+    put:
+      tags:
+        - "conversation"
+      summary: "清除会话真实未读"
+      description: |
+        清除或更新当前登录用户在 WuKongIM 中的真实未读状态。
+
+        当前服务端实现中，只要该请求本身有效并且目标会话存在手动未读标识，处理成功后
+        也会一并清除该用户的 `manual_unread`，然后发送会话扩展同步通知。因此：
+        - `unread=0`：清除真实未读，同时清除手动未读；
+        - `unread>0`：按 WuKongIM 语义设置/保留真实未读，同时也清除手动未读；
+        - 如果前端只想清除手动未读而保留真实未读，应调用 `/conversation/clearManualUnread`。
+
+        该接口不会清除其他用户的状态。
+      operationId: "clear conversation unread"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "body"
+          name: "body"
+          description: "WuKongIM 真实未读操作参数"
+          required: true
+          schema:
+            $ref: "#/definitions/clearConversationUnreadRequest"
+      responses:
+        200:
+          description: "处理成功"
+          schema:
+            $ref: "#/definitions/response"
+        400:
+          description: "请求参数或命令发送错误"
           schema:
             $ref: "#/definitions/response"
       security:
@@ -278,7 +392,15 @@ paths:
       tags:
         - "conversation"
       summary: "添加或更新最近会话扩展"
-      description: "添加或更新最近会话扩展"
+      description: |
+        更新当前登录用户指定会话的草稿、预览位置和会话恢复位置。
+
+        请求体不接受 `manual_unread`。手动未读状态必须使用专用的
+        `/conversation/setManualUnread` 或 `/conversation/clearManualUnread` 接口修改，
+        这样普通的草稿或滚动位置更新不会意外覆盖手动未读状态。
+
+        更新成功后服务端会生成新的会话扩展版本，并通过 `CMDSyncConversationExtra` 通知
+        当前用户的其他在线设备；其他设备再调用 `/conversation/extra/sync` 拉取数据。
       operationId: "add conversations extra"
       consumes:
         - "application/json"
@@ -297,7 +419,7 @@ paths:
           required: true
         - in: "body"
           name: "body"
-          description: "同步离线最近会话回执"
+          description: "要更新的会话扩展字段"
           required: true
           schema:
             type: object
@@ -340,6 +462,122 @@ securityDefinitions:
     description: "用户token"
 
 definitions:
+  conversationExtra:
+    type: "object"
+    description: "当前登录用户在指定会话上的 Octo 扩展数据"
+    properties:
+      channel_id:
+        type: string
+        description: "频道唯一 ID"
+      channel_type:
+        type: integer
+        format: uint8
+        enum: [1, 2, 5]
+        description: "频道类型：1=单聊，2=群聊，5=社区子区"
+      browse_to:
+        type: integer
+        format: int64
+        description: "预览到的最大消息序号；不等价于手动未读标识"
+      keep_message_seq:
+        type: integer
+        format: int64
+        description: "重新进入会话时恢复的消息序号"
+      keep_offset_y:
+        type: integer
+        description: "恢复会话滚动位置时的垂直偏移量"
+      draft:
+        type: string
+        description: "当前会话草稿"
+      version:
+        type: integer
+        format: int64
+        description: "会话扩展全局同步版本"
+      manual_unread:
+        type: boolean
+        description: "是否被当前用户手动标记为未读；不代表 unread 消息数量"
+  manualUnreadRequest:
+    type: "object"
+    required:
+      - channel_id
+      - channel_type
+    properties:
+      channel_id:
+        type: string
+        minLength: 1
+        description: "频道唯一 ID"
+      channel_type:
+        type: integer
+        format: uint8
+        enum: [1, 2, 5]
+        description: "频道类型：1=单聊，2=群聊，5=社区子区"
+  setManualUnreadResponse:
+    type: "object"
+    properties:
+      channel_id:
+        type: string
+        description: "频道唯一 ID"
+      channel_type:
+        type: integer
+        format: uint8
+        description: "频道类型"
+      manual_unread:
+        type: boolean
+        description: "处理后的手动未读状态"
+      changed:
+        type: boolean
+        description: "本次请求是否实际修改了状态"
+      version:
+        type: integer
+        format: int64
+        description: "状态发生变化时生成的会话扩展版本；未变化时省略"
+      reason:
+        type: string
+        enum: [already_unread, already_manual_unread]
+        description: "changed=false 时的原因；真实未读已存在或已经是手动未读"
+  clearManualUnreadResponse:
+    type: "object"
+    properties:
+      channel_id:
+        type: string
+        description: "频道唯一 ID"
+      channel_type:
+        type: integer
+        format: uint8
+        description: "频道类型"
+      manual_unread:
+        type: boolean
+        description: "处理后的手动未读状态，成功清除后为 false"
+      changed:
+        type: boolean
+        description: "本次请求是否实际修改了状态"
+      version:
+        type: integer
+        format: int64
+        description: "状态发生变化时生成的会话扩展版本；未变化时省略"
+  clearConversationUnreadRequest:
+    type: "object"
+    required:
+      - channel_id
+      - channel_type
+      - unread
+    properties:
+      channel_id:
+        type: string
+        minLength: 1
+        description: "频道唯一 ID"
+      channel_type:
+        type: integer
+        format: uint8
+        description: "频道类型；由 WuKongIM 处理"
+      unread:
+        type: integer
+        format: int64
+        minimum: 0
+        description: "目标真实未读数量；0 表示清除全部真实未读"
+      message_seq:
+        type: integer
+        format: int64
+        description: "超级群清除真实未读时使用的消息序号，普通会话通常为 0"
   group:
     type: "object"
     properties:

--- a/modules/message/swagger/conversation.yaml
+++ b/modules/message/swagger/conversation.yaml
@@ -257,7 +257,9 @@ paths:
         `manual_unread=true` 并返回 `changed=true`。
 
         设置成功后，服务端会更新 `conversation_extra.version`，并向当前用户的个人频道
-        发送 `CMDSyncConversationExtra`，通知其他在线设备调用 `/conversation/extra/sync`。
+        尝试发送 `CMDSyncConversationExtra`，通知其他在线设备调用
+        `/conversation/extra/sync`。该 CMD 是 best-effort 的瞬时通知：如果状态和版本已成功
+        写入数据库，CMD 发送失败只记录日志，接口仍返回已提交的成功结果。
       operationId: "set manual unread"
       consumes:
         - "application/json"
@@ -295,7 +297,9 @@ paths:
         标识的场景，尤其是本次消息拉取为空时。
 
         如果目标会话本来没有手动未读标识，接口按幂等成功处理并返回 `changed=false`。
-        状态发生变化后，服务端会更新扩展版本并通知当前用户的其他在线设备同步。
+        状态发生变化后，服务端会更新扩展版本并尝试通知当前用户的其他在线设备同步。
+        `CMDSyncConversationExtra` 是 best-effort 通知：数据库已提交后发送失败只记录日志，
+        不会将已完成的清除操作改成错误响应。
       operationId: "clear manual unread"
       consumes:
         - "application/json"
@@ -327,8 +331,10 @@ paths:
       description: |
         清除或更新当前登录用户在 WuKongIM 中的真实未读状态。
 
-        当前服务端实现中，只要群聊或子区请求本身有效并且目标会话存在手动未读标识，
-        处理成功后也会一并清除该用户的 `manual_unread`，然后发送会话扩展同步通知。因此：
+        服务端在 WuKongIM 接受真实未读操作后，会先发送原有的真实未读清除通知。
+        对于群聊和子区，随后再 best-effort 查询并清除当前用户的 `manual_unread`，
+        并尝试发送会话扩展同步通知。conversation-extra 查询、版本生成、写入或扩展
+        通知失败只会记录日志，不会抑制已完成的真实未读通知，也不会将核心操作改成错误响应。因此：
         - `unread=0`：清除真实未读，同时清除手动未读；
         - `unread>0`：按 WuKongIM 语义设置/保留真实未读，同时也清除手动未读；
         - 私聊：只处理 WuKongIM 真实未读，不查询或修改手动未读标识；

--- a/modules/message/swagger/conversation.yaml
+++ b/modules/message/swagger/conversation.yaml
@@ -28,8 +28,8 @@ paths:
           `GET /v1/groups/{group_no}/threads?status=archived`。
         - 当前用户已退群的群会话不返回。
         - `extra.manual_unread` 只表示用户手动设置的展示标识，不等价于 WuKongIM 的
-          `unread` 消息数量，也不会改变真实阅读位置。它不属于 recent 活跃时间窗口的
-          豁免条件；当 `recent_filter=true` 时，超过窗口的手动未读会话仍会被过滤。
+          `unread` 消息数量，也不会改变真实阅读位置。当 `recent_filter=true` 时，
+          群聊和子区的人工未读会话豁免 recent 活跃时间窗口。
 
         cursor 推进基于过滤前的 raw conversations，确保被过滤掉的会话不会让游标卡住
         导致客户端反复拉同一批数据。
@@ -60,7 +60,7 @@ paths:
                 description: "设备uuid"
               recent_filter:
                 type: boolean
-                description: "可选，默认 false。为 true 时对返回的会话列表套用 sidebar recent tab 同款的按频道类型活动窗口过滤（system_settings 的 sidebar.recent_filter_{group,thread,person}_days，0=该类型不过滤）。供 Web「最近」tab 使用；不传则行为与历史完全一致（不过滤）。cursor 推进与 per-Space 未读仍基于过滤前的原始会话。豁免：有未读、已置顶、系统 Bot 的 DM 永不被时间窗口隐藏（与 /v1/sidebar/sync 的 recent tab 逐条一致）；置顶集合查询失败时**整体跳过**本次窗口过滤（返回未过滤的完整列表），而不是套用一个已知不完整的豁免集合去藏东西。"
+                description: "可选，默认 false。为 true 时对返回的会话列表套用 sidebar recent tab 同款的按频道类型活动窗口过滤（system_settings 的 sidebar.recent_filter_{group,thread,person}_days，0=该类型不过滤）。供 Web「最近」tab 使用；不传则行为与历史完全一致（不过滤）。cursor 推进与 per-Space 未读仍基于过滤前的原始会话。豁免：有真实未读、群聊/子区人工未读、已置顶、系统 Bot 的 DM 永不被时间窗口隐藏（与 /v1/sidebar/sync 的 recent tab 逐条一致）；置顶集合查询失败时**整体跳过**本次窗口过滤（返回未过滤的完整列表），而不是套用一个已知不完整的豁免集合去藏东西。"
       responses:
         200:
           description: "返回"
@@ -207,8 +207,10 @@ paths:
         - `false`：该会话当前没有手动未读标识；
         - 它不会改变 `browse_to`、`keep_message_seq` 或 WuKongIM 的真实阅读位置。
 
-        收到 WuKongIM 的 `CMDSyncConversationExtra` 命令后，客户端应调用本接口拉取
-        实际变更数据。该命令只起到变更通知作用，不携带完整的扩展记录。
+        收到 WuKongIM 的 `CMDSyncConversationExtra` 命令后，客户端可以先根据命令
+        `param` 中的 `channel_id`、`channel_type`、`manual_unread` 和 `version` 立即
+        更新对应会话，再调用本接口拉取实际扩展变更用于恢复和游标推进。该命令携带
+        本次手动未读状态增量，但不替代完整的扩展记录同步。
       operationId: "sync conversation extra"
       consumes:
         - "application/json"
@@ -250,15 +252,17 @@ paths:
         `channel_type=1` 会按请求参数错误返回。
 
         该标识只属于当前用户，不会修改其他用户的会话状态，也不会修改 WuKongIM 的真实
-        未读数或阅读游标。服务端不会查询 WuKongIM 的会话或真实未读状态：即使目标会话
-        已有真实未读消息，也可以同时设置 `manual_unread=true`。
+        未读数或阅读游标。设置时不查询 WuKongIM Conversation，不校验目标会话
+        是否存在，也不根据真实 `unread` 阻止人工未读。
 
         目标会话已经是手动未读时，接口幂等返回 `changed=false`；否则写入
         `manual_unread=true` 并返回 `changed=true`。
 
         设置成功后，服务端会更新 `conversation_extra.version`，并向当前用户的个人频道
         尝试发送 `CMDSyncConversationExtra`，通知其他在线设备调用
-        `/conversation/extra/sync`。该 CMD 是 best-effort 的瞬时通知：如果状态和版本已成功
+        `/conversation/extra/sync`。CMD 的 `param` 同时直接携带 `channel_id`、
+        `channel_type`、`manual_unread=true` 和本次 `version`，客户端可立即更新目标会话，
+        并继续使用扩展同步做恢复。该 CMD 是 best-effort 的瞬时通知：如果状态和版本已成功
         写入数据库，CMD 发送失败只记录日志，接口仍返回已提交的成功结果。
       operationId: "set manual unread"
       consumes:
@@ -293,13 +297,14 @@ paths:
         该功能，`channel_type=1` 会按请求参数错误返回。
 
         该接口不会调用 WuKongIM 的 `clearUnread`，因此不会修改真实未读数量、阅读游标或
-        消息拉取位置。接口适用于用户进入会话后，前端确认当前页面不需要继续显示手动未读
-        标识的场景，尤其是本次消息拉取为空时。
+        消息拉取位置。用户重新进入一个进入前为手动未读的会话时，前端应调用该接口；
+        不再依赖消息拉取结果是否为空来决定是否清除。
 
         如果目标会话本来没有手动未读标识，接口按幂等成功处理并返回 `changed=false`。
         状态发生变化后，服务端会更新扩展版本并尝试通知当前用户的其他在线设备同步。
-        `CMDSyncConversationExtra` 是 best-effort 通知：数据库已提交后发送失败只记录日志，
-        不会将已完成的清除操作改成错误响应。
+        `CMDSyncConversationExtra` 的 `param` 直接携带频道、`manual_unread=false` 和本次版本。
+        该 CMD 是 best-effort 通知：数据库已提交后发送失败只记录日志，不会将已完成的清除
+        操作改成错误响应。
       operationId: "clear manual unread"
       consumes:
         - "application/json"
@@ -332,11 +337,11 @@ paths:
         清除或更新当前登录用户在 WuKongIM 中的真实未读状态。
 
         服务端在 WuKongIM 接受真实未读操作后，会先发送原有的真实未读清除通知。
-        对于群聊和子区，随后再 best-effort 查询并清除当前用户的 `manual_unread`，
+        对于群聊和子区，仅当请求 `unread=0` 时才随后 best-effort 查询并清除当前用户的 `manual_unread`，
         并尝试发送会话扩展同步通知。conversation-extra 查询、版本生成、写入或扩展
         通知失败只会记录日志，不会抑制已完成的真实未读通知，也不会将核心操作改成错误响应。因此：
         - `unread=0`：清除真实未读，同时清除手动未读；
-        - `unread>0`：按 WuKongIM 语义设置/保留真实未读，同时也清除手动未读；
+        - `unread>0`：按 WuKongIM 语义设置/保留真实未读，不修改手动未读；
         - 私聊：只处理 WuKongIM 真实未读，不查询或修改手动未读标识；
         - 如果前端只想清除手动未读而保留真实未读，应调用 `/conversation/clearManualUnread`。
 

--- a/modules/message/swagger/sidebar.yaml
+++ b/modules/message/swagger/sidebar.yaml
@@ -39,13 +39,13 @@ paths:
         - 排序：`pinned DESC` → `timestamp DESC`
 
         **活跃窗口的豁免（对 recent tab 与 `/v1/conversation/sync?recent_filter=true` 一致）**：
-        以下三类**永不**被时间窗口隐藏 ——
+        以下四类**永不**被时间窗口隐藏 ——
         - **有未读**（`unread > 0`）：隐藏会话会连同未读消息一起藏走，用户无从察觉；
+        - **群聊或子区人工未读**（`manual_unread=true`）：这是用户显式保留未读展示的请求；
         - **已置顶**：置顶是关于位置的显式声明，时间窗口不得推翻；
         - **系统 Bot 的 DM**：保证其在每个 Space 均可达（占位条目 `timestamp/unread` 均为 0）。
 
-        `manual_unread=true` 仍会作为会话展示标识返回，但它不是活跃窗口豁免条件；
-        超过窗口的手动未读会话不会出现在 recent tab。
+        因此，`manual_unread=true` 的群聊或子区即使超过时间窗口也会出现在 recent tab。
 
         **已归档子区（`status=2`）不出现在 recent tab 的 items 中**，与
         `/v1/conversation/sync` 的 `status=active` 语义一致。归档非终态：任何人发消息会

--- a/modules/message/swagger/sidebar.yaml
+++ b/modules/message/swagger/sidebar.yaml
@@ -44,6 +44,9 @@ paths:
         - **已置顶**：置顶是关于位置的显式声明，时间窗口不得推翻；
         - **系统 Bot 的 DM**：保证其在每个 Space 均可达（占位条目 `timestamp/unread` 均为 0）。
 
+        `manual_unread=true` 仍会作为会话展示标识返回，但它不是活跃窗口豁免条件；
+        超过窗口的手动未读会话不会出现在 recent tab。
+
         **已归档子区（`status=2`）不出现在 recent tab 的 items 中**，与
         `/v1/conversation/sync` 的 `status=active` 语义一致。归档非终态：任何人发消息会
         自动复活为 active、或由管理员取消归档，下一次 sync 即重新出现；客户端另有
@@ -148,6 +151,9 @@ definitions:
       unread:
         type: integer
         description: "未读消息数"
+      manual_unread:
+        type: boolean
+        description: "是否被当前用户手动标记为未读；独立于 unread，不改变真实未读数量"
       is_pinned:
         type: boolean
         description: "是否置顶（来自 user_pinned_channel）"


### PR DESCRIPTION
## Summary

This PR adds an application-level manual-unread marker for group and community-topic conversations without changing WuKongIM's real unread count or read cursor.

The marker is stored per user and channel in `conversation_extra.manual_unread`, synchronized through the existing conversation-extra cursor, and projected as `manual_unread` by both conversation and sidebar APIs. Person conversations are intentionally out of scope until their state can be isolated by Space.

## Related Issue

N/A

## Linked Spec

[Manual unread conversation state](.octospec/tasks/clear-manual-unread/brief.md)

## Changes

- Add the `manual_unread` database migration and dedicated, authenticated, UID-rate-limited endpoints:
  - `PUT /v1/conversation/setManualUnread`
  - `PUT /v1/conversation/clearManualUnread`
- Restrict the dedicated endpoints to Group and CommunityTopic channels. State is always scoped to the authenticated UID and exact `(channel_id, channel_type)` key.
- Keep `setManualUnread` independent of WuKongIM conversation existence and real unread state. It creates or updates only the caller's conversation-extra row and returns an idempotent `changed=false, reason=already_manual_unread` result when already set.
- Make explicit clear idempotent. A client should call `clearManualUnread` when re-entering a conversation that was manually unread before navigation, independently of the message-pull result.
- Preserve the existing `clearUnread` contract: clear the real WuKongIM unread state and broadcast `CMDConversationUnreadClear` first. Only `unread=0` then attempts supplementary manual-marker cleanup; `unread>0` preserves the marker. Supplementary cleanup and extra-sync notification are best effort and cannot fail an already completed real-unread clear.
- Keep that post-broadcast cleanup alive across an HTTP client disconnect by deriving a value-preserving context with `context.WithoutCancel` and an independent five-second timeout. This prevents request cancellation from leaving a ghost marker while still bounding Redis and database work.
- Send `CMDSyncConversationExtra` after a persisted marker transition. Its `param` directly carries `channel_id`, `channel_type`, `manual_unread`, and `version`, allowing compatible clients to update immediately and still use `/v1/conversation/extra/sync` for cursor-based reconciliation.
- Serialize all conversation-extra writes per UID with a Redis lease using a UUID owner, TTL, renewal, and Lua compare-delete/compare-renew. Add database-side version guards so stale versions cannot overwrite newer per-row versions.
- Expose `manual_unread` from `/v1/conversation/extra/sync`, `/v1/conversation/sync`, and `/v1/sidebar/sync` for supported channel types.
- Treat manual unread as a Recent-window exemption in both `/v1/conversation/sync?recent_filter=true` and the sidebar Recent tab. The marker can preserve an existing candidate but does not synthesize a conversation that is absent from the underlying list.
- Bound sidebar marker reads to the final or pre-filter candidate channel keys, select only `channel_id` and `channel_type`, and fail open when the auxiliary marker query is unavailable.
- Move the database and concurrency evidence out of the non-compiling integration-tag lane into the default test lane, and update Swagger and the linked task brief.

## Decision Record: Recent-window exemption

Earlier revisions deliberately kept manual-unread markers subject to the Recent activity window. The reason was mixed-client rollout safety: a mobile client that does not yet understand `manual_unread` could receive an old retained conversation with `unread=0`, render no dot, and have no dedicated clear action.

This PR now intentionally chooses the opposite behavior after the frontend API review: manual unread represents the user's explicit request to retain an existing conversation in Recent, so matching Group and CommunityTopic candidates are exempt from the activity window. The exemption still never creates a conversation or Sidebar item from `conversation_extra` alone.

The mixed-version trade-off remains real and is recorded here for product and maintainer sign-off: clients that have not implemented `manual_unread` may temporarily display an out-of-window retained conversation without its manual-unread indicator or clear action. If that rollout behavior is not acceptable, the exemption must be gated or deferred until supported clients ship rather than silently changing the semantics again.

## Testing

- [x] Unit and database-backed tests added/updated
- [x] Manually verified the changed package

Commands run locally:

```bash
go test ./modules/message/ -count=1

go test ./modules/message/ \
  -run '^TestIntegration_(SetManualUnreadDoesNotQueryIMConversation|ManualUnreadSupportsGroupAndCommunityTopic|ConcurrentSetManualUnreadHasOneStateTransition|SetManualUnreadAdvancesPastPersistedUIDHighWater)$' \
  -count=1

go test -race -shuffle=on ./modules/message/ \
  -run '^TestIntegration_(SetManualUnreadDoesNotQueryIMConversation|ManualUnreadSupportsGroupAndCommunityTopic|ConcurrentSetManualUnreadHasOneStateTransition|SetManualUnreadAdvancesPastPersistedUIDHighWater)$' \
  -count=1

go test ./modules/message/ \
  -run '^TestIntegration_ClearUnreadManualCleanupSurvivesClientDisconnect$' \
  -count=1

go test -race -shuffle=on ./modules/message/ \
  -run '^TestIntegration_(ClearManualUnreadAndClearUnreadZeroClearManualState|ClearUnreadBroadcastsCoreStateBeforeBestEffortManualSync|ClearUnreadManualCleanupSurvivesClientDisconnect)$' \
  -count=1

git diff --check
```

The full repository test suite and client implementations were not run locally; GitHub CI remains the broader verification lane.

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   The two new handlers validate the authenticated request and supported channel type, acquire a per-UID conversation-extra lease, read the exact row, allocate a monotonic extension version, and conditionally persist only `manual_unread` and `version`. They do not query WuKongIM or mutate its unread cursor. After commit, they best-effort send `CMDSyncConversationExtra` with the exact state and version. Existing conversation and sidebar synchronization overlay the marker for Group and CommunityTopic entries. Recent filtering loads a bounded marker set before applying the time window so manually unread candidates are retained. In `clearUnread`, the original WuKongIM clear and `CMDConversationUnreadClear` broadcast complete first; only an `unread=0` request then performs best-effort marker cleanup. That post-broadcast cleanup preserves request values but ignores client-disconnect cancellation and has an independent five-second timeout.

2. **What could break** because of it (dependents + failure mode)?

   The migration must be present before the new column is read or written. Compatible clients must understand the additive `manual_unread` field and direct CMD payload. During a mixed-client rollout, an older client may receive a manually retained out-of-window conversation but ignore the marker, show no dot, and omit the dedicated clear action; this is the explicit product trade-off recorded above. The dedicated endpoints deliberately do not require a current WuKongIM conversation or channel membership, so a marker row may exist without a corresponding list candidate; such a row is synchronized as extra state but does not create a sidebar or conversation item by itself. Redis or database failures fail a dedicated state transition. Post-commit notification delivery and `clearUnread` supplementary cleanup remain best effort; the detached cleanup is bounded to five seconds so infrastructure failure cannot hold the request indefinitely. Person conversations remain unsupported to avoid leaking a global marker across Spaces.

3. **How do you know it works** (specific test/repro/trace)?

   The default package test lane covers set/clear idempotency, supported channel types, absence of WuKongIM lookups, direct CMD payloads, clearUnread ordering and `unread=0` versus positive-unread behavior, Recent-window exemption in both synchronization paths, bounded/fail-open sidebar reads, database version rollback rejection, persisted UID high-water advancement, and concurrent first-set serialization. The disconnect regression cancels the original HTTP request context immediately after the fake WuKongIM receives `CMDConversationUnreadClear`, then verifies that `manual_unread` is still cleared and `CMDSyncConversationExtra` follows with the correct channel, state, and version. The focused clearUnread and concurrency sets pass under Go's race detector, and the complete `modules/message` package passes locally.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
