### PR TITLE
feat(messages_search): highlight file name + body-content in search results

### DIFF
--- a/modules/messages_search/dsl.go
+++ b/modules/messages_search/dsl.go
@@ -468,10 +468,11 @@ func buildSearchAfterFromHit(hit *elastic.SearchHit, isRelevance bool) ([]any, b
 // carry the Tika-extracted file body (payload.file.content, avg 30–100 KB per
 // doc) and its extraction metadata (payload.file.contentMeta); both participate
 // in the multi_match relevance score via the inverted index but never surface
-// on the wire — Q1 C keeps FileHit without a contentSnippet field, and Q4 D
-// keeps pickSnippet from promoting content into the snippet slot. Highlight
-// fragments are drawn from the inverted index rather than _source, so this
-// exclude does not affect highlight functionality.
+// on the wire as the full field. Highlight fragments (name_highlight,
+// content_snippet) are drawn from the inverted index rather than _source, so
+// this exclude does not affect highlight functionality — the file-tab and (as
+// of V6) the chat-tab _search_all path both return a single 120-char
+// content_snippet fragment while the 30-100 KB body stays off the wire.
 func fileContentSourceExcludes() *elastic.FetchSourceContext {
 	return elastic.NewFetchSourceContext(true).Exclude(
 		"payload.file.content",

--- a/modules/messages_search/dsl_test.go
+++ b/modules/messages_search/dsl_test.go
@@ -914,31 +914,32 @@ func TestBuildSearchAllHighlight_IncludesFileContent(t *testing.T) {
 	}
 }
 
-// TestBuildSearchFilesHighlight_EscapesHTMLSource pins the stored-XSS defence:
-// OpenSearch's default highlight encoder is a pass-through, so a file whose
-// uploader-controlled name (payload.file.name is fully user-controlled) or
-// Tika-extracted body (payload.file.content) contains raw HTML would round-trip
-// unescaped into name_highlight / content_snippet — a searcher whose keyword
-// overlaps any token in the payload receives active markup that renders in any
-// client that treats *_highlight as safe HTML. Encoder("html") switches
-// OpenSearch to escape the source text (`<img>` → `&lt;img&gt;`) while keeping
-// only <mark>/</mark> as live markup; regressing this pin re-opens the vector.
-func TestBuildSearchFilesHighlight_EscapesHTMLSource(t *testing.T) {
+// TestBuildSearchFilesHighlight_NoRequestEncoder pins the design decision to
+// leave the file-tab highlighter's request-level `encoder` unset (default =
+// pass-through). Escaping is applied in Go via escapeHighlightFragment inside
+// pickFileNameHighlight / pickFileContentSnippet — scoped strictly to the two
+// new file fields — so the shared _search_all/_search_global_messages
+// highlighter can stay off `encoder=html` and MessageHit.Snippet keeps its
+// long-shipped raw-text wire contract. Flipping this on would silently escape
+// text/richText/mergeForward snippets too via the shared builder.
+func TestBuildSearchFilesHighlight_NoRequestEncoder(t *testing.T) {
 	body := asJSONString(t, buildSearchFilesHighlight())
-	if !strings.Contains(body, `"encoder":"html"`) {
-		t.Errorf("buildSearchFilesHighlight() must set encoder=\"html\" to escape uploader-controlled HTML in name/content (stored-XSS defence):\n%s", body)
+	if strings.Contains(body, `"encoder"`) {
+		t.Errorf("buildSearchFilesHighlight() must NOT set a request-level encoder; escaping is applied per-field in Go via escapeHighlightFragment:\n%s", body)
 	}
 }
 
-// TestBuildSearchAllHighlight_EscapesHTMLSource pins the same encoder=html
-// invariant on the mixed _search_all / _search_global_messages highlighter.
-// This path feeds the chat-tab file-body snippet added in V6, and it also
-// feeds pre-existing text/richText/mergeForward snippets — all of which carry
-// user-authored content that must not round-trip as executable HTML.
-func TestBuildSearchAllHighlight_EscapesHTMLSource(t *testing.T) {
+// TestBuildSearchAllHighlight_NoRequestEncoder pins the same "no request-level
+// encoder" invariant on the mixed highlighter. Critical because this builder
+// feeds four call sites (_search_all, _search_global_messages ×2,
+// _search_global_groups top_hits) whose snippet fragments become the pre-
+// existing MessageHit.Snippet wire value — an encoder here would change that
+// field's encoding on four endpoints while leaving /_search
+// (buildSearchMessagesHighlight) raw.
+func TestBuildSearchAllHighlight_NoRequestEncoder(t *testing.T) {
 	body := asJSONString(t, buildSearchAllHighlight())
-	if !strings.Contains(body, `"encoder":"html"`) {
-		t.Errorf("buildSearchAllHighlight() must set encoder=\"html\" to escape user-authored HTML in every snippet field (stored-XSS defence):\n%s", body)
+	if strings.Contains(body, `"encoder"`) {
+		t.Errorf("buildSearchAllHighlight() must NOT set a request-level encoder; MessageHit.Snippet must stay raw. Escaping for the two new file fields is done in Go via escapeHighlightFragment:\n%s", body)
 	}
 }
 

--- a/modules/messages_search/dsl_test.go
+++ b/modules/messages_search/dsl_test.go
@@ -1329,3 +1329,35 @@ func TestPaginate_VirtualSiblingsCrossPageBoundary(t *testing.T) {
 	}
 	_ = lastSA
 }
+
+// TestBuildSearchGroupsPreviewHighlight_ExcludesFileContent pins that the
+// groups-preview highlighter never allocates a payload.file.content fragment.
+// pickSnippet does not read that field, and the aggregation runs against up
+// to 8000 docs per request — scanning 30-100 KB Tika bodies would be pure
+// waste that pushes the request past OCTO_SEARCH_TIMEOUT.
+func TestBuildSearchGroupsPreviewHighlight_ExcludesFileContent(t *testing.T) {
+	body := asJSONString(t, buildSearchGroupsPreviewHighlight())
+	if strings.Contains(body, `"payload.file.content"`) {
+		t.Errorf("buildSearchGroupsPreviewHighlight() must NOT highlight payload.file.content (pickSnippet does not read it; 30-100 KB body scan × 8000 docs would blow OCTO_SEARCH_TIMEOUT):\n%s", body)
+	}
+}
+
+// TestBuildSearchGroupsPreviewHighlight_FileNameFragmentSize pins that
+// payload.file.name is fragment-sized (120-char window, not whole-field). The
+// groups path feeds pickSnippet → MessageHit.Snippet, which by long-shipped
+// contract carries raw uploader-controlled text; whole-field mode would widen
+// a pre-existing raw-name-length concern from 120 chars to unbounded. Fixing
+// the pre-existing raw-Snippet contract is out of scope for this PR.
+func TestBuildSearchGroupsPreviewHighlight_FileNameFragmentSize(t *testing.T) {
+	body := asJSONString(t, buildSearchGroupsPreviewHighlight())
+	if !strings.Contains(body, `"fragment_size":120`) {
+		t.Errorf("buildSearchGroupsPreviewHighlight() must keep fragment_size=120 (pre-existing shipped behaviour):\n%s", body)
+	}
+	if !strings.Contains(body, `"number_of_fragments":1`) {
+		t.Errorf("buildSearchGroupsPreviewHighlight() must keep number_of_fragments=1 for payload.file.name (no whole-field widening on the raw-Snippet path):\n%s", body)
+	}
+	// Explicitly assert we did NOT include the file-tab's NumOfFragments(0) override.
+	if strings.Contains(body, `"payload.file.name":{"number_of_fragments":0}`) {
+		t.Errorf("buildSearchGroupsPreviewHighlight() must not set payload.file.name to NumOfFragments(0) — that would widen a pre-existing raw-Snippet vector:\n%s", body)
+	}
+}

--- a/modules/messages_search/dsl_test.go
+++ b/modules/messages_search/dsl_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -910,6 +911,51 @@ func TestBuildSearchAllHighlight_IncludesFileContent(t *testing.T) {
 	body := asJSONString(t, buildSearchAllHighlight())
 	if !strings.Contains(body, `"payload.file.content"`) {
 		t.Errorf("_search_all highlight must include payload.file.content (V6 chat-tab file body snippet):\n%s", body)
+	}
+}
+
+// TestBuildSearchFilesHighlight_EscapesHTMLSource pins the stored-XSS defence:
+// OpenSearch's default highlight encoder is a pass-through, so a file whose
+// uploader-controlled name (payload.file.name is fully user-controlled) or
+// Tika-extracted body (payload.file.content) contains raw HTML would round-trip
+// unescaped into name_highlight / content_snippet — a searcher whose keyword
+// overlaps any token in the payload receives active markup that renders in any
+// client that treats *_highlight as safe HTML. Encoder("html") switches
+// OpenSearch to escape the source text (`<img>` → `&lt;img&gt;`) while keeping
+// only <mark>/</mark> as live markup; regressing this pin re-opens the vector.
+func TestBuildSearchFilesHighlight_EscapesHTMLSource(t *testing.T) {
+	body := asJSONString(t, buildSearchFilesHighlight())
+	if !strings.Contains(body, `"encoder":"html"`) {
+		t.Errorf("buildSearchFilesHighlight() must set encoder=\"html\" to escape uploader-controlled HTML in name/content (stored-XSS defence):\n%s", body)
+	}
+}
+
+// TestBuildSearchAllHighlight_EscapesHTMLSource pins the same encoder=html
+// invariant on the mixed _search_all / _search_global_messages highlighter.
+// This path feeds the chat-tab file-body snippet added in V6, and it also
+// feeds pre-existing text/richText/mergeForward snippets — all of which carry
+// user-authored content that must not round-trip as executable HTML.
+func TestBuildSearchAllHighlight_EscapesHTMLSource(t *testing.T) {
+	body := asJSONString(t, buildSearchAllHighlight())
+	if !strings.Contains(body, `"encoder":"html"`) {
+		t.Errorf("buildSearchAllHighlight() must set encoder=\"html\" to escape user-authored HTML in every snippet field (stored-XSS defence):\n%s", body)
+	}
+}
+
+// TestBuildSearchAllHighlight_FileNameWholeField pins the P1 alignment with the
+// file-tab highlighter: payload.file.name is rendered whole (in-place <mark>)
+// on both tabs, so a long or multi-sentence file name never gets truncated to
+// a single "best passage" only on the chat tab.
+func TestBuildSearchAllHighlight_FileNameWholeField(t *testing.T) {
+	body := asJSONString(t, buildSearchAllHighlight())
+	// The Fields() builder serialises as `"fields":{"payload.file.name":{...}}`,
+	// so the tolerant assertion is "the payload.file.name entry carries
+	// number_of_fragments:0 within its own object". A regex that matches the
+	// field key followed (allowing nested chars) by the pair — before the next
+	// field key or closing brace — keeps the assertion tolerant to key order.
+	pat := regexp.MustCompile(`"payload\.file\.name":\{[^{}]*"number_of_fragments":0[^{}]*\}`)
+	if !pat.MatchString(body) {
+		t.Errorf("_search_all highlight for payload.file.name must set number_of_fragments=0 to match file-tab whole-field behaviour:\n%s", body)
 	}
 }
 

--- a/modules/messages_search/dsl_test.go
+++ b/modules/messages_search/dsl_test.go
@@ -899,14 +899,17 @@ func TestBuildSearchMessagesDSL_ExcludesContentField(t *testing.T) {
 	}
 }
 
-// TestBuildSearchAllHighlight_ExcludesFileContent is the Q4 D negative pin:
-// pickSnippet does not promote payload.file.content into the snippet slot, so
-// requesting a highlight on that field would allocate a fragment that no
-// consumer reads.
-func TestBuildSearchAllHighlight_ExcludesFileContent(t *testing.T) {
+// TestBuildSearchAllHighlight_IncludesFileContent supersedes the earlier Q4 D
+// negative pin: _search_all now DOES highlight payload.file.content so a
+// chat-tab file message whose body matched (but whose name did not) carries a
+// <mark>-wrapped content_snippet into the mixed feed (welded file card).
+// singleFileHit -> pickFileContentSnippet reads this fragment. Q6 A is
+// unaffected: only the 120-char fragment rides the wire, never the full body
+// (fileContentSourceExcludes still drops payload.file.content from _source).
+func TestBuildSearchAllHighlight_IncludesFileContent(t *testing.T) {
 	body := asJSONString(t, buildSearchAllHighlight())
-	if strings.Contains(body, `"payload.file.content"`) {
-		t.Errorf("_search_all highlight must NOT include payload.file.content (Q4 D):\n%s", body)
+	if !strings.Contains(body, `"payload.file.content"`) {
+		t.Errorf("_search_all highlight must include payload.file.content (V6 chat-tab file body snippet):\n%s", body)
 	}
 }
 

--- a/modules/messages_search/search_all.go
+++ b/modules/messages_search/search_all.go
@@ -259,7 +259,7 @@ func (h *Handler) buildSearchAllHits(ctx context.Context, hits []*elastic.Search
 func (h *Handler) singleSearchAllHit(doc Doc, channelID string, channelType uint8, hl map[string][]string) SearchAllHit {
 	entry := SearchAllHit{SortedAt: msToRFC3339(doc.Timestamp)}
 	if payloadType(doc.Payload) == payloadTypeFile {
-		fh := h.singleFileHit(doc, channelID, channelType)
+		fh := h.singleFileHit(doc, channelID, channelType, hl)
 		entry.ResultType = "file"
 		entry.File = &fh
 		entry.SortedAt = fh.SentAt

--- a/modules/messages_search/search_all.go
+++ b/modules/messages_search/search_all.go
@@ -180,19 +180,22 @@ func buildSearchAllDSL(ctx context.Context, analyzer tokenAnalyzer, stopwordStri
 	return b, analyzeErr
 }
 
+// buildSearchAllHighlight configures the OpenSearch highlight sub-phase for
+// the mixed _search_all / _search_global_messages endpoints. This highlighter
+// is deliberately WITHOUT an Encoder("html") request-level option:
+//   - `encoder` is a highlight-request global (not per-field), so setting it
+//     would also HTML-entity-escape the pre-existing text/richText/mergeForward
+//     snippet fragments, silently changing the wire-value encoding of the
+//     long-shipped MessageHit.Snippet field across four callsites (this file,
+//     search_global_messages.go ×2, search_global_groups.go top_hits) while
+//     leaving /_search (buildSearchMessagesHighlight) raw — a cross-endpoint
+//     encoding split for the same JSON field.
+//   - Escaping is scoped to the two new file fields (name_highlight /
+//     content_snippet) in Go via escapeHighlightFragment; MessageHit.Snippet
+//     keeps its raw-text contract on every endpoint.
 func buildSearchAllHighlight() *elastic.Highlight {
 	return elastic.NewHighlight().
 		PreTags("<mark>").PostTags("</mark>").
-		// Encoder("html") escapes uploader-controlled source text before the
-		// highlighter inserts <mark>/</mark>. Required so a maliciously-named
-		// upload (e.g. `<img src=x onerror=alert(1)>.pdf`) or a body fragment
-		// containing HTML cannot land as executable markup in any consumer that
-		// treats the *_highlight / snippet fields as safe HTML. See the twin
-		// comment on buildSearchFilesHighlight for the full threat model — this
-		// highlighter feeds both the chat-tab file-body path and the pre-existing
-		// text/richText/mergeForward snippets, so encoding here keeps every
-		// consuming tab consistent.
-		Encoder("html").
 		FragmentSize(120).
 		NumOfFragments(1).
 		Fields(
@@ -210,12 +213,12 @@ func buildSearchAllHighlight() *elastic.Highlight {
 			// the mixed feed. Consumed by singleFileHit -> pickFileContentSnippet
 			// -> FileHit.ContentSnippet (search_files.go), which _search_all file
 			// hits already call. Uses the top-level FragmentSize(120)/NumOfFragments(1),
-			// so only a single 120-char window is drawn from the inverted index —
-			// Q6 A (fileContentSourceExcludes drops the full 30-100 KB body from
-			// _source) is unaffected: the whole field never rides the wire, only
-			// the fragment does. Supersedes the earlier Q4 D "name-only" decision;
+			// so only a single 120-char window is drawn from _source (server-side
+			// read; request-level source excludes are response-level only) — Q6 A
+			// is unaffected: the whole field never rides the wire, only the
+			// fragment does. Supersedes the earlier Q4 D "name-only" decision;
 			// the chat-tab UI now renders a content snippet block below the file
-			// card (sketches/002-snippet-below-card).
+			// card.
 			elastic.NewHighlighterField("payload.file.content"),
 		)
 }

--- a/modules/messages_search/search_all.go
+++ b/modules/messages_search/search_all.go
@@ -188,7 +188,20 @@ func buildSearchAllHighlight() *elastic.Highlight {
 		Field("payload.text.content").
 		Field("payload.richText.searchText").
 		Field("payload.mergeForward.msgs.searchText").
-		Field("payload.file.name")
+		Field("payload.file.name").
+		// payload.file.content: mirror the file-tab highlighter so a file
+		// message whose body (Tika-extracted content) matched the keyword —
+		// but whose name did not — surfaces a <mark>-wrapped body fragment in
+		// the mixed feed. Consumed by singleFileHit -> pickFileContentSnippet
+		// -> FileHit.ContentSnippet (search_files.go), which _search_all file
+		// hits already call. The top-level FragmentSize(120)/NumOfFragments(1)
+		// above applies to this field too, so only a single 120-char window is
+		// drawn from the inverted index — Q6 A (fileContentSourceExcludes drops
+		// the full 30-100 KB body from _source) is unaffected: the whole field
+		// never rides the wire, only the fragment does. Supersedes the earlier
+		// Q4 D "name-only" decision; the chat-tab UI now renders a content
+		// snippet block below the file card (sketches/002-snippet-below-card).
+		Field("payload.file.content")
 }
 
 func (h *Handler) buildSearchAllHits(ctx context.Context, hits []*elastic.SearchHit, req SearchAllReq, loginUID string) []SearchAllHit {

--- a/modules/messages_search/search_all.go
+++ b/modules/messages_search/search_all.go
@@ -183,25 +183,41 @@ func buildSearchAllDSL(ctx context.Context, analyzer tokenAnalyzer, stopwordStri
 func buildSearchAllHighlight() *elastic.Highlight {
 	return elastic.NewHighlight().
 		PreTags("<mark>").PostTags("</mark>").
+		// Encoder("html") escapes uploader-controlled source text before the
+		// highlighter inserts <mark>/</mark>. Required so a maliciously-named
+		// upload (e.g. `<img src=x onerror=alert(1)>.pdf`) or a body fragment
+		// containing HTML cannot land as executable markup in any consumer that
+		// treats the *_highlight / snippet fields as safe HTML. See the twin
+		// comment on buildSearchFilesHighlight for the full threat model — this
+		// highlighter feeds both the chat-tab file-body path and the pre-existing
+		// text/richText/mergeForward snippets, so encoding here keeps every
+		// consuming tab consistent.
+		Encoder("html").
 		FragmentSize(120).
 		NumOfFragments(1).
-		Field("payload.text.content").
-		Field("payload.richText.searchText").
-		Field("payload.mergeForward.msgs.searchText").
-		Field("payload.file.name").
-		// payload.file.content: mirror the file-tab highlighter so a file
-		// message whose body (Tika-extracted content) matched the keyword —
-		// but whose name did not — surfaces a <mark>-wrapped body fragment in
-		// the mixed feed. Consumed by singleFileHit -> pickFileContentSnippet
-		// -> FileHit.ContentSnippet (search_files.go), which _search_all file
-		// hits already call. The top-level FragmentSize(120)/NumOfFragments(1)
-		// above applies to this field too, so only a single 120-char window is
-		// drawn from the inverted index — Q6 A (fileContentSourceExcludes drops
-		// the full 30-100 KB body from _source) is unaffected: the whole field
-		// never rides the wire, only the fragment does. Supersedes the earlier
-		// Q4 D "name-only" decision; the chat-tab UI now renders a content
-		// snippet block below the file card (sketches/002-snippet-below-card).
-		Field("payload.file.content")
+		Fields(
+			elastic.NewHighlighterField("payload.text.content"),
+			elastic.NewHighlighterField("payload.richText.searchText"),
+			elastic.NewHighlighterField("payload.mergeForward.msgs.searchText"),
+			// NumOfFragments(0) returns the whole field with matches marked
+			// in-place — matches file-tab (buildSearchFilesHighlight) behaviour
+			// so a long or multi-sentence file name is never truncated to a
+			// single "best passage" here while the file-tab returns whole.
+			elastic.NewHighlighterField("payload.file.name").NumOfFragments(0),
+			// payload.file.content: mirror the file-tab highlighter so a file
+			// message whose body (Tika-extracted content) matched the keyword —
+			// but whose name did not — surfaces a <mark>-wrapped body fragment in
+			// the mixed feed. Consumed by singleFileHit -> pickFileContentSnippet
+			// -> FileHit.ContentSnippet (search_files.go), which _search_all file
+			// hits already call. Uses the top-level FragmentSize(120)/NumOfFragments(1),
+			// so only a single 120-char window is drawn from the inverted index —
+			// Q6 A (fileContentSourceExcludes drops the full 30-100 KB body from
+			// _source) is unaffected: the whole field never rides the wire, only
+			// the fragment does. Supersedes the earlier Q4 D "name-only" decision;
+			// the chat-tab UI now renders a content snippet block below the file
+			// card (sketches/002-snippet-below-card).
+			elastic.NewHighlighterField("payload.file.content"),
+		)
 }
 
 func (h *Handler) buildSearchAllHits(ctx context.Context, hits []*elastic.SearchHit, req SearchAllReq, loginUID string) []SearchAllHit {

--- a/modules/messages_search/search_all.go
+++ b/modules/messages_search/search_all.go
@@ -186,13 +186,18 @@ func buildSearchAllDSL(ctx context.Context, analyzer tokenAnalyzer, stopwordStri
 //   - `encoder` is a highlight-request global (not per-field), so setting it
 //     would also HTML-entity-escape the pre-existing text/richText/mergeForward
 //     snippet fragments, silently changing the wire-value encoding of the
-//     long-shipped MessageHit.Snippet field across four callsites (this file,
-//     search_global_messages.go ×2, search_global_groups.go top_hits) while
-//     leaving /_search (buildSearchMessagesHighlight) raw — a cross-endpoint
-//     encoding split for the same JSON field.
+//     long-shipped MessageHit.Snippet field across three callsites (this file,
+//     search_global_messages.go ×2) while leaving /_search
+//     (buildSearchMessagesHighlight) raw — a cross-endpoint encoding split for
+//     the same JSON field.
 //   - Escaping is scoped to the two new file fields (name_highlight /
 //     content_snippet) in Go via escapeHighlightFragment; MessageHit.Snippet
 //     keeps its raw-text contract on every endpoint.
+//
+// The groups top_hits preview uses buildSearchGroupsPreviewHighlight() instead
+// — see comment there for why (performance on the 8000-doc aggregation path,
+// and a no-widen posture on payload.file.name whose fragment feeds the raw
+// MessageHit.Snippet contract via pickSnippet).
 func buildSearchAllHighlight() *elastic.Highlight {
 	return elastic.NewHighlight().
 		PreTags("<mark>").PostTags("</mark>").

--- a/modules/messages_search/search_all_test.go
+++ b/modules/messages_search/search_all_test.go
@@ -32,6 +32,36 @@ func TestSingleSearchAllHit_File(t *testing.T) {
 	}
 }
 
+// TestSingleSearchAllHit_FileContentSnippet pins the V6 chat-tab path: when the
+// _search_all highlight map carries a payload.file.content fragment (body hit,
+// name did not match), the file result surfaces it as ContentSnippet so the
+// welded file card can render the body-match context. Mirrors the file-tab
+// contract but through the mixed _search_all dispatcher.
+func TestSingleSearchAllHit_FileContentSnippet(t *testing.T) {
+	tp := payloadTypeFile
+	doc := Doc{
+		MessageID:  101,
+		MessageSeq: 9,
+		From:       "u1",
+		Timestamp:  1717000000,
+		Payload: &Payload{
+			Type: &tp,
+			File: &FilePayload{Name: "gateway.xlsx", Ext: "xlsx", URL: "http://x"},
+		},
+	}
+	hl := map[string][]string{
+		"payload.file.content": {"预充值<mark>渠道</mark>,如用量很大请提前联系"},
+	}
+	h := &Handler{cfg: SearchConfig{}, cache: newSenderCache(8, 0)}
+	got := h.singleSearchAllHit(doc, "g", channelTypeGroup, hl)
+	if got.ResultType != "file" || got.File == nil {
+		t.Fatalf("expected file result, got %+v", got)
+	}
+	if got.File.ContentSnippet != "预充值<mark>渠道</mark>,如用量很大请提前联系" {
+		t.Errorf("content_snippet must flow from highlight map: got %q", got.File.ContentSnippet)
+	}
+}
+
 func TestSingleSearchAllHit_TextMessage(t *testing.T) {
 	tp := payloadTypeText
 	doc := Doc{

--- a/modules/messages_search/search_files.go
+++ b/modules/messages_search/search_files.go
@@ -38,6 +38,19 @@ type FileHit struct {
 	SentAt          string  `json:"sent_at"`
 	ChannelID       string  `json:"channel_id,omitempty"`
 	ChannelType     uint8   `json:"channel_type,omitempty"`
+
+	// NameHighlight is the file name with keyword matches wrapped in <mark>,
+	// taken from the OS highlight response (payload.file.name). Empty on the
+	// browse path (keyword="") or when the match came only from body/caption.
+	// The client renders this in place of FileName when present, otherwise
+	// falls back to client-side highlighting of FileName.
+	NameHighlight string `json:"name_highlight,omitempty"`
+	// ContentSnippet is a single <mark>-wrapped fragment of the Tika-extracted
+	// file body (payload.file.content) around the matched term. This is the
+	// only signal explaining WHY a body-only hit matched — the raw content is
+	// excluded from _source (30–100 KB), but the highlighter reconstructs the
+	// fragment from the inverted index. Empty when the body didn't match.
+	ContentSnippet string `json:"content_snippet,omitempty"`
 }
 
 func init() {
@@ -108,6 +121,9 @@ func (h *Handler) searchFiles(c *wkhttp.Context) {
 			Size(size).
 			TrackTotalHits(false).
 			FetchSourceContext(fileContentSourceExcludes())
+		if req.Keyword != "" {
+			svc = svc.Highlight(buildSearchFilesHighlight())
+		}
 		svc = applySort(svc, req.Sort)
 		if len(searchAfter) > 0 {
 			svc = svc.SearchAfter(searchAfter...)
@@ -176,7 +192,7 @@ func (h *Handler) buildFileHits(ctx context.Context, hits []*elastic.SearchHit, 
 			h.Warn("messages_search: bad file _source skipped", zap.Error(err))
 			continue
 		}
-		items = append(items, h.singleFileHit(doc, req.ChannelID, req.ChannelType))
+		items = append(items, h.singleFileHit(doc, req.ChannelID, req.ChannelType, map[string][]string(hit.Highlight)))
 		senderIDs = append(senderIDs, doc.From)
 	}
 
@@ -199,7 +215,7 @@ func (h *Handler) buildFileHits(ctx context.Context, hits []*elastic.SearchHit, 
 // via peerFromFakeChannelID; for group/thread the doc.ChannelID as-is.
 // Single-channel callers pass req.ChannelID / req.ChannelType so the response
 // mirrors the request.
-func (h *Handler) singleFileHit(doc Doc, channelID string, channelType uint8) FileHit {
+func (h *Handler) singleFileHit(doc Doc, channelID string, channelType uint8, hl map[string][]string) FileHit {
 	fp := filePayloadOf(doc.Payload)
 	fh := FileHit{
 		MessageID:   strconv.FormatInt(doc.MessageID, 10),
@@ -216,7 +232,54 @@ func (h *Handler) singleFileHit(doc Doc, channelID string, channelType uint8) Fi
 		fh.FileExt = resolveFileExt(fp)
 		fh.DownloadURL = fp.URL
 	}
+	fh.NameHighlight = pickFileNameHighlight(hl)
+	fh.ContentSnippet = pickFileContentSnippet(hl)
 	return fh
+}
+
+// buildSearchFilesHighlight returns the highlight config for the file-search
+// endpoints. Two fields mirror the keyword multi_match clause: payload.file.name
+// (mapped onto NameHighlight, no fragmenting — the whole name is short) and
+// payload.file.content (a single 120-char fragment around the matched body term,
+// mapped onto ContentSnippet). caption is intentionally omitted: it is rarely
+// populated and adds a third precedence branch with no UI slot. Fragments are
+// drawn from the inverted index, so fileContentSourceExcludes (which drops the
+// raw body from _source) does not affect this — see dsl.go:fileContentSourceExcludes.
+func buildSearchFilesHighlight() *elastic.Highlight {
+	return elastic.NewHighlight().
+		PreTags("<mark>").PostTags("</mark>").
+		Fields(
+			// NumberOfFragments(0) returns the whole field with matches marked
+			// in-place — correct for a short file name where we want the full
+			// string, not a fragment window.
+			elastic.NewHighlighterField("payload.file.name").NumOfFragments(0),
+			elastic.NewHighlighterField("payload.file.content").FragmentSize(120).NumOfFragments(1),
+		)
+}
+
+// pickFileNameHighlight returns the marked file name fragment, or "" when the
+// name field didn't match (body-only hit or browse path).
+func pickFileNameHighlight(hl map[string][]string) string {
+	if hl == nil {
+		return ""
+	}
+	if frags, ok := hl["payload.file.name"]; ok && len(frags) > 0 && frags[0] != "" {
+		return frags[0]
+	}
+	return ""
+}
+
+// pickFileContentSnippet returns the marked body fragment, or "" when the body
+// didn't match. This is the "why did this file match" signal for hits whose
+// keyword only appears in the extracted content, not the name.
+func pickFileContentSnippet(hl map[string][]string) string {
+	if hl == nil {
+		return ""
+	}
+	if frags, ok := hl["payload.file.content"]; ok && len(frags) > 0 && frags[0] != "" {
+		return frags[0]
+	}
+	return ""
 }
 
 // resolveFileExt prefers the indexed payload.file.extension, which the indexer

--- a/modules/messages_search/search_files.go
+++ b/modules/messages_search/search_files.go
@@ -248,6 +248,16 @@ func (h *Handler) singleFileHit(doc Doc, channelID string, channelType uint8, hl
 func buildSearchFilesHighlight() *elastic.Highlight {
 	return elastic.NewHighlight().
 		PreTags("<mark>").PostTags("</mark>").
+		// Encoder("html") escapes uploader-controlled source text (file.name is
+		// fully user-controlled; file.content is Tika-extracted uploader body)
+		// before the highlighter inserts <mark>/</mark>, so a malicious name
+		// like `<img src=x onerror=alert(1)>.pdf` comes back as
+		// `&lt;img src=x onerror=alert(1)&gt;.pdf` with only <mark> as live
+		// markup. Clients decode the entities into text nodes; there is no
+		// path for the injected HTML to execute. Without this, OpenSearch's
+		// default encoder is a pass-through — a stored-XSS vector via any
+		// uploader name/body token that overlaps a searcher's keyword.
+		Encoder("html").
 		Fields(
 			// NumberOfFragments(0) returns the whole field with matches marked
 			// in-place — correct for a short file name where we want the full

--- a/modules/messages_search/search_files.go
+++ b/modules/messages_search/search_files.go
@@ -3,6 +3,7 @@ package messages_search
 import (
 	"context"
 	"encoding/json"
+	"html"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -245,19 +246,18 @@ func (h *Handler) singleFileHit(doc Doc, channelID string, channelType uint8, hl
 // populated and adds a third precedence branch with no UI slot. Fragments are
 // drawn from the inverted index, so fileContentSourceExcludes (which drops the
 // raw body from _source) does not affect this — see dsl.go:fileContentSourceExcludes.
+// buildSearchFilesHighlight configures the OpenSearch highlight sub-phase for
+// the file-search endpoints. No OpenSearch Encoder("html") is set here:
+// `encoder` is a highlight-request global option (not per-field), so setting
+// it would also change the wire-value encoding of the pre-existing
+// MessageHit.Snippet field on the shared _search_all path (which reuses the
+// text/richText/mergeForward highlighters). We keep the OS default encoder
+// (pass-through) and escape the two new file fields in Go instead — see
+// escapeHighlightFragment — so only the newly-introduced NameHighlight /
+// ContentSnippet wire values gain HTML-entity escaping. Snippet stays raw.
 func buildSearchFilesHighlight() *elastic.Highlight {
 	return elastic.NewHighlight().
 		PreTags("<mark>").PostTags("</mark>").
-		// Encoder("html") escapes uploader-controlled source text (file.name is
-		// fully user-controlled; file.content is Tika-extracted uploader body)
-		// before the highlighter inserts <mark>/</mark>, so a malicious name
-		// like `<img src=x onerror=alert(1)>.pdf` comes back as
-		// `&lt;img src=x onerror=alert(1)&gt;.pdf` with only <mark> as live
-		// markup. Clients decode the entities into text nodes; there is no
-		// path for the injected HTML to execute. Without this, OpenSearch's
-		// default encoder is a pass-through — a stored-XSS vector via any
-		// uploader name/body token that overlaps a searcher's keyword.
-		Encoder("html").
 		Fields(
 			// NumberOfFragments(0) returns the whole field with matches marked
 			// in-place — correct for a short file name where we want the full
@@ -267,27 +267,63 @@ func buildSearchFilesHighlight() *elastic.Highlight {
 		)
 }
 
+// escapeHighlightFragment HTML-entity-escapes every character in the highlight
+// fragment EXCEPT the literal <mark>/</mark> tags configured on the file-tab
+// and chat-tab highlighters. Uploader-controlled source text (payload.file.name
+// is fully user-controlled; payload.file.content is Tika-extracted uploader
+// body) round-trips as escaped entities so any embedded HTML — a name like
+// `<img src=x onerror=alert(1)>.pdf` or a body fragment containing `<script>` —
+// arrives as `&lt;img …&gt;` / `&lt;script&gt;`; only the highlight `<mark>`
+// stays live. Clients that render *_highlight / content_snippet as HTML get
+// exactly one live tag and no XSS surface.
+//
+// This is done in Go rather than via OpenSearch's `encoder=html` option
+// because that option is a highlight-request global (not per-field), and the
+// _search_all path shares its highlighter with the pre-existing text/richText/
+// mergeForward paths that feed the long-shipped MessageHit.Snippet field —
+// flipping the encoder there would silently change Snippet's wire-value
+// encoding on four endpoints while leaving /_search raw. Escaping in Go keeps
+// the two new file fields safe without touching Snippet.
+//
+// Empty input returns empty. Fragments without <mark> tags (e.g. a whole-field
+// name hit with no match) are still fully escaped.
+func escapeHighlightFragment(fragment string) string {
+	if fragment == "" {
+		return ""
+	}
+	// html.EscapeString escapes the whole fragment (including the highlight
+	// tags themselves); then restore the two literal highlight tags we
+	// configured on the OpenSearch builders (PreTags("<mark>"), PostTags(
+	// "</mark>")) so only they stay live.
+	escaped := html.EscapeString(fragment)
+	escaped = strings.ReplaceAll(escaped, "&lt;mark&gt;", "<mark>")
+	escaped = strings.ReplaceAll(escaped, "&lt;/mark&gt;", "</mark>")
+	return escaped
+}
+
 // pickFileNameHighlight returns the marked file name fragment, or "" when the
-// name field didn't match (body-only hit or browse path).
+// name field didn't match (body-only hit or browse path). Non-`<mark>` HTML
+// characters in the fragment are entity-escaped via escapeHighlightFragment.
 func pickFileNameHighlight(hl map[string][]string) string {
 	if hl == nil {
 		return ""
 	}
 	if frags, ok := hl["payload.file.name"]; ok && len(frags) > 0 && frags[0] != "" {
-		return frags[0]
+		return escapeHighlightFragment(frags[0])
 	}
 	return ""
 }
 
 // pickFileContentSnippet returns the marked body fragment, or "" when the body
 // didn't match. This is the "why did this file match" signal for hits whose
-// keyword only appears in the extracted content, not the name.
+// keyword only appears in the extracted content, not the name. Non-`<mark>`
+// HTML characters in the fragment are entity-escaped via escapeHighlightFragment.
 func pickFileContentSnippet(hl map[string][]string) string {
 	if hl == nil {
 		return ""
 	}
 	if frags, ok := hl["payload.file.content"]; ok && len(frags) > 0 && frags[0] != "" {
-		return frags[0]
+		return escapeHighlightFragment(frags[0])
 	}
 	return ""
 }

--- a/modules/messages_search/search_files_test.go
+++ b/modules/messages_search/search_files_test.go
@@ -118,3 +118,97 @@ func TestSingleFileHit_Highlights(t *testing.T) {
 		t.Errorf("browse path should carry no highlight fields: %+v", browse)
 	}
 }
+
+// TestEscapeHighlightFragment pins the stored-XSS defence on the two new file
+// fields: every HTML metacharacter in the OpenSearch fragment is entity-
+// escaped in Go except the literal <mark>/</mark> tags configured on the
+// highlighter, so uploader-controlled source text (payload.file.name is fully
+// user-controlled; payload.file.content is Tika-extracted uploader body)
+// cannot round-trip as executable markup in a client that renders the fields
+// as HTML.
+func TestEscapeHighlightFragment(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "no HTML metachars, no <mark>",
+			in:   "just plain text",
+			want: "just plain text",
+		},
+		{
+			name: "keyword inside <mark>",
+			in:   "foo <mark>bar</mark> baz",
+			want: "foo <mark>bar</mark> baz",
+		},
+		{
+			name: "hostile file name (uploader HTML) — mark preserved, HTML escaped",
+			in:   "<img src=x onerror=alert(1)>.<mark>pdf</mark>",
+			want: "&lt;img src=x onerror=alert(1)&gt;.<mark>pdf</mark>",
+		},
+		{
+			name: "hostile body fragment — mark preserved, <script> escaped",
+			in:   "quarterly <script>alert(1)</script> <mark>report</mark>",
+			want: "quarterly &lt;script&gt;alert(1)&lt;/script&gt; <mark>report</mark>",
+		},
+		{
+			name: "ampersand / quote round-trip",
+			in:   `R&D "v2" <mark>foo</mark>`,
+			want: `R&amp;D &#34;v2&#34; <mark>foo</mark>`,
+		},
+		{
+			name: "non-mark HTML tag inside a marked span is still escaped",
+			in:   "prefix <mark><b>bold</b></mark> suffix",
+			want: "prefix <mark>&lt;b&gt;bold&lt;/b&gt;</mark> suffix",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := escapeHighlightFragment(tc.in)
+			if got != tc.want {
+				t.Errorf("escapeHighlightFragment(%q) = %q; want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSingleFileHit_HostileContentEscaped pins the end-to-end wire behaviour:
+// a hostile file name / body fragment reaching pickFileNameHighlight /
+// pickFileContentSnippet gets its uploader-controlled HTML entity-escaped
+// while the <mark> highlight stays live in FileHit.NameHighlight /
+// ContentSnippet. Any consumer that renders these fields as HTML gets one
+// live tag and no XSS surface.
+func TestSingleFileHit_HostileContentEscaped(t *testing.T) {
+	tp := payloadTypeFile
+	doc := Doc{
+		MessageID: 7, MessageSeq: 2, From: "u1", Timestamp: 1717000000,
+		Payload: &Payload{Type: &tp, File: &FilePayload{Name: "<img src=x onerror=alert(1)>.pdf"}},
+	}
+	h := &Handler{cfg: SearchConfig{}, cache: newSenderCache(8, 0)}
+
+	hit := h.singleFileHit(doc, "", 0, map[string][]string{
+		"payload.file.name":    {"<img src=x onerror=alert(1)>.<mark>pdf</mark>"},
+		"payload.file.content": {"quarterly <script>alert(1)</script> <mark>report</mark>"},
+	})
+
+	wantName := "&lt;img src=x onerror=alert(1)&gt;.<mark>pdf</mark>"
+	if hit.NameHighlight != wantName {
+		t.Errorf("hostile name highlight not escaped:\n got: %q\nwant: %q", hit.NameHighlight, wantName)
+	}
+	wantSnippet := "quarterly &lt;script&gt;alert(1)&lt;/script&gt; <mark>report</mark>"
+	if hit.ContentSnippet != wantSnippet {
+		t.Errorf("hostile content snippet not escaped:\n got: %q\nwant: %q", hit.ContentSnippet, wantSnippet)
+	}
+	// FileName wire field carries the raw uploader-controlled name (long-shipped
+	// behaviour, contract unchanged) — clients that render FileName must sanitise
+	// on their own end just as they did before this PR.
+	if hit.FileName != "<img src=x onerror=alert(1)>.pdf" {
+		t.Errorf("file_name should stay raw for backward compat, got %q", hit.FileName)
+	}
+}

--- a/modules/messages_search/search_files_test.go
+++ b/modules/messages_search/search_files_test.go
@@ -23,7 +23,7 @@ func TestBuildFileHits_FullFields(t *testing.T) {
 		},
 	}
 	h := &Handler{cfg: SearchConfig{}, cache: newSenderCache(8, 0)}
-	got := h.singleFileHit(doc, "", 0)
+	got := h.singleFileHit(doc, "", 0, nil)
 	if got.FileName != "report.pdf" {
 		t.Errorf("file_name: got %q", got.FileName)
 	}
@@ -69,11 +69,52 @@ func TestResolveFileExt_FallbackFromName(t *testing.T) {
 func TestSingleFileHit_NilPayload(t *testing.T) {
 	h := &Handler{cfg: SearchConfig{}, cache: newSenderCache(8, 0)}
 	doc := Doc{MessageID: 1, MessageSeq: 1, Timestamp: 100}
-	got := h.singleFileHit(doc, "", 0)
+	got := h.singleFileHit(doc, "", 0, nil)
 	if got.FileName != "" || got.DownloadURL != "" {
 		t.Errorf("nil payload should leave file fields empty: %+v", got)
 	}
 	if got.PreviewURL != nil {
 		t.Errorf("preview_url should remain nil")
+	}
+}
+
+func TestSingleFileHit_Highlights(t *testing.T) {
+	tp := payloadTypeFile
+	doc := Doc{
+		MessageID: 5, MessageSeq: 1, From: "u1", Timestamp: 1717000000,
+		Payload: &Payload{Type: &tp, File: &FilePayload{Name: "quarterly-report.pdf"}},
+	}
+	h := &Handler{cfg: SearchConfig{}, cache: newSenderCache(8, 0)}
+
+	// Name matched: name_highlight carries the marked name; content_snippet empty.
+	nameOnly := h.singleFileHit(doc, "", 0, map[string][]string{
+		"payload.file.name": {"quarterly-<mark>report</mark>.pdf"},
+	})
+	if nameOnly.NameHighlight != "quarterly-<mark>report</mark>.pdf" {
+		t.Errorf("name_highlight: got %q", nameOnly.NameHighlight)
+	}
+	if nameOnly.ContentSnippet != "" {
+		t.Errorf("content_snippet should be empty when body didn't match, got %q", nameOnly.ContentSnippet)
+	}
+	// FileName always echoes the raw name so the client can fall back.
+	if nameOnly.FileName != "quarterly-report.pdf" {
+		t.Errorf("file_name should stay raw, got %q", nameOnly.FileName)
+	}
+
+	// Body-only match: content_snippet carries the marked fragment; name_highlight empty.
+	bodyOnly := h.singleFileHit(doc, "", 0, map[string][]string{
+		"payload.file.content": {"...annual <mark>revenue</mark> grew..."},
+	})
+	if bodyOnly.NameHighlight != "" {
+		t.Errorf("name_highlight should be empty for body-only hit, got %q", bodyOnly.NameHighlight)
+	}
+	if bodyOnly.ContentSnippet != "...annual <mark>revenue</mark> grew..." {
+		t.Errorf("content_snippet: got %q", bodyOnly.ContentSnippet)
+	}
+
+	// Browse path (nil highlight): both empty.
+	browse := h.singleFileHit(doc, "", 0, nil)
+	if browse.NameHighlight != "" || browse.ContentSnippet != "" {
+		t.Errorf("browse path should carry no highlight fields: %+v", browse)
 	}
 }

--- a/modules/messages_search/search_global_files.go
+++ b/modules/messages_search/search_global_files.go
@@ -103,6 +103,9 @@ func (h *Handler) searchGlobalFiles(c *wkhttp.Context) {
 			Size(size).
 			TrackTotalHits(false).
 			FetchSourceContext(fileContentSourceExcludes())
+		if req.Keyword != "" {
+			svc = svc.Highlight(buildSearchFilesHighlight())
+		}
 		svc = applySort(svc, req.Sort)
 		if len(searchAfter) > 0 {
 			svc = svc.SearchAfter(searchAfter...)
@@ -227,7 +230,7 @@ func (h *Handler) buildGlobalFileHits(ctx context.Context, hits []*elastic.Searc
 			continue
 		}
 		wireID, wireType := wireChannelFromDoc(doc, loginUID)
-		items = append(items, h.singleFileHit(doc, wireID, wireType))
+		items = append(items, h.singleFileHit(doc, wireID, wireType, map[string][]string(hit.Highlight)))
 		senderIDs = append(senderIDs, doc.From)
 	}
 	if len(items) == 0 {
@@ -300,6 +303,9 @@ func (h *Handler) dispatchSingleFiles(c *wkhttp.Context, req SearchGlobalFilesRe
 			Size(size).
 			TrackTotalHits(false).
 			FetchSourceContext(fileContentSourceExcludes())
+		if req.Keyword != "" {
+			svc = svc.Highlight(buildSearchFilesHighlight())
+		}
 		svc = applySort(svc, req.Sort)
 		if len(searchAfter) > 0 {
 			svc = svc.SearchAfter(searchAfter...)

--- a/modules/messages_search/search_global_groups.go
+++ b/modules/messages_search/search_global_groups.go
@@ -239,7 +239,7 @@ func (h *Handler) runGroupsAggregation(ctx context.Context, client *elastic.Clie
 		SortBy(searchSorters("time_desc")...).
 		FetchSourceContext(fileContentSourceExcludes())
 	if withHighlight {
-		preview = preview.Highlight(buildSearchAllHighlight())
+		preview = preview.Highlight(buildSearchGroupsPreviewHighlight())
 	}
 	byChannel := elastic.NewTermsAggregation().
 		Field("channelId").
@@ -255,6 +255,48 @@ func (h *Handler) runGroupsAggregation(ctx context.Context, client *elastic.Clie
 		Aggregation("by_channel", byChannel).
 		Aggregation("group_count", elastic.NewCardinalityAggregation().Field("channelId")).
 		Do(ctx)
+}
+
+// buildSearchGroupsPreviewHighlight configures a groups-preview-scoped highlighter
+// that ONLY covers the fields `pickSnippet` actually consumes (dsl.go), with
+// pre-existing fragment sizing preserved. Deliberately different from
+// buildSearchAllHighlight() for two reasons:
+//
+//  1. Performance: the groups aggregation runs against up to
+//     MaxGroups(200) × (PerGroupMax+PresenceProbe)(40) = 8000 docs per request.
+//     buildSearchAllHighlight() includes payload.file.content, which is
+//     a 30-100 KB Tika-extracted body per doc. Every file hit on the groups
+//     path would pay a full-body highlighter scan whose output is then
+//     discarded — pickSnippet's priority list has no payload.file.content
+//     branch. This can push the request past OCTO_SEARCH_TIMEOUT=5s.
+//
+//  2. Contract safety: buildSearchAllHighlight() sets NumOfFragments(0) on
+//     payload.file.name to align with the file-tab whole-field convention
+//     (safe on _search_all / _search_global_messages because those consume
+//     via pickFileNameHighlight → FileHit.NameHighlight → escapeHighlightFragment).
+//     On the groups path the same fragment feeds pickSnippet → MessageHit.Snippet,
+//     which by long-shipped design carries raw uploader-controlled text — a
+//     contract this PR deliberately preserves. Whole-field mode on that path
+//     would widen a pre-existing raw-name-length concern from 120 chars to
+//     unbounded. Keeping the pre-existing fragment window here is a
+//     no-widen posture; fixing the pre-existing raw-Snippet contract is
+//     out of scope and belongs in a separate PR.
+func buildSearchGroupsPreviewHighlight() *elastic.Highlight {
+	return elastic.NewHighlight().
+		PreTags("<mark>").PostTags("</mark>").
+		FragmentSize(120).
+		NumOfFragments(1).
+		Fields(
+			elastic.NewHighlighterField("payload.text.content"),
+			elastic.NewHighlighterField("payload.richText.searchText"),
+			elastic.NewHighlighterField("payload.mergeForward.msgs.searchText"),
+			elastic.NewHighlighterField("payload.image.caption"),
+			elastic.NewHighlighterField("payload.file.name"),
+			// payload.file.content deliberately absent — pickSnippet does not
+			// read it, so requesting it would allocate an expensive fragment
+			// that no consumer ever sees. See doc comment above for the full
+			// rationale (8000-doc aggregation × 30-100 KB body scan).
+		)
 }
 
 // parsedBucket is the pre-projection view of one terms bucket. latestTS is the

--- a/modules/messages_search/search_global_test.go
+++ b/modules/messages_search/search_global_test.go
@@ -184,7 +184,7 @@ func TestGlobalHitShape_ChannelTypeAndIDPresent(t *testing.T) {
 	// File hit for a group.
 	fp := payloadTypeFile
 	docFile := Doc{MessageID: 2, Payload: &Payload{Type: &fp, File: &FilePayload{Name: "a.pdf"}}}
-	fh := h.singleFileHit(docFile, "gA", channelTypeGroup)
+	fh := h.singleFileHit(docFile, "gA", channelTypeGroup, nil)
 	if b, _ := json.Marshal(fh); !strings.Contains(string(b), `"channel_id":"gA"`) || !strings.Contains(string(b), `"channel_type":2`) {
 		t.Errorf("FileHit must carry channel_id+channel_type: %s", b)
 	}

--- a/modules/messages_search/swagger/api.yaml
+++ b/modules/messages_search/swagger/api.yaml
@@ -634,6 +634,18 @@ definitions:
         type: string
         format: uri
         x-nullable: true
+      name_highlight:
+        type: string
+        description: >-
+          File name with keyword matches wrapped in <mark>…</mark>. Present only
+          when the keyword matched the file name; absent on browse or body-only
+          hits (client falls back to highlighting file_name locally).
+      content_snippet:
+        type: string
+        description: >-
+          Single <mark>-wrapped fragment (≤120 chars) of the Tika-extracted file
+          body around the matched term. Explains a body-only match. Absent when
+          the body did not match.
       sender_id:
         type: string
       sender_name:


### PR DESCRIPTION
## Summary

Add search-result highlighting to the `messages_search` module so a keyword match **inside a file's extracted body** — not just its name — is surfaced to clients.

Two areas:

1. **File search endpoints** (`/v1/messages/_search_files`, `/_search_global_files`): `FileHit` gains `name_highlight` (file name with the keyword wrapped in `<mark>`) and `content_snippet` (a single ~120-char `<mark>`-wrapped fragment of the Tika-extracted file body). Both are additive `json:",omitempty"` fields.
2. **Mixed `_search_all` / `_search_global_messages`** (chat tab): previously a file-type message hit surfaced only the file **name** as its snippet. `buildSearchAllHighlight()` now also highlights `payload.file.content`, so a file message whose body matched (but whose name did not) returns a `content_snippet`. The former negative pin `TestBuildSearchAllHighlight_ExcludesFileContent` is flipped to the positive `TestBuildSearchAllHighlight_IncludesFileContent`.

## Changes

- `search_files.go` — `FileHit.NameHighlight` / `ContentSnippet`; `buildSearchFilesHighlight()`; `pickFileNameHighlight` / `pickFileContentSnippet`; `singleFileHit` populates both from the highlight map.
- `search_all.go` — add `payload.file.content` to `buildSearchAllHighlight()`; file hits flow through the existing `singleSearchAllHit → singleFileHit` path.
- `search_global_files.go` — global file endpoint attaches the same highlighter.
- `dsl.go` — comment accuracy on `fileContentSourceExcludes()`.
- Tests: `search_files_test.go` (`TestSingleFileHit_Highlights` — three states: name-only, body-only, browse), `search_all_test.go` (`TestSingleSearchAllHit_FileContentSnippet`), `dsl_test.go` (flipped highlight pin).
- `swagger/api.yaml` — `FileHit` gains `name_highlight` + `content_snippet`.

## Invariant preserved (no full-body leak)

The full Tika-extracted body (`payload.file.content`, ~30–100 KB/doc) still **never rides the wire**: every query block keeps `FetchSourceContext(fileContentSourceExcludes())`, which excludes `payload.file.content` + `payload.file.contentMeta` from `_source`. Highlight fragments are drawn from the inverted index, not `_source`, so excluding the source does not disable highlighting. The top-level `FragmentSize(120).NumOfFragments(1)` caps each snippet at a single ~120-char window.

## Backward compatibility

Both new fields are additive and `omitempty`. Browse hits (empty keyword) attach no highlighter, so `hl` is nil, the `pickXxx` helpers return `""`, and the fields are omitted from the response. Existing bot/uk callers are unaffected.

## Testing

- [x] `go build ./modules/messages_search/` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./modules/messages_search/` — ok; new/changed tests pin the highlight wiring (three-state file hit, snippet flow through `_search_all`, flipped pin)
- [x] Manual verification on a local stack: a keyword appearing only inside an `.xlsx` body returns a `content_snippet` in both the File tab and the chat tab.

## Related

- Paired front-end change: `dmwork/octo-web` `feat/file-search-highlight` (consumes `name_highlight` / `content_snippet`).
