### PR TITLE
fix(thread): make snapshot-reconcile shim per-ID, guard message_count ALTERs (#831)

### DIFF
--- a/modules/thread/sql/20260410000003_thread_legacy01.sql
+++ b/modules/thread/sql/20260410000003_thread_legacy01.sql
@@ -1,6 +1,42 @@
 -- +migrate Up
 
-ALTER TABLE `thread` ADD COLUMN `message_count` BIGINT NOT NULL DEFAULT 0 COMMENT '消息数量';
-ALTER TABLE `thread` ADD COLUMN `last_message_at` TIMESTAMP NULL DEFAULT NULL COMMENT '最后一条消息时间';
-ALTER TABLE `thread` ADD COLUMN `last_message_content` VARCHAR(500) NOT NULL DEFAULT '' COMMENT '最后一条消息内容';
-ALTER TABLE `thread` ADD COLUMN `last_message_sender_uid` VARCHAR(40) NOT NULL DEFAULT '' COMMENT '最后一条消息发送者UID';
+-- MySQL DDL auto-commits per-statement and is NOT covered by sql-migrate's
+-- surrounding transaction, so a mid-migration failure (or two processes
+-- racing the same migration during a rolling deploy) can leave some of
+-- these four columns already applied while gorp_migrations never got the
+-- ledger row for this migration ID. On the next run sql-migrate treats the
+-- whole file as pending again and re-issues every ADD COLUMN, tripping
+-- MySQL Error 1060 on whichever column landed last time. Guard each ADD
+-- COLUMN with an INFORMATION_SCHEMA existence check (see #252) so the
+-- migration is safe to replay from any partially-applied state.
+
+SET @mc_exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'thread' AND COLUMN_NAME = 'message_count');
+SET @mc_sql = IF(@mc_exists = 0, 'ALTER TABLE `thread` ADD COLUMN `message_count` BIGINT NOT NULL DEFAULT 0 COMMENT ''消息数量''', 'SELECT 1');
+PREPARE mc_stmt FROM @mc_sql;
+EXECUTE mc_stmt;
+DEALLOCATE PREPARE mc_stmt;
+
+SET @lma_exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'thread' AND COLUMN_NAME = 'last_message_at');
+SET @lma_sql = IF(@lma_exists = 0, 'ALTER TABLE `thread` ADD COLUMN `last_message_at` TIMESTAMP NULL DEFAULT NULL COMMENT ''最后一条消息时间''', 'SELECT 1');
+PREPARE lma_stmt FROM @lma_sql;
+EXECUTE lma_stmt;
+DEALLOCATE PREPARE lma_stmt;
+
+SET @lmc_exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'thread' AND COLUMN_NAME = 'last_message_content');
+SET @lmc_sql = IF(@lmc_exists = 0, 'ALTER TABLE `thread` ADD COLUMN `last_message_content` VARCHAR(500) NOT NULL DEFAULT '''' COMMENT ''最后一条消息内容''', 'SELECT 1');
+PREPARE lmc_stmt FROM @lmc_sql;
+EXECUTE lmc_stmt;
+DEALLOCATE PREPARE lmc_stmt;
+
+SET @lmsu_exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'thread' AND COLUMN_NAME = 'last_message_sender_uid');
+SET @lmsu_sql = IF(@lmsu_exists = 0, 'ALTER TABLE `thread` ADD COLUMN `last_message_sender_uid` VARCHAR(40) NOT NULL DEFAULT '''' COMMENT ''最后一条消息发送者UID''', 'SELECT 1');
+PREPARE lmsu_stmt FROM @lmsu_sql;
+EXECUTE lmsu_stmt;
+DEALLOCATE PREPARE lmsu_stmt;
+
+-- +migrate Down
+ALTER TABLE `thread`
+  DROP COLUMN `message_count`,
+  DROP COLUMN `last_message_at`,
+  DROP COLUMN `last_message_content`,
+  DROP COLUMN `last_message_sender_uid`;

--- a/pkg/db/migrate_compat.go
+++ b/pkg/db/migrate_compat.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 )
 
 // migrationIDMapping is the old-filename → new-filename map produced by
@@ -241,28 +242,55 @@ func ReconcileThreadSchemaRecords(ctx context.Context, db *sql.DB) error {
 	if err != nil {
 		return fmt.Errorf("read gorp_migrations: %w", err)
 	}
-	// Only reconcile the "snapshot install" case — where the schema came
-	// from init-db.sql and gorp_migrations has no record of the thread
-	// module at all. The moment any thread-* row is present, sql-migrate
-	// is already tracking the module: missing rows on top of that mean a
-	// genuine pending migration (e.g. a new ADD INDEX added in a later
-	// release) that must run, not a snapshot gap to paper over. Pre-
-	// seeding only the missing IDs there would silently mark unapplied
-	// schema changes as applied and let sql-migrate skip them, producing
-	// invisible schema drift.
-	// Pre-seed only the snapshot-baseline IDs. Post-snapshot migrations
-	// (e.g. new ADD INDEX) must remain as "pending" so sql-migrate.Exec
-	// actually applies them.
-	var toRecord []string
-	var anyPresent bool
+	// Historically this loop used an all-or-nothing "anyPresent" gate: if
+	// *any* thread-* ID was already recorded, the whole reconciliation was
+	// skipped, on the theory that sql-migrate was already tracking the
+	// module and any gap must be a genuine pending migration (e.g. a new
+	// ADD INDEX).
+	//
+	// That gate has a hole (see #831): MySQL DDL auto-commits per
+	// statement and is NOT covered by sql-migrate's surrounding
+	// transaction, so a mid-migration failure — or two pods racing the
+	// same migration during a single-replica RollingUpdate window — can
+	// leave a migration's columns/tables physically applied while its
+	// gorp_migrations row never got written. That produces a *partial*
+	// thread-* ledger: some snapshot IDs present, some missing, even
+	// though every ID's underlying schema effect already landed via
+	// sql-migrate (not a snapshot). The old gate saw anyPresent=true and
+	// bailed, leaving the missing ID pending; sql-migrate then replayed
+	// its ADD COLUMN against a table that already had the column,
+	// panicking with MySQL Error 1060 on every restart.
+	//
+	// Fix: judge each missing ID independently by checking whether its
+	// actual DDL effect is already present in the schema (INFORMATION_SCHEMA
+	// guard, same pattern as #252). Only pre-seed IDs whose effect we can
+	// positively confirm; leave any ID we can't confirm as genuinely
+	// pending so sql-migrate still applies it. This keeps both original
+	// invariants (snapshot installs still get seeded; genuinely-new
+	// post-snapshot migrations still run) while also covering the
+	// partial-ledger case the anyPresent gate could not.
+	var missing []string
 	for _, id := range threadModuleSnapshotMigrationIDs {
-		if existing[id] {
-			anyPresent = true
-		} else {
+		if !existing[id] {
+			missing = append(missing, id)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+
+	appliedEffects, err := probeThreadSnapshotEffects(ctx, db)
+	if err != nil {
+		return fmt.Errorf("probe thread migration effects: %w", err)
+	}
+
+	var toRecord []string
+	for _, id := range missing {
+		if appliedEffects[id] {
 			toRecord = append(toRecord, id)
 		}
 	}
-	if anyPresent || len(toRecord) == 0 {
+	if len(toRecord) == 0 {
 		return nil
 	}
 
@@ -297,6 +325,115 @@ func ReconcileThreadSchemaRecords(ctx context.Context, db *sql.DB) error {
 		return fmt.Errorf("commit: %w", err)
 	}
 	return nil
+}
+
+// probeThreadSnapshotEffects reports, per snapshot-baseline migration ID,
+// whether that migration's DDL effect is already physically present in the
+// schema. This lets ReconcileThreadSchemaRecords judge each missing
+// gorp_migrations row independently instead of relying on an all-or-nothing
+// "any thread-* row present" gate (see #831): a partially-recorded ledger
+// (some IDs present, some missing) no longer blocks seeding the ones whose
+// columns/tables/index we can positively confirm already exist.
+//
+// Every check here must mirror the actual DDL in the corresponding
+// modules/thread/sql/*.sql file. If a listed migration's SQL changes, this
+// map must be updated in the same change, or a real pending migration could
+// be wrongly marked as applied.
+func probeThreadSnapshotEffects(ctx context.Context, db *sql.DB) (map[string]bool, error) {
+	cols, err := loadTableColumns(ctx, db, "thread")
+	if err != nil {
+		return nil, fmt.Errorf("load thread columns: %w", err)
+	}
+	tables, err := loadExistingTables(ctx, db, []string{"thread", "thread_member", "thread_setting"})
+	if err != nil {
+		return nil, fmt.Errorf("load thread tables: %w", err)
+	}
+
+	effects := map[string]bool{
+		// CREATE TABLE `thread` (no IF NOT EXISTS).
+		"20260402000001_thread_legacy01.sql": tables["thread"],
+		// CREATE TABLE IF NOT EXISTS `thread_member`.
+		"20260402000002_thread_legacy02.sql": tables["thread_member"],
+		// Four ADD COLUMN statements on `thread`; only "applied" once all four
+		// columns are present, matching the migration's own INFORMATION_SCHEMA
+		// guards.
+		"20260410000003_thread_legacy01.sql": cols["message_count"] && cols["last_message_at"] &&
+			cols["last_message_content"] && cols["last_message_sender_uid"],
+		// ADD COLUMN thread_md / thread_md_version / thread_md_updated_at /
+		// thread_md_updated_by on `thread`.
+		"20260413000001_thread_legacy01.sql": cols["thread_md"] && cols["thread_md_version"] &&
+			cols["thread_md_updated_at"] && cols["thread_md_updated_by"],
+		// CREATE TABLE `thread_setting` (no IF NOT EXISTS).
+		"20260422000001_thread_legacy01.sql": tables["thread_setting"],
+	}
+
+	hasIdx, err := hasIndex(ctx, db, "thread", "idx_status_last_msg_id")
+	if err != nil {
+		return nil, fmt.Errorf("check thread index: %w", err)
+	}
+	// ADD INDEX idx_status_last_msg_id on `thread`.
+	effects["20260511000001_thread_legacy01.sql"] = hasIdx
+
+	return effects, nil
+}
+
+func loadTableColumns(ctx context.Context, db *sql.DB, table string) (map[string]bool, error) {
+	rows, err := db.QueryContext(ctx,
+		"SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?",
+		table)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string]bool{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		out[name] = true
+	}
+	return out, rows.Err()
+}
+
+func loadExistingTables(ctx context.Context, db *sql.DB, tables []string) (map[string]bool, error) {
+	if len(tables) == 0 {
+		return map[string]bool{}, nil
+	}
+	placeholders := make([]string, len(tables))
+	args := make([]any, len(tables))
+	for i, t := range tables {
+		placeholders[i] = "?"
+		args[i] = t
+	}
+	query := fmt.Sprintf(
+		"SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN (%s)",
+		strings.Join(placeholders, ", "))
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string]bool{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		out[name] = true
+	}
+	return out, rows.Err()
+}
+
+func hasIndex(ctx context.Context, db *sql.DB, table, index string) (bool, error) {
+	var count int
+	err := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ?",
+		table, index).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }
 
 func loadMigrationIDMapping() (map[string]string, error) {

--- a/pkg/db/migrate_compat_test.go
+++ b/pkg/db/migrate_compat_test.go
@@ -273,7 +273,25 @@ func TestReconcileThreadSchemaRecords(t *testing.T) {
 		mustExpectationsMet(t, mock)
 	})
 
-	t.Run("all tables present, gorp empty of thread-* — INSERT all 6", func(t *testing.T) {
+	// sqlmock.Rows are single-use iterators; each subtest below builds its
+	// own fresh set rather than sharing one across t.Run closures (a
+	// shared Rows would be drained by the first subtest that reads it and
+	// return no rows to every subsequent one).
+	newAllThreadCols := func() *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"COLUMN_NAME"}).
+			AddRow("message_count").AddRow("last_message_at").AddRow("last_message_content").
+			AddRow("last_message_sender_uid").AddRow("thread_md").AddRow("thread_md_version").
+			AddRow("thread_md_updated_at").AddRow("thread_md_updated_by")
+	}
+	newAllThreadTables := func() *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"TABLE_NAME"}).
+			AddRow("thread").AddRow("thread_member").AddRow("thread_setting")
+	}
+	newAllThreadIdx := func() *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(1)
+	}
+
+	t.Run("all tables present, gorp empty of thread-* — probes effects, INSERT all 6", func(t *testing.T) {
 		db, mock := openMock(t)
 		defer db.Close()
 		mock.ExpectQuery(probeQuery).
@@ -284,6 +302,17 @@ func TestReconcileThreadSchemaRecords(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("gorp_migrations"))
 		mock.ExpectQuery(regexp.QuoteMeta("SELECT id FROM gorp_migrations")).
 			WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("some_other_migration.sql"))
+		// All six IDs are missing from the ledger, so the reconciler probes
+		// the schema to confirm each one's effect before inserting.
+		mock.ExpectQuery(regexp.QuoteMeta(
+			"SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?")).
+			WithArgs("thread").WillReturnRows(newAllThreadCols())
+		mock.ExpectQuery(regexp.QuoteMeta(
+			"SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN (?, ?, ?)")).
+			WithArgs("thread", "thread_member", "thread_setting").WillReturnRows(newAllThreadTables())
+		mock.ExpectQuery(regexp.QuoteMeta(
+			"SELECT COUNT(*) FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ?")).
+			WithArgs("thread", "idx_status_last_msg_id").WillReturnRows(newAllThreadIdx())
 		mock.ExpectBegin()
 		stmt := mock.ExpectPrepare(regexp.QuoteMeta(
 			"INSERT IGNORE INTO gorp_migrations (id, applied_at) VALUES (?, NOW())"))
@@ -297,13 +326,60 @@ func TestReconcileThreadSchemaRecords(t *testing.T) {
 		mustExpectationsMet(t, mock)
 	})
 
-	t.Run("partial state — any thread-* present means sql-migrate owns it, no-op", func(t *testing.T) {
-		// Regression test for the silent-corruption bug: if even one
-		// thread-* row is already in gorp_migrations, sql-migrate is
-		// actively tracking the module. Any *missing* thread-* row is a
-		// genuine unapplied migration (e.g. a future ADD INDEX) and the
-		// shim must NOT pre-seed it — doing so would mark a real DDL as
-		// applied without ever running it.
+	t.Run("partial ledger — missing ID's effect already applied — seeds just that ID", func(t *testing.T) {
+		// Regression test for #831: MySQL DDL auto-commits per statement and
+		// is not covered by sql-migrate's surrounding transaction, so a
+		// mid-migration failure (or two pods racing the same migration
+		// during a rolling deploy) can leave a migration's schema effect
+		// applied while its gorp_migrations row never got written. The old
+		// all-or-nothing "anyPresent" gate saw the other five IDs recorded
+		// and bailed entirely, leaving 20260410000003 pending forever and
+		// making sql-migrate replay its ADD COLUMNs against a table that
+		// already had them (MySQL Error 1060, permanent CrashLoopBackOff).
+		// The fix probes the missing ID's actual columns and seeds it since
+		// they're all already present.
+		db, mock := openMock(t)
+		defer db.Close()
+		mock.ExpectQuery(probeQuery).
+			WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).
+				AddRow("thread").AddRow("thread_member").AddRow("thread_setting"))
+		mock.ExpectQuery(regexp.QuoteMeta(
+			"SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'gorp_migrations'")).
+			WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("gorp_migrations"))
+		// Five of six thread-* rows are recorded; 20260410000003 (index 2)
+		// is the missing one, but its four columns are already on `thread`.
+		rows := sqlmock.NewRows([]string{"id"})
+		for i, id := range threadModuleSnapshotMigrationIDs {
+			if i == 2 {
+				continue
+			}
+			rows.AddRow(id)
+		}
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT id FROM gorp_migrations")).WillReturnRows(rows)
+		mock.ExpectQuery(regexp.QuoteMeta(
+			"SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?")).
+			WithArgs("thread").WillReturnRows(newAllThreadCols())
+		mock.ExpectQuery(regexp.QuoteMeta(
+			"SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN (?, ?, ?)")).
+			WithArgs("thread", "thread_member", "thread_setting").WillReturnRows(newAllThreadTables())
+		mock.ExpectQuery(regexp.QuoteMeta(
+			"SELECT COUNT(*) FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ?")).
+			WithArgs("thread", "idx_status_last_msg_id").WillReturnRows(newAllThreadIdx())
+		mock.ExpectBegin()
+		stmt := mock.ExpectPrepare(regexp.QuoteMeta(
+			"INSERT IGNORE INTO gorp_migrations (id, applied_at) VALUES (?, NOW())"))
+		stmt.ExpectExec().WithArgs(threadModuleSnapshotMigrationIDs[2]).WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectCommit()
+		if err := ReconcileThreadSchemaRecords(context.Background(), db); err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+		mustExpectationsMet(t, mock)
+	})
+
+	t.Run("partial ledger — missing ID's effect NOT applied — stays pending for sql-migrate", func(t *testing.T) {
+		// The other half of the #831 fix: if the missing ID's effect is
+		// genuinely absent (e.g. a real future ADD INDEX that hasn't run
+		// yet), the shim must not seed it — sql-migrate has to apply it.
 		db, mock := openMock(t)
 		defer db.Close()
 		mock.ExpectQuery(probeQuery).
@@ -313,14 +389,25 @@ func TestReconcileThreadSchemaRecords(t *testing.T) {
 			"SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'gorp_migrations'")).
 			WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("gorp_migrations"))
 		// Only the first five thread-* rows are recorded; the sixth
-		// (a hypothetical ADD INDEX in a later release) is genuinely
-		// pending and must be left for sql-migrate to apply.
+		// (idx_status_last_msg_id) is genuinely pending — no such index
+		// exists yet.
 		rows := sqlmock.NewRows([]string{"id"})
 		for _, id := range threadModuleSnapshotMigrationIDs[:5] {
 			rows.AddRow(id)
 		}
 		mock.ExpectQuery(regexp.QuoteMeta("SELECT id FROM gorp_migrations")).WillReturnRows(rows)
-		// No transaction — the shim must hand control back to sql-migrate.
+		mock.ExpectQuery(regexp.QuoteMeta(
+			"SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?")).
+			WithArgs("thread").WillReturnRows(newAllThreadCols())
+		mock.ExpectQuery(regexp.QuoteMeta(
+			"SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN (?, ?, ?)")).
+			WithArgs("thread", "thread_member", "thread_setting").WillReturnRows(newAllThreadTables())
+		mock.ExpectQuery(regexp.QuoteMeta(
+			"SELECT COUNT(*) FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ?")).
+			WithArgs("thread", "idx_status_last_msg_id").
+			WillReturnRows(sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(0))
+		// No transaction — the effect isn't confirmed, so the shim hands
+		// control back to sql-migrate rather than seeding the row.
 		if err := ReconcileThreadSchemaRecords(context.Background(), db); err != nil {
 			t.Fatalf("expected nil for partial state, got %v", err)
 		}


### PR DESCRIPTION
## 问题

`ocho-server` 开启 thread 模块后偶发 panic：

```
panic: Error 1060 (42S21): Duplicate column name 'message_count' handling 20260410000003_thread_legacy01.sql
```

导致永久 CrashLoopBackOff，重启不会自愈。

## 根因

1. `modules/thread/sql/20260410000003_thread_legacy01.sql` 有 4 条独立 `ALTER TABLE thread ADD COLUMN` 语句，没有 `NoTransaction` 标记。MySQL DDL 是隐式提交、不受 sql-migrate 事务包裹保护的：如果中途某条语句失败（或滚动更新时新旧 Pod 并发跑到同一条迁移被打断），前面几条 `ADD COLUMN` 已经物理落地，但 `gorp_migrations` 里从未写入这条迁移的记账 —— 形成"部分已提交但记账缺失"的半应用态。
2. `pkg/db/migrate_compat.go` 里 `ReconcileThreadSchemaRecords` 的判断逻辑是全有全无的开关：只要 thread 模块 6 条快照迁移 ID 里有任意一条已经被记录，就整体判定"sql-migrate 已经在管这个模块了"，直接放弃补种剩下缺失的 ID。这个半应用态恰好命中该分支，于是 `20260410000003` 仍是 pending 状态，下次重启 sql-migrate 照常从头重放这条迁移，撞上已存在的列，MySQL 1060，panic。

详见 issue #831 讨论（含手工构造复现步骤）。

## 修复

1. **`modules/thread/sql/20260410000003_thread_legacy01.sql`**：参考 #252 的修复模式，给 4 条 `ADD COLUMN` 分别加上 `INFORMATION_SCHEMA.COLUMNS` 存在性判断，使迁移本身在任意半应用状态下都可安全重放。
2. **`pkg/db/migrate_compat.go`**：`ReconcileThreadSchemaRecords` 改为逐条判断 —— 对每个缺失的快照 ID，探测其对应 DDL 效果（列/表/索引）是否已经物理存在于 schema 中，能确认的才补种记账，不能确认的仍留给 sql-migrate 正常执行。保留原有两个不变量：全新快照装库仍会补种全部 6 条；真正未执行的新迁移（如未来的 `ADD INDEX`）仍会被正常执行，不会被误标记为已应用。
3. **`pkg/db/migrate_compat_test.go`**：替换原来的"任一存在即放弃"回归测试，新增两个测试覆盖新的逐条判断行为（缺失 ID 的效果已确认存在 → 补种；缺失 ID 的效果未确认存在 → 保持 pending）。

## 验证

```
go build ./...
go vet ./pkg/db/...
go test ./pkg/db/... -v
```

全部通过，包括 `TestReconcileThreadSchemaRecords` 全部子测试和 `TestThreadModuleMigrationIDsMatchDisk`。

Fixes #831