### PR TITLE
fix(bot-api): bind bot tokens to one OpenClaw instance

### DIFF
--- a/.octospec/tasks/bot-token-single-binding/brief.md
+++ b/.octospec/tasks/bot-token-single-binding/brief.md
@@ -12,6 +12,8 @@ instance receives an explicit HTTP 409 conflict.
 - Binding acquisition is atomic across octo-server replicas.
 - Raw Bot API tokens never appear in binding keys or diagnostic details.
 - A bound token returns credentials only to its owning `instance_id`.
+- `instance_id` is a persisted UUID v4 shared by all Bot accounts in one
+  OpenClaw installation.
 - Existing clients without `instance_id` remain compatible until a new client
   claims the token; after that, omission is a conflict rather than a bypass.
 - `force_refresh=true` does not bypass ownership.
@@ -19,6 +21,12 @@ instance receives an explicit HTTP 409 conflict.
 - The IM credential issued for a newly bound token is distinct from the Bot API
   token, so a rejected legacy client cannot reconnect directly with the bearer
   token after a binding is established.
+- Startup restoration treats the binding table as authoritative and re-checks
+  after each external token update, so a concurrent first claim cannot be
+  overwritten by a stale Bot API token.
+- A legacy registration re-checks ownership after its external token update;
+  if a first claim raced it, the bound credential is restored and the legacy
+  request receives HTTP 409.
 
 ## Out of scope
 
@@ -36,7 +44,8 @@ instance receives an explicit HTTP 409 conflict.
 - Legacy registration remains unchanged while no binding exists.
 - User Bot and App Bot registration share the same binding behavior.
 - Focused unit tests cover validation, idempotency, conflict, legacy transition,
-  and the migration's uniqueness constraints.
+  startup reconciliation, the legacy/claim race repair, and the migration's
+  uniqueness constraints.
 
 ## Rollout
 

--- a/.octospec/tasks/bot-token-single-binding/brief.md
+++ b/.octospec/tasks/bot-token-single-binding/brief.md
@@ -1,0 +1,50 @@
+# Bot token single-instance binding
+
+## Goal
+
+Prevent one Bot API token from registering more than one OpenClaw installation.
+The first client that supplies an `instance_id` owns that token permanently;
+re-registration by the same instance is idempotent, while a different or legacy
+instance receives an explicit HTTP 409 conflict.
+
+## Load-bearing behavior
+
+- Binding acquisition is atomic across octo-server replicas.
+- Raw Bot API tokens never appear in binding keys or diagnostic details.
+- A bound token returns credentials only to its owning `instance_id`.
+- Existing clients without `instance_id` remain compatible until a new client
+  claims the token; after that, omission is a conflict rather than a bypass.
+- `force_refresh=true` does not bypass ownership.
+- User-facing failures use the localized error envelope and a real HTTP 409.
+- The IM credential issued for a newly bound token is distinct from the Bot API
+  token, so a rejected legacy client cannot reconnect directly with the bearer
+  token after a binding is established.
+
+## Out of scope
+
+- Changing WuKongIM's Master connection replacement semantics.
+- Time-based leases or automatic ownership expiry.
+- Adding a new unbind endpoint. Rotating the Bot Token creates a fresh binding
+  identity and is the explicit recovery/transfer mechanism.
+
+## Acceptance
+
+- The first non-empty `instance_id` atomically creates a binding.
+- The same `instance_id` can register repeatedly and receives the same IM token.
+- Once claimed, a different or missing `instance_id` receives HTTP 409 with
+  `err.server.bot_api.instance_conflict`.
+- Legacy registration remains unchanged while no binding exists.
+- User Bot and App Bot registration share the same binding behavior.
+- Focused unit tests cover validation, idempotency, conflict, legacy transition,
+  and the migration's uniqueness constraints.
+
+## Rollout
+
+- Release and upgrade `openclaw-channel-octo` first. Older servers safely ignore
+  the new `instance_id` request field.
+- Deploy this server change only after supported clients persist and send an
+  installation ID. During a multi-replica rollout, old and new registration
+  logic must not remain active together because an old replica can overwrite
+  the binding-scoped IM token with the Bot API token.
+- Existing legacy clients can register only until a modern client claims the
+  token. After the claim, requests without the owning `instance_id` receive 409.

--- a/modules/bot_api/api_i18n.go
+++ b/modules/bot_api/api_i18n.go
@@ -112,6 +112,12 @@ func respondBotAPIBotUnavailable(c *wkhttp.Context) {
 	c.Abort()
 }
 
+// respondBotAPIInstanceConflict rejects a registration owned by another
+// OpenClaw installation. Do not expose the stored instance identifier.
+func respondBotAPIInstanceConflict(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIInstanceConflict, nil, nil)
+}
+
 // ---- checkSendPermission classifier -----------------------------------------
 
 // Sentinel errors returned by checkSendPermission so the call sites

--- a/modules/bot_api/api_i18n.go
+++ b/modules/bot_api/api_i18n.go
@@ -116,6 +116,7 @@ func respondBotAPIBotUnavailable(c *wkhttp.Context) {
 // OpenClaw installation. Do not expose the stored instance identifier.
 func respondBotAPIInstanceConflict(c *wkhttp.Context) {
 	httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIInstanceConflict, nil, nil)
+	c.Abort()
 }
 
 // ---- checkSendPermission classifier -----------------------------------------

--- a/modules/bot_api/api_i18n_test.go
+++ b/modules/bot_api/api_i18n_test.go
@@ -105,6 +105,25 @@ func helperHarness(probe func(c *wkhttp.Context)) *wkhttp.WKHttp {
 	return r
 }
 
+func TestRespondBotAPIInstanceConflictAbortsHandlerChain(t *testing.T) {
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	nextCalled := false
+	r.GET("/probe", respondBotAPIInstanceConflict, func(c *wkhttp.Context) {
+		nextCalled = true
+	})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/probe", nil))
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("HTTP status = %d, want %d; body=%s", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+	if nextCalled {
+		t.Fatal("instance conflict must abort the remaining handler chain")
+	}
+}
+
 func TestRespondBotAPIHelpers(t *testing.T) {
 	// ba carries only a logger — enough for the helpers that log (identity
 	// guard) without standing up DB / redis / IM.

--- a/modules/bot_api/api_i18n_test.go
+++ b/modules/bot_api/api_i18n_test.go
@@ -327,6 +327,14 @@ func TestRespondBotAPIHelpers(t *testing.T) {
 			wantContains:    "OBO 授权已存在",
 		},
 		{
+			name:            "respondBotAPIInstanceConflict preserves 409",
+			probe:           respondBotAPIInstanceConflict,
+			wantCodeID:      "err.server.bot_api.instance_conflict",
+			wantSemStatus:   http.StatusConflict,
+			wantTransStatus: http.StatusConflict,
+			wantContains:    "该 Bot Token 已绑定到另一个 OpenClaw 实例",
+		},
+		{
 			name:            "ErrBotAPISharedAuthRequired preserves 401",
 			probe:           func(c *wkhttp.Context) { httperrLWS(c, errcode.ErrBotAPISharedAuthRequired) },
 			wantCodeID:      "err.shared.auth.required",

--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -36,6 +36,7 @@ const (
 type BotAPI struct {
 	ctx           *config.Context
 	db            *botAPIDB
+	updateIMToken func(config.UpdateIMTokenReq) (*config.UpdateIMTokenResp, error)
 	userService   user.IService
 	fileService   file.IService
 	groupService  group.IService
@@ -296,6 +297,11 @@ func NewBotAPI(ctx *config.Context) *BotAPI {
 
 // Route registers all Bot API routes.
 func (ba *BotAPI) Route(r *wkhttp.WKHttp) {
+	// Restore User Bot IM credentials from the binding-aware source of truth.
+	// Keeping this asynchronous preserves the existing startup behavior; the
+	// restore path re-checks ownership after every external token update.
+	go ba.syncAllBotTokens()
+
 	// register endpoint (token needed but not via authBot group — handled inline).
 	//
 	// **两层限流,顺序载荷性**:先 per-IP,再 per-token。

--- a/modules/bot_api/instance_binding.go
+++ b/modules/bot_api/instance_binding.go
@@ -17,7 +17,7 @@ const (
 
 var (
 	errBotInstanceConflict = errors.New("bot token is bound to another instance")
-	instanceIDPattern      = regexp.MustCompile(`^[A-Za-z0-9._:-]{16,128}$`)
+	instanceIDPattern      = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
 )
 
 type botInstanceBinding struct {

--- a/modules/bot_api/instance_binding.go
+++ b/modules/bot_api/instance_binding.go
@@ -1,0 +1,108 @@
+package bot_api
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"regexp"
+
+	"github.com/gocraft/dbr/v2"
+)
+
+const (
+	botKindUser = "user"
+	botKindApp  = "app"
+)
+
+var (
+	errBotInstanceConflict = errors.New("bot token is bound to another instance")
+	instanceIDPattern      = regexp.MustCompile(`^[A-Za-z0-9._:-]{16,128}$`)
+)
+
+type botInstanceBinding struct {
+	TokenFingerprint []byte `db:"token_fingerprint"`
+	BotKind          string `db:"bot_kind"`
+	RobotID          string `db:"robot_id"`
+	InstanceID       string `db:"instance_id"`
+	IMToken          string `db:"im_token"`
+}
+
+func validInstanceID(instanceID string) bool {
+	return instanceIDPattern.MatchString(instanceID)
+}
+
+func botBindingFingerprint(token string) []byte {
+	sum := sha256.Sum256([]byte(token))
+	return sum[:]
+}
+
+func generateBindingIMToken() (string, error) {
+	random := make([]byte, 32)
+	if _, err := rand.Read(random); err != nil {
+		return "", err
+	}
+	return "im_" + hex.EncodeToString(random), nil
+}
+
+// resolveRegistrationIMToken atomically claims a Bot Token for instanceID.
+//
+// The unique token fingerprint is the cross-replica lock: concurrent INSERTs
+// can create only one row, and every contender then reads the winning owner.
+// A legacy request remains compatible while no binding exists, but cannot
+// bypass a binding after a modern client has claimed the token.
+func (d *botAPIDB) resolveRegistrationIMToken(
+	botToken string,
+	botKind string,
+	robotID string,
+	instanceID string,
+) (string, bool, error) {
+	fingerprint := botBindingFingerprint(botToken)
+	if instanceID == "" {
+		binding, err := d.queryBotInstanceBinding(fingerprint)
+		if errors.Is(err, dbr.ErrNotFound) {
+			return botToken, false, nil
+		}
+		if err != nil {
+			return "", false, err
+		}
+		if binding != nil {
+			return "", false, errBotInstanceConflict
+		}
+		return botToken, false, nil
+	}
+
+	candidate, err := generateBindingIMToken()
+	if err != nil {
+		return "", false, err
+	}
+	_, err = d.session.InsertBySql(
+		"INSERT INTO bot_instance_binding (token_fingerprint, bot_kind, robot_id, instance_id, im_token) "+
+			"VALUES (?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE token_fingerprint=token_fingerprint",
+		fingerprint, botKind, robotID, instanceID, candidate,
+	).Exec()
+	if err != nil {
+		return "", false, err
+	}
+
+	binding, err := d.queryBotInstanceBinding(fingerprint)
+	if err != nil {
+		return "", false, err
+	}
+	if binding == nil || binding.BotKind != botKind || binding.RobotID != robotID || binding.InstanceID != instanceID {
+		return "", false, errBotInstanceConflict
+	}
+	return binding.IMToken, true, nil
+}
+
+func (d *botAPIDB) queryBotInstanceBinding(fingerprint []byte) (*botInstanceBinding, error) {
+	var binding botInstanceBinding
+	err := d.session.Select("token_fingerprint", "bot_kind", "robot_id", "instance_id", "im_token").
+		From("bot_instance_binding").
+		Where("token_fingerprint=?", fingerprint).
+		LoadOne(&binding)
+	if err != nil {
+		return nil, err
+	}
+	return &binding, nil
+}

--- a/modules/bot_api/instance_binding_test.go
+++ b/modules/bot_api/instance_binding_test.go
@@ -2,7 +2,6 @@ package bot_api
 
 import (
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -17,9 +16,9 @@ func bindingRows(fingerprint []byte, kind, robotID, instanceID, imToken string) 
 func TestValidInstanceID(t *testing.T) {
 	t.Parallel()
 	require.True(t, validInstanceID("550e8400-e29b-41d4-a716-446655440000"))
-	require.True(t, validInstanceID("instance_node-01:primary"))
+	require.False(t, validInstanceID("instance_node-01:primary"))
 	require.False(t, validInstanceID("too-short"))
-	require.False(t, validInstanceID(strings.Repeat("a", 129)))
+	require.False(t, validInstanceID("550e8400-e29b-11d4-a716-446655440000"))
 	require.False(t, validInstanceID("550e8400-e29b-41d4-a716-44665544/000"))
 }
 

--- a/modules/bot_api/instance_binding_test.go
+++ b/modules/bot_api/instance_binding_test.go
@@ -1,0 +1,122 @@
+package bot_api
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+)
+
+func bindingRows(fingerprint []byte, kind, robotID, instanceID, imToken string) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"token_fingerprint", "bot_kind", "robot_id", "instance_id", "im_token"}).
+		AddRow(fingerprint, kind, robotID, instanceID, imToken)
+}
+
+func TestValidInstanceID(t *testing.T) {
+	t.Parallel()
+	require.True(t, validInstanceID("550e8400-e29b-41d4-a716-446655440000"))
+	require.True(t, validInstanceID("instance_node-01:primary"))
+	require.False(t, validInstanceID("too-short"))
+	require.False(t, validInstanceID(strings.Repeat("a", 129)))
+	require.False(t, validInstanceID("550e8400-e29b-41d4-a716-44665544/000"))
+}
+
+func TestBotTokenFingerprintDoesNotContainRawToken(t *testing.T) {
+	t.Parallel()
+	token := "bf_super_secret_token"
+	fingerprint := botBindingFingerprint(token)
+	require.Len(t, fingerprint, 32)
+	require.NotContains(t, string(fingerprint), token)
+}
+
+func TestResolveRegistrationIMTokenFirstClaimReturnsStoredToken(t *testing.T) {
+	d, mock, closer := newSqlmockBotAPIDB(t)
+	defer closer()
+
+	fingerprint := botBindingFingerprint("bf_token")
+	mock.ExpectExec("INSERT INTO bot_instance_binding").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("SELECT .* FROM bot_instance_binding").
+		WillReturnRows(bindingRows(fingerprint, botKindUser, "bot_1", "instance_0000001", "im_winner"))
+
+	imToken, bound, err := d.resolveRegistrationIMToken("bf_token", botKindUser, "bot_1", "instance_0000001")
+	require.NoError(t, err)
+	require.True(t, bound)
+	require.Equal(t, "im_winner", imToken)
+	require.NotEqual(t, "bf_token", imToken)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestResolveRegistrationIMTokenSameInstanceIsIdempotent(t *testing.T) {
+	d, mock, closer := newSqlmockBotAPIDB(t)
+	defer closer()
+
+	fingerprint := botBindingFingerprint("app_token")
+	mock.ExpectExec("INSERT INTO bot_instance_binding").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SELECT .* FROM bot_instance_binding").
+		WillReturnRows(bindingRows(fingerprint, botKindApp, "app_1_bot", "instance_0000001", "im_existing"))
+
+	imToken, bound, err := d.resolveRegistrationIMToken("app_token", botKindApp, "app_1_bot", "instance_0000001")
+	require.NoError(t, err)
+	require.True(t, bound)
+	require.Equal(t, "im_existing", imToken)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestResolveRegistrationIMTokenRejectsDifferentInstance(t *testing.T) {
+	d, mock, closer := newSqlmockBotAPIDB(t)
+	defer closer()
+
+	fingerprint := botBindingFingerprint("bf_token")
+	mock.ExpectExec("INSERT INTO bot_instance_binding").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SELECT .* FROM bot_instance_binding").
+		WillReturnRows(bindingRows(fingerprint, botKindUser, "bot_1", "instance_0000001", "im_existing"))
+
+	_, _, err := d.resolveRegistrationIMToken("bf_token", botKindUser, "bot_1", "instance_0000002")
+	require.ErrorIs(t, err, errBotInstanceConflict)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestResolveRegistrationIMTokenLegacyTransition(t *testing.T) {
+	t.Run("unclaimed token keeps legacy credential", func(t *testing.T) {
+		d, mock, closer := newSqlmockBotAPIDB(t)
+		defer closer()
+
+		mock.ExpectQuery("SELECT .* FROM bot_instance_binding").
+			WillReturnRows(sqlmock.NewRows([]string{"token_fingerprint", "bot_kind", "robot_id", "instance_id", "im_token"}))
+
+		imToken, bound, err := d.resolveRegistrationIMToken("bf_legacy", botKindUser, "bot_1", "")
+		require.NoError(t, err)
+		require.False(t, bound)
+		require.Equal(t, "bf_legacy", imToken)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("claimed token rejects a legacy client", func(t *testing.T) {
+		d, mock, closer := newSqlmockBotAPIDB(t)
+		defer closer()
+
+		fingerprint := botBindingFingerprint("bf_claimed")
+		mock.ExpectQuery("SELECT .* FROM bot_instance_binding").
+			WillReturnRows(bindingRows(fingerprint, botKindUser, "bot_1", "instance_0000001", "im_existing"))
+
+		_, _, err := d.resolveRegistrationIMToken("bf_claimed", botKindUser, "bot_1", "")
+		require.ErrorIs(t, err, errBotInstanceConflict)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestBotInstanceBindingMigrationPinsAtomicOwnership(t *testing.T) {
+	t.Parallel()
+	data, err := os.ReadFile("sql/20260903000001_bot_instance_binding.sql")
+	require.NoError(t, err)
+	sql := string(data)
+	require.Contains(t, sql, "token_fingerprint BINARY(32)")
+	require.Contains(t, sql, "PRIMARY KEY (token_fingerprint)")
+	require.Contains(t, sql, "instance_id       VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin")
+	require.NotContains(t, sql, "bot_token ")
+}

--- a/modules/bot_api/register.go
+++ b/modules/bot_api/register.go
@@ -2,9 +2,9 @@ package bot_api
 
 import (
 	"errors"
+	"io"
 	"strings"
 
-	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/pkg/botutil"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
@@ -40,7 +40,10 @@ func (ba *BotAPI) register(c *wkhttp.Context) {
 	}
 
 	var req BotRegisterReq
-	_ = c.ShouldBindJSON(&req)
+	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
+		respondBotAPIRequestInvalid(c, "body")
+		return
+	}
 	if req.InstanceID != "" && !validInstanceID(req.InstanceID) {
 		respondBotAPIRequestInvalid(c, "instance_id")
 		return
@@ -85,16 +88,22 @@ func (ba *BotAPI) registerUserBot(c *wkhttp.Context, token string, req BotRegist
 			return
 		}
 	}
-	resp, tokenErr := ba.ctx.UpdateIMToken(config.UpdateIMTokenReq{
-		UID:         robot.RobotID,
-		Token:       imToken,
-		DeviceFlag:  config.APP,
-		DeviceLevel: config.DeviceLevelMaster,
-	})
-	if tokenErr != nil || resp.Status != config.UpdateTokenStatusSuccess {
-		ba.Error("获取IM Token失败", zap.Any("error", tokenErr), zap.String("robotID", robot.RobotID), zap.Any("status", resp))
+	if tokenErr := ba.installIMToken(robot.RobotID, imToken); tokenErr != nil {
+		ba.Error("获取IM Token失败", zap.Error(tokenErr), zap.String("robotID", robot.RobotID))
 		httperr.ResponseErrorL(c, errcode.ErrBotAPIIMTokenFailed, nil, nil)
 		return
+	}
+	if !bound {
+		conflict, reconcileErr := ba.reconcileBindingAfterUnboundUpdate(token, botKindUser, robot.RobotID, imToken)
+		if reconcileErr != nil {
+			ba.Error("复核 Bot 实例绑定失败", zap.Error(reconcileErr), zap.String("robotID", robot.RobotID))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIIMTokenFailed, nil, nil)
+			return
+		}
+		if conflict {
+			respondBotAPIInstanceConflict(c)
+			return
+		}
 	}
 
 	// Optional: persist agent version info.
@@ -161,7 +170,7 @@ func (ba *BotAPI) registerAppBot(c *wkhttp.Context, token string, req BotRegiste
 		return
 	}
 
-	imToken, _, err := ba.db.resolveRegistrationIMToken(token, botKindApp, appBot.UID, req.InstanceID)
+	imToken, bound, err := ba.db.resolveRegistrationIMToken(token, botKindApp, appBot.UID, req.InstanceID)
 	if errors.Is(err, errBotInstanceConflict) {
 		respondBotAPIInstanceConflict(c)
 		return
@@ -171,16 +180,22 @@ func (ba *BotAPI) registerAppBot(c *wkhttp.Context, token string, req BotRegiste
 		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
 		return
 	}
-	resp, tokenErr := ba.ctx.UpdateIMToken(config.UpdateIMTokenReq{
-		UID:         appBot.UID,
-		Token:       imToken,
-		DeviceFlag:  config.APP,
-		DeviceLevel: config.DeviceLevelMaster,
-	})
-	if tokenErr != nil || resp.Status != config.UpdateTokenStatusSuccess {
-		ba.Error("App Bot IM Token注册失败", zap.Any("error", tokenErr), zap.String("uid", appBot.UID), zap.Any("status", resp))
+	if tokenErr := ba.installIMToken(appBot.UID, imToken); tokenErr != nil {
+		ba.Error("App Bot IM Token注册失败", zap.Error(tokenErr), zap.String("uid", appBot.UID))
 		httperr.ResponseErrorL(c, errcode.ErrBotAPIIMTokenFailed, nil, nil)
 		return
+	}
+	if !bound {
+		conflict, reconcileErr := ba.reconcileBindingAfterUnboundUpdate(token, botKindApp, appBot.UID, imToken)
+		if reconcileErr != nil {
+			ba.Error("复核 App Bot 实例绑定失败", zap.Error(reconcileErr), zap.String("uid", appBot.UID))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIIMTokenFailed, nil, nil)
+			return
+		}
+		if conflict {
+			respondBotAPIInstanceConflict(c)
+			return
+		}
 	}
 
 	cfg := ba.ctx.GetConfig()

--- a/modules/bot_api/register.go
+++ b/modules/bot_api/register.go
@@ -1,6 +1,7 @@
 package bot_api
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -16,6 +17,7 @@ type BotRegisterReq struct {
 	AgentPlatform string `json:"agent_platform"`
 	AgentVersion  string `json:"agent_version"`
 	PluginVersion string `json:"plugin_version"`
+	InstanceID    string `json:"instance_id"`
 }
 
 // BotRegisterResp is the response for bot registration.
@@ -37,15 +39,22 @@ func (ba *BotAPI) register(c *wkhttp.Context) {
 		return
 	}
 
+	var req BotRegisterReq
+	_ = c.ShouldBindJSON(&req)
+	if req.InstanceID != "" && !validInstanceID(req.InstanceID) {
+		respondBotAPIRequestInvalid(c, "instance_id")
+		return
+	}
+
 	if strings.HasPrefix(token, "app_") {
-		ba.registerAppBot(c, token)
+		ba.registerAppBot(c, token, req)
 	} else {
-		ba.registerUserBot(c, token)
+		ba.registerUserBot(c, token, req)
 	}
 }
 
 // registerUserBot handles registration for User Bot (bf_ token).
-func (ba *BotAPI) registerUserBot(c *wkhttp.Context, token string) {
+func (ba *BotAPI) registerUserBot(c *wkhttp.Context, token string, req BotRegisterReq) {
 	robot, err := ba.db.queryRobotByBotToken(token)
 	if err != nil {
 		ba.Error("查询机器人失败", zap.Error(err))
@@ -57,8 +66,25 @@ func (ba *BotAPI) registerUserBot(c *wkhttp.Context, token string) {
 		return
 	}
 
-	// Use bot_token as im_token — single token design
-	imToken := robot.BotToken
+	imToken, bound, err := ba.db.resolveRegistrationIMToken(token, botKindUser, robot.RobotID, req.InstanceID)
+	if errors.Is(err, errBotInstanceConflict) {
+		respondBotAPIInstanceConflict(c)
+		return
+	}
+	if err != nil {
+		ba.Error("解析 Bot 实例绑定失败", zap.Error(err), zap.String("robotID", robot.RobotID))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
+		return
+	}
+	// Persist before changing WuKongIM. If the external call fails, the same
+	// owner can retry; a server restart still restores the binding-scoped token.
+	if bound && robot.IMTokenCache != imToken {
+		if cacheErr := ba.db.updateRobotIMTokenCache(robot.RobotID, imToken); cacheErr != nil {
+			ba.Error("保存 Bot IM Token 失败", zap.Error(cacheErr), zap.String("robotID", robot.RobotID))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
+			return
+		}
+	}
 	resp, tokenErr := ba.ctx.UpdateIMToken(config.UpdateIMTokenReq{
 		UID:         robot.RobotID,
 		Token:       imToken,
@@ -70,13 +96,8 @@ func (ba *BotAPI) registerUserBot(c *wkhttp.Context, token string) {
 		httperr.ResponseErrorL(c, errcode.ErrBotAPIIMTokenFailed, nil, nil)
 		return
 	}
-	if robot.IMTokenCache != imToken {
-		ba.db.updateRobotIMTokenCache(robot.RobotID, imToken)
-	}
 
-	// Optional: parse agent version info
-	var req BotRegisterReq
-	_ = c.ShouldBindJSON(&req)
+	// Optional: persist agent version info.
 	if req.AgentPlatform != "" || req.AgentVersion != "" || req.PluginVersion != "" {
 		merged := struct{ platform, version, plugin string }{
 			platform: req.AgentPlatform,
@@ -122,7 +143,7 @@ func (ba *BotAPI) registerUserBot(c *wkhttp.Context, token string) {
 }
 
 // registerAppBot handles registration for App Bot (app_ token).
-func (ba *BotAPI) registerAppBot(c *wkhttp.Context, token string) {
+func (ba *BotAPI) registerAppBot(c *wkhttp.Context, token string, req BotRegisterReq) {
 	appBot, err := ba.db.queryAppBotByToken(token)
 	if err != nil {
 		ba.Error("查询App Bot失败", zap.Error(err))
@@ -140,12 +161,16 @@ func (ba *BotAPI) registerAppBot(c *wkhttp.Context, token string) {
 		return
 	}
 
-	// Design: App Bot uses the same token for API auth and IM WebSocket connection.
-	// This is intentional — simpler than managing two tokens, and the caller already
-	// possesses the token (used it to authenticate this request). Token rotation via
-	// the admin API invalidates both simultaneously. Tradeoff acknowledged:
-	// intercepting the WS connection reveals the API credential.
-	imToken := appBot.Token
+	imToken, _, err := ba.db.resolveRegistrationIMToken(token, botKindApp, appBot.UID, req.InstanceID)
+	if errors.Is(err, errBotInstanceConflict) {
+		respondBotAPIInstanceConflict(c)
+		return
+	}
+	if err != nil {
+		ba.Error("解析 App Bot 实例绑定失败", zap.Error(err), zap.String("uid", appBot.UID))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
+		return
+	}
 	resp, tokenErr := ba.ctx.UpdateIMToken(config.UpdateIMTokenReq{
 		UID:         appBot.UID,
 		Token:       imToken,

--- a/modules/bot_api/register_test.go
+++ b/modules/bot_api/register_test.go
@@ -1,0 +1,32 @@
+package bot_api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterRejectsMalformedBodyBeforeBotLookup(t *testing.T) {
+	ba := &BotAPI{}
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	r.POST("/v1/bot/register", ba.register)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/bot/register", strings.NewReader(`{"instance_id":`))
+	req.Header.Set("Authorization", "Bearer bf_test")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	var env errEnvelope
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &env))
+	require.Equal(t, "err.server.bot_api.request_invalid", env.Error.Code)
+	require.Equal(t, map[string]any{"field": "body"}, env.Error.Details)
+}

--- a/modules/bot_api/sql/20260903000001_bot_instance_binding.sql
+++ b/modules/bot_api/sql/20260903000001_bot_instance_binding.sql
@@ -1,0 +1,15 @@
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS bot_instance_binding (
+  token_fingerprint BINARY(32)   NOT NULL COMMENT 'SHA-256 of the Bot API token.',
+  bot_kind          VARCHAR(16)  NOT NULL COMMENT 'user or app.',
+  robot_id          VARCHAR(64)  NOT NULL,
+  instance_id       VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  im_token          VARCHAR(200) NOT NULL,
+  created_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (token_fingerprint),
+  KEY idx_bot_instance_binding_robot (robot_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- +migrate Down
+DROP TABLE IF EXISTS bot_instance_binding;

--- a/modules/bot_api/token_sync.go
+++ b/modules/bot_api/token_sync.go
@@ -1,0 +1,142 @@
+package bot_api
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/gocraft/dbr/v2"
+	"go.uber.org/zap"
+)
+
+func (ba *BotAPI) setIMToken(req config.UpdateIMTokenReq) (*config.UpdateIMTokenResp, error) {
+	if ba.updateIMToken != nil {
+		return ba.updateIMToken(req)
+	}
+	return ba.ctx.UpdateIMToken(req)
+}
+
+func (ba *BotAPI) installIMToken(uid, token string) error {
+	resp, err := ba.setIMToken(config.UpdateIMTokenReq{
+		UID:         uid,
+		Token:       token,
+		DeviceFlag:  config.APP,
+		DeviceLevel: config.DeviceLevelMaster,
+	})
+	if err != nil {
+		return err
+	}
+	if resp == nil || resp.Status != config.UpdateTokenStatusSuccess {
+		return fmt.Errorf("unexpected IM token update response: %#v", resp)
+	}
+	return nil
+}
+
+// matchingBinding returns the binding for this exact bot identity. An
+// inconsistent row is a conflict, never permission to install a caller-owned
+// credential.
+func (ba *BotAPI) matchingBinding(botToken, botKind, robotID string) (*botInstanceBinding, error) {
+	binding, err := ba.db.queryBotInstanceBinding(botBindingFingerprint(botToken))
+	if errors.Is(err, dbr.ErrNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if binding.BotKind != botKind || binding.RobotID != robotID {
+		return nil, errBotInstanceConflict
+	}
+	return binding, nil
+}
+
+// reconcileBindingAfterUnboundUpdate closes the race where a modern client
+// claims the token after a legacy registration's first lookup but before its
+// WuKongIM update. The owner's credential is restored before the legacy
+// request receives a conflict response.
+func (ba *BotAPI) reconcileBindingAfterUnboundUpdate(
+	botToken string,
+	botKind string,
+	robotID string,
+	installedToken string,
+) (bool, error) {
+	binding, err := ba.matchingBinding(botToken, botKind, robotID)
+	if err != nil {
+		return false, err
+	}
+	if binding == nil {
+		return false, nil
+	}
+	if binding.IMToken != installedToken {
+		if err := ba.installIMToken(robotID, binding.IMToken); err != nil {
+			return true, err
+		}
+	}
+	return true, nil
+}
+
+// resolveRobotSyncToken reads current robot state at push time instead of
+// trusting the startup snapshot. Once a binding exists, its IM token is the
+// sole restore credential; the raw Bot API token must never be reinstalled.
+func (ba *BotAPI) resolveRobotSyncToken(robotID string) (string, bool, error) {
+	robot, err := ba.db.queryRobotByRobotID(robotID)
+	if err != nil {
+		return "", false, err
+	}
+	if robot == nil || robot.Status != 1 || strings.TrimSpace(robot.BotToken) == "" {
+		return "", false, nil
+	}
+	binding, err := ba.matchingBinding(robot.BotToken, botKindUser, robot.RobotID)
+	if err != nil {
+		return "", false, err
+	}
+	if binding != nil {
+		return binding.IMToken, true, nil
+	}
+	if strings.TrimSpace(robot.IMTokenCache) != "" {
+		return robot.IMTokenCache, true, nil
+	}
+	return robot.BotToken, true, nil
+}
+
+func (ba *BotAPI) syncRobotIMToken(robotID string) error {
+	token, active, err := ba.resolveRobotSyncToken(robotID)
+	if err != nil || !active {
+		return err
+	}
+	if err := ba.installIMToken(robotID, token); err != nil {
+		return err
+	}
+
+	// A first claim or token rotation may have committed while the external
+	// update was in flight. Resolve once more and repair before declaring this
+	// robot synchronized; the latest database state stays authoritative.
+	latest, stillActive, err := ba.resolveRobotSyncToken(robotID)
+	if err != nil || !stillActive {
+		return err
+	}
+	if latest != token {
+		return ba.installIMToken(robotID, latest)
+	}
+	return nil
+}
+
+// syncAllBotTokens restores User Bot credentials after WuKongIM/server
+// restarts. This lives in bot_api because binding ownership is authoritative
+// here; BotFather must not independently restore a raw bearer token.
+func (ba *BotAPI) syncAllBotTokens() {
+	robots, err := ba.db.queryAllActiveRobots()
+	if err != nil {
+		ba.Error("同步 bot token 失败: 查询 robot 出错", zap.Error(err))
+		return
+	}
+	successCount := 0
+	for _, robot := range robots {
+		if err := ba.syncRobotIMToken(robot.RobotID); err != nil {
+			ba.Warn("同步 bot token 失败", zap.String("robotID", robot.RobotID), zap.Error(err))
+			continue
+		}
+		successCount++
+	}
+	ba.Info("Bot token 启动同步完成", zap.Int("total", len(robots)), zap.Int("success", successCount))
+}

--- a/modules/bot_api/token_sync_test.go
+++ b/modules/bot_api/token_sync_test.go
@@ -1,0 +1,101 @@
+package bot_api
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/stretchr/testify/require"
+)
+
+func robotSyncRows(robotID, botToken, imTokenCache string) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"robot_id", "bot_token", "im_token_cache", "status"}).
+		AddRow(robotID, botToken, imTokenCache, 1)
+}
+
+func successfulTokenRecorder(tokens *[]string) func(config.UpdateIMTokenReq) (*config.UpdateIMTokenResp, error) {
+	return func(req config.UpdateIMTokenReq) (*config.UpdateIMTokenResp, error) {
+		*tokens = append(*tokens, req.Token)
+		return &config.UpdateIMTokenResp{Status: config.UpdateTokenStatusSuccess}, nil
+	}
+}
+
+func TestResolveRobotSyncTokenPrefersBindingOverLegacyState(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		cachedToken string
+	}{
+		{name: "raw token cache", cachedToken: "bf_token"},
+		{name: "empty cache after disconnect", cachedToken: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, mock, closer := newSqlmockBotAPIDB(t)
+			defer closer()
+
+			const (
+				robotID  = "bot_1"
+				botToken = "bf_token"
+			)
+			mock.ExpectQuery("SELECT .* FROM robot").
+				WillReturnRows(robotSyncRows(robotID, botToken, tc.cachedToken))
+			mock.ExpectQuery("SELECT .* FROM bot_instance_binding").
+				WillReturnRows(bindingRows(botBindingFingerprint(botToken), botKindUser, robotID,
+					"550e8400-e29b-41d4-a716-446655440000", "im_bound"))
+
+			ba := &BotAPI{db: d}
+			token, active, err := ba.resolveRobotSyncToken(robotID)
+			require.NoError(t, err)
+			require.True(t, active)
+			require.Equal(t, "im_bound", token)
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestSyncRobotIMTokenRepairsBindingClaimedDuringPush(t *testing.T) {
+	d, mock, closer := newSqlmockBotAPIDB(t)
+	defer closer()
+
+	const (
+		robotID  = "bot_1"
+		botToken = "bf_token"
+	)
+	// First resolution sees the legacy state.
+	mock.ExpectQuery("SELECT .* FROM robot").
+		WillReturnRows(robotSyncRows(robotID, botToken, botToken))
+	mock.ExpectQuery("SELECT .* FROM bot_instance_binding").
+		WillReturnRows(sqlmock.NewRows([]string{"token_fingerprint", "bot_kind", "robot_id", "instance_id", "im_token"}))
+	// The post-update resolution observes a concurrently committed first claim.
+	mock.ExpectQuery("SELECT .* FROM robot").
+		WillReturnRows(robotSyncRows(robotID, botToken, "im_bound"))
+	mock.ExpectQuery("SELECT .* FROM bot_instance_binding").
+		WillReturnRows(bindingRows(botBindingFingerprint(botToken), botKindUser, robotID,
+			"550e8400-e29b-41d4-a716-446655440000", "im_bound"))
+
+	var installed []string
+	ba := &BotAPI{db: d, updateIMToken: successfulTokenRecorder(&installed)}
+	require.NoError(t, ba.syncRobotIMToken(robotID))
+	require.Equal(t, []string{botToken, "im_bound"}, installed)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestReconcileBindingAfterUnboundUpdateRepairsAndConflicts(t *testing.T) {
+	d, mock, closer := newSqlmockBotAPIDB(t)
+	defer closer()
+
+	const (
+		robotID  = "bot_1"
+		botToken = "bf_token"
+	)
+	mock.ExpectQuery("SELECT .* FROM bot_instance_binding").
+		WillReturnRows(bindingRows(botBindingFingerprint(botToken), botKindUser, robotID,
+			"550e8400-e29b-41d4-a716-446655440000", "im_bound"))
+
+	var installed []string
+	ba := &BotAPI{db: d, updateIMToken: successfulTokenRecorder(&installed)}
+	conflict, err := ba.reconcileBindingAfterUnboundUpdate(botToken, botKindUser, robotID, botToken)
+	require.NoError(t, err)
+	require.True(t, conflict)
+	require.Equal(t, []string{"im_bound"}, installed)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/modules/botfather/api.go
+++ b/modules/botfather/api.go
@@ -86,10 +86,6 @@ func (bf *BotFather) Route(r *wkhttp.WKHttp) {
 	// BotFather now only handles: documentation, User Bot management (BotFather commands),
 	// User API Key endpoints, and Robot Apply endpoints.
 
-	// 启动时批量同步所有 bot 的 token 到 WuKongIM（防止 WuKongIM 重启后 token 丢失）
-	// TODO: Move to bot_api module after confirming no startup ordering issue.
-	go bf.syncAllBotTokens()
-
 	// 文档端点（无需认证）
 	r.GET("/v1/bot/skill.md", bf.skillMD)
 	r.GET("/v1/bot/cli-guide.md", bf.cliGuideMD)
@@ -430,35 +426,4 @@ func extractBotToken(c *wkhttp.Context) string {
 		return strings.TrimPrefix(auth, "Bearer ")
 	}
 	return ""
-}
-
-// syncAllBotTokens 启动时将所有活跃 bot 的 token 同步到 WuKongIM
-// 使用旧 im_token_cache（兼容未重启的 adapter），新 register 后会切换到 bot_token
-func (bf *BotFather) syncAllBotTokens() {
-	robots, err := bf.db.queryAllActiveRobots()
-	if err != nil {
-		bf.Error("同步 bot token 失败: 查询 robot 出错", zap.Error(err))
-		return
-	}
-	successCount := 0
-	for _, robot := range robots {
-		// 优先用旧 im_token_cache（兼容还没 re-register 的旧 adapter）
-		// 旧 adapter 下次 register 后会自动切换到 bot_token
-		token := robot.IMTokenCache
-		if strings.TrimSpace(token) == "" {
-			token = robot.BotToken
-		}
-		resp, tokenErr := bf.ctx.UpdateIMToken(config.UpdateIMTokenReq{
-			UID:         robot.RobotID,
-			Token:       token,
-			DeviceFlag:  config.APP,
-			DeviceLevel: config.DeviceLevelMaster,
-		})
-		if tokenErr != nil || resp.Status != config.UpdateTokenStatusSuccess {
-			bf.Warn("同步 bot token 失败", zap.String("robotID", robot.RobotID), zap.Any("error", tokenErr), zap.Any("status", resp))
-			continue
-		}
-		successCount++
-	}
-	bf.Info("Bot token 启动同步完成", zap.Int("total", len(robots)), zap.Int("success", successCount))
 }

--- a/modules/botfather/db.go
+++ b/modules/botfather/db.go
@@ -318,7 +318,8 @@ func (d *botfatherDB) updateRobotIMTokenCache(robotID string, imToken string) er
 // updateRobotBotToken 重置机器人的Bot Token
 func (d *botfatherDB) updateRobotBotToken(robotID string, newToken string) error {
 	_, err := d.session.Update("robot").SetMap(map[string]interface{}{
-		"bot_token": newToken,
+		"bot_token":      newToken,
+		"im_token_cache": "",
 	}).Where("robot_id=?", robotID).Exec()
 	return err
 }

--- a/modules/robot/db.go
+++ b/modules/robot/db.go
@@ -134,7 +134,8 @@ func (d *robotDB) queryRobotByBotToken(botToken string) (*robot, error) {
 // updateRobotBotToken 重置机器人的Bot Token
 func (d *robotDB) updateRobotBotToken(robotID string, newToken string) error {
 	_, err := d.session.Update("robot").SetMap(map[string]interface{}{
-		"bot_token": newToken,
+		"bot_token":      newToken,
+		"im_token_cache": "",
 	}).Where("robot_id=?", robotID).Exec()
 	return err
 }

--- a/pkg/errcode/bot_api.go
+++ b/pkg/errcode/bot_api.go
@@ -274,6 +274,13 @@ var (
 		HTTPStatus:     http.StatusConflict,
 		DefaultMessage: "The message has not finished delivering; please retry.",
 	})
+	// ErrBotAPIInstanceConflict means this Bot Token was already claimed by a
+	// different OpenClaw installation. The owning instance ID stays private.
+	ErrBotAPIInstanceConflict = register(codes.Code{
+		ID:             "err.server.bot_api.instance_conflict",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "This Bot Token is already bound to another OpenClaw instance.",
+	})
 
 	// ---- bot auth (401, anti-enumeration) ------------------------------------
 

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -1192,6 +1192,9 @@ other = "OBO 授权范围已存在。"
 ["err.server.bot_api.message_not_delivered"]
 other = "消息尚未投递完成，请稍后重试。"
 
+["err.server.bot_api.instance_conflict"]
+other = "该 Bot Token 已绑定到另一个 OpenClaw 实例。"
+
 ["err.server.bot_api.auth_failed"]
 other = "机器人认证失败。"
 

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -117,6 +117,9 @@ other = "Group not found."
 ["err.server.bot_api.im_token_failed"]
 other = "Failed to obtain an IM token."
 
+["err.server.bot_api.instance_conflict"]
+other = "This Bot Token is already bound to another OpenClaw instance."
+
 ["err.server.bot_api.limit_exceeded"]
 other = "The request exceeds the maximum allowed items."
 


### PR DESCRIPTION
## Summary

Bind each Bot Token permanently to the first OpenClaw installation that registers it. Later installations receive a real HTTP 409 before any WebSocket credential is issued.

## Related Issue

Closes Mininglamp-OSS/openclaw-channel-octo#233

Plugin counterpart: Mininglamp-OSS/openclaw-channel-octo#234

## Linked Spec

`.octospec/tasks/bot-token-single-binding/brief.md`

## Changes

- Add a first-writer-wins `bot_instance_binding` table keyed by the full SHA-256 fingerprint of the Bot Token.
- Accept a UUID v4 `instance_id` during User Bot and App Bot registration; make registration idempotent for the owning instance and reject every other or legacy instance after binding.
- Issue a binding-specific random IM token so rejected clients cannot continue by using the Bot API token as a WebSocket credential.
- Move User Bot startup restoration into the Bot API module, make the binding row authoritative even when `im_token_cache` is empty, and re-read current state before and after each WuKongIM update so a concurrent first claim or token rotation is repaired.
- Reconcile both User Bot and App Bot legacy registration after their WuKongIM update. If a first claim raced the legacy request, restore the owner's bound credential and return HTTP 409.
- Reject malformed JSON bodies instead of silently downgrading them to legacy registration, while preserving the existing empty-body legacy request.
- Abort the handler chain after rendering the localized binding conflict.
- Clear the cached User Bot IM token when its Bot Token rotates.

## Scope

- No time-based lease or automatic expiry.
- No REST-wide `instance_id` enforcement; ownership is enforced on registration and therefore on the WebSocket credential used to receive messages.
- No unbind endpoint. Rotating the Bot Token is the explicit transfer/recovery mechanism.
- App Bots keep their existing restart behavior: they re-register to restore their persisted binding credential. No startup path currently writes an App Bot's raw token.

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified against a running MySQL/Redis/WuKongIM stack
- `go test ./modules/bot_api -run 'Test(ValidInstanceID|BotTokenFingerprintDoesNotContainRawToken|ResolveRegistrationIMToken|BotInstanceBindingMigrationPinsAtomicOwnership|RespondBotAPIHelpers|RespondBotAPIInstanceConflictAbortsHandlerChain|ResolveRobotSyncToken|SyncRobotIMToken|ReconcileBinding|RegisterRejectsMalformedBody)'`
- `go vet ./modules/bot_api`
- `make i18n-extract-check`
- `make i18n-lint`

The broader DB-backed suite requires the local MySQL/Redis/WuKongIM test environment; MySQL was not available at `127.0.0.1:3306` in this workspace. This sparse checkout also cannot run `go build ./...` because unrelated module directories are intentionally absent.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**

   Registration atomically claims a Bot Token fingerprint for a stable OpenClaw UUID. The winning instance receives a persistent, separate IM credential; the same instance can register again, while a different or missing instance ID receives `err.server.bot_api.instance_conflict` with HTTP 409. Startup restore and legacy registration re-check the binding around external WuKongIM updates so they cannot leave the raw bearer token active after a claim.

2. **What could break because of it (dependents + failure mode)?**

   Once a modern client claims a token, older clients that omit `instance_id` are intentionally rejected. A mixed old/new server deployment remains unsafe because an old binary has no binding-aware reconciliation. Release/upgrade `openclaw-channel-octo` first, then deploy this server change without leaving old and new server binaries active together. Operators must rotate the Bot Token to transfer ownership after losing the persisted instance ID.

3. **How do you know it works (specific test/repro/trace)?**

   SQL-mock tests cover first claim, same-instance idempotency, second-instance rejection, legacy transition, binding precedence when the cache is empty after disconnect, startup claim-vs-push repair, and legacy registration claim-vs-push repair. Additional tests pin UUID validation, full token hashing, migration uniqueness, malformed-body rejection, localized real-409 rendering, and handler-chain abort behavior. The affected package passes focused tests and `go vet`; i18n extraction and linting also pass.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
