### PR TITLE
feat(bot-task): add generic task ingress

### DIFF
--- a/.octospec/tasks/bot-task/brief.md
+++ b/.octospec/tasks/bot-task/brief.md
@@ -1,0 +1,49 @@
+---
+type: Task
+title: "Task: bot-task"
+description: Add a source-authenticated, idempotent generic Bot Task ingress and bot event contract
+tags: [bot-task, bot-api, wire-contract, auth]
+timestamp: 2026-09-06T00:00:00Z
+slug: bot-task
+upstream: Loop comment Bot mentions
+source: self
+---
+
+# Task: bot-task
+
+## Goal
+
+Add `POST /v1/internal/bot-tasks` so trusted business backends can deliver a
+complete prompt to a target User Bot. The server authenticates the configured
+source, validates and deduplicates the request, and atomically enqueues one
+fixed `bot_task` event for the existing Bot Event poller.
+
+The transport is business-neutral: `source` and `task_type` are opaque
+observability fields. The server does not interpret Loop, Doc, profiles,
+capabilities, or execution steps.
+
+## Load-bearing list
+
+- Source authentication is fail-closed and uses constant-time token checks.
+- Only active robots may receive tasks; per-source Bot allowlists are enforced.
+- Idempotency scope is `(source, bot_uid, idempotency_key)` and stores a request fingerprint.
+- Claim completion and Bot Event queue insertion are one atomic Redis operation.
+- The wire event type is always `bot_task`.
+- New error paths use localized error envelopes with real HTTP status codes.
+- Prompt and structured JSON input are bounded at the ingress trust boundary.
+
+## Out of scope
+
+- Business-specific prompt generation or task execution.
+- `execution`, `profile`, `capabilities`, and `steps` fields.
+- ACK result payload changes or migration of `doc_comment_mention`.
+- Loop write-operation idempotency.
+
+## Acceptance
+
+- A configured source can create a task and receives HTTP 202.
+- Same-key/same-request replay receives HTTP 200 without another event.
+- Same-key/different-request receives HTTP 409.
+- Invalid sources, disallowed/nonexistent Bots, malformed and oversize payloads are rejected.
+- The queued event is `bot_task` and preserves the validated generic payload.
+- Existing Bot Event types and the Doc Mention ingress remain unchanged.

--- a/docs/bot-events-longpoll.md
+++ b/docs/bot-events-longpoll.md
@@ -33,6 +33,28 @@ error, so there is no 408 and no error envelope.
 The server always **reads before waiting**: a caller with a backlog is answered
 immediately, whatever `wait` it sent.
 
+### Generic Bot Task events
+
+Trusted business systems create tasks through `POST /v1/internal/bot-tasks`.
+Consumers receive one fixed event type, `bot_task`, whose `event_data` contains:
+
+| Field | Meaning |
+|---|---|
+| `source` | Opaque source identifier configured by the producer. |
+| `task_type` | Opaque business task type. |
+| `idempotency_key` | Producer-supplied key, scoped by source and target Bot. |
+| `bot_uid` | Target User Bot. |
+| `actor_uid` | User who initiated the task. |
+| `session_key` | Stable business-thread session key. |
+| `prompt` | Complete execution prompt supplied by the business system. |
+| `context` | Opaque JSON object used by the prompt. |
+| `metadata` | Optional opaque JSON object. |
+| `enqueued_at` | Server enqueue time in Unix seconds. |
+
+The transport does not interpret profiles, capabilities, execution steps, or
+business-specific fields. Consumers ACK the event only after it reaches their
+terminal processing state.
+
 ## How the wake-up works
 
 Every producer that ZADDs into `robotEvent:{robotID}` also rings a per-bot

--- a/internal/modules.go
+++ b/internal/modules.go
@@ -30,6 +30,7 @@ import (
 	_ "github.com/Mininglamp-OSS/octo-server/modules/robot"
 
 	_ "github.com/Mininglamp-OSS/octo-server/modules/bot_mention"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/bot_task"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/botfather"
 
 	_ "github.com/Mininglamp-OSS/octo-server/modules/card_template_catalog"

--- a/modules/bot_task/1module.go
+++ b/modules/bot_task/1module.go
@@ -1,0 +1,15 @@
+package bot_task
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
+)
+
+func init() {
+	register.AddModule(func(ctx interface{}) register.Module {
+		return register.Module{
+			Name:     "bot_task",
+			SetupAPI: func() register.APIRouter { return New(ctx.(*config.Context)) },
+		}
+	})
+}

--- a/modules/bot_task/README.md
+++ b/modules/bot_task/README.md
@@ -22,6 +22,18 @@ registry disables ingress. `allowed_bot_uids` should list explicit Bot IDs;
 `"*"` permits that source to address every active Bot across all Spaces and
 should only be used in controlled development environments.
 
-The endpoint is protected by a strict per-IP rate limit. Defaults are 20
-requests/second with a burst of 60 and can be changed with
-`DM_BOT_TASK_IP_RPS` and `DM_BOT_TASK_IP_BURST`.
+The endpoint authenticates the bearer token before reading the request body.
+The authenticated source must match the body `source`; one source cannot spend
+another source's quota or submit tasks under its name.
+
+Two rate-limit layers protect the endpoint:
+
+- A strict per-IP floor defaults to 100 requests/second with a burst of 200.
+  Configure it with `DM_BOT_TASK_IP_RPS` and `DM_BOT_TASK_IP_BURST`.
+- A Redis-backed per-source quota defaults to 20 requests/second with a burst
+  of 60. Configure it with `DM_BOT_TASK_SOURCE_RPS` and
+  `DM_BOT_TASK_SOURCE_BURST`.
+
+Each process also keeps the same per-source token bucket locally. It remains
+active when Redis is unavailable, so a Redis outage degrades cluster-wide
+coordination without making the authenticated ingress unbounded.

--- a/modules/bot_task/README.md
+++ b/modules/bot_task/README.md
@@ -1,0 +1,27 @@
+# Generic Bot Task ingress
+
+`POST /v1/internal/bot-tasks` accepts source-authenticated work for an active
+User Bot and enqueues the fixed `bot_task` event consumed by Octo channel
+plugins. The server treats `source`, `task_type`, `prompt`, `context`, and
+`metadata` as business-neutral transport data.
+
+Configure sources with `OCTO_BOT_TASK_SOURCES`:
+
+```json
+{
+  "loop": {
+    "token": "<redacted>",
+    "enabled": true,
+    "allowed_bot_uids": ["bot-uid"]
+  }
+}
+```
+
+Each source must have a unique token of at least 32 bytes. An empty or invalid
+registry disables ingress. `allowed_bot_uids` should list explicit Bot IDs;
+`"*"` permits that source to address every active Bot across all Spaces and
+should only be used in controlled development environments.
+
+The endpoint is protected by a strict per-IP rate limit. Defaults are 20
+requests/second with a burst of 60 and can be changed with
+`DM_BOT_TASK_IP_RPS` and `DM_BOT_TASK_IP_BURST`.

--- a/modules/bot_task/api.go
+++ b/modules/bot_task/api.go
@@ -1,0 +1,214 @@
+package bot_task
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/robot"
+	"github.com/Mininglamp-OSS/octo-server/pkg/botevent"
+	"github.com/Mininglamp-OSS/octo-server/pkg/ratelimit"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
+	"go.uber.org/zap"
+)
+
+type robotService interface {
+	ExistRobot(uid string) (bool, error)
+	PrepareBotTypedEvent(robotID, eventType string, eventData map[string]interface{}) (robot.PreparedBotTypedEvent, error)
+}
+type claimService interface {
+	Lookup(key, sha string) (claimOutcome, error)
+	Begin(key, sha string) (claimOutcome, *claimLease, error)
+	Commit(lease *claimLease, event robot.PreparedBotTypedEvent) (bool, error)
+	Release(lease *claimLease) (bool, error)
+}
+type BotTask struct {
+	ctx            *config.Context
+	robots         robotService
+	claims         claimService
+	sources        sourceRegistry
+	now            func() time.Time
+	notifyBotEvent func(robotID string)
+	log.Log
+}
+type ingressResponse struct {
+	Accepted bool  `json:"accepted"`
+	Replay   bool  `json:"replay"`
+	EventID  int64 `json:"event_id,omitempty"`
+}
+
+func New(ctx *config.Context) *BotTask {
+	logger := log.NewTLog("BotTask")
+	sources, err := sourceRegistryFromEnv()
+	if err != nil {
+		logger.Error(err.Error())
+	}
+	return &BotTask{
+		ctx: ctx, robots: robot.NewService(ctx), claims: newRedisClaimStore(ctx), sources: sources, now: time.Now,
+		notifyBotEvent: func(robotID string) { botevent.Notify(ctx.GetConfig(), robotID) }, Log: logger,
+	}
+}
+func (m *BotTask) Route(r *wkhttp.WKHttp) {
+	rlRedis := octoredis.NewInstrumentedClient(m.ctx.GetConfig(), func(options *rd.Options) {
+		options.MaxRetries = 1
+		options.PoolSize = 10
+	})
+	rps := ratelimit.SanitizeRPS(wkhttp.ParseRPSFromEnv("DM_BOT_TASK_IP_RPS", 20), 20)
+	burst := ratelimit.SanitizeBurst(wkhttp.ParseBurstFromEnv("DM_BOT_TASK_IP_BURST", 60), 60)
+	ipLimit := r.StrictIPRateLimitMiddleware(context.Background(), rlRedis, "internal_bot_task", rps, burst)
+	// This service-to-service ingress uses the per-source bearer token below
+	// instead of end-user AuthMiddleware and does not access Space-scoped data.
+	r.Group("/v1/internal").POST("/bot-tasks", ipLimit, m.create)
+}
+
+func (m *BotTask) create(c *wkhttp.Context) {
+	request, err := decodeTaskRequest(c)
+	if err != nil {
+		respondInvalid(c, "body")
+		return
+	}
+	request.Source = strings.TrimSpace(request.Source)
+	source, ok := m.sources[request.Source]
+	if !ok || !source.Enabled || !validBearerToken(c.GetHeader("Authorization"), source.Token) {
+		respondUnauthorized(c)
+		return
+	}
+	task, err := normalizeTaskRequest(request)
+	if err != nil {
+		respondInvalid(c, invalidField(err))
+		return
+	}
+	if !source.allowsBot(task.BotUID) {
+		respondForbidden(c)
+		return
+	}
+
+	claimKey := taskClaimKey(task.Source, task.BotUID, task.IdempotencyKey)
+	fingerprint := taskFingerprint(task)
+	existing, err := m.claims.Lookup(claimKey, fingerprint)
+	if err != nil {
+		m.Error("bot task idempotency lookup failed", zap.Error(err), zap.String("idempotency_hash", claimLogHash(claimKey)))
+		respondStoreFailed(c)
+		return
+	}
+	if m.respondClaimOutcome(c, existing) {
+		return
+	}
+
+	exists, err := m.robots.ExistRobot(task.BotUID)
+	if err != nil {
+		m.Error("bot task robot lookup failed", zap.Error(err), zap.String("bot_uid", task.BotUID))
+		respondStoreFailed(c)
+		return
+	}
+	if !exists {
+		respondNotFound(c)
+		return
+	}
+
+	outcome, lease, err := m.claims.Begin(claimKey, fingerprint)
+	if err != nil {
+		m.Error("bot task idempotency claim failed", zap.Error(err), zap.String("idempotency_hash", claimLogHash(claimKey)))
+		respondStoreFailed(c)
+		return
+	}
+	if m.respondClaimOutcome(c, outcome) {
+		return
+	}
+	if outcome.State != claimAcquired || lease == nil {
+		respondStoreFailed(c)
+		return
+	}
+
+	prepared, err := m.robots.PrepareBotTypedEvent(task.BotUID, botTaskEventType, taskEventData(task, m.now().Unix()))
+	if err != nil {
+		if released, releaseErr := m.claims.Release(lease); releaseErr != nil || !released {
+			m.Warn("bot task claim release failed", zap.NamedError("release_error", releaseErr), zap.Bool("released", released), zap.String("idempotency_hash", claimLogHash(claimKey)))
+		}
+		m.Error("bot task event preparation failed", zap.Error(err), zap.String("bot_uid", task.BotUID))
+		respondStoreFailed(c)
+		return
+	}
+	committed, commitErr := m.claims.Commit(lease, prepared)
+	if commitErr != nil || !committed {
+		current, lookupErr := m.claims.Lookup(claimKey, fingerprint)
+		if lookupErr == nil && m.respondClaimOutcome(c, current) {
+			if current.State == claimReplay {
+				m.notify(task.BotUID)
+			}
+			return
+		}
+		m.Error("bot task atomic enqueue failed", zap.NamedError("commit_error", commitErr), zap.NamedError("lookup_error", lookupErr), zap.Int64("event_id", prepared.EventID))
+		respondStoreFailed(c)
+		return
+	}
+
+	m.notify(task.BotUID)
+	m.Info("bot task ingress completed", zap.Int64("event_id", prepared.EventID), zap.String("source", task.Source), zap.String("task_type", task.TaskType), zap.String("bot_uid", task.BotUID), zap.String("idempotency_hash", claimLogHash(claimKey)))
+	c.ResponseWithStatus(http.StatusAccepted, ingressResponse{Accepted: true, Replay: false, EventID: prepared.EventID})
+}
+
+func decodeTaskRequest(c *wkhttp.Context) (taskRequest, error) {
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxRequestBodyBytes)
+	decoder := json.NewDecoder(c.Request.Body)
+	decoder.DisallowUnknownFields()
+	var request taskRequest
+	if err := decoder.Decode(&request); err != nil {
+		return taskRequest{}, err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return taskRequest{}, errors.New("bot task request contains multiple JSON values")
+		}
+		return taskRequest{}, err
+	}
+	return request, nil
+}
+func validBearerToken(header, expected string) bool {
+	const prefix = "Bearer "
+	if !strings.HasPrefix(header, prefix) || expected == "" {
+		return false
+	}
+	actual := strings.TrimSpace(strings.TrimPrefix(header, prefix))
+	return subtle.ConstantTimeCompare([]byte(actual), []byte(expected)) == 1
+}
+func taskEventData(task normalizedTask, enqueuedAt int64) map[string]interface{} {
+	data := map[string]interface{}{
+		"source": task.Source, "task_type": task.TaskType, "idempotency_key": task.IdempotencyKey,
+		"bot_uid": task.BotUID, "actor_uid": task.ActorUID, "session_key": task.SessionKey,
+		"prompt": task.Prompt, "context": json.RawMessage(task.Context), "enqueued_at": enqueuedAt,
+	}
+	if len(task.Metadata) > 0 {
+		data["metadata"] = json.RawMessage(task.Metadata)
+	}
+	return data
+}
+func (m *BotTask) respondClaimOutcome(c *wkhttp.Context, outcome claimOutcome) bool {
+	switch outcome.State {
+	case claimMissing, claimAcquired:
+		return false
+	case claimPending:
+		respondInProgress(c)
+	case claimReplay:
+		c.Response(ingressResponse{Accepted: true, Replay: true, EventID: outcome.EventID})
+	case claimConflict:
+		respondConflict(c)
+	default:
+		respondStoreFailed(c)
+	}
+	return true
+}
+func (m *BotTask) notify(botUID string) {
+	if m.notifyBotEvent != nil {
+		m.notifyBotEvent(botUID)
+	}
+}

--- a/modules/bot_task/api.go
+++ b/modules/bot_task/api.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"crypto/subtle"
 	"encoding/json"
-	"errors"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -165,12 +163,10 @@ func decodeTaskRequest(c *wkhttp.Context) (taskRequest, error) {
 	if err := decoder.Decode(&request); err != nil {
 		return taskRequest{}, err
 	}
-	if err := decoder.Decode(&struct{}{}); err != io.EOF {
-		if err == nil {
-			return taskRequest{}, errors.New("bot task request contains multiple JSON values")
-		}
-		return taskRequest{}, err
-	}
+	// Do not probe the socket for a trailing JSON value here. MaxBytesReader
+	// bounds bytes, not time, so a client that sends one complete object without
+	// terminating the request body would otherwise pin this unauthenticated
+	// handler indefinitely. This matches the other HTTP ingresses in this repo.
 	return request, nil
 }
 func validBearerToken(header, expected string) bool {

--- a/modules/bot_task/api.go
+++ b/modules/bot_task/api.go
@@ -1,10 +1,14 @@
 package bot_task
 
 import (
+	"bytes"
 	"context"
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -36,6 +40,8 @@ type BotTask struct {
 	sources        sourceRegistry
 	now            func() time.Time
 	notifyBotEvent func(robotID string)
+	sourceLimiter  *ratelimit.Limiter
+	sourceFloor    *sourceLocalFloor
 	log.Log
 }
 type ingressResponse struct {
@@ -60,26 +66,50 @@ func (m *BotTask) Route(r *wkhttp.WKHttp) {
 		options.MaxRetries = 1
 		options.PoolSize = 10
 	})
-	rps := ratelimit.SanitizeRPS(wkhttp.ParseRPSFromEnv("DM_BOT_TASK_IP_RPS", 20), 20)
-	burst := ratelimit.SanitizeBurst(wkhttp.ParseBurstFromEnv("DM_BOT_TASK_IP_BURST", 60), 60)
+	rps := ratelimit.SanitizeRPS(wkhttp.ParseRPSFromEnv("DM_BOT_TASK_IP_RPS", 100), 100)
+	burst := ratelimit.SanitizeBurst(wkhttp.ParseBurstFromEnv("DM_BOT_TASK_IP_BURST", 200), 200)
 	ipLimit := r.StrictIPRateLimitMiddleware(context.Background(), rlRedis, "internal_bot_task", rps, burst)
+	sourceRPS := ratelimit.SanitizeRPS(wkhttp.ParseRPSFromEnv("DM_BOT_TASK_SOURCE_RPS", 20), 20)
+	sourceBurst := ratelimit.SanitizeBurst(wkhttp.ParseBurstFromEnv("DM_BOT_TASK_SOURCE_BURST", 60), 60)
+	m.sourceLimiter = ratelimit.New(
+		rlRedis,
+		"ratelimit:bot_task_source:",
+		"bot_task_source",
+		func() ratelimit.Params {
+			return ratelimit.Params{Enabled: true, RPS: sourceRPS, Burst: sourceBurst}
+		},
+		nil,
+		ratelimit.Params{Enabled: true, RPS: 20, Burst: 60},
+	)
+	m.sourceFloor = newSourceLocalFloor(m.sources, sourceRPS, sourceBurst)
 	// This service-to-service ingress uses the per-source bearer token below
 	// instead of end-user AuthMiddleware and does not access Space-scoped data.
-	r.Group("/v1/internal").POST("/bot-tasks", ipLimit, m.create)
+	r.Group("/v1/internal").POST(
+		"/bot-tasks",
+		ipLimit,
+		m.sourceAuthMiddleware(),
+		m.sourceRateLimitMiddleware(),
+		m.create,
+	)
 }
 
 func (m *BotTask) create(c *wkhttp.Context) {
+	authenticatedSource, ok := authenticatedTaskSource(c)
+	if !ok {
+		respondUnauthorized(c)
+		return
+	}
 	request, err := decodeTaskRequest(c)
 	if err != nil {
 		respondInvalid(c, "body")
 		return
 	}
 	request.Source = strings.TrimSpace(request.Source)
-	source, ok := m.sources[request.Source]
-	if !ok || !source.Enabled || !validBearerToken(c.GetHeader("Authorization"), source.Token) {
+	if request.Source != authenticatedSource {
 		respondUnauthorized(c)
 		return
 	}
+	source := m.sources[authenticatedSource]
 	task, err := normalizeTaskRequest(request)
 	if err != nil {
 		respondInvalid(c, invalidField(err))
@@ -163,11 +193,78 @@ func decodeTaskRequest(c *wkhttp.Context) (taskRequest, error) {
 	if err := decoder.Decode(&request); err != nil {
 		return taskRequest{}, err
 	}
-	// Do not probe the socket for a trailing JSON value here. MaxBytesReader
-	// bounds bytes, not time, so a client that sends one complete object without
-	// terminating the request body would otherwise pin this unauthenticated
-	// handler indefinitely. This matches the other HTTP ingresses in this repo.
+	// Inspect only bytes the decoder already buffered. Reading decoder.Buffered
+	// cannot wait on the socket, so a complete object still returns promptly,
+	// while an already-received second value or oversized tail is rejected.
+	trailing, err := io.ReadAll(decoder.Buffered())
+	if err != nil {
+		return taskRequest{}, err
+	}
+	if len(bytes.TrimSpace(trailing)) > 0 {
+		return taskRequest{}, errors.New("bot task request contains trailing data")
+	}
 	return request, nil
+}
+
+const authenticatedTaskSourceKey = "bot_task_source"
+
+func (m *BotTask) sourceAuthMiddleware() wkhttp.HandlerFunc {
+	return func(c *wkhttp.Context) {
+		header := c.GetHeader("Authorization")
+		authenticatedSource := ""
+		for source, cfg := range m.sources {
+			if cfg.Enabled && validBearerToken(header, cfg.Token) {
+				authenticatedSource = source
+			}
+		}
+		if authenticatedSource == "" {
+			respondUnauthorized(c)
+			c.Abort()
+			return
+		}
+		c.Set(authenticatedTaskSourceKey, authenticatedSource)
+		c.Next()
+	}
+}
+
+func authenticatedTaskSource(c *wkhttp.Context) (string, bool) {
+	value, ok := c.Get(authenticatedTaskSourceKey)
+	source, typeOK := value.(string)
+	return source, ok && typeOK && source != ""
+}
+
+func (m *BotTask) sourceRateLimitMiddleware() wkhttp.HandlerFunc {
+	return func(c *wkhttp.Context) {
+		source, ok := authenticatedTaskSource(c)
+		if !ok {
+			respondUnauthorized(c)
+			c.Abort()
+			return
+		}
+		if m.sourceFloor != nil && !m.sourceFloor.Allow(source) {
+			c.Header("Retry-After", "1")
+			respondRateLimited(c)
+			c.Abort()
+			return
+		}
+		if m.sourceLimiter != nil {
+			result := m.sourceLimiter.Check(source)
+			if result.ShouldSetHeaders() {
+				c.Header("X-RateLimit-Limit", strconv.Itoa(result.Burst))
+				c.Header("X-RateLimit-Remaining", strconv.Itoa(result.Remaining))
+				c.Header("X-RateLimit-Scope", "source")
+				if result.RetryAfter > 0 {
+					c.Header("Retry-After", strconv.Itoa(result.RetryAfter))
+				}
+			}
+			if result.ShouldReject() {
+				respondRateLimited(c)
+				c.Abort()
+				return
+			}
+		}
+		c.Next()
+	}
 }
 func validBearerToken(header, expected string) bool {
 	const prefix = "Bearer "

--- a/modules/bot_task/api_i18n.go
+++ b/modules/bot_task/api_i18n.go
@@ -1,0 +1,38 @@
+package bot_task
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+func respondUnauthorized(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedTokenInvalid, nil, nil)
+}
+func respondInvalid(c *wkhttp.Context, field string) {
+	var details i18n.Details
+	if field != "" {
+		details = i18n.Details{"field": field}
+	}
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedParamInvalid, nil, details)
+}
+func respondNotFound(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedNotFound, nil, nil)
+}
+func respondForbidden(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrBotTaskForbidden, nil, nil)
+}
+func respondInProgress(c *wkhttp.Context) {
+	c.Header("Retry-After", strconv.Itoa(int(claimRetryAfter/time.Second)))
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrBotTaskInProgress, nil, nil)
+}
+func respondConflict(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrBotTaskIdempotencyConflict, nil, nil)
+}
+func respondStoreFailed(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrBotTaskStoreFailed, nil, nil)
+}

--- a/modules/bot_task/api_i18n.go
+++ b/modules/bot_task/api_i18n.go
@@ -26,6 +26,9 @@ func respondNotFound(c *wkhttp.Context) {
 func respondForbidden(c *wkhttp.Context) {
 	httperr.ResponseErrorLWithStatus(c, errcode.ErrBotTaskForbidden, nil, nil)
 }
+func respondRateLimited(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedRateLimited, nil, nil)
+}
 func respondInProgress(c *wkhttp.Context) {
 	c.Header("Retry-After", strconv.Itoa(int(claimRetryAfter/time.Second)))
 	httperr.ResponseErrorLWithStatus(c, errcode.ErrBotTaskInProgress, nil, nil)

--- a/modules/bot_task/api_i18n_test.go
+++ b/modules/bot_task/api_i18n_test.go
@@ -1,0 +1,41 @@
+package bot_task
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestBotTaskNoLegacyResponseError(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob module files: %v", err)
+	}
+	banned := []string{".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus("}
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`c\.JSON\(\s*(?:http\.Status[A-Z]|[1-5]\d{2}\b)`),
+		regexp.MustCompile(`c\.AbortWithStatus(?:JSON)?\(`),
+	}
+	for _, file := range files {
+		if strings.HasSuffix(file, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		cleaned := string(data)
+		for _, token := range banned {
+			if strings.Contains(cleaned, token) {
+				t.Fatalf("%s must use localized errors, found %s", file, token)
+			}
+		}
+		for _, pattern := range patterns {
+			if match := pattern.FindString(cleaned); match != "" {
+				t.Fatalf("%s contains raw error response %q", file, match)
+			}
+		}
+	}
+}

--- a/modules/bot_task/api_test.go
+++ b/modules/bot_task/api_test.go
@@ -1,0 +1,328 @@
+package bot_task
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/robot"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+const testSourceToken = "0123456789abcdef0123456789abcdef"
+
+type stubTaskRobotService struct {
+	mu sync.Mutex
+
+	exists     bool
+	existErr   error
+	prepareErr error
+	eventID    int64
+
+	existCalls   int
+	prepareCalls int
+	robotID      string
+	eventType    string
+	eventData    map[string]interface{}
+
+	prepareStarted  chan struct{}
+	prepareContinue chan struct{}
+	startOnce       sync.Once
+}
+
+func (s *stubTaskRobotService) ExistRobot(string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.existCalls++
+	return s.exists, s.existErr
+}
+
+func (s *stubTaskRobotService) PrepareBotTypedEvent(robotID, eventType string, eventData map[string]interface{}) (robot.PreparedBotTypedEvent, error) {
+	s.mu.Lock()
+	s.prepareCalls++
+	s.robotID = robotID
+	s.eventType = eventType
+	s.eventData = eventData
+	started := s.prepareStarted
+	continuation := s.prepareContinue
+	prepareErr := s.prepareErr
+	eventID := s.eventID
+	s.mu.Unlock()
+	if prepareErr != nil {
+		return robot.PreparedBotTypedEvent{}, prepareErr
+	}
+	if started != nil {
+		s.startOnce.Do(func() { close(started) })
+	}
+	if continuation != nil {
+		<-continuation
+	}
+	return robot.PreparedBotTypedEvent{
+		EventID:  eventID,
+		QueueKey: "robotEvent:" + robotID,
+		Member:   fmt.Sprintf(`{"event_id":%d}`, eventID),
+	}, nil
+}
+
+func (s *stubTaskRobotService) counts() (int, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.existCalls, s.prepareCalls
+}
+
+type taskErrorEnvelope struct {
+	Error struct {
+		Code       string `json:"code"`
+		HTTPStatus int    `json:"http_status"`
+	} `json:"error"`
+}
+
+type ambiguousTaskClaimStore struct {
+	committed bool
+	eventID   int64
+}
+
+func (s *ambiguousTaskClaimStore) Lookup(string, string) (claimOutcome, error) {
+	if s.committed {
+		return claimOutcome{State: claimReplay, EventID: s.eventID}, nil
+	}
+	return claimOutcome{State: claimMissing}, nil
+}
+func (s *ambiguousTaskClaimStore) Begin(string, string) (claimOutcome, *claimLease, error) {
+	return claimOutcome{State: claimAcquired}, &claimLease{}, nil
+}
+func (s *ambiguousTaskClaimStore) Commit(_ *claimLease, event robot.PreparedBotTypedEvent) (bool, error) {
+	s.committed = true
+	s.eventID = event.EventID
+	return false, errors.New("redis response lost after commit")
+}
+func (s *ambiguousTaskClaimStore) Release(*claimLease) (bool, error) { return true, nil }
+
+func newTestBotTask(robots robotService, claims claimService) *BotTask {
+	return &BotTask{
+		robots: robots,
+		claims: claims,
+		sources: sourceRegistry{
+			"loop": {Token: testSourceToken, Enabled: true, AllowedBotUIDs: []string{"bot-1"}},
+		},
+		now: func() time.Time { return time.Unix(1_788_768_000, 0) },
+		Log: log.NewTLog("BotTaskTest"),
+	}
+}
+
+func newTaskRouter(module *BotTask) *wkhttp.WKHttp {
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	// Route without the Redis-backed rate limiter so these unit tests exercise
+	// only the handler contract.
+	r.Group("/v1/internal").POST("/bot-tasks", module.create)
+	return r
+}
+
+func validTaskRequest() taskRequest {
+	return taskRequest{
+		Source: "loop", TaskType: "loop_issue_comment_mention", IdempotencyKey: "comment-1:bot-1",
+		BotUID: "bot-1", ActorUID: "user-1", SessionKey: "issue:1:thread:2",
+		Prompt:   "Use octo-cli to handle the task and reply.",
+		Context:  json.RawMessage(`{"issue_id":9007199254740993}`),
+		Metadata: json.RawMessage(`{"schema_version":"future","anchor":"comment-1"}`),
+	}
+}
+
+func doTaskRequest(t *testing.T, router *wkhttp.WKHttp, token string, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	var raw []byte
+	switch value := body.(type) {
+	case []byte:
+		raw = value
+	default:
+		var err error
+		raw, err = json.Marshal(value)
+		if err != nil {
+			t.Fatalf("marshal request: %v", err)
+		}
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/internal/bot-tasks", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func decodeTaskError(t *testing.T, w *httptest.ResponseRecorder) taskErrorEnvelope {
+	t.Helper()
+	var response taskErrorEnvelope
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode error %s: %v", w.Body.String(), err)
+	}
+	return response
+}
+
+func TestBotTaskAcceptedReplayAndPayload(t *testing.T) {
+	backend := &memoryClaimBackend{values: map[string]string{}}
+	robots := &stubTaskRobotService{exists: true, eventID: 4242}
+	module := newTestBotTask(robots, &claimStore{backend: backend, doneTTL: time.Hour})
+	notifications := 0
+	module.notifyBotEvent = func(uid string) {
+		if uid != "bot-1" {
+			t.Fatalf("notified bot = %q", uid)
+		}
+		notifications++
+	}
+	router := newTaskRouter(module)
+
+	first := doTaskRequest(t, router, testSourceToken, validTaskRequest())
+	if first.Code != http.StatusAccepted {
+		t.Fatalf("accepted status=%d body=%s", first.Code, first.Body.String())
+	}
+	second := doTaskRequest(t, router, testSourceToken, validTaskRequest())
+	if second.Code != http.StatusOK {
+		t.Fatalf("replay status=%d body=%s", second.Code, second.Body.String())
+	}
+	var replay ingressResponse
+	if err := json.Unmarshal(second.Body.Bytes(), &replay); err != nil || !replay.Accepted || !replay.Replay || replay.EventID != 4242 {
+		t.Fatalf("replay=%+v err=%v", replay, err)
+	}
+
+	exists, prepares := robots.counts()
+	if exists != 1 || prepares != 1 || len(backend.events) != 1 || notifications != 1 {
+		t.Fatalf("exists=%d prepares=%d events=%d notifications=%d", exists, prepares, len(backend.events), notifications)
+	}
+	if robots.robotID != "bot-1" || robots.eventType != botTaskEventType {
+		t.Fatalf("target/type=%q/%q", robots.robotID, robots.eventType)
+	}
+	contextRaw, ok := robots.eventData["context"].(json.RawMessage)
+	if !ok || string(contextRaw) != `{"issue_id":9007199254740993}` {
+		t.Fatalf("context=%T(%s)", robots.eventData["context"], contextRaw)
+	}
+}
+
+func TestBotTaskSameKeyDifferentLargeNumberConflicts(t *testing.T) {
+	backend := &memoryClaimBackend{values: map[string]string{}}
+	module := newTestBotTask(&stubTaskRobotService{exists: true, eventID: 9}, &claimStore{backend: backend, doneTTL: time.Hour})
+	router := newTaskRouter(module)
+	if w := doTaskRequest(t, router, testSourceToken, validTaskRequest()); w.Code != http.StatusAccepted {
+		t.Fatalf("first status=%d body=%s", w.Code, w.Body.String())
+	}
+	changed := validTaskRequest()
+	changed.Context = json.RawMessage(`{"issue_id":9007199254740992}`)
+	w := doTaskRequest(t, router, testSourceToken, changed)
+	if w.Code != http.StatusConflict || decodeTaskError(t, w).Error.Code != "err.server.bot_task.idempotency_conflict" {
+		t.Fatalf("conflict status=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestBotTaskConcurrentDuplicateEnqueuesOnce(t *testing.T) {
+	backend := &memoryClaimBackend{values: map[string]string{}}
+	robots := &stubTaskRobotService{
+		exists:          true,
+		eventID:         42,
+		prepareStarted:  make(chan struct{}),
+		prepareContinue: make(chan struct{}),
+	}
+	module := newTestBotTask(robots, &claimStore{backend: backend, doneTTL: time.Hour})
+	router := newTaskRouter(module)
+	body, err := json.Marshal(validTaskRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() { firstDone <- doTaskRequest(t, router, testSourceToken, body) }()
+	select {
+	case <-robots.prepareStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first request did not reach event preparation")
+	}
+
+	for range 4 {
+		w := doTaskRequest(t, router, testSourceToken, body)
+		if w.Code != http.StatusConflict || w.Header().Get("Retry-After") != "2" {
+			t.Fatalf("duplicate status=%d retry-after=%q body=%s", w.Code, w.Header().Get("Retry-After"), w.Body.String())
+		}
+	}
+	close(robots.prepareContinue)
+	if w := <-firstDone; w.Code != http.StatusAccepted {
+		t.Fatalf("first status=%d body=%s", w.Code, w.Body.String())
+	}
+	_, prepares := robots.counts()
+	if prepares != 1 {
+		t.Fatalf("prepare calls=%d, want 1", prepares)
+	}
+}
+
+func TestBotTaskRecoversAmbiguousCommitAsReplay(t *testing.T) {
+	store := &ambiguousTaskClaimStore{}
+	module := newTestBotTask(&stubTaskRobotService{exists: true, eventID: 77}, store)
+	notifications := 0
+	module.notifyBotEvent = func(string) { notifications++ }
+	w := doTaskRequest(t, newTaskRouter(module), testSourceToken, validTaskRequest())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var response ingressResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil || !response.Replay || response.EventID != 77 {
+		t.Fatalf("response=%+v err=%v", response, err)
+	}
+	if notifications != 1 {
+		t.Fatalf("notifications=%d, want 1", notifications)
+	}
+}
+
+func TestBotTaskRejectsUnauthorizedDisallowedAndMissingBot(t *testing.T) {
+	tests := []struct {
+		name       string
+		token      string
+		request    taskRequest
+		robots     *stubTaskRobotService
+		wantStatus int
+		wantCode   string
+	}{
+		{name: "missing token", request: validTaskRequest(), robots: &stubTaskRobotService{exists: true}, wantStatus: http.StatusUnauthorized, wantCode: "err.shared.auth.token_invalid"},
+		{name: "wrong token", token: strings.Repeat("x", 32), request: validTaskRequest(), robots: &stubTaskRobotService{exists: true}, wantStatus: http.StatusUnauthorized, wantCode: "err.shared.auth.token_invalid"},
+		{name: "disallowed bot", token: testSourceToken, request: func() taskRequest { r := validTaskRequest(); r.BotUID = "bot-2"; return r }(), robots: &stubTaskRobotService{exists: true}, wantStatus: http.StatusForbidden, wantCode: "err.server.bot_task.forbidden"},
+		{name: "missing bot", token: testSourceToken, request: validTaskRequest(), robots: &stubTaskRobotService{exists: false}, wantStatus: http.StatusNotFound, wantCode: "err.shared.not_found"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := doTaskRequest(t, newTaskRouter(newTestBotTask(tc.robots, &claimStore{backend: &memoryClaimBackend{values: map[string]string{}}, doneTTL: time.Hour})), tc.token, tc.request)
+			if w.Code != tc.wantStatus || decodeTaskError(t, w).Error.Code != tc.wantCode {
+				t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestBotTaskRejectsMalformedAndOversizeBodies(t *testing.T) {
+	module := newTestBotTask(&stubTaskRobotService{exists: true}, &claimStore{backend: &memoryClaimBackend{values: map[string]string{}}, doneTTL: time.Hour})
+	router := newTaskRouter(module)
+	for _, body := range [][]byte{[]byte("{not-json"), []byte(strings.Repeat("x", maxRequestBodyBytes+1))} {
+		w := doTaskRequest(t, router, testSourceToken, body)
+		if w.Code != http.StatusBadRequest || decodeTaskError(t, w).Error.Code != "err.shared.param.invalid" {
+			t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+		}
+	}
+}
+
+func TestBotTaskPrepareFailureReleasesClaim(t *testing.T) {
+	backend := &memoryClaimBackend{values: map[string]string{}}
+	module := newTestBotTask(&stubTaskRobotService{exists: true, prepareErr: errors.New("allocate failed")}, &claimStore{backend: backend, doneTTL: time.Hour})
+	w := doTaskRequest(t, newTaskRouter(module), testSourceToken, validTaskRequest())
+	if w.Code != http.StatusInternalServerError || decodeTaskError(t, w).Error.Code != "err.server.bot_task.store_failed" {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	if len(backend.values) != 0 {
+		t.Fatalf("claim was not released: %#v", backend.values)
+	}
+}

--- a/modules/bot_task/api_test.go
+++ b/modules/bot_task/api_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/robot"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	sharedratelimit "github.com/Mininglamp-OSS/octo-server/pkg/ratelimit"
+	"github.com/go-redis/redis"
 )
 
 const testSourceToken = "0123456789abcdef0123456789abcdef"
@@ -145,8 +147,8 @@ func newTaskRouter(module *BotTask) *wkhttp.WKHttp {
 	r := wkhttp.New()
 	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
 	// Route without the Redis-backed rate limiter so these unit tests exercise
-	// only the handler contract.
-	r.Group("/v1/internal").POST("/bot-tasks", module.create)
+	// only authentication and the handler contract.
+	r.Group("/v1/internal").POST("/bot-tasks", module.sourceAuthMiddleware(), module.create)
 	return r
 }
 
@@ -361,6 +363,35 @@ func TestBotTaskAuthenticatesBeforeFieldValidation(t *testing.T) {
 	}
 }
 
+func TestBotTaskAuthenticatesBeforeBodyDecode(t *testing.T) {
+	module := newTestBotTask(
+		&stubTaskRobotService{exists: true},
+		&claimStore{backend: &memoryClaimBackend{values: map[string]string{}}, doneTTL: time.Hour},
+	)
+	w := doTaskRequest(t, newTaskRouter(module), strings.Repeat("x", 32), []byte("{not-json"))
+	if w.Code != http.StatusUnauthorized || decodeTaskError(t, w).Error.Code != "err.shared.auth.token_invalid" {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestBotTaskRejectsAuthenticatedSourceMismatch(t *testing.T) {
+	module := newTestBotTask(
+		&stubTaskRobotService{exists: true},
+		&claimStore{backend: &memoryClaimBackend{values: map[string]string{}}, doneTTL: time.Hour},
+	)
+	module.sources["wiki"] = sourceConfig{
+		Token:          strings.Repeat("w", 32),
+		Enabled:        true,
+		AllowedBotUIDs: []string{"bot-1"},
+	}
+	request := validTaskRequest()
+	request.Source = "wiki"
+	w := doTaskRequest(t, newTaskRouter(module), testSourceToken, request)
+	if w.Code != http.StatusUnauthorized || decodeTaskError(t, w).Error.Code != "err.shared.auth.token_invalid" {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
 func TestBotTaskCompleteObjectDoesNotWaitForRequestEOF(t *testing.T) {
 	module := newTestBotTask(
 		&stubTaskRobotService{exists: true, eventID: 79},
@@ -406,7 +437,21 @@ func TestBotTaskCompleteObjectDoesNotWaitForRequestEOF(t *testing.T) {
 func TestBotTaskRejectsMalformedAndOversizeBodies(t *testing.T) {
 	module := newTestBotTask(&stubTaskRobotService{exists: true}, &claimStore{backend: &memoryClaimBackend{values: map[string]string{}}, doneTTL: time.Hour})
 	router := newTaskRouter(module)
-	for _, body := range [][]byte{[]byte("{not-json"), []byte(strings.Repeat("x", maxRequestBodyBytes+1))} {
+	oversize := validTaskRequest()
+	oversize.Prompt = strings.Repeat("x", maxRequestBodyBytes+1)
+	oversizeJSON, err := json.Marshal(oversize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validJSON, err := json.Marshal(validTaskRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, body := range [][]byte{
+		[]byte("{not-json"),
+		oversizeJSON,
+		append(append([]byte{}, validJSON...), []byte(` {"source":"loop"}`)...),
+	} {
 		w := doTaskRequest(t, router, testSourceToken, body)
 		if w.Code != http.StatusBadRequest || decodeTaskError(t, w).Error.Code != "err.shared.param.invalid" {
 			t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
@@ -423,5 +468,53 @@ func TestBotTaskPrepareFailureReleasesClaim(t *testing.T) {
 	}
 	if len(backend.values) != 0 {
 		t.Fatalf("claim was not released: %#v", backend.values)
+	}
+}
+
+func TestBotTaskSourceRateLimitIsIndependentAndFailClosedWhenRedisIsDown(t *testing.T) {
+	const wikiToken = "wiki-token-0123456789abcdef0123456789"
+	module := newTestBotTask(
+		&stubTaskRobotService{exists: true, eventID: 88},
+		&claimStore{backend: &memoryClaimBackend{values: map[string]string{}}, doneTTL: time.Hour},
+	)
+	module.sources["wiki"] = sourceConfig{Token: wikiToken, Enabled: true, AllowedBotUIDs: []string{"bot-1"}}
+	module.sourceFloor = newSourceLocalFloor(module.sources, 0.001, 1)
+	redisClient := redis.NewClient(&redis.Options{
+		Addr:         "127.0.0.1:1",
+		DialTimeout:  10 * time.Millisecond,
+		ReadTimeout:  10 * time.Millisecond,
+		WriteTimeout: 10 * time.Millisecond,
+		MaxRetries:   0,
+	})
+	t.Cleanup(func() { _ = redisClient.Close() })
+	module.sourceLimiter = sharedratelimit.New(
+		redisClient,
+		"ratelimit:test_bot_task_source:",
+		"bot_task_source",
+		func() sharedratelimit.Params {
+			return sharedratelimit.Params{Enabled: true, RPS: 0.001, Burst: 1}
+		},
+		nil,
+		sharedratelimit.Params{Enabled: true, RPS: 0.001, Burst: 1},
+	)
+	router := wkhttp.New()
+	router.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	router.Group("/v1/internal").POST(
+		"/bot-tasks",
+		module.sourceAuthMiddleware(),
+		module.sourceRateLimitMiddleware(),
+		module.create,
+	)
+
+	if first := doTaskRequest(t, router, testSourceToken, validTaskRequest()); first.Code != http.StatusAccepted {
+		t.Fatalf("first loop request status=%d body=%s", first.Code, first.Body.String())
+	}
+	if denied := doTaskRequest(t, router, testSourceToken, validTaskRequest()); denied.Code != http.StatusTooManyRequests {
+		t.Fatalf("second loop request status=%d body=%s", denied.Code, denied.Body.String())
+	}
+	wikiRequest := validTaskRequest()
+	wikiRequest.Source = "wiki"
+	if independent := doTaskRequest(t, router, wikiToken, wikiRequest); independent.Code != http.StatusAccepted {
+		t.Fatalf("independent wiki request status=%d body=%s", independent.Code, independent.Body.String())
 	}
 }

--- a/modules/bot_task/api_test.go
+++ b/modules/bot_task/api_test.go
@@ -13,12 +13,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/robot"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
-	sharedratelimit "github.com/Mininglamp-OSS/octo-server/pkg/ratelimit"
-	"github.com/go-redis/redis"
 )
 
 const testSourceToken = "0123456789abcdef0123456789abcdef"
@@ -86,6 +85,9 @@ type taskErrorEnvelope struct {
 	Error struct {
 		Code       string `json:"code"`
 		HTTPStatus int    `json:"http_status"`
+		Details    struct {
+			Field string `json:"field"`
+		} `json:"details"`
 	} `json:"error"`
 }
 
@@ -449,13 +451,19 @@ func TestBotTaskRejectsMalformedAndOversizeBodies(t *testing.T) {
 	}
 	for _, body := range [][]byte{
 		[]byte("{not-json"),
-		oversizeJSON,
 		append(append([]byte{}, validJSON...), []byte(` {"source":"loop"}`)...),
 	} {
 		w := doTaskRequest(t, router, testSourceToken, body)
 		if w.Code != http.StatusBadRequest || decodeTaskError(t, w).Error.Code != "err.shared.param.invalid" {
 			t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
 		}
+	}
+	oversizeResponse := doTaskRequest(t, router, testSourceToken, oversizeJSON)
+	oversizeError := decodeTaskError(t, oversizeResponse)
+	if oversizeResponse.Code != http.StatusBadRequest ||
+		oversizeError.Error.Code != "err.shared.param.invalid" ||
+		oversizeError.Error.Details.Field != "body" {
+		t.Fatalf("oversize body must be rejected by the body cap: status=%d body=%s", oversizeResponse.Code, oversizeResponse.Body.String())
 	}
 }
 
@@ -473,38 +481,22 @@ func TestBotTaskPrepareFailureReleasesClaim(t *testing.T) {
 
 func TestBotTaskSourceRateLimitIsIndependentAndFailClosedWhenRedisIsDown(t *testing.T) {
 	const wikiToken = "wiki-token-0123456789abcdef0123456789"
+	t.Setenv("DM_BOT_TASK_IP_RPS", "1000")
+	t.Setenv("DM_BOT_TASK_IP_BURST", "1000")
+	t.Setenv("DM_BOT_TASK_SOURCE_RPS", "0.001")
+	t.Setenv("DM_BOT_TASK_SOURCE_BURST", "1")
+	cfg := config.New()
+	cfg.Test = true
+	cfg.DB.RedisAddr = "127.0.0.1:1"
 	module := newTestBotTask(
 		&stubTaskRobotService{exists: true, eventID: 88},
 		&claimStore{backend: &memoryClaimBackend{values: map[string]string{}}, doneTTL: time.Hour},
 	)
+	module.ctx = config.NewContext(cfg)
 	module.sources["wiki"] = sourceConfig{Token: wikiToken, Enabled: true, AllowedBotUIDs: []string{"bot-1"}}
-	module.sourceFloor = newSourceLocalFloor(module.sources, 0.001, 1)
-	redisClient := redis.NewClient(&redis.Options{
-		Addr:         "127.0.0.1:1",
-		DialTimeout:  10 * time.Millisecond,
-		ReadTimeout:  10 * time.Millisecond,
-		WriteTimeout: 10 * time.Millisecond,
-		MaxRetries:   0,
-	})
-	t.Cleanup(func() { _ = redisClient.Close() })
-	module.sourceLimiter = sharedratelimit.New(
-		redisClient,
-		"ratelimit:test_bot_task_source:",
-		"bot_task_source",
-		func() sharedratelimit.Params {
-			return sharedratelimit.Params{Enabled: true, RPS: 0.001, Burst: 1}
-		},
-		nil,
-		sharedratelimit.Params{Enabled: true, RPS: 0.001, Burst: 1},
-	)
 	router := wkhttp.New()
 	router.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
-	router.Group("/v1/internal").POST(
-		"/bot-tasks",
-		module.sourceAuthMiddleware(),
-		module.sourceRateLimitMiddleware(),
-		module.create,
-	)
+	module.Route(router)
 
 	if first := doTaskRequest(t, router, testSourceToken, validTaskRequest()); first.Code != http.StatusAccepted {
 		t.Fatalf("first loop request status=%d body=%s", first.Code, first.Body.String())

--- a/modules/bot_task/api_test.go
+++ b/modules/bot_task/api_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -106,6 +107,27 @@ func (s *ambiguousTaskClaimStore) Commit(_ *claimLease, event robot.PreparedBotT
 	return false, errors.New("redis response lost after commit")
 }
 func (s *ambiguousTaskClaimStore) Release(*claimLease) (bool, error) { return true, nil }
+
+type failedCommitTaskClaimStore struct {
+	current   claimOutcome
+	lookupErr error
+	committed bool
+}
+
+func (s *failedCommitTaskClaimStore) Lookup(string, string) (claimOutcome, error) {
+	if s.committed {
+		return s.current, s.lookupErr
+	}
+	return claimOutcome{State: claimMissing}, nil
+}
+func (s *failedCommitTaskClaimStore) Begin(string, string) (claimOutcome, *claimLease, error) {
+	return claimOutcome{State: claimAcquired}, &claimLease{}, nil
+}
+func (s *failedCommitTaskClaimStore) Commit(*claimLease, robot.PreparedBotTypedEvent) (bool, error) {
+	s.committed = true
+	return false, nil
+}
+func (s *failedCommitTaskClaimStore) Release(*claimLease) (bool, error) { return true, nil }
 
 func newTestBotTask(robots robotService, claims claimService) *BotTask {
 	return &BotTask{
@@ -280,6 +302,29 @@ func TestBotTaskRecoversAmbiguousCommitAsReplay(t *testing.T) {
 	}
 }
 
+func TestBotTaskCommitFailureDispatchesCurrentOutcome(t *testing.T) {
+	tests := []struct {
+		name       string
+		current    claimOutcome
+		lookupErr  error
+		wantStatus int
+		wantCode   string
+	}{
+		{name: "conflict", current: claimOutcome{State: claimConflict}, wantStatus: http.StatusConflict, wantCode: "err.server.bot_task.idempotency_conflict"},
+		{name: "lookup failure", lookupErr: errors.New("redis unavailable"), wantStatus: http.StatusInternalServerError, wantCode: "err.server.bot_task.store_failed"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &failedCommitTaskClaimStore{current: tc.current, lookupErr: tc.lookupErr}
+			module := newTestBotTask(&stubTaskRobotService{exists: true, eventID: 78}, store)
+			w := doTaskRequest(t, newTaskRouter(module), testSourceToken, validTaskRequest())
+			if w.Code != tc.wantStatus || decodeTaskError(t, w).Error.Code != tc.wantCode {
+				t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
 func TestBotTaskRejectsUnauthorizedDisallowedAndMissingBot(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -301,6 +346,60 @@ func TestBotTaskRejectsUnauthorizedDisallowedAndMissingBot(t *testing.T) {
 				t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
 			}
 		})
+	}
+}
+
+func TestBotTaskAuthenticatesBeforeFieldValidation(t *testing.T) {
+	request := validTaskRequest()
+	request.Prompt = ""
+	w := doTaskRequest(t, newTaskRouter(newTestBotTask(
+		&stubTaskRobotService{exists: true},
+		&claimStore{backend: &memoryClaimBackend{values: map[string]string{}}, doneTTL: time.Hour},
+	)), strings.Repeat("x", 32), request)
+	if w.Code != http.StatusUnauthorized || decodeTaskError(t, w).Error.Code != "err.shared.auth.token_invalid" {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestBotTaskCompleteObjectDoesNotWaitForRequestEOF(t *testing.T) {
+	module := newTestBotTask(
+		&stubTaskRobotService{exists: true, eventID: 79},
+		&claimStore{backend: &memoryClaimBackend{values: map[string]string{}}, doneTTL: time.Hour},
+	)
+	router := newTaskRouter(module)
+	raw, err := json.Marshal(validTaskRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	bodyReader, bodyWriter := io.Pipe()
+	defer bodyWriter.Close()
+	writeDone := make(chan error, 1)
+	go func() {
+		_, writeErr := bodyWriter.Write(raw)
+		writeDone <- writeErr
+	}()
+	req := httptest.NewRequest(http.MethodPost, "/v1/internal/bot-tasks", bodyReader)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testSourceToken)
+	w := httptest.NewRecorder()
+	handlerDone := make(chan struct{})
+	go func() {
+		router.ServeHTTP(w, req)
+		close(handlerDone)
+	}()
+
+	select {
+	case <-handlerDone:
+		if w.Code != http.StatusAccepted {
+			t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+		}
+	case <-time.After(500 * time.Millisecond):
+		_ = bodyWriter.Close()
+		<-handlerDone
+		t.Fatal("handler waited for request EOF after receiving one complete JSON object")
+	}
+	if err := <-writeDone; err != nil {
+		t.Fatalf("write request body: %v", err)
 	}
 }
 

--- a/modules/bot_task/config.go
+++ b/modules/bot_task/config.go
@@ -1,0 +1,173 @@
+package bot_task
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+const (
+	botTaskEventType    = "bot_task"
+	sourcesEnv          = "OCTO_BOT_TASK_SOURCES"
+	maxRequestBodyBytes = 256 * 1024
+	maxIdentifierBytes  = 256
+	maxPromptBytes      = 24 * 1024
+	maxContextBytes     = 24 * 1024
+	maxMetadataBytes    = 8 * 1024
+	maxTaskTypeBytes    = 128
+	minSourceTokenBytes = 32
+)
+
+type sourceConfig struct {
+	Token          string   `json:"token"`
+	Enabled        bool     `json:"enabled"`
+	AllowedBotUIDs []string `json:"allowed_bot_uids"`
+}
+type sourceRegistry map[string]sourceConfig
+
+func sourceRegistryFromEnv() (sourceRegistry, error) {
+	return parseSourceRegistry(os.Getenv(sourcesEnv))
+}
+
+func parseSourceRegistry(raw string) (sourceRegistry, error) {
+	if strings.TrimSpace(raw) == "" {
+		return sourceRegistry{}, errors.New("OCTO_BOT_TASK_SOURCES not set; bot task ingress disabled")
+	}
+	var registry sourceRegistry
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&registry); err != nil {
+		return sourceRegistry{}, fmt.Errorf("decode OCTO_BOT_TASK_SOURCES: %w", err)
+	}
+	if len(registry) == 0 {
+		return sourceRegistry{}, errors.New("OCTO_BOT_TASK_SOURCES is empty; bot task ingress disabled")
+	}
+	if err := decoder.Decode(&struct{}{}); err == nil {
+		return sourceRegistry{}, errors.New("decode OCTO_BOT_TASK_SOURCES: multiple JSON values")
+	} else if !errors.Is(err, io.EOF) {
+		return sourceRegistry{}, fmt.Errorf("decode OCTO_BOT_TASK_SOURCES trailing data: %w", err)
+	}
+	seenTokens := make(map[string]string, len(registry))
+	for source, cfg := range registry {
+		trimmedSource := strings.TrimSpace(source)
+		cfg.Token = strings.TrimSpace(cfg.Token)
+		if trimmedSource == "" || trimmedSource != source || len(source) > maxIdentifierBytes || len(cfg.Token) < minSourceTokenBytes {
+			return sourceRegistry{}, fmt.Errorf("invalid bot task source %q", source)
+		}
+		if other, exists := seenTokens[cfg.Token]; exists {
+			return sourceRegistry{}, fmt.Errorf("bot task sources %q and %q share a token", other, source)
+		}
+		seenTokens[cfg.Token] = source
+		registry[source] = cfg
+	}
+	return registry, nil
+}
+
+func (c sourceConfig) allowsBot(uid string) bool {
+	for _, allowed := range c.AllowedBotUIDs {
+		if allowed = strings.TrimSpace(allowed); allowed == "*" || allowed == uid {
+			return true
+		}
+	}
+	return false
+}
+
+type taskRequest struct {
+	Source         string          `json:"source"`
+	TaskType       string          `json:"task_type"`
+	IdempotencyKey string          `json:"idempotency_key"`
+	BotUID         string          `json:"bot_uid"`
+	ActorUID       string          `json:"actor_uid"`
+	SessionKey     string          `json:"session_key"`
+	Prompt         string          `json:"prompt"`
+	Context        json.RawMessage `json:"context"`
+	Metadata       json.RawMessage `json:"metadata,omitempty"`
+}
+type normalizedTask = taskRequest
+
+type requestValidationError struct{ field string }
+
+func (e *requestValidationError) Error() string {
+	return fmt.Sprintf("invalid bot task field %q", e.field)
+}
+
+func invalidField(err error) string {
+	var validationErr *requestValidationError
+	if errors.As(err, &validationErr) {
+		return validationErr.field
+	}
+	return ""
+}
+
+func normalizeTaskRequest(req taskRequest) (normalizedTask, error) {
+	task := normalizedTask{
+		Source: strings.TrimSpace(req.Source), TaskType: strings.TrimSpace(req.TaskType),
+		IdempotencyKey: strings.TrimSpace(req.IdempotencyKey), BotUID: strings.TrimSpace(req.BotUID),
+		ActorUID: strings.TrimSpace(req.ActorUID), SessionKey: strings.TrimSpace(req.SessionKey), Prompt: req.Prompt,
+	}
+	for _, field := range []struct {
+		name, value string
+		max         int
+	}{
+		{"source", task.Source, maxIdentifierBytes}, {"task_type", task.TaskType, maxTaskTypeBytes},
+		{"idempotency_key", task.IdempotencyKey, maxIdentifierBytes}, {"bot_uid", task.BotUID, maxIdentifierBytes},
+		{"actor_uid", task.ActorUID, maxIdentifierBytes}, {"session_key", task.SessionKey, maxIdentifierBytes},
+	} {
+		if field.value == "" || len(field.value) > field.max {
+			return normalizedTask{}, &requestValidationError{field: field.name}
+		}
+	}
+	if strings.TrimSpace(task.Prompt) == "" || len(task.Prompt) > maxPromptBytes {
+		return normalizedTask{}, &requestValidationError{field: "prompt"}
+	}
+	context, err := normalizeJSONObject(req.Context, true, maxContextBytes)
+	if err != nil {
+		return normalizedTask{}, &requestValidationError{field: "context"}
+	}
+	metadata, err := normalizeJSONObject(req.Metadata, false, maxMetadataBytes)
+	if err != nil {
+		return normalizedTask{}, &requestValidationError{field: "metadata"}
+	}
+	task.Context, task.Metadata = context, metadata
+	return task, nil
+}
+
+func normalizeJSONObject(raw json.RawMessage, required bool, max int) (json.RawMessage, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		if required {
+			return nil, errors.New("required object missing")
+		}
+		return nil, nil
+	}
+	if len(raw) > max {
+		return nil, errors.New("object too large")
+	}
+	var value map[string]interface{}
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	decoder.UseNumber()
+	if err := decoder.Decode(&value); err != nil || value == nil {
+		return nil, errors.New("value is not an object")
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return nil, errors.New("value contains trailing data")
+	}
+	return json.Marshal(value)
+}
+
+func taskFingerprint(task normalizedTask) string {
+	raw, err := json.Marshal(task)
+	if err != nil {
+		panic(fmt.Sprintf("marshal normalized bot task: %v", err))
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+func claimLogHash(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(sum[:6])
+}

--- a/modules/bot_task/config_test.go
+++ b/modules/bot_task/config_test.go
@@ -1,0 +1,90 @@
+package bot_task
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestParseSourceRegistry(t *testing.T) {
+	token := strings.Repeat("a", minSourceTokenBytes)
+	registry, err := parseSourceRegistry(`{"loop":{"token":"` + token + `","enabled":true,"allowed_bot_uids":["bot-1"]}}`)
+	if err != nil {
+		t.Fatalf("parse valid registry: %v", err)
+	}
+	if !registry["loop"].allowsBot("bot-1") || registry["loop"].allowsBot("bot-2") {
+		t.Fatalf("unexpected allow-list behavior: %+v", registry["loop"])
+	}
+
+	bad := []string{
+		``,
+		`null`,
+		`{}`,
+		`{"loop":{"token":"short","enabled":true,"allowed_bot_uids":["*"]}}`,
+		`{" loop":{"token":"` + token + `","enabled":true,"allowed_bot_uids":["*"]}}`,
+		`{"loop":{"token":"` + token + `","enabled":true,"allowed_bot_uids":[]}} {}`,
+		`{"loop":{"token":"` + token + `","enabled":true,"allowed_bot_uids":[]},"doc":{"token":"` + token + `","enabled":true,"allowed_bot_uids":[]}}`,
+	}
+	for _, raw := range bad {
+		if _, err := parseSourceRegistry(raw); err == nil {
+			t.Fatalf("parseSourceRegistry(%q) unexpectedly succeeded", raw)
+		}
+	}
+}
+
+func TestNormalizeTaskRequestAndFingerprint(t *testing.T) {
+	req := taskRequest{
+		Source: " loop ", TaskType: " custom ", IdempotencyKey: " key ",
+		BotUID: " bot-1 ", ActorUID: " user-1 ", SessionKey: " thread-1 ",
+		Prompt: "do work", Context: json.RawMessage(`{"z":1,"a":2}`),
+		Metadata: json.RawMessage(`{"schema_version":"future"}`),
+	}
+	normalized, err := normalizeTaskRequest(req)
+	if err != nil {
+		t.Fatalf("normalizeTaskRequest: %v", err)
+	}
+	if normalized.Source != "loop" || normalized.BotUID != "bot-1" {
+		t.Fatalf("identifiers were not trimmed: %+v", normalized)
+	}
+	second := normalized
+	second.Context = json.RawMessage(`{"a":2,"z":1}`)
+	second, err = normalizeTaskRequest(second)
+	if err != nil {
+		t.Fatalf("normalize second task: %v", err)
+	}
+	if taskFingerprint(normalized) != taskFingerprint(second) {
+		t.Fatal("semantically identical JSON objects must have the same fingerprint")
+	}
+
+	if string(normalized.Metadata) != `{"schema_version":"future"}` {
+		t.Fatalf("metadata was interpreted instead of passed through: %s", normalized.Metadata)
+	}
+}
+
+func TestNormalizeJSONObjectPreservesLargeJSONNumbers(t *testing.T) {
+	first, err := normalizeJSONObject(json.RawMessage(`{"reply_to":9007199254740993}`), true, maxContextBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := normalizeJSONObject(json.RawMessage(`{"reply_to":9007199254740992}`), true, maxContextBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != `{"reply_to":9007199254740993}` {
+		t.Fatalf("large integer changed: %s", first)
+	}
+	if string(first) == string(second) {
+		t.Fatalf("distinct large integers collapsed: %s", first)
+	}
+}
+
+func TestValidBearerToken(t *testing.T) {
+	if !validBearerToken("Bearer secret", "secret") {
+		t.Fatal("valid bearer token rejected")
+	}
+	for _, header := range []string{"secret", "bearer secret", "Bearer wrong", "Bearer "} {
+		if validBearerToken(header, "secret") {
+			t.Fatalf("invalid bearer token accepted: %q", header)
+		}
+	}
+}

--- a/modules/bot_task/idempotency.go
+++ b/modules/bot_task/idempotency.go
@@ -1,0 +1,196 @@
+package bot_task
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/modules/robot"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
+)
+
+const (
+	claimPrefix         = "bottask:"
+	claimPendingTTL     = 60 * time.Second
+	claimRetryAfter     = 2 * time.Second
+	defaultClaimDoneTTL = 7 * 24 * time.Hour
+	claimRecordPending  = "pending"
+	claimRecordDone     = "done"
+)
+
+var errClaimNotFound = errors.New("bot task claim not found")
+
+type claimState uint8
+
+const (
+	claimMissing claimState = iota
+	claimAcquired
+	claimPending
+	claimReplay
+	claimConflict
+)
+
+type claimOutcome struct {
+	State   claimState
+	EventID int64
+}
+type claimRecord struct {
+	State   string `json:"state"`
+	SHA     string `json:"sha"`
+	Token   string `json:"token,omitempty"`
+	EventID int64  `json:"event_id,omitempty"`
+}
+type claimLease struct{ key, sha, pendingValue string }
+
+type claimBackend interface {
+	Get(key string) (string, error)
+	SetNX(key, value string, ttl time.Duration) (bool, error)
+	CompareAndEnqueue(key, oldValue, newValue string, ttl time.Duration, event robot.PreparedBotTypedEvent) (bool, error)
+	CompareAndDelete(key, oldValue string) (bool, error)
+}
+type claimStore struct {
+	backend claimBackend
+	doneTTL time.Duration
+}
+
+func newRedisClaimStore(ctx *config.Context) *claimStore {
+	doneTTL := ctx.GetConfig().Robot.MessageExpire
+	if doneTTL <= 0 {
+		doneTTL = defaultClaimDoneTTL
+	}
+	client := octoredis.NewInstrumentedClient(ctx.GetConfig(), func(options *rd.Options) {
+		options.MaxRetries = 3
+		options.ReadTimeout = 3 * time.Second
+		options.WriteTimeout = 3 * time.Second
+		options.DialTimeout = 3 * time.Second
+	})
+	return &claimStore{backend: &redisClaimBackend{client: client}, doneTTL: doneTTL}
+}
+
+func taskClaimKey(source, botUID, idempotencyKey string) string {
+	sum := sha256.Sum256([]byte(source + "\x00" + botUID + "\x00" + idempotencyKey))
+	return claimPrefix + hex.EncodeToString(sum[:])
+}
+func newClaimToken() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("generate bot task claim token: %w", err)
+	}
+	return hex.EncodeToString(raw[:]), nil
+}
+
+func (s *claimStore) Lookup(key, sha string) (claimOutcome, error) {
+	raw, err := s.backend.Get(key)
+	if errors.Is(err, errClaimNotFound) {
+		return claimOutcome{State: claimMissing}, nil
+	}
+	if err != nil {
+		return claimOutcome{}, fmt.Errorf("lookup bot task claim: %w", err)
+	}
+	var record claimRecord
+	if err := json.Unmarshal([]byte(raw), &record); err != nil {
+		return claimOutcome{}, fmt.Errorf("decode bot task claim: %w", err)
+	}
+	if record.SHA != sha {
+		return claimOutcome{State: claimConflict}, nil
+	}
+	switch record.State {
+	case claimRecordPending:
+		return claimOutcome{State: claimPending}, nil
+	case claimRecordDone:
+		if record.EventID <= 0 {
+			return claimOutcome{}, errors.New("decode bot task claim: missing event_id")
+		}
+		return claimOutcome{State: claimReplay, EventID: record.EventID}, nil
+	default:
+		return claimOutcome{}, fmt.Errorf("decode bot task claim: unknown state %q", record.State)
+	}
+}
+
+func (s *claimStore) Begin(key, sha string) (claimOutcome, *claimLease, error) {
+	existing, err := s.Lookup(key, sha)
+	if err != nil || existing.State != claimMissing {
+		return existing, nil, err
+	}
+	token, err := newClaimToken()
+	if err != nil {
+		return claimOutcome{}, nil, err
+	}
+	pending, err := json.Marshal(claimRecord{State: claimRecordPending, SHA: sha, Token: token})
+	if err != nil {
+		return claimOutcome{}, nil, err
+	}
+	created, err := s.backend.SetNX(key, string(pending), claimPendingTTL)
+	if err != nil {
+		return claimOutcome{}, nil, fmt.Errorf("reserve bot task claim: %w", err)
+	}
+	if !created {
+		outcome, lookupErr := s.Lookup(key, sha)
+		if lookupErr == nil && outcome.State == claimMissing {
+			outcome.State = claimPending
+		}
+		return outcome, nil, lookupErr
+	}
+	return claimOutcome{State: claimAcquired}, &claimLease{key: key, sha: sha, pendingValue: string(pending)}, nil
+}
+
+func (s *claimStore) Commit(lease *claimLease, event robot.PreparedBotTypedEvent) (bool, error) {
+	if lease == nil || event.EventID <= 0 || event.QueueKey == "" || event.Member == "" {
+		return false, errors.New("commit bot task event: invalid lease or event")
+	}
+	done, err := json.Marshal(claimRecord{State: claimRecordDone, SHA: lease.sha, EventID: event.EventID})
+	if err != nil {
+		return false, err
+	}
+	return s.backend.CompareAndEnqueue(lease.key, lease.pendingValue, string(done), s.doneTTL, event)
+}
+func (s *claimStore) Release(lease *claimLease) (bool, error) {
+	if lease == nil {
+		return false, errors.New("release bot task claim: nil lease")
+	}
+	return s.backend.CompareAndDelete(lease.key, lease.pendingValue)
+}
+
+type redisClaimBackend struct{ client *rd.Client }
+
+func (b *redisClaimBackend) Get(key string) (string, error) {
+	value, err := b.client.Get(key).Result()
+	if err == rd.Nil {
+		return "", errClaimNotFound
+	}
+	return value, err
+}
+func (b *redisClaimBackend) SetNX(key, value string, ttl time.Duration) (bool, error) {
+	return b.client.SetNX(key, value, ttl).Result()
+}
+
+var compareAndEnqueueClaimScript = rd.NewScript(`
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  redis.call("zadd", KEYS[2], ARGV[4], ARGV[5])
+  redis.call("pexpire", KEYS[2], ARGV[3])
+  redis.call("psetex", KEYS[1], ARGV[3], ARGV[2])
+  return 1
+end
+return 0
+`)
+
+func (b *redisClaimBackend) CompareAndEnqueue(key, oldValue, newValue string, ttl time.Duration, event robot.PreparedBotTypedEvent) (bool, error) {
+	result, err := compareAndEnqueueClaimScript.Run(b.client, []string{key, event.QueueKey}, oldValue, newValue, ttl.Milliseconds(), event.EventID, event.Member).Int64()
+	return result == 1, err
+}
+
+var compareAndDeleteClaimScript = rd.NewScript(`
+if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) end
+return 0
+`)
+
+func (b *redisClaimBackend) CompareAndDelete(key, oldValue string) (bool, error) {
+	result, err := compareAndDeleteClaimScript.Run(b.client, []string{key}, oldValue).Int64()
+	return result == 1, err
+}

--- a/modules/bot_task/idempotency_test.go
+++ b/modules/bot_task/idempotency_test.go
@@ -1,0 +1,93 @@
+package bot_task
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/modules/robot"
+)
+
+type memoryClaimBackend struct {
+	mu     sync.Mutex
+	values map[string]string
+	events []robot.PreparedBotTypedEvent
+}
+
+func (b *memoryClaimBackend) Get(key string) (string, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	value, ok := b.values[key]
+	if !ok {
+		return "", errClaimNotFound
+	}
+	return value, nil
+}
+func (b *memoryClaimBackend) SetNX(key, value string, _ time.Duration) (bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if _, ok := b.values[key]; ok {
+		return false, nil
+	}
+	b.values[key] = value
+	return true, nil
+}
+func (b *memoryClaimBackend) CompareAndEnqueue(key, oldValue, newValue string, _ time.Duration, event robot.PreparedBotTypedEvent) (bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.values[key] != oldValue {
+		return false, nil
+	}
+	b.values[key] = newValue
+	b.events = append(b.events, event)
+	return true, nil
+}
+func (b *memoryClaimBackend) CompareAndDelete(key, oldValue string) (bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.values[key] != oldValue {
+		return false, nil
+	}
+	delete(b.values, key)
+	return true, nil
+}
+
+func TestClaimStoreCommitReplayAndConflict(t *testing.T) {
+	backend := &memoryClaimBackend{values: map[string]string{}}
+	store := &claimStore{backend: backend, doneTTL: time.Hour}
+	outcome, lease, err := store.Begin("key", "sha-1")
+	if err != nil || outcome.State != claimAcquired || lease == nil {
+		t.Fatalf("begin = %+v, %v, %v", outcome, lease, err)
+	}
+	event := robot.PreparedBotTypedEvent{EventID: 42, QueueKey: "queue", Member: `{"event_id":42}`}
+	committed, err := store.Commit(lease, event)
+	if err != nil || !committed || len(backend.events) != 1 {
+		t.Fatalf("commit = %v, %v, events=%d", committed, err, len(backend.events))
+	}
+	replay, err := store.Lookup("key", "sha-1")
+	if err != nil || replay.State != claimReplay || replay.EventID != 42 {
+		t.Fatalf("replay = %+v, %v", replay, err)
+	}
+	conflict, err := store.Lookup("key", "sha-2")
+	if err != nil || conflict.State != claimConflict {
+		t.Fatalf("conflict = %+v, %v", conflict, err)
+	}
+}
+
+func TestClaimStoreReleaseRequiresLeaseValue(t *testing.T) {
+	backend := &memoryClaimBackend{values: map[string]string{}}
+	store := &claimStore{backend: backend, doneTTL: time.Hour}
+	_, lease, err := store.Begin("key", "sha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend.values["key"] = "new-owner"
+	released, err := store.Release(lease)
+	if err != nil || released {
+		t.Fatalf("stale release = %v, %v", released, err)
+	}
+	if _, err := store.Lookup("missing", "sha"); err != nil && !errors.Is(err, errClaimNotFound) {
+		t.Fatalf("missing lookup: %v", err)
+	}
+}

--- a/modules/bot_task/ratelimit.go
+++ b/modules/bot_task/ratelimit.go
@@ -1,0 +1,30 @@
+package bot_task
+
+import (
+	"golang.org/x/time/rate"
+)
+
+// sourceLocalFloor keeps the authenticated per-source quota effective when
+// Redis is unavailable. The configured source registry bounds this map, and
+// rate.Limiter is safe for concurrent use.
+type sourceLocalFloor struct {
+	limiters map[string]*rate.Limiter
+}
+
+func newSourceLocalFloor(sources sourceRegistry, rps float64, burst int) *sourceLocalFloor {
+	limiters := make(map[string]*rate.Limiter, len(sources))
+	for source, cfg := range sources {
+		if cfg.Enabled {
+			limiters[source] = rate.NewLimiter(rate.Limit(rps), burst)
+		}
+	}
+	return &sourceLocalFloor{limiters: limiters}
+}
+
+func (f *sourceLocalFloor) Allow(source string) bool {
+	if f == nil {
+		return true
+	}
+	limiter, ok := f.limiters[source]
+	return ok && limiter.Allow()
+}

--- a/modules/bot_task/redis_integration_test.go
+++ b/modules/bot_task/redis_integration_test.go
@@ -1,0 +1,332 @@
+package bot_task
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/bot_api"
+	"github.com/Mininglamp-OSS/octo-server/modules/robot"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/go-redis/redis"
+)
+
+const botTaskIntegrationExpire = 2 * time.Minute
+
+// TestBotTaskMySQLRedisRobotQueueIntegration covers the production path that
+// unit fakes cannot: authenticate a source, reserve the real Redis claim,
+// atomically CAS it to done while enqueueing a real robot event, consume that
+// event through /v1/bot/events, and ACK it from the queue.
+func TestBotTaskMySQLRedisRobotQueueIntegration(t *testing.T) {
+	ctx, cfg := newBotTaskIntegrationContext(t, botTaskIntegrationExpire)
+	nonce := time.Now().UnixNano()
+	botID := fmt.Sprintf("bt-%d", nonce)
+	botToken := fmt.Sprintf("bf_bt_%d", nonce)
+	source := fmt.Sprintf("loop-%d", nonce)
+	sourceToken := fmt.Sprintf("source-token-%d-0123456789abcdef", nonce)
+	request := validTaskRequest()
+	request.Source = source
+	request.BotUID = botID
+	request.IdempotencyKey = fmt.Sprintf("comment-%d", nonce)
+	request.Context = json.RawMessage(`{"issue_id":9007199254740993,"comment_id":"comment-1"}`)
+	request.Metadata = json.RawMessage(`{"anchor":"comment-1"}`)
+
+	ensureBotTaskIntegrationSchema(t, ctx)
+	prepareBotTaskActiveUserBot(t, ctx, botID, botToken)
+
+	claims := newRedisClaimStore(ctx)
+	redisClient := claims.backend.(*redisClaimBackend).client
+	t.Cleanup(func() { _ = redisClient.Close() })
+	if err := redisClient.Ping().Err(); err != nil {
+		t.Fatalf("real Redis is required for bot task integration test at %s: %v", cfg.DB.RedisAddr, err)
+	}
+
+	queueKey := "robotEvent:" + botID
+	claimKey := taskClaimKey(source, botID, request.IdempotencyKey)
+	t.Cleanup(func() {
+		_ = redisClient.Del(queueKey, claimKey, "ratelimit:bot_task_source:"+source).Err()
+	})
+
+	module := &BotTask{
+		ctx:            ctx,
+		robots:         robot.NewService(ctx),
+		claims:         claims,
+		sources:        sourceRegistry{source: {Token: sourceToken, Enabled: true, AllowedBotUIDs: []string{botID}}},
+		now:            time.Now,
+		notifyBotEvent: func(string) {},
+		Log:            log.NewTLog("BotTaskRedisIntegrationTest"),
+	}
+	router := wkhttp.New()
+	router.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	module.Route(router)
+	bot_api.NewBotAPI(ctx).Route(router)
+
+	first := doTaskRequest(t, router, sourceToken, request)
+	if first.Code != http.StatusAccepted {
+		t.Fatalf("first ingress status=%d body=%s", first.Code, first.Body.String())
+	}
+	accepted := decodeBotTaskIngress(t, first)
+	if !accepted.Accepted || accepted.Replay || accepted.EventID <= 0 {
+		t.Fatalf("first ingress response=%+v", accepted)
+	}
+	if got := redisClient.ZCard(queueKey).Val(); got != 1 {
+		t.Fatalf("queue size after ingress=%d, want 1", got)
+	}
+	assertBotTaskRedisTTL(t, redisClient.TTL(queueKey).Val(), cfg.Robot.MessageExpire, "queue")
+	assertBotTaskRedisTTL(t, redisClient.TTL(claimKey).Val(), cfg.Robot.MessageExpire, "confirmed claim")
+
+	replay := doTaskRequest(t, router, sourceToken, request)
+	if replay.Code != http.StatusOK {
+		t.Fatalf("replay status=%d body=%s", replay.Code, replay.Body.String())
+	}
+	replayed := decodeBotTaskIngress(t, replay)
+	if !replayed.Accepted || !replayed.Replay || replayed.EventID != accepted.EventID {
+		t.Fatalf("replay response=%+v, want event_id=%d", replayed, accepted.EventID)
+	}
+	if got := redisClient.ZCard(queueKey).Val(); got != 1 {
+		t.Fatalf("queue size after replay=%d, want 1", got)
+	}
+
+	pulled := doBotTaskBotAPIRequest(t, router, http.MethodPost, "/v1/bot/events", botToken, []byte(`{"event_id":0,"limit":10}`))
+	if pulled.Code != http.StatusOK {
+		t.Fatalf("pull status=%d body=%s", pulled.Code, pulled.Body.String())
+	}
+	var events struct {
+		Status  int `json:"status"`
+		Results []struct {
+			EventID   int64           `json:"event_id"`
+			EventType string          `json:"event_type"`
+			EventData json.RawMessage `json:"event_data"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(pulled.Body.Bytes(), &events); err != nil {
+		t.Fatalf("decode pulled events: %v body=%s", err, pulled.Body.String())
+	}
+	if events.Status != 1 || len(events.Results) != 1 {
+		t.Fatalf("pulled events=%+v", events)
+	}
+	event := events.Results[0]
+	if event.EventID != accepted.EventID || event.EventType != botTaskEventType {
+		t.Fatalf("pulled event id/type=%d/%q", event.EventID, event.EventType)
+	}
+	assertBotTaskEventData(t, event.EventData, request)
+
+	ackPath := fmt.Sprintf("/v1/bot/events/%d/ack", accepted.EventID)
+	acked := doBotTaskBotAPIRequest(t, router, http.MethodPost, ackPath, botToken, nil)
+	if acked.Code != http.StatusOK {
+		t.Fatalf("ack status=%d body=%s", acked.Code, acked.Body.String())
+	}
+	if got := redisClient.ZCard(queueKey).Val(); got != 0 {
+		t.Fatalf("queue size after ACK=%d, want 0", got)
+	}
+
+	afterACKReplay := doTaskRequest(t, router, sourceToken, request)
+	if afterACKReplay.Code != http.StatusOK {
+		t.Fatalf("post-ACK replay status=%d body=%s", afterACKReplay.Code, afterACKReplay.Body.String())
+	}
+	if response := decodeBotTaskIngress(t, afterACKReplay); !response.Replay || response.EventID != accepted.EventID {
+		t.Fatalf("post-ACK replay response=%+v", response)
+	}
+	if got := redisClient.ZCard(queueKey).Val(); got != 0 {
+		t.Fatalf("queue size after post-ACK replay=%d, want 0", got)
+	}
+
+	assertBotTaskRealRedisClaimCAS(t, claims, redisClient)
+}
+
+func newBotTaskIntegrationContext(t *testing.T, messageExpire time.Duration) (*config.Context, *config.Config) {
+	t.Helper()
+	cfg := config.New()
+	cfg.Test = true
+	cfg.Robot.MessageExpire = messageExpire
+	cfg.DB.MySQLAddr = "root:demo@tcp(127.0.0.1:3306)/test?charset=utf8mb4&parseTime=true"
+	if dsn := os.Getenv("OCTO_TEST_MYSQL_DSN"); dsn != "" {
+		cfg.DB.MySQLAddr = dsn
+	}
+	if addr := os.Getenv("OCTO_TEST_REDIS_ADDR"); addr != "" {
+		cfg.DB.RedisAddr = addr
+	}
+	ctx := config.NewContext(cfg)
+	var one int
+	if err := ctx.DB().SelectBySql("SELECT 1").LoadOne(&one); err != nil || one != 1 {
+		t.Fatalf("real MySQL is required for bot task integration test: SELECT 1=%d, %v", one, err)
+	}
+	t.Cleanup(func() { _ = ctx.DB().Close() })
+	return ctx, cfg
+}
+
+func ensureBotTaskIntegrationSchema(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	statements := []string{
+		`CREATE TABLE IF NOT EXISTS robot (
+			id BIGINT NOT NULL AUTO_INCREMENT,
+			robot_id VARCHAR(40) NOT NULL DEFAULT '',
+			token VARCHAR(100) NOT NULL DEFAULT '',
+			version BIGINT NOT NULL DEFAULT 0,
+			status SMALLINT NOT NULL DEFAULT 1,
+			creator_uid VARCHAR(40) NOT NULL DEFAULT '',
+			bot_token VARCHAR(100) NOT NULL DEFAULT '',
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (id),
+			UNIQUE KEY robot_id_robot_index (robot_id),
+			UNIQUE KEY idx_robot_bot_token (bot_token)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci`,
+		`CREATE TABLE IF NOT EXISTS app_bot (
+			id VARCHAR(40) NOT NULL,
+			uid VARCHAR(40) NOT NULL,
+			display_name VARCHAR(100) NOT NULL,
+			description VARCHAR(500) NOT NULL DEFAULT '',
+			avatar VARCHAR(200) NOT NULL DEFAULT '',
+			scope VARCHAR(20) NOT NULL DEFAULT 'platform',
+			space_id VARCHAR(40) DEFAULT NULL,
+			status TINYINT NOT NULL DEFAULT 0,
+			token VARCHAR(100) NOT NULL,
+			welcome_msg VARCHAR(500) NOT NULL DEFAULT '',
+			created_by VARCHAR(40) NOT NULL,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			PRIMARY KEY (id),
+			UNIQUE KEY uk_app_bot_uid (uid),
+			UNIQUE KEY uk_app_bot_token (token)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci`,
+		`CREATE TABLE IF NOT EXISTS seq (
+			id INT NOT NULL AUTO_INCREMENT,
+			` + "`key`" + ` VARCHAR(100) NOT NULL DEFAULT '',
+			min_seq BIGINT NOT NULL DEFAULT 1000000,
+			step INT NOT NULL DEFAULT 1000,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (id),
+			UNIQUE KEY seq_uidx (` + "`key`" + `)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci`,
+		`CREATE TABLE IF NOT EXISTS system_setting (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			category VARCHAR(64) NOT NULL,
+			key_name VARCHAR(128) NOT NULL,
+			value TEXT NOT NULL,
+			value_type VARCHAR(16) NOT NULL DEFAULT 'string',
+			description VARCHAR(255) NOT NULL DEFAULT '',
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			PRIMARY KEY (id),
+			UNIQUE KEY uk_category_key (category, key_name)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci`,
+	}
+	for index, statement := range statements {
+		if _, err := ctx.DB().DB.Exec(statement); err != nil {
+			t.Fatalf("create integration schema statement %d: %v", index, err)
+		}
+	}
+}
+
+func prepareBotTaskActiveUserBot(t *testing.T, ctx *config.Context, botID, botToken string) {
+	t.Helper()
+	if _, err := ctx.DB().InsertBySql(
+		"INSERT INTO robot (robot_id, status, creator_uid, bot_token) VALUES (?, 1, ?, ?)",
+		botID, "bot-task-integration-owner", botToken,
+	).Exec(); err != nil {
+		t.Fatalf("insert integration User Bot: %v", err)
+	}
+	seqKey := "seq:" + common.RobotEventSeqKey + botID
+	t.Cleanup(func() {
+		if _, err := ctx.DB().DeleteFrom("seq").Where("`key`=?", seqKey).Exec(); err != nil {
+			t.Errorf("cleanup integration sequence: %v", err)
+		}
+		if _, err := ctx.DB().DeleteFrom("robot").Where("robot_id=?", botID).Exec(); err != nil {
+			t.Errorf("cleanup integration User Bot: %v", err)
+		}
+	})
+}
+
+func decodeBotTaskIngress(t *testing.T, response *httptest.ResponseRecorder) ingressResponse {
+	t.Helper()
+	var decoded ingressResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode ingress response: %v body=%s", err, response.Body.String())
+	}
+	return decoded
+}
+
+func doBotTaskBotAPIRequest(t *testing.T, router *wkhttp.WKHttp, method, path, token string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, req)
+	return response
+}
+
+func assertBotTaskRedisTTL(t *testing.T, got, want time.Duration, kind string) {
+	t.Helper()
+	if got <= want-3*time.Second || got > want {
+		t.Fatalf("%s TTL=%v, want within (%v, %v]", kind, got, want-3*time.Second, want)
+	}
+}
+
+func assertBotTaskEventData(t *testing.T, raw json.RawMessage, request taskRequest) {
+	t.Helper()
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var data map[string]interface{}
+	if err := decoder.Decode(&data); err != nil {
+		t.Fatalf("decode event_data: %v data=%s", err, raw)
+	}
+	if data["source"] != request.Source || data["task_type"] != request.TaskType ||
+		data["idempotency_key"] != request.IdempotencyKey || data["bot_uid"] != request.BotUID ||
+		data["actor_uid"] != request.ActorUID || data["session_key"] != request.SessionKey ||
+		data["prompt"] != request.Prompt {
+		t.Fatalf("event_data fields=%#v", data)
+	}
+	context, ok := data["context"].(map[string]interface{})
+	if !ok || context["issue_id"] != json.Number("9007199254740993") || context["comment_id"] != "comment-1" {
+		t.Fatalf("event_data context=%#v", data["context"])
+	}
+	metadata, ok := data["metadata"].(map[string]interface{})
+	if !ok || metadata["anchor"] != "comment-1" {
+		t.Fatalf("event_data metadata=%#v", data["metadata"])
+	}
+	if _, ok := data["enqueued_at"].(json.Number); !ok {
+		t.Fatalf("event_data enqueued_at=%#v", data["enqueued_at"])
+	}
+}
+
+func assertBotTaskRealRedisClaimCAS(t *testing.T, claims *claimStore, client *redis.Client) {
+	t.Helper()
+	key := claimPrefix + fmt.Sprintf("cas-%d", time.Now().UnixNano())
+	queueKey := "robotEvent:" + key
+	t.Cleanup(func() { _ = client.Del(key, queueKey).Err() })
+	outcome, lease, err := claims.Begin(key, "sha-original")
+	if err != nil || outcome.State != claimAcquired || lease == nil {
+		t.Fatalf("real Redis begin=%+v lease=%+v err=%v", outcome, lease, err)
+	}
+	assertBotTaskRedisTTL(t, client.TTL(key).Val(), claimPendingTTL, "pending claim")
+	replacement := `{"state":"pending","sha":"sha-replacement","token":"replacement"}`
+	if err := client.Set(key, replacement, claimPendingTTL).Err(); err != nil {
+		t.Fatalf("replace pending claim: %v", err)
+	}
+	if released, err := claims.Release(lease); err != nil || released {
+		t.Fatalf("stale real Redis release=%v, %v; want false, nil", released, err)
+	}
+	prepared := robot.PreparedBotTypedEvent{EventID: 99, QueueKey: queueKey, Member: `{"event_id":99}`}
+	if committed, err := claims.Commit(lease, prepared); err != nil || committed {
+		t.Fatalf("stale real Redis commit=%v, %v; want false, nil", committed, err)
+	}
+	if got := client.ZCard(queueKey).Val(); got != 0 {
+		t.Fatalf("stale real Redis commit queued %d events, want 0", got)
+	}
+	if got, err := client.Get(key).Result(); err != nil || !strings.Contains(got, "sha-replacement") {
+		t.Fatalf("replacement claim after stale CAS=%q, %v", got, err)
+	}
+}

--- a/pkg/errcode/bot_task.go
+++ b/pkg/errcode/bot_task.go
@@ -1,0 +1,14 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+var (
+	ErrBotTaskForbidden           = register(codes.Code{ID: "err.server.bot_task.forbidden", HTTPStatus: http.StatusForbidden, DefaultMessage: "This source cannot deliver tasks to the requested bot."})
+	ErrBotTaskInProgress          = register(codes.Code{ID: "err.server.bot_task.in_progress", HTTPStatus: http.StatusConflict, DefaultMessage: "A task with this idempotency key is still being accepted."})
+	ErrBotTaskIdempotencyConflict = register(codes.Code{ID: "err.server.bot_task.idempotency_conflict", HTTPStatus: http.StatusConflict, DefaultMessage: "This idempotency key was already used with a different task."})
+	ErrBotTaskStoreFailed         = register(codes.Code{ID: "err.server.bot_task.store_failed", HTTPStatus: http.StatusInternalServerError, DefaultMessage: "Failed to accept the bot task.", Internal: true})
+)

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -1418,6 +1418,18 @@ other = "该幂等键已用于不同的请求。"
 ["err.server.bot_mention.store_failed"]
 other = "文档评论机器人事件处理失败。"
 
+["err.server.bot_task.forbidden"]
+other = "该来源无权向指定机器人投递任务。"
+
+["err.server.bot_task.in_progress"]
+other = "使用此幂等键的任务仍在接收中。"
+
+["err.server.bot_task.idempotency_conflict"]
+other = "此幂等键已用于其他任务。"
+
+["err.server.bot_task.store_failed"]
+other = "接收机器人任务失败。"
+
 # ---- modules/notification：账号级快捷静音 ----
 
 ["err.server.notification.pause.invalid_time"]

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -222,6 +222,18 @@ other = "Invalid request."
 ["err.server.bot_provision.space_forbidden"]
 other = "You are not a member of this space."
 
+["err.server.bot_task.forbidden"]
+other = "This source cannot deliver tasks to the requested bot."
+
+["err.server.bot_task.idempotency_conflict"]
+other = "This idempotency key was already used with a different task."
+
+["err.server.bot_task.in_progress"]
+other = "A task with this idempotency key is still being accepted."
+
+["err.server.bot_task.store_failed"]
+other = "Failed to accept the bot task."
+
 ["err.server.botfather.already_friends"]
 other = "You are already friends."
 


### PR DESCRIPTION
## Summary

Add a source-registered generic Bot Task ingress that delivers business-defined prompts to Bot event consumers without hard-coded profiles, capabilities, or execution steps.

## Related Issue

N/A

## Linked Spec

`.octospec/tasks/bot-task/brief.md`

## Changes

- Add `POST /v1/internal/bot-tasks` with per-source Bearer authentication and Bot allowlists.
- Validate payload limits, target Bot existence, rate limits, and atomic idempotent enqueue.
- Deliver normalized `bot_task` events through the existing Bot event queue.
- Add localized errors, tests, configuration documentation, and module registration.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   It adds a new authenticated service-to-service ingress that writes generic tasks into the existing per-Bot event queue. Existing document mention and card-action paths remain unchanged.

2. **What could break** because of it (dependents + failure mode)?

   Misconfigured source tokens or Bot allowlists reject ingress fail-closed. Queue or idempotency-store failures return errors without publishing a partially committed task. Consumers that do not recognize `bot_task` continue using their existing event handling behavior.

3. **How do you know it works** (specific test/repro/trace)?

   Module tests cover authentication, allowlists, validation, Bot existence, replay/conflict behavior, concurrent duplicate delivery, and atomic enqueue failure recovery. The end-to-end Loop/OpenClaw flow was also exercised in the development environment.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)

Closes #847