### PR TITLE
refactor: extract pkg/internaltoken registry for fixed internal-token envs

### DIFF
--- a/.octospec/journal/shared/internal-token-registry.md
+++ b/.octospec/journal/shared/internal-token-registry.md
@@ -1,0 +1,98 @@
+---
+type: Journal
+title: "Journal: internal-token-registry"
+description: Extract pkg/internaltoken — one registry for the fixed internal-token envs, with registration order as a precedence order, so cross-capability collision coverage is complete by construction instead of by each author remembering the sibling list.
+tags: ["auth", "trust-boundary", "config", "internal", "testing"]
+timestamp: 2026-09-07T18:00:00+08:00
+# --- octospec extension fields ---
+task: internal-token-registry
+source: self
+---
+
+# Journal: internal-token-registry
+
+## What was done
+
+Four fixed internal-token envs each hand-rolled their own "must differ from
+sibling X" check, and each author compared only against what existed when they
+wrote it: `NOTIFY_INTERNAL_TOKEN` against 0 siblings, `OCTO_DOCS_NOTIFY_TOKEN`
+against 1, `OCTO_DOCS_BOT_MENTION_TOKEN` against 2, `OCTO_DRIVE_INTERNAL_TOKEN`
+against 3.
+
+- `pkg/internaltoken` (new) — owns the registry, `Resolve(env, getenv)`, the
+  `X-Internal-Token` header name, and `DefaultMinBytes`. Resolve enforces the
+  spec's length floor and compares the value against every env registered
+  *before* it. Refusal returns `("", *Error)` with a typed `Reason`; the empty
+  token is what makes each caller's auth middleware fail closed.
+- `modules/notify`, `modules/bot_mention`, `modules/internal_resolve` — the
+  three hand-rolled resolvers collapse to one call each. `notify` splits its log
+  level on `Reason` (unset → WARN, collision/too-short → ERROR); the other two
+  now do the same instead of logging every refusal at ERROR.
+- `internal/cardactiondispatch/registry.go` — its two hardcoded `32` literals
+  now read `internaltoken.DefaultMinBytes`, so "one bar operators have to
+  remember" is one value rather than a claim in a doc comment.
+- `main.go` — `ValidateNotifyTokenExclusions` is fed from
+  `internaltoken.Values(os.Getenv)` instead of a hand-written argument list, and
+  a new `reportFixedInternalTokenCollisions` logs one line per colliding pair
+  naming the survivor and the disabled env.
+
+## The structural point: registration order is a precedence order
+
+The first implementation made `Resolve` symmetric — compare against every
+*other* env, disable both sides of a collision. It read well ("when one secret
+opens two doors, neither should stay open") and it was wrong.
+
+Under the pre-existing behaviour, `NOTIFY_INTERNAL_TOKEN == OCTO_DOCS_NOTIFY_TOKEN`
+disabled docs and left the legacy ingress serving. Symmetric resolution turns
+that same misconfiguration into `internalToken == "" && docsToken == "" &&
+actionService == nil`, which 401s **every** request to the `/v1/internal` notify
+group. A deployment that had been serving for months goes dark on the next
+rolling deploy, for a config that was already contained.
+
+Making the registry order a *precedence* order recovers both properties at once:
+
+- **Coverage is still complete by construction.** Every unordered pair `{i, j}`
+  is compared exactly once, by whichever side was registered later. Appending a
+  Spec guards it against all existing envs and them against it, with no edit
+  anywhere else.
+- **Which side yields is decided, not arbitrary.** The incumbent keeps serving;
+  the newcomer that duplicated an existing secret is the one that goes dark —
+  which is exactly what the four hand-rolled ladders already did.
+
+So the ladder the modules had built by accident was the right semantics. What
+was wrong was that it lived in four places and depended on memory. The fix was
+to make it a property of the data, not to replace it.
+
+## Gotchas worth remembering
+
+- **A "complete by construction" rewrite can quietly widen the blast radius.**
+  The symmetric version was strictly more coverage and strictly worse
+  operationally. Ask what a *misconfigured but currently working* deployment
+  does on the next deploy, not just whether the invariant holds.
+- **Length floors are a rollout decision, not a refactor decision.** Three of
+  the four envs ship without the 32-byte bar. Applying it uniformly would have
+  disabled any live ingress running a shorter secret — and `pilote2e` proves
+  short values are in use. The waivers are explicit `MinBytes: 0` entries pinned
+  by a test, so lifting one is a deliberate one-line change in two places.
+- **`Values`/`Collisions` panic on a nil `getenv`.** Returning an empty slice
+  would make `ValidateNotifyTokenExclusions(Values(nil)...)` — the one gate here
+  that *aborts* startup — a silent no-op. Same posture as `mustLookupSharedCode`
+  in the i18n helpers.
+- **A source-grep guard is only as strong as the expression it pins.** The
+  pre-existing `main_wiring_test.go` grepped for one literal argument. Replacing
+  it with `internaltoken.Values(` alone would have been weaker — a stub lookup
+  passes. It pins `internaltoken.Values(os.Getenv)` plus a runtime assertion
+  that the registry contains the drive env.
+
+## Verification
+
+`go build ./...`, `go vet ./...`, `golangci-lint`, `make i18n-extract-check`,
+`make i18n-lint` clean. Full suite run locally the way CI runs it
+(`ci/run-unit-tests.sh` + `ci/run-e2e-shard.sh 1 1`, with MySQL 8.0 / Redis 7 /
+WuKongIM v2.2.4-20260313): **102 packages, 0 failures**.
+
+`pilote2e` (build-tagged, not in either CI lane) has 3 failing tests —
+`cardtmpl registry ... default catalog not wired`, because the package has no
+TestMain wiring the registry the way `modules/notify/testmain_test.go` does.
+Verified pre-existing by checking out the parent commit and reproducing the
+identical three failures.

--- a/.octospec/journal/shared/internal-token-registry.md
+++ b/.octospec/journal/shared/internal-token-registry.md
@@ -84,6 +84,59 @@ to make it a property of the data, not to replace it.
   passes. It pins `internaltoken.Values(os.Getenv)` plus a runtime assertion
   that the registry contains the drive env.
 
+## Review round 2 (PR #853) — the symmetric claim outlived the symmetric code
+
+Two reviewers, one human and one automated, independently found the same thing:
+the PR *documented and tested a symmetric guard the registry deliberately does
+not implement.* When the design changed from symmetric to precedence, the
+`bot_mention` and `notify` tests were rewritten into the `yields_to_` /
+`outranks_` two-branch shape — and `modules/internal_resolve/api_test.go` was
+not. It asserted refusal against **every** other registered env.
+
+It passed. Not because it was right, but because `OCTO_DRIVE_INTERNAL_TOKEN`
+happens to be registered last, which makes every sibling a senior. Appending one
+`Spec` — the single operation the package doc tells you is "the whole change" —
+turns it red:
+
+```
+api_test.go:434: expected error when OCTO_DRIVE_INTERNAL_TOKEN == OCTO_FUTURE_CAP_TOKEN
+```
+
+That is worse than a stale comment. The next person to append a `Spec` meets a
+red assertion whose comment says the code guarantees something it does not, and
+the cheapest way out of a red assertion is to weaken it. The
+coverage-by-convention decay this task set out to end would have survived — it
+would just have moved from a comment in `config.go` to a comment in
+`api_test.go`.
+
+Four prose sites carried the same overstatement (`internal_resolve/config.go`
+×2, `bot_mention/config.go`, `notify/api.go` — the last one neither reviewer
+caught), plus the brief's own Acceptance section, which claimed "no test edit"
+while the tree required one.
+
+Fixed by giving `internal_resolve` the same two-branch shape, which also buys
+the `outranks_*` half nothing previously asserted, and by rewording every site to
+"every env registered BEFORE it". Verified the way a reader would: append a
+hypothetical fifth `Spec` and confirm the module tests **re-classify** the new
+env as a junior instead of failing.
+
+### `Collisions` is now derived from `Resolve`
+
+Both reviewers also flagged the boot report. It compared every unordered pair
+independently of `Resolve`, so it could contradict it two ways: it ignored the
+length floor (re-surfacing the sibling name that `Resolve`'s ordering
+deliberately suppresses), and in a three-way collision it emitted the
+(docs-notify, bot-mention) pair with docs-notify as `serving_env` — a capability
+`Resolve` had already disabled. An operator acting on that line rotates the wrong
+secret and leaves a second ingress dark.
+
+Rewritten to call `Resolve` per env and report only the ones refused with
+`ReasonCollision`. Now the report cannot disagree with the thing it reports on:
+a too-short value yields no pair, and a three-way collision produces two lines,
+both naming the first env. The `SeniorServing` field carries the "still serving"
+claim explicitly, because a senior *can* be dark for its own reason once the
+registry grows an env with a floor above index 0.
+
 ## Verification
 
 `go build ./...`, `go vet ./...`, `golangci-lint`, `make i18n-extract-check`,

--- a/.octospec/learnings/pending/centralising-a-check-must-preserve-who-yields.md
+++ b/.octospec/learnings/pending/centralising-a-check-must-preserve-who-yields.md
@@ -91,3 +91,28 @@ it a property of the data, not to replace it with something tidier.**
 - **Ask the availability question out loud in review.** "What does a broken-but-
   working deployment do on the next deploy?" catches this class; "does the
   invariant hold?" does not.
+
+## Postscript: the abandoned design leaves fingerprints
+
+Switching from the symmetric rule to precedence updated the implementation and
+two of the three module tests. The third kept asserting the symmetric shape —
+"refuse against every OTHER registered env" — and **passed**, because its subject
+happened to be registered last, which made every sibling a senior. Five prose
+comments kept describing the symmetric guard too, in security-sensitive files.
+
+Two reviewers found it independently; the test suite and the linter could not,
+because a positional accident is invisible to both.
+
+So the rule has a second half: **when you abandon a design mid-change, grep for
+the sentences and the assertions that described it.** An executable assertion
+that outlives the design it was written for is worse than a stale comment — the
+next person to exercise the new design meets a red test whose comment says the
+code guarantees something it does not, and the cheapest way out of a red
+assertion is to weaken it. That is the same convention-decay the centralisation
+was meant to end, relocated into the test file.
+
+The check that catches it is cheap and specific: **perform the extension the new
+design advertises.** Here that was "append one registry entry and re-run" — it
+produced the failure in seconds, and after the fix it produced a passing
+`outranks_*` subtest instead, which is the positive proof that the claim
+"appending needs no edit anywhere else" is now true.

--- a/.octospec/learnings/pending/centralising-a-check-must-preserve-who-yields.md
+++ b/.octospec/learnings/pending/centralising-a-check-must-preserve-who-yields.md
@@ -1,0 +1,93 @@
+---
+type: Learning
+title: "Learning: centralising a scattered check must preserve which side yields, not just that the check happens"
+description: Replacing N hand-rolled pairwise guards with one symmetric rule looks like strictly more coverage, but the scattered originals also encoded WHICH side loses. Symmetry silently converts a contained misconfiguration into an outage on the next deploy.
+tags: ["refactor", "auth", "config", "trust-boundary", "availability", "review"]
+timestamp: 2026-09-07T18:00:00+08:00
+# --- octospec extension fields ---
+task: internal-token-registry
+status: pending
+---
+# Centralising a scattered check must preserve which side yields
+
+## What happened
+
+Four capabilities each owned a fixed internal-token env, and each hand-rolled a
+"must differ from sibling X" guard against whatever siblings existed when it was
+written — 0, 1, 2 and 3 siblings respectively. The stated goal of the refactor
+was to make coverage complete by construction: one registry, one resolve
+function, compare against **every other** registered env.
+
+That symmetric rule is strictly more coverage than the ladder it replaced. It was
+also, operationally, strictly worse.
+
+The scattered guards had a second property nobody had written down: they were
+directional. `OCTO_DOCS_NOTIFY_TOKEN` yielded to `NOTIFY_INTERNAL_TOKEN`, never
+the reverse. So a deployment that had mistakenly set both to the same value ran
+with docs disabled and the **legacy ingress still serving** — and had been doing
+so, quietly, for as long as the mistake existed.
+
+Under the symmetric rule both sides resolve to `""`. The auth middleware's
+"nothing configured" branch then rejects *every* request to the whole
+`/v1/internal` notify group. Same misconfiguration, same invariant satisfied,
+but a working production ingress goes dark on the next rolling deploy — with no
+boot failure and no readiness signal, only two log lines.
+
+## Why it was easy to miss
+
+The symmetric version is easier to justify in the abstract. "When one secret
+opens two doors, neither door should stay open" is a clean sentence, and it is
+even true as a security argument: the invariant ("one credential grants exactly
+one capability") is satisfied either way.
+
+What the sentence hides is that the invariant was **already satisfied** by the
+asymmetric rule. Disabling one side is sufficient. The second disable buys no
+additional containment — it only spends availability.
+
+Every test passed in both designs, because no test encoded "and the other one
+keeps working". The scattered originals expressed it only as the *direction* of
+a comparison, which is exactly the kind of detail that evaporates when four
+call sites are folded into one.
+
+## The rule
+
+**Before folding N scattered guards into one, recover what the scattered
+versions decided in addition to what they checked.** Ask specifically:
+
+1. For each existing guard, *which* side does it disable, and would the unified
+   rule disable a different or larger set?
+2. What does a currently-misconfigured-but-serving deployment do on the next
+   deploy under the new rule? Not "is the invariant held" — it was held before —
+   but "what stops working that was working".
+3. Is the extra strictness buying containment, or only cost?
+
+For this case the answer was a **precedence order**: registration position
+decides who yields, and Resolve compares against every env registered *before*
+it. That recovers both properties at once —
+
+- every unordered pair is still compared exactly once, by whichever side was
+  registered later, so appending an entry needs no edit anywhere else; and
+- the incumbent keeps serving, the newcomer that duplicated an existing secret
+  is the one disabled — precisely what the four ladders already did.
+
+The ladder built by accident was the right semantics. What was wrong was that it
+lived in four places and depended on each author's memory. **The fix was to make
+it a property of the data, not to replace it with something tidier.**
+
+## Generalisation
+
+- **"Complete by construction" is a claim about coverage, not about behaviour.**
+  A rewrite can be more complete and less correct. Coverage and blast radius are
+  independent axes; a centralisation PR is exactly where they get conflated.
+- **Order-dependence in scattered code is often load-bearing, not accidental.**
+  When each site was written against "everything that existed then", the
+  resulting order *is* a precedence relation. Preserve it explicitly and pin it
+  with a test, or you will re-derive it after an incident.
+- **The same applies to uniform limits.** The same refactor was asked to apply
+  one 32-byte length floor everywhere; three of four envs shipped without it, and
+  live configs use shorter values. Applying it uniformly would have disabled
+  running ingresses for the same "it's more correct now" reason. Explicit,
+  test-pinned waivers keep the gap visible and make lifting it a deliberate act.
+- **Ask the availability question out loud in review.** "What does a broken-but-
+  working deployment do on the next deploy?" catches this class; "does the
+  invariant hold?" does not.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -29,6 +29,44 @@ change-log convention (§7). Newest first.
   [journal](journal/shared/project-collaboration-roles.md); reusable pagination guidance
   is staged in [learnings/pending](learnings/pending/project-collaboration-roles.md).
 
+## 2026-09-07 — internal-token-registry (extract pkg/internaltoken)
+
+- **Done** — one registry now owns the four fixed internal-token envs, the
+  `X-Internal-Token` header name and the shared 32-byte floor.
+  `Resolve(env, getenv)` enforces the floor and compares against every env
+  registered *before* it, so every unordered pair is checked exactly once and
+  appending a Spec needs no edit anywhere else. `modules/notify`,
+  `modules/bot_mention` and `modules/internal_resolve` collapse to one call each;
+  `main.go` feeds `ValidateNotifyTokenExclusions` from `internaltoken.Values`
+  and logs each colliding pair by ENV name before the card-dispatch installers,
+  so a malformed `OCTO_CARD_ACTION_ROUTES` cannot swallow the diagnostic.
+  `internal/cardactiondispatch` drops its two hardcoded `32` literals.
+- **Learned (the load-bearing one)** — the first cut made `Resolve` symmetric
+  ("one secret opens two doors, neither stays open"). It was strictly more
+  coverage and strictly worse: `NOTIFY_INTERNAL_TOKEN == OCTO_DOCS_NOTIFY_TOKEN`
+  had been disabling docs only and leaving the legacy ingress serving; symmetric
+  resolution 401s the whole `/v1/internal` notify group on the next rolling
+  deploy. Registration order as a *precedence* order keeps complete coverage AND
+  the pre-existing survivor. The ladder the four modules had built by accident
+  was the right semantics — what was wrong was that it lived in four places.
+- **Learned** — length floors are a rollout decision, not a refactor decision.
+  Three of four envs ship without the 32-byte bar and `pilote2e` proves short
+  values are in use; the waivers are explicit `MinBytes: 0` entries pinned by a
+  test rather than a silent uniform raise.
+- **Learned** — `Values`/`Collisions` panic on a nil `getenv`: returning an empty
+  slice would turn the one gate that *aborts* startup into a no-op.
+- **Gotcha (environment, not code)** — running the suite locally needs the two
+  things CI sets and a naive `go test ./...` does not: `OCTO_MASTER_KEY` and
+  `SET GLOBAL max_connections = 1000`. Skipping them produced 5 failures that
+  looked like regressions and were not. `ci/run-unit-tests.sh` +
+  `ci/run-e2e-shard.sh` already do the per-package DB drop/recreate (each package
+  registers only its own module set's migrations, so a shared ledger aborts with
+  `unknown migration in database`) and fall back to local binaries when
+  `MYSQL_CID`/`REDIS_CID` are unset — use them instead of hand-rolling a runner.
+- **Verified** — 102 packages, 0 failures via both CI lanes. `pilote2e`'s 3
+  failures (`cardtmpl ... default catalog not wired`) reproduce identically on
+  the parent commit.
+
 ## 2026-09-06 — project-p0-foundation (PR #841 第一轮 review：TDD 修复 blocker 与 Q 项)
 
 - **Fixed (blocking)** — remove 批次中途解散丢弃已提交部分（errProjectGone 镜像 add 的

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -29,6 +29,42 @@ change-log convention (§7). Newest first.
   [journal](journal/shared/project-collaboration-roles.md); reusable pagination guidance
   is staged in [learnings/pending](learnings/pending/project-collaboration-roles.md).
 
+## 2026-09-08 — internal-token-registry (PR #853 review round 2)
+
+- **Fixed (blocking, P1)** — `modules/internal_resolve/api_test.go` still
+  asserted the *symmetric* guard the registry stopped implementing when the
+  design moved to precedence. It passed only because `OCTO_DRIVE_INTERNAL_TOKEN`
+  is registered last; appending one `Spec` — the operation the package doc calls
+  "the whole change" — turned it red. Rewritten into the `yields_to_` /
+  `outranks_` two-branch shape the other two modules already used, which also
+  adds the previously-unasserted "drive keeps serving when a junior duplicates
+  its value" half.
+- **Fixed (P2)** — `Collisions` is now derived from `Resolve` instead of
+  re-deriving the comparison. It had drifted in two directions: it ignored the
+  length floor (undoing `Resolve`'s deliberate "don't name a sibling for a value
+  that is too short anyway"), and in a three-way collision it named an
+  already-disabled env as `serving_env`. The boot line no longer asserts a cause
+  it cannot verify; `SeniorServing` carries the claim as a field.
+- **Fixed (P2)** — `DefaultMinBytes` doc now records that the two sites it feeds
+  have different blast radii: a fixed env below the floor degrades
+  module-locally, a dynamic route credential below it **panics** boot. Raising
+  the constant is a rollout decision, not a one-line bump.
+- **Fixed (docs)** — five prose sites claimed the guard compares against "every
+  OTHER" / "ANY other" registered env. It compares against every env registered
+  *before* it. Corrected in `internal_resolve/config.go` ×2,
+  `bot_mention/config.go`, `notify/api.go`, `main_wiring_test.go`, and in the
+  brief's Acceptance section, which had claimed "no test edit" while the tree
+  required one.
+- **Learned** — *a design change has to sweep the prose and the tests that
+  asserted the old design, not just the code.* The symmetric→precedence switch
+  updated the implementation and two of three module tests. The third test plus
+  five comments kept asserting symmetry, and the one that was executable passed
+  by positional accident. Both reviewers found it independently; neither the
+  suite nor `golangci-lint` could.
+- **Learned** — *derive a report from the decision it reports on.* A parallel
+  re-implementation of "which envs collide" drifted from `Resolve` in two ways at
+  once; deriving it made both unrepresentable.
+
 ## 2026-09-07 — internal-token-registry (extract pkg/internaltoken)
 
 - **Done** — one registry now owns the four fixed internal-token envs, the

--- a/.octospec/tasks/internal-token-registry/brief.md
+++ b/.octospec/tasks/internal-token-registry/brief.md
@@ -1,0 +1,130 @@
+---
+type: Task
+title: "Task: internal-token-registry"
+description: Extract one shared registry (pkg/internaltoken) for the fixed internal-token envs so cross-capability collision coverage is complete by construction.
+tags: ["auth", "trust-boundary", "config"]
+timestamp: 2026-09-07T00:00:00Z
+# --- octospec extension fields ---
+slug: internal-token-registry
+upstream: self
+source: self
+---
+
+# Task: internal-token-registry
+
+## Goal
+
+One credential grants exactly one capability. Make that invariant hold *by
+construction* for the fixed internal-token envs, instead of by each module
+author remembering the full sibling list.
+
+`pkg/internaltoken` owns the registry of those envs and exposes one resolve
+function that takes the env being resolved, enforces its length floor, and
+compares it against every env registered before it. Registration order is a
+precedence order, so every unordered pair is compared exactly once — by
+whichever side was registered later — and the junior side is the one disabled.
+The capabilities that own one of these envs go through it, and it also owns the
+`X-Internal-Token` header name and the shared 32-byte floor.
+
+## Background
+
+Each module hand-rolled its own "must differ from sibling X" comparison, and
+each author compared only against what existed at the time:
+
+| Env | Owner | Siblings it compared against |
+|---|---|---|
+| `NOTIFY_INTERNAL_TOKEN` | `modules/notify` | 0 |
+| `OCTO_DOCS_NOTIFY_TOKEN` | `modules/notify` | 1 |
+| `OCTO_DOCS_BOT_MENTION_TOKEN` | `modules/bot_mention` | 2 |
+| `OCTO_DRIVE_INTERNAL_TOKEN` | `modules/internal_resolve` | 3 |
+
+That ladder does cover all six of today's pairs — each newer env checks every
+older one — but only by convention. The (N+1)th capability is protected solely
+if its author remembers the whole list, and the N modules already in the tree
+never learn the new env exists. The length floor drifted the same way: only
+`OCTO_DRIVE_INTERNAL_TOKEN` enforces the 32-byte bar, and
+`internal/cardactiondispatch` hardcoded its own copy of `32`. The
+`X-Internal-Token` header was hand-copied in three modules, each with a comment
+naming the other two.
+
+The fix keeps the ladder's *semantics* and makes it a property of the data:
+appending a Spec guards it against every existing env, and every existing env
+against it, with no edit anywhere else.
+
+`main.go` remains the only place that also sees the *dynamic* per-route notify
+tokens and callback secrets from `OCTO_CARD_ACTION_ROUTES`.
+
+## Load-bearing list
+
+- **Collisions must not fail boot.** A collision between two *fixed*
+  internal-token envs disables the affected capability module-locally (resolved
+  token becomes `""`, so the auth middleware fails closed) and the server still
+  boots. A collision with a *dynamic* route credential fails startup. Pinned by
+  `TestCardActionDispatchScopesBotMentionTokenCollisionFailures`
+  (`main_carddispatch_test.go`).
+- **`main.go`'s cross-check with dynamic route credentials.**
+  `cardactiondispatch.Registry.ValidateNotifyTokenExclusions` still runs, now
+  fed from `internaltoken.Values` instead of a hand-written argument list.
+  `modules/internal_resolve/main_wiring_test.go` pins that wiring.
+- **Reasons never carry a token value.** They are logged, and in some callers
+  surfaced at boot.
+- **Existing length behaviour.** Only the drive token has a 32-byte floor.
+  `pilote2e` and `internal/cardactiondispatch` integration tests run notify with
+  short values; live deployments may too.
+- Per-module collision tests: `modules/internal_resolve/api_test.go`,
+  `modules/internal_resolve/boot_config_test.go`,
+  `modules/bot_mention/config_test.go`.
+
+## Out of scope
+
+- **Promoting fixed-vs-fixed collisions to boot failures.** A separate rollout
+  decision; the current contract is pinned by `main_carddispatch_test.go`.
+- **Raising the length floor on the three legacy envs.** Doing so would disable
+  a live ingress on the next deploy of any installation running a shorter
+  secret. The waivers are explicit in the registry and pinned by
+  `TestLegacyLengthWaiversAreExplicit` so lifting one is a deliberate one-line
+  change.
+- Dynamic `OCTO_CARD_ACTION_ROUTES` credentials — those stay owned by
+  `internal/cardactiondispatch`.
+- Any change to the wire header, route paths, rate limits, or auth middleware.
+
+## Operator-visible changes
+
+- **Boot log wording.** Refusal reasons are now generated from one template, so
+  the four messages are reworded. The unset case keeps the substring `will
+  reject all requests` that three of the four previously shared, so log-based
+  alerting keyed on that phrase still fires.
+- **Log level.** An unset env now logs at WARN (a capability that is simply not
+  in use is a normal deployment shape); collisions and undersized values stay at
+  ERROR. Previously `modules/internal_resolve` and `modules/bot_mention` logged
+  both at ERROR.
+- **Collision report.** `main.go` logs one ERROR line per colliding pair, naming
+  the env that keeps serving and the one that was disabled. It runs before the
+  card-dispatch installers so a malformed `OCTO_CARD_ACTION_ROUTES` cannot
+  swallow the diagnostic.
+
+No capability that was enabled before is disabled now, and no capability that
+was disabled before is enabled now.
+
+## Acceptance
+
+- `pkg/internaltoken` table test enumerates the registry and asserts every
+  unordered pair is covered exactly once, that the junior side is disabled and
+  the senior side keeps serving, so a newly registered env is covered against
+  all existing ones with no test edit
+  (`TestResolveCoversEveryRegisteredPair`). The precedence order itself is
+  pinned by `TestRegistryPrecedenceOrderIsStable`.
+- `Values` / `Collisions` panic on a nil lookup rather than reporting an empty
+  credential set, so the one gate that aborts startup cannot degrade into a
+  no-op (`TestValuesPanicsOnNilGetenv`), and `main_wiring_test.go` pins that
+  `main.go` feeds them `os.Getenv`.
+- Error strings never contain a token value
+  (`TestErrorsNeverContainTokenValue`).
+- Per-module tests enumerate `internaltoken.Envs()` rather than a hand-written
+  sibling list — including `boot_config_test.go`, which now builds the
+  exclusion argument list from `internaltoken.Values` over its own getenv
+  instead of reading the ambient process environment.
+- `go build ./... && go vet ./...` clean; `golangci-lint run` clean on the
+  touched packages; `make i18n-extract-check` + `make i18n-lint` pass.
+- All previously-passing tests still pass (MySQL/Redis-backed integration tests
+  are unrunnable in the sandbox and fail identically before and after).

--- a/.octospec/tasks/internal-token-registry/brief.md
+++ b/.octospec/tasks/internal-token-registry/brief.md
@@ -49,7 +49,12 @@ naming the other two.
 
 The fix keeps the ladder's *semantics* and makes it a property of the data:
 appending a Spec guards it against every existing env, and every existing env
-against it, with no edit anywhere else.
+against it, with no edit anywhere else. The guard is **directional** — the
+appended env yields to all of them, and they are protected from the other
+direction, by it disabling itself. Module tests must therefore branch on the
+precedence index; a test that asserts the symmetric shape passes only while its
+subject happens to be registered last, and goes red the moment the registry
+grows (PR #853 review, P1).
 
 `main.go` remains the only place that also sees the *dynamic* per-route notify
 tokens and callback secrets from `OCTO_CARD_ACTION_ROUTES`.
@@ -110,10 +115,16 @@ was disabled before is enabled now.
 
 - `pkg/internaltoken` table test enumerates the registry and asserts every
   unordered pair is covered exactly once, that the junior side is disabled and
-  the senior side keeps serving, so a newly registered env is covered against
-  all existing ones with no test edit
-  (`TestResolveCoversEveryRegisteredPair`). The precedence order itself is
-  pinned by `TestRegistryPrecedenceOrderIsStable`.
+  the senior side keeps serving (`TestResolveCoversEveryRegisteredPair`). The
+  precedence order itself is pinned by `TestRegistryPrecedenceOrderIsStable`.
+- **Appending a fifth `Spec` requires no edit to production code or to any
+  test.** Verified the way a reader would: append a hypothetical entry, run
+  `pkg/internaltoken` plus the three module packages, and confirm the module
+  tests re-classify the new env as a junior (`outranks_*`) instead of failing.
+- The boot collision report never names a disabled env as the survivor, and
+  never reports a value refused for length as a collision
+  (`TestCollisionsNeverNameADarkEnvAsTheSurvivor`,
+  `TestCollisionsRespectTheLengthFloor`).
 - `Values` / `Collisions` panic on a nil lookup rather than reporting an empty
   credential set, so the one gate that aborts startup cannot degrade into a
   no-op (`TestValuesPanicsOnNilGetenv`), and `main_wiring_test.go` pins that

--- a/ci/unit-packages.txt
+++ b/ci/unit-packages.txt
@@ -29,6 +29,7 @@
 ./pkg/i18n
 ./pkg/i18n/cmd/octo-i18n-extract
 ./pkg/i18n/codes
+./pkg/internaltoken
 ./pkg/keylock
 ./pkg/log
 ./pkg/markdown

--- a/docs/card-action-callback-dispatch.md
+++ b/docs/card-action-callback-dispatch.md
@@ -108,9 +108,16 @@ a network zone, or a public boundary.
 `notify_token_env` is optional for callback-only routes whose initial card is
 produced elsewhere. When present, it dynamically installs an `octo/v2`,
 DM-only producer bound to the route owner and the shared `notification` sender.
-The token must differ from the callback secret, `NOTIFY_INTERNAL_TOKEN`, every
-other owner token, and `OCTO_DOCS_NOTIFY_TOKEN`. The producer only sends cards
-while `OCTO_CARD_MESSAGE_ENABLED` is `true`.
+The token must differ from the callback secret, from every other owner token,
+and from **every fixed internal-token env** — the registry in
+`pkg/internaltoken` is the authoritative list, so this doc does not repeat it
+(today: `NOTIFY_INTERNAL_TOKEN`, `OCTO_DOCS_NOTIFY_TOKEN`,
+`OCTO_DOCS_BOT_MENTION_TOKEN`, `OCTO_DRIVE_INTERNAL_TOKEN`). Reusing one of
+those values is not a warning: startup aborts with `cardactiondispatch: action
+notify token conflicts with an existing notify token`, because a route
+credential that also unlocks a fixed capability breaks the "one credential /
+one capability" invariant. The producer only sends cards while
+`OCTO_CARD_MESSAGE_ENABLED` is `true`.
 
 `OCTO_CARD_MESSAGE_ENABLED` is the deployment-level master gate. With it off
 (unset or `false`) octo-server still starts with routes left in the config: the

--- a/internal/cardactiondispatch/registry.go
+++ b/internal/cardactiondispatch/registry.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/internaltoken"
 )
 
 type ResolutionKind string
@@ -298,16 +300,16 @@ func validateRouteSpec(spec RouteSpec, getenv func(string) string) error {
 	if !secretEnvPattern.MatchString(spec.SecretEnv) {
 		return errors.New("invalid secret_env")
 	}
-	if len(getenv(spec.SecretEnv)) < 32 {
-		return errors.New("callback secret must contain at least 32 bytes")
+	if len(getenv(spec.SecretEnv)) < internaltoken.DefaultMinBytes {
+		return fmt.Errorf("callback secret must contain at least %d bytes", internaltoken.DefaultMinBytes)
 	}
 	if spec.NotifyTokenEnv != "" {
 		if !secretEnvPattern.MatchString(spec.NotifyTokenEnv) {
 			return errors.New("invalid notify_token_env")
 		}
 		notifyToken := getenv(spec.NotifyTokenEnv)
-		if len(notifyToken) < 32 {
-			return errors.New("notify token must contain at least 32 bytes")
+		if len(notifyToken) < internaltoken.DefaultMinBytes {
+			return fmt.Errorf("notify token must contain at least %d bytes", internaltoken.DefaultMinBytes)
 		}
 		if spec.NotifyTokenEnv == spec.SecretEnv || notifyToken == getenv(spec.SecretEnv) {
 			return errors.New("notify token must differ from callback secret")

--- a/main.go
+++ b/main.go
@@ -679,18 +679,24 @@ func (r *cardActionDispatchRuntime) Stop() {
 	}
 }
 
-// reportFixedInternalTokenCollisions logs one line per pair of fixed
-// internal-token envs sharing a value, naming the env that keeps serving and
-// the one pkg/internaltoken disabled. Env names only — never a value.
+// reportFixedInternalTokenCollisions logs one line per capability that
+// pkg/internaltoken disabled over a duplicated value, naming the env that
+// duplicated and the earlier env it duplicated. Env names only — never a value.
+//
+// The message does not claim the other env is still serving; the
+// duplicates_env_serving field says so, because a senior can be dark for its
+// own reason (a value below its floor) and an operator who rotates the wrong
+// secret on the strength of a "still serving" line leaves an ingress off.
 //
 // Log-only by design: a fixed-vs-fixed collision degrades module-locally and
 // must not fail boot (main_carddispatch_test.go). Promoting it to a boot
 // failure is a separate rollout decision.
 func reportFixedInternalTokenCollisions(getenv func(string) string) {
 	for _, collision := range internaltoken.Collisions(getenv) {
-		log.Error("two fixed internal-token envs share a value; the junior capability is disabled — give each one its own secret",
-			zap.String("serving_env", collision.Senior),
-			zap.String("disabled_env", collision.Junior))
+		log.Error("fixed internal-token env disabled: its value duplicates an earlier env — give each capability its own secret",
+			zap.String("disabled_env", collision.Junior),
+			zap.String("duplicates_env", collision.Senior),
+			zap.Bool("duplicates_env_serving", collision.SeniorServing))
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -30,7 +30,6 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
 	cardtemplatecatalog "github.com/Mininglamp-OSS/octo-server/modules/card_template_catalog"
 	commonmodule "github.com/Mininglamp-OSS/octo-server/modules/common"
-	"github.com/Mininglamp-OSS/octo-server/modules/internal_resolve"
 	"github.com/Mininglamp-OSS/octo-server/modules/notify"
 	"github.com/Mininglamp-OSS/octo-server/modules/project"
 	"github.com/Mininglamp-OSS/octo-server/modules/space"
@@ -48,6 +47,7 @@ import (
 	summaryfailed "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/summary_failed"
 	octodb "github.com/Mininglamp-OSS/octo-server/pkg/db"
 	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/Mininglamp-OSS/octo-server/pkg/internaltoken"
 	"github.com/Mininglamp-OSS/octo-server/pkg/metrics"
 	ratelimitpkg "github.com/Mininglamp-OSS/octo-server/pkg/ratelimit"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
@@ -385,6 +385,20 @@ func runAPI(ctx *config.Context) {
 			return ratelimitpkg.Params{}
 		}
 	})
+	// Report fixed internal-token env collisions before anything that can abort
+	// boot on unrelated config.
+	//
+	// pkg/internaltoken already disables the junior capability on its own
+	// (module-locally, without failing boot — main_carddispatch_test.go pins
+	// that contract). What a module cannot do is show the whole picture: an
+	// operator reading "docs capability disabled" as a standalone line has to
+	// work out which other env it collided with, and that the other one is
+	// still serving. This runs ahead of installCardDispatch /
+	// installCardActionDispatch precisely so that a malformed
+	// OCTO_CARD_ACTION_ROUTES cannot swallow the diagnostic: the two problems
+	// are independent, and an operator fixing the route config should not have
+	// to redeploy again to discover a capability was silently off.
+	reportFixedInternalTokenCollisions(os.Getenv)
 	// Install the one process registry before register.GetModules constructs
 	// module instances. The foundation rollout deliberately has no production
 	// producer registrations; later enablement injects only a bound Sender into
@@ -665,6 +679,21 @@ func (r *cardActionDispatchRuntime) Stop() {
 	}
 }
 
+// reportFixedInternalTokenCollisions logs one line per pair of fixed
+// internal-token envs sharing a value, naming the env that keeps serving and
+// the one pkg/internaltoken disabled. Env names only — never a value.
+//
+// Log-only by design: a fixed-vs-fixed collision degrades module-locally and
+// must not fail boot (main_carddispatch_test.go). Promoting it to a boot
+// failure is a separate rollout decision.
+func reportFixedInternalTokenCollisions(getenv func(string) string) {
+	for _, collision := range internaltoken.Collisions(getenv) {
+		log.Error("two fixed internal-token envs share a value; the junior capability is disabled — give each one its own secret",
+			zap.String("serving_env", collision.Senior),
+			zap.String("disabled_env", collision.Junior))
+	}
+}
+
 func installCardActionDispatch(ctx *config.Context) (*cardActionDispatchRuntime, error) {
 	specs, err := cardactiondispatch.LoadRouteSpecs(os.Getenv("OCTO_CARD_ACTION_ROUTES"))
 	if err != nil {
@@ -681,55 +710,48 @@ func installCardActionDispatch(ctx *config.Context) (*cardActionDispatchRuntime,
 	if err != nil {
 		return nil, err
 	}
-	if err := registry.ValidateNotifyTokenExclusions(
-		os.Getenv("NOTIFY_INTERNAL_TOKEN"),
-		os.Getenv("OCTO_DOCS_NOTIFY_TOKEN"),
-		os.Getenv("OCTO_DOCS_BOT_MENTION_TOKEN"),
-		// Cross-capability exclusion for OCTO_DRIVE_INTERNAL_TOKEN vs the
-		// dynamic route-scoped notify tokens / callback secrets loaded from
-		// OCTO_CARD_ACTION_ROUTES MUST happen here — modules/internal_resolve
-		// only sees the four fixed internal-token envs and cannot detect a
-		// collision with route-level credentials. Without this argument, an
-		// operator who accidentally sets the drive token equal to a route's
-		// notify_token_env value would pass all three local checks (drive
-		// module, registry construction, and this call), and a single leaked
-		// value would then authorize BOTH resolve-bot-owner AND route notify
-		// — breaking the "one credential / one capability" invariant.
-		//
-		// modules/internal_resolve/main_wiring_test.go asserts this argument
-		// stays present so a future refactor cannot delete it silently.
-		os.Getenv(internal_resolve.DriveInternalTokenEnv),
-		// Same reasoning for the marketplace internal token: it authorizes
-		// reading any uid's role in any Space, so if it ever equalled a route's
-		// notify_token_env value one leaked credential would grant both the
-		// Space role lookup AND route notify. Registered by qualified constant,
-		// not a literal, so main_wiring_test.go can assert it stays present.
+	// Cross-capability exclusion between the credentials this process holds and
+	// the *dynamic* route-scoped notify tokens / callback secrets loaded from
+	// OCTO_CARD_ACTION_ROUTES MUST happen here — the owning modules only see
+	// their own credentials and cannot detect a collision with route-level ones.
+	// Unlike a fixed-vs-fixed collision, this one FAILS startup: a route
+	// credential that also unlocks a fixed capability breaks the "one credential
+	// / one capability" invariant in a way no module-local degradation can
+	// contain.
+	//
+	// The fixed internal-token envs are sourced from internaltoken.Values rather
+	// than hand-written, so a capability registered there joins this check
+	// automatically instead of waiting for someone to remember to extend the
+	// argument list. modules/internal_resolve/main_wiring_test.go and
+	// modules/space/main_wiring_test.go assert that wiring stays.
+	//
+	// Two credential families are still passed explicitly, because they are NOT
+	// in that registry:
+	//
+	//   - the project provisioning secrets, which gate fleet/drive container
+	//     provisioning rather than an X-Internal-Token ingress, and which
+	//     modules/project checks on its own;
+	//   - modules/space's marketplace token, until the follow-up on PR #853
+	//     moves it into the registry.
+	//
+	// TestMainWiresProvisioningSecretsIntoValidateNotifyTokenExclusions
+	// (modules/project/provisioning_guard_test.go) and modules/space's wiring
+	// guard assert their arguments stay present so a refactor cannot drop them.
+	//
+	// NOT covered here, stated because the absence is otherwise invisible:
+	// modules/bot_task's per-source bearer tokens live inside the
+	// OCTO_BOT_TASK_SOURCES JSON registry rather than in a single env, so no
+	// os.Getenv can reach them and they cannot be passed to this call. They are
+	// deduped only WITHIN that registry, which means a value shared between a
+	// bot_task source and any credential named here is detected by nothing.
+	// Closing it needs that module to expose its configured token values — a
+	// change there, not here.
+	if err := registry.ValidateNotifyTokenExclusions(append(
+		internaltoken.Values(os.Getenv),
 		os.Getenv(space.MarketplaceInternalTokenEnv),
-		// The two project provisioning secrets, for the same reason and with the same
-		// limitation: modules/project can check them against each other and against the
-		// four FIXED internal-token envs, but it cannot see the dynamic route-scoped
-		// notify tokens / callback secrets. Without these two arguments an operator who
-		// set a provisioning secret equal to a route's notify_token_env would pass every
-		// local check, and one leaked value would then authorize BOTH provisioning a
-		// container into fleet/drive AND minting that route's card action.
-		//
-		// TestMainWiresProvisioningSecretsIntoValidateNotifyTokenExclusions in
-		// modules/project/provisioning_guard_test.go asserts both arguments stay present
-		// so a refactor cannot drop them silently. (This pointer exists so a future
-		// refactorer can find the guard — an earlier version named a file that does not
-		// exist, which defeats the only purpose the comment has.)
 		os.Getenv(project.ProvisionFleetSecretEnv),
 		os.Getenv(project.ProvisionDriveSecretEnv),
-		// NOT covered here, stated because the absence is otherwise invisible:
-		// modules/bot_task's per-source bearer tokens live inside the
-		// OCTO_BOT_TASK_SOURCES JSON registry rather than in a single env, so no
-		// os.Getenv can reach them and they cannot be passed to this call. They are
-		// deduped only WITHIN that registry, which means a value shared between a
-		// bot_task source and any credential named here is detected by nothing.
-		// Closing it needs that module to expose its configured token values — a
-		// change there, not here. Recorded at the call site because this is where a
-		// reader counts the arguments and concludes the set is complete.
-	); err != nil {
+	)...); err != nil {
 		return nil, err
 	}
 	// OCTO_CARD_MESSAGE_ENABLED is the deployment-level master gate (rollout /

--- a/modules/bot_mention/api.go
+++ b/modules/bot_mention/api.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/robot"
 	"github.com/Mininglamp-OSS/octo-server/pkg/botevent"
+	"github.com/Mininglamp-OSS/octo-server/pkg/internaltoken"
 	"go.uber.org/zap"
 )
 
@@ -51,7 +52,16 @@ func New(ctx *config.Context) *BotMention {
 	logger := log.NewTLog("BotMention")
 	token, tokenErr := resolveBotMentionInternalToken(os.Getenv)
 	if tokenErr != nil {
-		logger.Error(tokenErr.Error())
+		// An unset env is a normal deployment shape (the capability is simply
+		// not in use); a collision or an undersized value is an operator
+		// mistake that silently turns an ingress off. Logging both at ERROR
+		// teaches operators to ignore the level that carries the real ones.
+		var resolveErr *internaltoken.Error
+		if errors.As(tokenErr, &resolveErr) && resolveErr.Reason == internaltoken.ReasonUnset {
+			logger.Warn(tokenErr.Error())
+		} else {
+			logger.Error(tokenErr.Error())
+		}
 	}
 	return &BotMention{
 		robots:        robot.NewService(ctx),

--- a/modules/bot_mention/config.go
+++ b/modules/bot_mention/config.go
@@ -167,7 +167,8 @@ func mentionClaimLogHash(claimKey string) string {
 // unset or equal to the value of any env registered BEFORE it. That is more
 // than the two siblings this function used to know about by hand, and it grows
 // on its own; it is not symmetric, though — a capability registered after this
-// one is normally the side that yields.
+// one is the side that yields, disabling itself rather than this ingress.
+// Refusal returns the empty string, which fails the ingress closed.
 //
 // OCTO_MARKETPLACE_INTERNAL_TOKEN (#827) is the exception: it is registered
 // after this env, but that pair was deliberately made symmetric, so the

--- a/modules/bot_mention/config.go
+++ b/modules/bot_mention/config.go
@@ -27,9 +27,6 @@ const (
 	// from the shared registry so the name cannot drift from the entry that
 	// the cross-capability check compares against.
 	internalTokenEnv = internaltoken.BotMentionTokenEnv
-	// marketplaceInternalTokenEnv is modules/space.MarketplaceInternalTokenEnv;
-	// a local literal only until that env joins the registry (PR #853 follow-up).
-	marketplaceInternalTokenEnv = "OCTO_MARKETPLACE_INTERNAL_TOKEN"
 	// internalTokenHeader is owned by pkg/internaltoken so the credential
 	// family has one spelling across every internal ingress.
 	internalTokenHeader        = internaltoken.Header
@@ -170,21 +167,15 @@ func mentionClaimLogHash(claimKey string) string {
 // one is the side that yields, disabling itself rather than this ingress.
 // Refusal returns the empty string, which fails the ingress closed.
 //
-// OCTO_MARKETPLACE_INTERNAL_TOKEN (#827) is the exception: it is registered
-// after this env, but that pair was deliberately made symmetric, so the
-// mirror-image branch below stays until the env is absorbed into the registry.
+// OCTO_MARKETPLACE_INTERNAL_TOKEN (#827) is the exception, and it is now the
+// registry's exception rather than this file's: that Spec is marked Mutual, so
+// Resolve disables this capability on a shared value even though the
+// marketplace env is registered later.
 //
 // Refusal returns the empty string, which fails the ingress closed. Error
 // messages are logger-safe: env names only, never a token value.
 func resolveBotMentionInternalToken(getenv func(string) string) (string, error) {
-	token, err := internaltoken.Resolve(internalTokenEnv, getenv)
-	if err != nil {
-		return "", err
-	}
-	if getenv(marketplaceInternalTokenEnv) == token {
-		return "", errors.New("OCTO_DOCS_BOT_MENTION_TOKEN must differ from OCTO_MARKETPLACE_INTERNAL_TOKEN; bot mention capability disabled")
-	}
-	return token, nil
+	return internaltoken.Resolve(internalTokenEnv, getenv)
 }
 
 type featureGate struct {

--- a/modules/bot_mention/config.go
+++ b/modules/bot_mention/config.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/internaltoken"
 )
 
 const (
@@ -18,11 +20,19 @@ const (
 	maxTextBytes        = 10 * 1024
 	maxURLBytes         = 2048
 
-	featureEnabledEnv          = "OCTO_DOCS_BOT_MENTION_ENABLED"
-	spaceAllowlistEnv          = "OCTO_DOCS_BOT_MENTION_SPACE_ALLOWLIST"
-	documentAllowlistEnv       = "OCTO_DOCS_BOT_MENTION_DOC_ALLOWLIST"
-	internalTokenEnv           = "OCTO_DOCS_BOT_MENTION_TOKEN"
-	internalTokenHeader        = "X-Internal-Token"
+	featureEnabledEnv    = "OCTO_DOCS_BOT_MENTION_ENABLED"
+	spaceAllowlistEnv    = "OCTO_DOCS_BOT_MENTION_SPACE_ALLOWLIST"
+	documentAllowlistEnv = "OCTO_DOCS_BOT_MENTION_DOC_ALLOWLIST"
+	// internalTokenEnv gates the doc-comment bot-mention ingress. Sourced
+	// from the shared registry so the name cannot drift from the entry that
+	// the cross-capability check compares against.
+	internalTokenEnv = internaltoken.BotMentionTokenEnv
+	// marketplaceInternalTokenEnv is modules/space.MarketplaceInternalTokenEnv;
+	// a local literal only until that env joins the registry (PR #853 follow-up).
+	marketplaceInternalTokenEnv = "OCTO_MARKETPLACE_INTERNAL_TOKEN"
+	// internalTokenHeader is owned by pkg/internaltoken so the credential
+	// family has one spelling across every internal ingress.
+	internalTokenHeader        = internaltoken.Header
 	docCommentMentionEventType = "doc_comment_mention"
 
 	// docKindHTML 标记 doc_id 是 octo-doc 的 slug(HTML 文档),而不是 docs-backend 的 docId。
@@ -39,14 +49,14 @@ type mentionRequest struct {
 	// 「文档真的不存在」无法区分,靠试错回退会把后者误判成 HTML 再失败一次。
 	//
 	// 空 = 默认 docs-backend 文档(doc/sheet/board),与加这个字段之前的行为一致。
-	DocKind        string `json:"doc_kind,omitempty"`
-	CommentID      string `json:"comment_id"`
-	ParentID       string `json:"parent_id,omitempty"`
-	FromUID        string `json:"from_uid"`
-	BotUID         string `json:"bot_uid"`
-	Text           string `json:"text"`
-	URL            string `json:"url,omitempty"`
-	SpaceID        string `json:"space_id,omitempty"`
+	DocKind   string `json:"doc_kind,omitempty"`
+	CommentID string `json:"comment_id"`
+	ParentID  string `json:"parent_id,omitempty"`
+	FromUID   string `json:"from_uid"`
+	BotUID    string `json:"bot_uid"`
+	Text      string `json:"text"`
+	URL       string `json:"url,omitempty"`
+	SpaceID   string `json:"space_id,omitempty"`
 }
 
 type normalizedMention struct {
@@ -152,40 +162,28 @@ func mentionClaimLogHash(claimKey string) string {
 	return hex.EncodeToString(sum[:6])
 }
 
-// resolveBotMentionInternalToken loads OCTO_DOCS_BOT_MENTION_TOKEN and refuses
-// to enable the capability when it is unset or collides with a sibling *fixed*
-// internal-token env, so one leaked value can never grant two capabilities.
+// resolveBotMentionInternalToken loads OCTO_DOCS_BOT_MENTION_TOKEN through the
+// shared registry in pkg/internaltoken, which refuses the value when it is
+// unset or equal to the value of any env registered BEFORE it. That is more
+// than the two siblings this function used to know about by hand, and it grows
+// on its own; it is not symmetric, though — a capability registered after this
+// one is normally the side that yields.
 //
-// OCTO_MARKETPLACE_INTERNAL_TOKEN is the newest member of that set
-// (modules/space.MarketplaceInternalTokenEnv). modules/space rejects a value
-// shared with this module's token, so the branch below is the mirror-image
-// half: a deployment that sets one value for both fails BOTH capabilities
-// closed instead of picking an arbitrary winner. The other, pre-existing pairs
-// are left exactly as they were.
+// OCTO_MARKETPLACE_INTERNAL_TOKEN (#827) is the exception: it is registered
+// after this env, but that pair was deliberately made symmetric, so the
+// mirror-image branch below stays until the env is absorbed into the registry.
 //
-// The env names are duplicated as literals rather than imported from their
-// owning packages, matching modules/internal_resolve/config.go: no module
-// should take a production dependency on another just to learn a string.
-// config_test.go pins the spellings.
-//
-// Returned error messages are logger-safe (they never contain token values).
+// Refusal returns the empty string, which fails the ingress closed. Error
+// messages are logger-safe: env names only, never a token value.
 func resolveBotMentionInternalToken(getenv func(string) string) (string, error) {
-	if getenv == nil {
-		return "", errors.New("OCTO_DOCS_BOT_MENTION_TOKEN lookup unavailable; bot mention capability disabled")
+	token, err := internaltoken.Resolve(internalTokenEnv, getenv)
+	if err != nil {
+		return "", err
 	}
-	token := getenv(internalTokenEnv)
-	switch {
-	case token == "":
-		return "", errors.New("OCTO_DOCS_BOT_MENTION_TOKEN not set; internal bot mention API will reject all requests")
-	case token == getenv("NOTIFY_INTERNAL_TOKEN"):
-		return "", errors.New("OCTO_DOCS_BOT_MENTION_TOKEN must differ from NOTIFY_INTERNAL_TOKEN; bot mention capability disabled")
-	case token == getenv("OCTO_DOCS_NOTIFY_TOKEN"):
-		return "", errors.New("OCTO_DOCS_BOT_MENTION_TOKEN must differ from OCTO_DOCS_NOTIFY_TOKEN; bot mention capability disabled")
-	case token == getenv("OCTO_MARKETPLACE_INTERNAL_TOKEN"):
+	if getenv(marketplaceInternalTokenEnv) == token {
 		return "", errors.New("OCTO_DOCS_BOT_MENTION_TOKEN must differ from OCTO_MARKETPLACE_INTERNAL_TOKEN; bot mention capability disabled")
-	default:
-		return token, nil
 	}
+	return token, nil
 }
 
 type featureGate struct {

--- a/modules/bot_mention/config_test.go
+++ b/modules/bot_mention/config_test.go
@@ -148,28 +148,15 @@ func TestResolveBotMentionInternalTokenLeavesPreExistingPairsAlone(t *testing.T)
 
 // TestResolveBotMentionInternalTokenCoversEverySibling pins what the shared
 // registry buys this module: the mention token is compared against every env
-// registered BEFORE it, not just the two the original hand-rolled switch
-// happened to list. Enumerating internaltoken.Envs() means a capability
-// registered later is covered with no edit to this file — from the other
-// direction, by that junior capability disabling itself.
+// it yields to — its seniors, plus any env marked Mutual regardless of
+// registration order — not just the two the original hand-rolled switch
+// happened to list. Enumerating internaltoken.Envs() and branching on
+// internaltoken.Yields means an appended Spec, or an existing one newly marked
+// Mutual, is covered with no edit to this file.
 func TestResolveBotMentionInternalTokenCoversEverySibling(t *testing.T) {
 	const shared = "shared-internal-token-value-0000"
-	envs := internaltoken.Envs()
-	subjectIndex := -1
-	for i, env := range envs {
-		if env == internalTokenEnv {
-			subjectIndex = i
-		}
-	}
-	if subjectIndex < 0 {
-		t.Fatalf("%s missing from internaltoken.Envs() = %v", internalTokenEnv, envs)
-	}
-	if subjectIndex == 0 {
-		t.Fatalf("%s is first in the registry, so it yields to nothing; this test would be vacuous",
-			internalTokenEnv)
-	}
-
-	for siblingIndex, sibling := range envs {
+	yielding := 0
+	for _, sibling := range internaltoken.Envs() {
 		if sibling == internalTokenEnv {
 			continue
 		}
@@ -179,11 +166,15 @@ func TestResolveBotMentionInternalTokenCoversEverySibling(t *testing.T) {
 			}
 			return ""
 		}
-		if siblingIndex < subjectIndex {
+		// Ask the registry which side yields rather than restating the rule:
+		// this token yields to its seniors AND to any Mutual env whatever the
+		// order. Both shapes are live today.
+		if internaltoken.Yields(internalTokenEnv, sibling) {
+			yielding++
 			t.Run("yields_to_"+sibling, func(t *testing.T) {
 				token, err := resolveBotMentionInternalToken(getenv)
 				if err == nil {
-					t.Fatalf("expected a refusal when %s == the senior env %s", internalTokenEnv, sibling)
+					t.Fatalf("expected a refusal when %s == %s", internalTokenEnv, sibling)
 				}
 				if token != "" {
 					t.Fatalf("token = %q on collision; must be empty so the ingress fails closed", token)
@@ -198,9 +189,6 @@ func TestResolveBotMentionInternalTokenCoversEverySibling(t *testing.T) {
 			continue
 		}
 		t.Run("outranks_"+sibling, func(t *testing.T) {
-			// The junior env is the side that gets disabled, so this ingress
-			// keeps serving. Verified from this module so a future reordering
-			// of the registry shows up as a behaviour change here too.
 			token, err := resolveBotMentionInternalToken(getenv)
 			if err != nil {
 				t.Fatalf("unexpected refusal when the junior env %s duplicates this token: %v", sibling, err)
@@ -209,6 +197,9 @@ func TestResolveBotMentionInternalTokenCoversEverySibling(t *testing.T) {
 				t.Fatalf("token = %q, want the configured value", token)
 			}
 		})
+	}
+	if yielding == 0 {
+		t.Fatal("registry exposed no env this token yields to; the guard would be vacuous")
 	}
 }
 

--- a/modules/bot_mention/config_test.go
+++ b/modules/bot_mention/config_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/internaltoken"
 )
 
 func TestFeatureGate(t *testing.T) {
@@ -141,6 +143,72 @@ func TestResolveBotMentionInternalTokenLeavesPreExistingPairsAlone(t *testing.T)
 	}
 	if token != shared {
 		t.Fatalf("token = %q, want the configured value", token)
+	}
+}
+
+// TestResolveBotMentionInternalTokenCoversEverySibling pins what the shared
+// registry buys this module: the mention token is compared against every env
+// registered BEFORE it, not just the two the original hand-rolled switch
+// happened to list. Enumerating internaltoken.Envs() means a capability
+// registered later is covered with no edit to this file — from the other
+// direction, by that junior capability disabling itself.
+func TestResolveBotMentionInternalTokenCoversEverySibling(t *testing.T) {
+	const shared = "shared-internal-token-value-0000"
+	envs := internaltoken.Envs()
+	subjectIndex := -1
+	for i, env := range envs {
+		if env == internalTokenEnv {
+			subjectIndex = i
+		}
+	}
+	if subjectIndex < 0 {
+		t.Fatalf("%s missing from internaltoken.Envs() = %v", internalTokenEnv, envs)
+	}
+	if subjectIndex == 0 {
+		t.Fatalf("%s is first in the registry, so it yields to nothing; this test would be vacuous",
+			internalTokenEnv)
+	}
+
+	for siblingIndex, sibling := range envs {
+		if sibling == internalTokenEnv {
+			continue
+		}
+		getenv := func(key string) string {
+			if key == internalTokenEnv || key == sibling {
+				return shared
+			}
+			return ""
+		}
+		if siblingIndex < subjectIndex {
+			t.Run("yields_to_"+sibling, func(t *testing.T) {
+				token, err := resolveBotMentionInternalToken(getenv)
+				if err == nil {
+					t.Fatalf("expected a refusal when %s == the senior env %s", internalTokenEnv, sibling)
+				}
+				if token != "" {
+					t.Fatalf("token = %q on collision; must be empty so the ingress fails closed", token)
+				}
+				if !strings.Contains(err.Error(), sibling) {
+					t.Fatalf("reason %q must name the colliding env", err.Error())
+				}
+				if strings.Contains(err.Error(), shared) {
+					t.Fatalf("reason leaked the token value: %q", err.Error())
+				}
+			})
+			continue
+		}
+		t.Run("outranks_"+sibling, func(t *testing.T) {
+			// The junior env is the side that gets disabled, so this ingress
+			// keeps serving. Verified from this module so a future reordering
+			// of the registry shows up as a behaviour change here too.
+			token, err := resolveBotMentionInternalToken(getenv)
+			if err != nil {
+				t.Fatalf("unexpected refusal when the junior env %s duplicates this token: %v", sibling, err)
+			}
+			if token != shared {
+				t.Fatalf("token = %q, want the configured value", token)
+			}
+		})
 	}
 }
 

--- a/modules/internal_resolve/api.go
+++ b/modules/internal_resolve/api.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
+	"github.com/Mininglamp-OSS/octo-server/pkg/internaltoken"
 	"github.com/Mininglamp-OSS/octo-server/pkg/ratelimit"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	rd "github.com/go-redis/redis"
@@ -67,7 +68,16 @@ func New(ctx *config.Context) *Module {
 	logger := log.NewTLog("InternalResolve")
 	token, tokenErr := resolveDriveInternalToken(os.Getenv)
 	if tokenErr != nil {
-		logger.Error(tokenErr.Error())
+		// An unset env is a normal deployment shape (a deployment without the
+		// drive integration); a collision or an undersized value is an operator
+		// mistake that silently turns this endpoint off. Splitting the levels
+		// keeps ERROR meaning "someone needs to look at this".
+		var resolveErr *internaltoken.Error
+		if errors.As(tokenErr, &resolveErr) && resolveErr.Reason == internaltoken.ReasonUnset {
+			logger.Warn(tokenErr.Error())
+		} else {
+			logger.Error(tokenErr.Error())
+		}
 	}
 	return &Module{
 		ctx:           ctx,
@@ -156,9 +166,11 @@ func (m *Module) Route(r *wkhttp.WKHttp) {
 	)
 }
 
-// internalAuthMiddleware fails closed when the token is unset (matches
-// modules/notify/api.go:207-232) and uses constant-time comparison to defeat
-// timing side-channels (same guarantee as modules/bot_mention/api.go:79).
+// internalAuthMiddleware fails closed when the token is unset (matching
+// notify.internalAuthMiddleware and bot_mention's equivalent) and uses
+// constant-time comparison to defeat timing side-channels. Referenced by name
+// rather than by line number so the cross-reference survives edits to those
+// files.
 func (m *Module) internalAuthMiddleware() wkhttp.HandlerFunc {
 	return func(c *wkhttp.Context) {
 		token := c.GetHeader(internalTokenHeader)

--- a/modules/internal_resolve/api_test.go
+++ b/modules/internal_resolve/api_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
 	"github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/Mininglamp-OSS/octo-server/pkg/internaltoken"
 )
 
 // testInternalToken is 32 bytes so it clears the minInternalTokenBytes floor
@@ -410,32 +411,97 @@ func TestResolveDriveInternalTokenRejectsShortValue(t *testing.T) {
 }
 
 func TestResolveDriveInternalTokenRejectsSiblingCollision(t *testing.T) {
-	// Use a 32-byte shared value so the length gate passes and we exercise
-	// the collision cases individually.
+	// Enumerate the shared registry rather than a hand-written sibling list.
+	//
+	// The registry guard is directional: the drive token yields to every env
+	// registered BEFORE it, and an env registered after it is covered from the
+	// other direction, by that junior capability disabling itself. Branching on
+	// the precedence index rather than asserting refusal against every sibling
+	// is what makes this test survive an appended Spec.
+	//
+	// OCTO_MARKETPLACE_INTERNAL_TOKEN is checked separately below: it is not in
+	// the registry yet, and #827 made that pair symmetric rather than
+	// precedence-ordered.
+	//
+	// Use a 32-byte shared value so the length gate passes and we exercise the
+	// collision path.
 	sharedSecret := strings.Repeat("s", minInternalTokenBytes)
-	cases := []struct {
-		name    string
-		sibling string
-	}{
-		{"notify", notifyInternalTokenEnv},
-		{"docs-notify", docsNotifyInternalToken},
-		{"bot-mention", botMentionInternalToken},
-		{"marketplace", marketplaceInternalToken},
+	envs := internaltoken.Envs()
+	subjectIndex := -1
+	for i, env := range envs {
+		if env == DriveInternalTokenEnv {
+			subjectIndex = i
+		}
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			getenv := func(k string) string {
-				if k == DriveInternalTokenEnv || k == tc.sibling {
-					return sharedSecret
-				}
-				return ""
+	if subjectIndex < 0 {
+		t.Fatalf("%s missing from internaltoken.Envs() = %v", DriveInternalTokenEnv, envs)
+	}
+	if subjectIndex == 0 {
+		t.Fatalf("%s is first in the registry, so it yields to nothing; this test would be vacuous",
+			DriveInternalTokenEnv)
+	}
+
+	seniors := 0
+	for siblingIndex, sibling := range envs {
+		if sibling == DriveInternalTokenEnv {
+			continue
+		}
+		getenv := func(k string) string {
+			if k == DriveInternalTokenEnv || k == sibling {
+				return sharedSecret
 			}
-			_, err := resolveDriveInternalToken(getenv)
-			if err == nil {
-				t.Fatalf("expected error when %s == %s", DriveInternalTokenEnv, tc.sibling)
+			return ""
+		}
+		if siblingIndex < subjectIndex {
+			seniors++
+			t.Run("yields_to_"+sibling, func(t *testing.T) {
+				token, err := resolveDriveInternalToken(getenv)
+				if err == nil {
+					t.Fatalf("expected a refusal when %s == the senior env %s", DriveInternalTokenEnv, sibling)
+				}
+				if token != "" {
+					t.Fatalf("token = %q on collision; must be empty so the auth middleware fails closed", token)
+				}
+				if !strings.Contains(err.Error(), sibling) {
+					t.Fatalf("reason %q must name the colliding env", err.Error())
+				}
+				if strings.Contains(err.Error(), sharedSecret) {
+					t.Fatalf("reason leaked the token value: %q", err.Error())
+				}
+			})
+			continue
+		}
+		t.Run("outranks_"+sibling, func(t *testing.T) {
+			token, err := resolveDriveInternalToken(getenv)
+			if err != nil {
+				t.Fatalf("unexpected refusal when the junior env %s duplicates this token: %v", sibling, err)
+			}
+			if token != sharedSecret {
+				t.Fatalf("token = %q, want the configured value", token)
 			}
 		})
 	}
+	if seniors == 0 {
+		t.Fatal("registry exposed no senior envs; the cross-capability guard would be vacuous")
+	}
+
+	// The marketplace pair is symmetric by #827's design, so it is asserted
+	// explicitly rather than through the precedence branches above.
+	t.Run("symmetric_"+marketplaceInternalToken, func(t *testing.T) {
+		getenv := func(k string) string {
+			if k == DriveInternalTokenEnv || k == marketplaceInternalToken {
+				return sharedSecret
+			}
+			return ""
+		}
+		token, err := resolveDriveInternalToken(getenv)
+		if err == nil {
+			t.Fatalf("expected a refusal when %s == %s", DriveInternalTokenEnv, marketplaceInternalToken)
+		}
+		if token != "" {
+			t.Fatalf("token = %q on collision; must be empty", token)
+		}
+	})
 }
 
 // TestMarketplaceInternalTokenLiteralMatchesSpaceConstant pins the duplicated

--- a/modules/internal_resolve/api_test.go
+++ b/modules/internal_resolve/api_test.go
@@ -413,11 +413,13 @@ func TestResolveDriveInternalTokenRejectsShortValue(t *testing.T) {
 func TestResolveDriveInternalTokenRejectsSiblingCollision(t *testing.T) {
 	// Enumerate the shared registry rather than a hand-written sibling list.
 	//
-	// The registry guard is directional: the drive token yields to every env
-	// registered BEFORE it, and an env registered after it is covered from the
-	// other direction, by that junior capability disabling itself. Branching on
-	// the precedence index rather than asserting refusal against every sibling
-	// is what makes this test survive an appended Spec.
+	// The guard is directional: the drive token yields to every env registered
+	// BEFORE it; envs registered after it are covered from the other direction,
+	// by that junior capability disabling itself. Branching on the precedence
+	// index rather than asserting refusal against every sibling is what makes
+	// this test survive an appended Spec — asserting the symmetric shape would
+	// go red the moment the registry grows, and the cheapest way out of a red
+	// assertion is to delete it.
 	//
 	// OCTO_MARKETPLACE_INTERNAL_TOKEN is checked separately below: it is not in
 	// the registry yet, and #827 made that pair symmetric rather than
@@ -472,6 +474,9 @@ func TestResolveDriveInternalTokenRejectsSiblingCollision(t *testing.T) {
 			continue
 		}
 		t.Run("outranks_"+sibling, func(t *testing.T) {
+			// The junior env is the side that gets disabled, so this endpoint
+			// keeps serving. Asserted from this module so a future reordering of
+			// the registry shows up as a behaviour change here too.
 			token, err := resolveDriveInternalToken(getenv)
 			if err != nil {
 				t.Fatalf("unexpected refusal when the junior env %s duplicates this token: %v", sibling, err)

--- a/modules/internal_resolve/api_test.go
+++ b/modules/internal_resolve/api_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
-	"github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/Mininglamp-OSS/octo-server/pkg/internaltoken"
 )
@@ -411,40 +410,23 @@ func TestResolveDriveInternalTokenRejectsShortValue(t *testing.T) {
 }
 
 func TestResolveDriveInternalTokenRejectsSiblingCollision(t *testing.T) {
-	// Enumerate the shared registry rather than a hand-written sibling list.
+	// Enumerate the shared registry rather than a hand-written sibling list,
+	// and branch on internaltoken.Yields rather than on the precedence index.
 	//
-	// The guard is directional: the drive token yields to every env registered
-	// BEFORE it; envs registered after it are covered from the other direction,
-	// by that junior capability disabling itself. Branching on the precedence
-	// index rather than asserting refusal against every sibling is what makes
-	// this test survive an appended Spec — asserting the symmetric shape would
-	// go red the moment the registry grows, and the cheapest way out of a red
-	// assertion is to delete it.
-	//
-	// OCTO_MARKETPLACE_INTERNAL_TOKEN is checked separately below: it is not in
-	// the registry yet, and #827 made that pair symmetric rather than
-	// precedence-ordered.
+	// The guard is directional and not uniform: the drive token yields to every
+	// env registered BEFORE it, AND to any env marked Mutual regardless of
+	// order (OCTO_MARKETPLACE_INTERNAL_TOKEN is one — #827 made that pair
+	// symmetric on purpose). Asking the registry which way a pair falls is what
+	// keeps this test correct through an appended Spec and through a Spec being
+	// marked Mutual; hard-coding either shape passes only by accident of the
+	// current ordering, and the cheapest way out of a red assertion is to
+	// delete it.
 	//
 	// Use a 32-byte shared value so the length gate passes and we exercise the
 	// collision path.
 	sharedSecret := strings.Repeat("s", minInternalTokenBytes)
-	envs := internaltoken.Envs()
-	subjectIndex := -1
-	for i, env := range envs {
-		if env == DriveInternalTokenEnv {
-			subjectIndex = i
-		}
-	}
-	if subjectIndex < 0 {
-		t.Fatalf("%s missing from internaltoken.Envs() = %v", DriveInternalTokenEnv, envs)
-	}
-	if subjectIndex == 0 {
-		t.Fatalf("%s is first in the registry, so it yields to nothing; this test would be vacuous",
-			DriveInternalTokenEnv)
-	}
-
-	seniors := 0
-	for siblingIndex, sibling := range envs {
+	yielding, outranking := 0, 0
+	for _, sibling := range internaltoken.Envs() {
 		if sibling == DriveInternalTokenEnv {
 			continue
 		}
@@ -454,12 +436,12 @@ func TestResolveDriveInternalTokenRejectsSiblingCollision(t *testing.T) {
 			}
 			return ""
 		}
-		if siblingIndex < subjectIndex {
-			seniors++
+		if internaltoken.Yields(DriveInternalTokenEnv, sibling) {
+			yielding++
 			t.Run("yields_to_"+sibling, func(t *testing.T) {
 				token, err := resolveDriveInternalToken(getenv)
 				if err == nil {
-					t.Fatalf("expected a refusal when %s == the senior env %s", DriveInternalTokenEnv, sibling)
+					t.Fatalf("expected a refusal when %s == %s", DriveInternalTokenEnv, sibling)
 				}
 				if token != "" {
 					t.Fatalf("token = %q on collision; must be empty so the auth middleware fails closed", token)
@@ -473,10 +455,12 @@ func TestResolveDriveInternalTokenRejectsSiblingCollision(t *testing.T) {
 			})
 			continue
 		}
+		outranking++
 		t.Run("outranks_"+sibling, func(t *testing.T) {
-			// The junior env is the side that gets disabled, so this endpoint
-			// keeps serving. Asserted from this module so a future reordering of
-			// the registry shows up as a behaviour change here too.
+			// A junior, non-Mutual env is the side that gets disabled, so this
+			// endpoint keeps serving. Asserted from this module so a registry
+			// reorder — or a Spec newly marked Mutual — surfaces as a behaviour
+			// change here too.
 			token, err := resolveDriveInternalToken(getenv)
 			if err != nil {
 				t.Fatalf("unexpected refusal when the junior env %s duplicates this token: %v", sibling, err)
@@ -486,41 +470,10 @@ func TestResolveDriveInternalTokenRejectsSiblingCollision(t *testing.T) {
 			}
 		})
 	}
-	if seniors == 0 {
-		t.Fatal("registry exposed no senior envs; the cross-capability guard would be vacuous")
+	if yielding == 0 {
+		t.Fatal("registry exposed no env this token yields to; the cross-capability guard would be vacuous")
 	}
-
-	// The marketplace pair is symmetric by #827's design, so it is asserted
-	// explicitly rather than through the precedence branches above.
-	t.Run("symmetric_"+marketplaceInternalToken, func(t *testing.T) {
-		getenv := func(k string) string {
-			if k == DriveInternalTokenEnv || k == marketplaceInternalToken {
-				return sharedSecret
-			}
-			return ""
-		}
-		token, err := resolveDriveInternalToken(getenv)
-		if err == nil {
-			t.Fatalf("expected a refusal when %s == %s", DriveInternalTokenEnv, marketplaceInternalToken)
-		}
-		if token != "" {
-			t.Fatalf("token = %q on collision; must be empty", token)
-		}
-	})
-}
-
-// TestMarketplaceInternalTokenLiteralMatchesSpaceConstant pins the duplicated
-// env-name literal in config.go to the exported constant that owns it. The
-// literal exists so this module has no production dependency on modules/space;
-// the cost is that a rename over there would silently turn our collision check
-// into a comparison against an env nobody sets. This test converts that silent
-// failure into a build-time-visible one.
-func TestMarketplaceInternalTokenLiteralMatchesSpaceConstant(t *testing.T) {
-	if marketplaceInternalToken != space.MarketplaceInternalTokenEnv {
-		t.Fatalf("marketplaceInternalToken = %q, want %q (modules/space renamed the env; "+
-			"update config.go or the intra-set collision check silently stops working)",
-			marketplaceInternalToken, space.MarketplaceInternalTokenEnv)
-	}
+	_ = outranking
 }
 
 func TestResolveDriveInternalTokenAcceptsUnique(t *testing.T) {

--- a/modules/internal_resolve/boot_config_test.go
+++ b/modules/internal_resolve/boot_config_test.go
@@ -9,17 +9,25 @@ package internal_resolve_test
 // immediately (the review that produced this file, CHANGES_REQUESTED P1 on
 // PR #711, showed exactly that gap and this test pins it closed).
 //
+// These tests build the exclusion argument list the way main.go does — from
+// internaltoken.Values over the test's OWN getenv — rather than spelling out
+// the fixed envs by hand. Two reasons: a hand-written list would be the last
+// copy of the very thing pkg/internaltoken exists to own, and it silently
+// pinned a call shape main.go no longer uses. Feeding the test's getenv also
+// keeps the assertions off the ambient process environment, which the previous
+// os.Getenv("NOTIFY_INTERNAL_TOKEN") arguments were coupled to.
+//
 // External-package test (_test) so we consume only exported identifiers —
 // DriveInternalTokenEnv is exported for this reason.
 
 import (
-	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
 	"github.com/Mininglamp-OSS/octo-server/modules/internal_resolve"
+	"github.com/Mininglamp-OSS/octo-server/pkg/internaltoken"
 )
 
 // testValidRouteSpec is a locally-owned copy of the cardactiondispatch package
@@ -73,12 +81,7 @@ func TestDriveInternalTokenCollidesWithRouteNotifyToken(t *testing.T) {
 	// this argument list, the collision goes undetected and Registry
 	// silently authorizes a token holder to mint route notifications AND
 	// call resolve-bot-owner — the exact P1 hazard.
-	err = registry.ValidateNotifyTokenExclusions(
-		os.Getenv("NOTIFY_INTERNAL_TOKEN"),
-		os.Getenv("OCTO_DOCS_NOTIFY_TOKEN"),
-		os.Getenv("OCTO_DOCS_BOT_MENTION_TOKEN"),
-		getenv(internal_resolve.DriveInternalTokenEnv),
-	)
+	err = registry.ValidateNotifyTokenExclusions(internaltoken.Values(getenv)...)
 	if err == nil {
 		t.Fatal("ValidateNotifyTokenExclusions() = nil; expected collision rejection " +
 			"when OCTO_DRIVE_INTERNAL_TOKEN == a route's notify_token_env value")
@@ -94,7 +97,10 @@ func TestDriveInternalTokenCollidesWithRouteNotifyToken(t *testing.T) {
 func TestDriveInternalTokenCollidesWithCallbackSecret(t *testing.T) {
 	spec := testValidRouteSpec()
 	spec.SecretEnv = "MY_ROUTE_SECRET"
-	// notify_token_env may point anywhere; we're testing the OTHER slot.
+	// notify_token_env may point anywhere; we're testing the OTHER slot. It is
+	// deliberately a registered fixed env here: Values now feeds every fixed
+	// env in, so this also covers the route-token slot being satisfied by a
+	// fixed env without masking the callback-secret collision below.
 	spec.NotifyTokenEnv = "OCTO_DOCS_NOTIFY_TOKEN"
 
 	// Drive token equals the ROUTE'S CALLBACK SECRET.
@@ -114,10 +120,7 @@ func TestDriveInternalTokenCollidesWithCallbackSecret(t *testing.T) {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
 
-	err = registry.ValidateNotifyTokenExclusions(
-		"", "", "",
-		getenv(internal_resolve.DriveInternalTokenEnv),
-	)
+	err = registry.ValidateNotifyTokenExclusions(internaltoken.Values(getenv)...)
 	if err == nil {
 		t.Fatal("ValidateNotifyTokenExclusions() = nil; expected collision rejection " +
 			"when OCTO_DRIVE_INTERNAL_TOKEN == a route's callback secret env value")
@@ -147,10 +150,7 @@ func TestDriveInternalTokenPassesWhenUniqueAcrossDynamicRoutes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
-	err = registry.ValidateNotifyTokenExclusions(
-		"", "", "",
-		getenv(internal_resolve.DriveInternalTokenEnv),
-	)
+	err = registry.ValidateNotifyTokenExclusions(internaltoken.Values(getenv)...)
 	if err != nil {
 		t.Fatalf("ValidateNotifyTokenExclusions() = %v; expected nil for a unique drive token", err)
 	}

--- a/modules/internal_resolve/config.go
+++ b/modules/internal_resolve/config.go
@@ -12,12 +12,15 @@ import (
 // / rotate one consumer without disturbing the rest, and shrinks the blast
 // radius if any single token leaks.
 //
-// The intra-set guard — "OCTO_DRIVE_INTERNAL_TOKEN must differ from every
-// other fixed internal-token env" — is no longer hand-rolled here. It lives in
-// pkg/internaltoken, which owns the registry of those envs and compares the
-// one being resolved against every OTHER registered entry, so a capability
-// added tomorrow is covered without this file changing. See that package's doc
-// for why coverage-by-convention was replaced.
+// The intra-set guard is no longer hand-rolled here. It lives in
+// pkg/internaltoken, which owns the registry of those envs and compares the one
+// being resolved against every entry registered BEFORE it. Registration order
+// is a precedence order, so the guard is directional, not symmetric: this token
+// yields to its seniors, and a capability registered after it is covered from
+// the other direction — by that junior capability disabling itself. Either way
+// a shared value never leaves two capabilities enabled, and a capability added
+// tomorrow needs no edit in this file. See that package's doc for why
+// coverage-by-convention was replaced.
 //
 // The strongest cross-capability guard still lives in main.go's
 // cardactiondispatch.Registry.ValidateNotifyTokenExclusions call, which is
@@ -85,8 +88,10 @@ const (
 
 // resolveDriveInternalToken loads OCTO_DRIVE_INTERNAL_TOKEN through the shared
 // registry, which refuses to enable the capability when the value is unset, too
-// short, or equal to ANY other registered fixed internal-token env. Refusal
-// yields the empty string, so ratelimitedInternalTokenAuth below fails closed.
+// short, or equal to the value of any env registered BEFORE it. Refusal yields
+// the empty string, so ratelimitedInternalTokenAuth below fails closed. A
+// capability registered AFTER this one is the side that yields on a collision,
+// so it disables itself rather than this endpoint.
 //
 // Cross-capability collision with the *dynamic* per-route notify tokens /
 // callback secrets loaded from OCTO_CARD_ACTION_ROUTES is checked centrally by

--- a/modules/internal_resolve/config.go
+++ b/modules/internal_resolve/config.go
@@ -2,68 +2,57 @@ package internal_resolve
 
 import (
 	"errors"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/internaltoken"
 )
 
 // Environment variable names and shared constants.
 //
 // A distinct token per internal consumer is deliberate: it lets us revoke
 // / rotate one consumer without disturbing the rest, and shrinks the blast
-// radius if any single token leaks. See modules/notify/api.go:96-98 and
-// modules/bot_mention/config.go:142-145 for the same "must differ from
-// sibling tokens" hardening.
+// radius if any single token leaks.
 //
-// The strongest cross-capability guard lives in main.go's
+// The intra-set guard — "OCTO_DRIVE_INTERNAL_TOKEN must differ from every
+// other fixed internal-token env" — is no longer hand-rolled here. It lives in
+// pkg/internaltoken, which owns the registry of those envs and compares the
+// one being resolved against every OTHER registered entry, so a capability
+// added tomorrow is covered without this file changing. See that package's doc
+// for why coverage-by-convention was replaced.
+//
+// The strongest cross-capability guard still lives in main.go's
 // cardactiondispatch.Registry.ValidateNotifyTokenExclusions call, which is
 // the single place that also sees the *dynamic* per-route notify tokens and
-// callback secrets loaded from OCTO_CARD_ACTION_ROUTES. This module
-// contributes OCTO_DRIVE_INTERNAL_TOKEN to that global check so a route-scoped
-// token can never accidentally inherit the resolve-bot-owner capability, and
-// vice versa. Locally we only guard the four fixed internal-token envs against
-// intra-set collision (drive vs notify / docs-notify / bot-mention).
+// callback secrets loaded from OCTO_CARD_ACTION_ROUTES. main.go now sources
+// its argument list from internaltoken.Values, so this module's token reaches
+// that check through the registry rather than through a literal argument.
 const (
 	// DriveInternalTokenEnv gates the drive-facing resolve endpoints. The
 	// docs-auto-mount polling loop in octo-drive presents this token in the
 	// X-Internal-Token header on every call.
 	//
-	// Exported so main.go can feed the value into
-	// cardactiondispatch.Registry.ValidateNotifyTokenExclusions alongside the
-	// other three fixed internal-token envs, without a second literal string
-	// drifting out of sync with this constant.
-	DriveInternalTokenEnv = "OCTO_DRIVE_INTERNAL_TOKEN"
+	// Re-exported from the shared registry so callers (main.go, this module's
+	// tests) keep a single name for it and no second literal can drift.
+	DriveInternalTokenEnv = internaltoken.DriveInternalTokenEnv
 
-	// Sibling internal-token envs we forbid intra-set collision with, so a
-	// single leaked value can't grant multiple fixed capabilities.
-	notifyInternalTokenEnv  = "NOTIFY_INTERNAL_TOKEN"
-	docsNotifyInternalToken = "OCTO_DOCS_NOTIFY_TOKEN"
-	botMentionInternalToken = "OCTO_DOCS_BOT_MENTION_TOKEN"
-	// marketplaceInternalToken is modules/space.MarketplaceInternalTokenEnv,
-	// which gates GET /v1/internal/spaces/:space_id/members/:uid/role.
-	// Duplicated as a literal (like the three above) rather than imported, so
-	// this module keeps zero production dependencies on modules/space;
-	// api_test.go pins the two spellings together so they cannot drift.
-	//
-	// The check is symmetric on purpose — modules/space, modules/notify and
-	// modules/bot_mention all run the mirror-image comparison. With only one
-	// half, a deployment that set two tokens to the same value would disable
-	// exactly one of the capabilities (an arbitrary winner) instead of failing
-	// both closed.
+	// marketplaceInternalToken is modules/space.MarketplaceInternalTokenEnv.
+	// Kept as a local literal (and a local check below) only until that env is
+	// absorbed into pkg/internaltoken; see the follow-up commit on PR #853.
 	marketplaceInternalToken = "OCTO_MARKETPLACE_INTERNAL_TOKEN"
 
-	// internalTokenHeader is the wire header carrying the credential. Same
-	// value as modules/notify.InternalTokenHeader and modules/bot_mention's
-	// internalTokenHeader — one convention across octo-server internal APIs.
-	internalTokenHeader = "X-Internal-Token"
+	// internalTokenHeader is the wire header carrying the credential. Owned by
+	// pkg/internaltoken alongside the env names — one convention across every
+	// octo-server internal API, and one place to change it.
+	internalTokenHeader = internaltoken.Header
 
 	// Body byte cap. resolve-bot-owner takes a single uid; 4KB is more than
 	// enough and closes any body-size DoS window even with a valid token.
 	maxRequestBodyBytes = 4 * 1024
 
 	// minInternalTokenBytes is the minimum acceptable byte length for
-	// OCTO_DRIVE_INTERNAL_TOKEN. Aligns with the repository-wide 32-byte
-	// minimum enforced on new internal-route credentials — a one-byte value
-	// would otherwise enable this endpoint. Matching the notify module keeps
-	// operators from having to remember two different bars.
-	minInternalTokenBytes = 32
+	// OCTO_DRIVE_INTERNAL_TOKEN, enforced by internaltoken.Resolve. Aliased
+	// here so the module's own tests can state the bar without duplicating the
+	// number.
+	minInternalTokenBytes = internaltoken.DefaultMinBytes
 
 	// Per-IP strict rate-limit knobs for /v1/internal/user/resolve-bot-owner.
 	//
@@ -94,39 +83,28 @@ const (
 	resolveBotOwnerRateLimitTag = "internal_resolve_bot_owner"
 )
 
-// resolveDriveInternalToken loads OCTO_DRIVE_INTERNAL_TOKEN and refuses to
-// enable the capability when it is unset, too short, or collides with any of
-// the three sibling *fixed* internal-token envs. Cross-capability collision
-// with the *dynamic* per-route notify tokens / callback secrets loaded from
-// OCTO_CARD_ACTION_ROUTES is checked centrally by
-// cardactiondispatch.Registry.ValidateNotifyTokenExclusions in main.go — we
-// expose DriveInternalTokenEnv above so that call can include our token in
-// its argument list without duplicating the literal string.
+// resolveDriveInternalToken loads OCTO_DRIVE_INTERNAL_TOKEN through the shared
+// registry, which refuses to enable the capability when the value is unset, too
+// short, or equal to ANY other registered fixed internal-token env. Refusal
+// yields the empty string, so ratelimitedInternalTokenAuth below fails closed.
 //
-// Returned error messages are logger-safe (no token values).
+// Cross-capability collision with the *dynamic* per-route notify tokens /
+// callback secrets loaded from OCTO_CARD_ACTION_ROUTES is checked centrally by
+// cardactiondispatch.Registry.ValidateNotifyTokenExclusions in main.go.
+//
+// Returned error messages are logger-safe (no token values) — pinned by
+// pkg/internaltoken's TestErrorsNeverContainTokenValue.
 func resolveDriveInternalToken(getenv func(string) string) (string, error) {
-	if getenv == nil {
-		return "", errors.New("OCTO_DRIVE_INTERNAL_TOKEN lookup unavailable; drive internal API disabled")
+	token, err := internaltoken.Resolve(DriveInternalTokenEnv, getenv)
+	if err != nil {
+		return "", err
 	}
-	token := getenv(DriveInternalTokenEnv)
-	switch {
-	case token == "":
-		return "", errors.New("OCTO_DRIVE_INTERNAL_TOKEN not set; drive internal API will reject all requests")
-	case len(token) < minInternalTokenBytes:
-		// Length check goes BEFORE collision checks: a short token is
-		// unusable regardless of whether it happens to collide, and we don't
-		// want to leak "your token collides with X" for values too short to
-		// authenticate anyway.
-		return "", errors.New("OCTO_DRIVE_INTERNAL_TOKEN must be at least 32 bytes; drive internal API disabled")
-	case token == getenv(notifyInternalTokenEnv):
-		return "", errors.New("OCTO_DRIVE_INTERNAL_TOKEN must differ from NOTIFY_INTERNAL_TOKEN; drive internal API disabled")
-	case token == getenv(docsNotifyInternalToken):
-		return "", errors.New("OCTO_DRIVE_INTERNAL_TOKEN must differ from OCTO_DOCS_NOTIFY_TOKEN; drive internal API disabled")
-	case token == getenv(botMentionInternalToken):
-		return "", errors.New("OCTO_DRIVE_INTERNAL_TOKEN must differ from OCTO_DOCS_BOT_MENTION_TOKEN; drive internal API disabled")
-	case token == getenv(marketplaceInternalToken):
+	// Mirror-image half for OCTO_MARKETPLACE_INTERNAL_TOKEN (#827). That env is
+	// registered AFTER this one, so the registry's precedence rule alone would
+	// leave this capability serving; #827 made that pair symmetric on purpose.
+	// Absorbed into the registry by the next commit.
+	if getenv(marketplaceInternalToken) == token {
 		return "", errors.New("OCTO_DRIVE_INTERNAL_TOKEN must differ from OCTO_MARKETPLACE_INTERNAL_TOKEN; drive internal API disabled")
-	default:
-		return token, nil
 	}
+	return token, nil
 }

--- a/modules/internal_resolve/config.go
+++ b/modules/internal_resolve/config.go
@@ -1,8 +1,6 @@
 package internal_resolve
 
 import (
-	"errors"
-
 	"github.com/Mininglamp-OSS/octo-server/pkg/internaltoken"
 )
 
@@ -36,11 +34,6 @@ const (
 	// Re-exported from the shared registry so callers (main.go, this module's
 	// tests) keep a single name for it and no second literal can drift.
 	DriveInternalTokenEnv = internaltoken.DriveInternalTokenEnv
-
-	// marketplaceInternalToken is modules/space.MarketplaceInternalTokenEnv.
-	// Kept as a local literal (and a local check below) only until that env is
-	// absorbed into pkg/internaltoken; see the follow-up commit on PR #853.
-	marketplaceInternalToken = "OCTO_MARKETPLACE_INTERNAL_TOKEN"
 
 	// internalTokenHeader is the wire header carrying the credential. Owned by
 	// pkg/internaltoken alongside the env names — one convention across every
@@ -100,16 +93,5 @@ const (
 // Returned error messages are logger-safe (no token values) — pinned by
 // pkg/internaltoken's TestErrorsNeverContainTokenValue.
 func resolveDriveInternalToken(getenv func(string) string) (string, error) {
-	token, err := internaltoken.Resolve(DriveInternalTokenEnv, getenv)
-	if err != nil {
-		return "", err
-	}
-	// Mirror-image half for OCTO_MARKETPLACE_INTERNAL_TOKEN (#827). That env is
-	// registered AFTER this one, so the registry's precedence rule alone would
-	// leave this capability serving; #827 made that pair symmetric on purpose.
-	// Absorbed into the registry by the next commit.
-	if getenv(marketplaceInternalToken) == token {
-		return "", errors.New("OCTO_DRIVE_INTERNAL_TOKEN must differ from OCTO_MARKETPLACE_INTERNAL_TOKEN; drive internal API disabled")
-	}
-	return token, nil
+	return internaltoken.Resolve(DriveInternalTokenEnv, getenv)
 }

--- a/modules/internal_resolve/main_wiring_test.go
+++ b/modules/internal_resolve/main_wiring_test.go
@@ -6,12 +6,19 @@ package internal_resolve_test
 // that boot_config_test.go's collision cases would still pass even if the
 // production argument in main.go's ValidateNotifyTokenExclusions call were
 // deleted — because those tests build their own argument list. This test
-// closes that loop by asserting the production source itself passes the
-// drive token to the exclusions call.
+// closes that loop by asserting the production source itself feeds the drive
+// token into the exclusions call.
 //
-// It is a source-level grep rather than a runtime assertion because the
-// exclusion call happens inside installCardDispatch, which requires a real
-// config/DB/redis rig to invoke. A file grep is coarser but gives us
+// The call no longer takes a hand-written argument list: main.go passes
+// internaltoken.Values(os.Getenv), so the wiring is now two claims instead of
+// one — main.go sources its arguments from the shared registry, AND the
+// registry contains the drive token. Both are checked below; together they are
+// strictly stronger than grepping for a single literal argument, because they
+// also hold for every capability registered after this one.
+//
+// The main.go half stays a source-level grep rather than a runtime assertion
+// because the exclusion call happens inside installCardActionDispatch, which
+// takes a real route config to reach. A file grep is coarser but gives us
 // tamper-detection with zero extra fixtures.
 
 import (
@@ -20,6 +27,9 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/modules/internal_resolve"
+	"github.com/Mininglamp-OSS/octo-server/pkg/internaltoken"
 )
 
 // TestMainWiresDriveTokenIntoValidateNotifyTokenExclusions guards the exact
@@ -70,19 +80,49 @@ func TestMainWiresDriveTokenIntoValidateNotifyTokenExclusions(t *testing.T) {
 		t.Fatalf("main.go: could not find balanced closing paren for ValidateNotifyTokenExclusions call")
 	}
 
-	// The critical argument: the drive token env value. Grep for the fully
-	// qualified reference to the exported constant so a future refactor that
-	// unqualifies the import or copy-pastes a stale literal cannot silently
-	// pass.
-	wantRef := "internal_resolve.DriveInternalTokenEnv"
-	if !strings.Contains(args, wantRef) {
-		t.Fatalf("main.go: registry.ValidateNotifyTokenExclusions(...) no longer includes %s\n"+
+	// Claim 1: the argument list comes from the shared registry, fed by the real
+	// process environment. Both halves matter — `internaltoken.Values(` alone
+	// would still pass for a stub lookup that yields nothing, which would make
+	// the whole gate a no-op. (pkg/internaltoken's Values panics on a nil
+	// getenv for the same reason; this catches the non-nil stubs it cannot.)
+	const wantSource = "internaltoken.Values(os.Getenv)"
+	if !strings.Contains(strings.Join(strings.Fields(args), ""), strings.ReplaceAll(wantSource, " ", "")) {
+		t.Fatalf("main.go: registry.ValidateNotifyTokenExclusions(...) no longer sources its arguments from %s\n"+
 			"Args block:\n%s\n\n"+
-			"P1 from PR #711 review requires the drive token to be checked against "+
-			"the dynamic per-route notify tokens / callback secrets loaded from "+
-			"OCTO_CARD_ACTION_ROUTES. Removing this argument reopens the "+
-			"one-credential-two-capabilities hazard.",
-			wantRef, args)
+			"P1 from PR #711 review requires the fixed internal-token envs to be checked "+
+			"against the dynamic per-route notify tokens / callback secrets loaded from "+
+			"OCTO_CARD_ACTION_ROUTES. A hand-written list reopens the "+
+			"one-credential-two-capabilities hazard the moment someone forgets an entry.",
+			wantSource, args)
+	}
+
+	// Claim 2: the drive token is actually in that registry. Without this, claim 1
+	// could hold over an empty or drive-less registry and the P1 would be back.
+	if !internaltoken.Registered(internal_resolve.DriveInternalTokenEnv) {
+		t.Fatalf("%s is not in pkg/internaltoken's registry; main.go's exclusion gate "+
+			"therefore never sees it, reopening the one-credential-two-capabilities hazard",
+			internal_resolve.DriveInternalTokenEnv)
+	}
+}
+
+// TestDriveTokenIsGuardedAgainstEverySibling pins the property this module used
+// to hand-roll: the drive token is compared against every OTHER fixed
+// internal-token env, not just the ones that existed when this module was
+// written. Enumerating the registry means a capability added later is covered
+// with no edit here.
+func TestDriveTokenIsGuardedAgainstEverySibling(t *testing.T) {
+	envs := internaltoken.Envs()
+	if len(envs) < 2 {
+		t.Fatalf("registry holds %d envs; the cross-capability guard would be vacuous", len(envs))
+	}
+	found := false
+	for _, env := range envs {
+		if env == internal_resolve.DriveInternalTokenEnv {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("%s missing from internaltoken.Envs() = %v", internal_resolve.DriveInternalTokenEnv, envs)
 	}
 }
 

--- a/modules/internal_resolve/main_wiring_test.go
+++ b/modules/internal_resolve/main_wiring_test.go
@@ -105,12 +105,16 @@ func TestMainWiresDriveTokenIntoValidateNotifyTokenExclusions(t *testing.T) {
 	}
 }
 
-// TestDriveTokenIsGuardedAgainstEverySibling pins the property this module used
-// to hand-roll: the drive token is compared against every OTHER fixed
-// internal-token env, not just the ones that existed when this module was
-// written. Enumerating the registry means a capability added later is covered
-// with no edit here.
-func TestDriveTokenIsGuardedAgainstEverySibling(t *testing.T) {
+// TestDriveTokenIsRegisteredWithSiblings pins the precondition this module used
+// to hand-roll for itself: the drive token is in the shared registry alongside
+// the other fixed internal-token envs, so Resolve compares it against its
+// seniors and any capability added later yields to it. Enumerating the registry
+// means an appended env needs no edit here.
+//
+// This asserts membership, not the comparison itself — that is
+// TestResolveDriveInternalTokenRejectsSiblingCollision's job, and it branches on
+// the precedence index because the guard is directional.
+func TestDriveTokenIsRegisteredWithSiblings(t *testing.T) {
 	envs := internaltoken.Envs()
 	if len(envs) < 2 {
 		t.Fatalf("registry holds %d envs; the cross-capability guard would be vacuous", len(envs))

--- a/modules/notify/api.go
+++ b/modules/notify/api.go
@@ -27,12 +27,16 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/Mininglamp-OSS/octo-server/pkg/internaltoken"
 	"github.com/gocraft/dbr/v2"
 	"go.uber.org/zap"
 )
 
 // InternalTokenHeader is the header key for internal service authentication.
-const InternalTokenHeader = "X-Internal-Token"
+// Owned by pkg/internaltoken alongside the env names, so the credential family
+// has one spelling; re-exported here because callers outside this module
+// already reference notify.InternalTokenHeader.
+const InternalTokenHeader = internaltoken.Header
 
 const notifyCapabilityContextKey = "octo.notify.capability"
 

--- a/modules/notify/config.go
+++ b/modules/notify/config.go
@@ -1,5 +1,11 @@
 package notify
 
+import (
+	"errors"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/internaltoken"
+)
+
 // Internal-token resolution for modules/notify.
 //
 // # What this file adds, and what it deliberately leaves alone
@@ -39,8 +45,10 @@ package notify
 // §5.1 describes it as such.
 
 const (
-	notifyInternalTokenEnv     = "NOTIFY_INTERNAL_TOKEN"
-	docsNotifyInternalTokenEnv = "OCTO_DOCS_NOTIFY_TOKEN"
+	// The two notify credentials, sourced from the shared registry so their
+	// spellings cannot drift from the entry the collision check compares.
+	notifyInternalTokenEnv     = internaltoken.NotifyInternalTokenEnv
+	docsNotifyInternalTokenEnv = internaltoken.DocsNotifyTokenEnv
 
 	// marketplaceInternalTokenEnvForExclusion is
 	// modules/space.MarketplaceInternalTokenEnv. Duplicated as a literal rather
@@ -77,26 +85,36 @@ func resolveInternalTokens(getenv func(string) string) (token, docsToken string,
 	if getenv == nil {
 		return "", "", nil, []string{"internal token lookup unavailable; notify internal API disabled"}
 	}
-	token = getenv(notifyInternalTokenEnv)
-	docsToken = getenv(docsNotifyInternalTokenEnv)
 
-	if token == "" {
-		warnings = append(warnings,
-			notifyInternalTokenEnv+" not set — internal API will reject all requests")
-	}
-	if docsToken == "" {
-		warnings = append(warnings,
-			docsNotifyInternalTokenEnv+" not set — docs notification requests will be rejected")
+	// resolve runs one env through the shared registry, which enforces the
+	// length floor and compares the value against every env registered BEFORE
+	// it. For NOTIFY_INTERNAL_TOKEN (registered first) that is nothing; for
+	// OCTO_DOCS_NOTIFY_TOKEN it is the legacy token — i.e. exactly the
+	// intra-module tie-break this function used to run by hand, in the same
+	// direction. An unset env is a normal deployment shape and reports as a
+	// warning; a collision or an undersized value is an operator mistake that
+	// silently turns an ingress off, and reports as a boot error.
+	resolve := func(env string) string {
+		value, err := internaltoken.Resolve(env, getenv)
+		if err == nil {
+			return value
+		}
+		var resolveErr *internaltoken.Error
+		if errors.As(err, &resolveErr) && resolveErr.Reason == internaltoken.ReasonUnset {
+			warnings = append(warnings, err.Error())
+			return ""
+		}
+		bootErrors = append(bootErrors, err.Error())
+		return ""
 	}
 
-	// Pre-existing intra-module tie-break, unchanged. Runs first so the docs
-	// token is already cleared before the foreign check looks at it.
-	if token != "" && docsToken == token {
-		bootErrors = append(bootErrors, docsNotifyInternalTokenEnv+" must differ from "+
-			notifyInternalTokenEnv+"; docs capability disabled")
-		docsToken = ""
-	}
+	token = resolve(notifyInternalTokenEnv)
+	docsToken = resolve(docsNotifyInternalTokenEnv)
 
+	// Mirror-image half for OCTO_MARKETPLACE_INTERNAL_TOKEN (#827). That env is
+	// not in the registry yet, and its pairs were deliberately made symmetric
+	// rather than precedence-ordered, so both halves stay explicit until the
+	// follow-up absorbs it.
 	if env := collidesWithForeignFixedToken(token, getenv); env != "" {
 		bootErrors = append(bootErrors, notifyInternalTokenEnv+" must differ from "+env+
 			"; legacy notify capability disabled")

--- a/modules/notify/config.go
+++ b/modules/notify/config.go
@@ -16,23 +16,23 @@ import (
 // process env — the same shape modules/internal_resolve, modules/bot_mention
 // and modules/space already use.
 //
-// The one NEW rule is the exclusion against OCTO_MARKETPLACE_INTERNAL_TOKEN,
-// the single fixed internal-token env this change introduces
-// (modules/space.MarketplaceInternalTokenEnv). modules/space refuses to enable
-// the Space role lookup on a value shared with either notify credential; this
-// is the mirror-image half, so a deployment that sets one value for both fails
-// BOTH capabilities closed instead of picking an arbitrary winner and leaving
-// the leaked value serving here.
+// Both rules now come from pkg/internaltoken rather than from branches here:
 //
-// Scope note: the exclusion set is deliberately NOT extended to the other
-// pre-existing fixed internal-token envs (OCTO_DOCS_BOT_MENTION_TOKEN,
-// OCTO_DRIVE_INTERNAL_TOKEN). Those pairs predate this change; switching a
-// currently-serving deployment's notify path off is not something a marketplace
-// feature gets to do as a side effect.
+//   - the intra-module tie-break (OCTO_DOCS_NOTIFY_TOKEN yields to
+//     NOTIFY_INTERNAL_TOKEN) is the registry's precedence rule, in the same
+//     direction this file used to hand-roll it;
+//   - the exclusion against OCTO_MARKETPLACE_INTERNAL_TOKEN is that Spec's
+//     Mutual flag, which disables BOTH sides — the mirror-image behaviour #827
+//     introduced, expressed once instead of in four modules.
 //
-// Comparison is byte-exact on the raw env values, matching modules/space,
-// modules/bot_mention and modules/internal_resolve. No normalization is applied
-// anywhere in this file: the tokens returned here are what
+// The pre-existing pairs against OCTO_DOCS_BOT_MENTION_TOKEN and
+// OCTO_DRIVE_INTERNAL_TOKEN keep behaving exactly as they did: both are
+// registered after these two envs and are not Mutual, so they are the side that
+// yields. Switching a currently-serving deployment's notify path off is still
+// not something this file does.
+//
+// Comparison is byte-exact on the raw env values, in pkg/internaltoken as it
+// was here. No normalization is applied anywhere: the tokens returned here are what
 // internalAuthMiddleware compares against the request header, and
 // NOTIFY_INTERNAL_TOKEN / OCTO_DOCS_NOTIFY_TOKEN are pre-existing production
 // credentials whose accepted bytes must not change. Trimming on one side only
@@ -49,29 +49,7 @@ const (
 	// spellings cannot drift from the entry the collision check compares.
 	notifyInternalTokenEnv     = internaltoken.NotifyInternalTokenEnv
 	docsNotifyInternalTokenEnv = internaltoken.DocsNotifyTokenEnv
-
-	// marketplaceInternalTokenEnvForExclusion is
-	// modules/space.MarketplaceInternalTokenEnv. Duplicated as a literal rather
-	// than imported, matching modules/internal_resolve/config.go and
-	// modules/bot_mention/config.go: no module should take a production
-	// dependency on another just to learn a string. The spelling is pinned
-	// against the owning package by a test.
-	marketplaceInternalTokenEnvForExclusion = "OCTO_MARKETPLACE_INTERNAL_TOKEN"
 )
-
-// collidesWithForeignFixedToken reports the foreign env name a non-empty token
-// collides with, or "" when it is clean. An empty token never "collides":
-// unset already means the capability is disabled, and reporting a collision
-// between two unset envs would produce a confusing boot error.
-func collidesWithForeignFixedToken(token string, getenv func(string) string) string {
-	if token == "" || getenv == nil {
-		return ""
-	}
-	if getenv(marketplaceInternalTokenEnvForExclusion) == token {
-		return marketplaceInternalTokenEnvForExclusion
-	}
-	return ""
-}
 
 // resolveInternalTokens loads NOTIFY_INTERNAL_TOKEN and OCTO_DOCS_NOTIFY_TOKEN
 // and returns them alongside human-readable, logger-safe diagnostics (never
@@ -111,19 +89,5 @@ func resolveInternalTokens(getenv func(string) string) (token, docsToken string,
 	token = resolve(notifyInternalTokenEnv)
 	docsToken = resolve(docsNotifyInternalTokenEnv)
 
-	// Mirror-image half for OCTO_MARKETPLACE_INTERNAL_TOKEN (#827). That env is
-	// not in the registry yet, and its pairs were deliberately made symmetric
-	// rather than precedence-ordered, so both halves stay explicit until the
-	// follow-up absorbs it.
-	if env := collidesWithForeignFixedToken(token, getenv); env != "" {
-		bootErrors = append(bootErrors, notifyInternalTokenEnv+" must differ from "+env+
-			"; legacy notify capability disabled")
-		token = ""
-	}
-	if env := collidesWithForeignFixedToken(docsToken, getenv); env != "" {
-		bootErrors = append(bootErrors, docsNotifyInternalTokenEnv+" must differ from "+env+
-			"; docs notify capability disabled")
-		docsToken = ""
-	}
 	return token, docsToken, warnings, bootErrors
 }

--- a/modules/notify/internal_token_test.go
+++ b/modules/notify/internal_token_test.go
@@ -117,21 +117,11 @@ func TestResolveNotifyTokenCollisionDisablesTheJuniorCapability(t *testing.T) {
 // disabling itself.
 func TestResolveNotifyTokenCoversEverySibling(t *testing.T) {
 	const shared = "shared-internal-token-value-0000"
-	envs := internaltoken.Envs()
+	owned := []string{internaltoken.NotifyInternalTokenEnv, internaltoken.DocsNotifyTokenEnv}
 
-	index := func(target string) int {
-		for i, env := range envs {
-			if env == target {
-				return i
-			}
-		}
-		t.Fatalf("%s missing from internaltoken.Envs() = %v", target, envs)
-		return -1
-	}
-
-	for _, subject := range []string{internaltoken.NotifyInternalTokenEnv, internaltoken.DocsNotifyTokenEnv} {
-		subjectIndex := index(subject)
-		for siblingIndex, sibling := range envs {
+	yielding := 0
+	for _, subject := range owned {
+		for _, sibling := range internaltoken.Envs() {
 			if sibling == subject {
 				continue
 			}
@@ -141,10 +131,15 @@ func TestResolveNotifyTokenCoversEverySibling(t *testing.T) {
 				}
 				return ""
 			}
-			if siblingIndex < subjectIndex {
+			// Branch on the registry's own rule. NOTIFY_INTERNAL_TOKEN is
+			// registered first, so it yields to nothing by precedence — but it
+			// still yields to a Mutual env, which is how #827's marketplace
+			// pair behaves and why this cannot be a "seniors only" test.
+			if internaltoken.Yields(subject, sibling) {
+				yielding++
 				t.Run(subject+"_yields_to_"+sibling, func(t *testing.T) {
 					if got := resolveOne(t, subject, getenv); got != "" {
-						t.Fatalf("%s = %q while sharing a value with the senior env %s; want it disabled",
+						t.Fatalf("%s = %q while sharing a value with %s; want it disabled",
 							subject, got, sibling)
 					}
 				})
@@ -153,17 +148,16 @@ func TestResolveNotifyTokenCoversEverySibling(t *testing.T) {
 			t.Run(subject+"_outranks_"+sibling, func(t *testing.T) {
 				if got := resolveOne(t, subject, getenv); got != shared {
 					t.Fatalf("%s = %q while sharing a value with the junior env %s; the senior "+
-						"capability must keep serving (%s is the side that gets disabled)",
-						subject, got, sibling, sibling)
+						"capability must keep serving", subject, got, sibling)
 				}
 			})
 		}
 	}
+	if yielding == 0 {
+		t.Fatal("neither notify env yields to anything; the guard would be vacuous")
+	}
 }
 
-// TestNotifyOwnsItsEnvsInTheSharedRegistry keeps the module and the registry
-// from drifting apart: an env this module reads but nobody registered would
-// silently skip every cross-capability comparison.
 func TestNotifyOwnsItsEnvsInTheSharedRegistry(t *testing.T) {
 	for _, env := range []string{internaltoken.NotifyInternalTokenEnv, internaltoken.DocsNotifyTokenEnv} {
 		if !internaltoken.Registered(env) {

--- a/modules/notify/internal_token_test.go
+++ b/modules/notify/internal_token_test.go
@@ -1,0 +1,173 @@
+package notify
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/internaltoken"
+)
+
+// This module owns two of the fixed internal-token envs. Both now resolve
+// through pkg/internaltoken instead of the hand-rolled comparison that used to
+// live in New().
+
+// resolveOne runs one of this module's two envs through the production resolver
+// (#827's resolveInternalTokens, which now delegates to pkg/internaltoken) and
+// returns just that env's token, so the directional assertions below stay
+// readable.
+func resolveOne(t *testing.T, env string, getenv func(string) string) string {
+	t.Helper()
+	token, docsToken, _, _ := resolveInternalTokens(getenv)
+	switch env {
+	case internaltoken.NotifyInternalTokenEnv:
+		return token
+	case internaltoken.DocsNotifyTokenEnv:
+		return docsToken
+	default:
+		t.Fatalf("resolveOne: %s is not owned by modules/notify", env)
+		return ""
+	}
+}
+
+func TestResolveNotifyTokenAcceptsDistinctValues(t *testing.T) {
+	getenv := func(key string) string {
+		switch key {
+		case internaltoken.NotifyInternalTokenEnv:
+			return "legacy-notify-token"
+		case internaltoken.DocsNotifyTokenEnv:
+			return "docs-notify-token"
+		default:
+			return ""
+		}
+	}
+	if got := resolveOne(t, internaltoken.NotifyInternalTokenEnv, getenv); got != "legacy-notify-token" {
+		t.Fatalf("legacy token = %q, want it enabled", got)
+	}
+	if got := resolveOne(t, internaltoken.DocsNotifyTokenEnv, getenv); got != "docs-notify-token" {
+		t.Fatalf("docs token = %q, want it enabled", got)
+	}
+}
+
+// TestResolveNotifyTokenHasNoLengthFloor pins the legacy waiver these two envs
+// carry: values below internaltoken.DefaultMinBytes still enable the
+// capability. Raising the bar would disable a live ingress on the next deploy
+// of any installation running a shorter secret, so it is a rollout decision,
+// not something this refactor makes silently. Deployments in the tree (see
+// pilote2e) do run short values.
+func TestResolveNotifyTokenHasNoLengthFloor(t *testing.T) {
+	short := "short-token"
+	if len(short) >= internaltoken.DefaultMinBytes {
+		t.Fatalf("fixture is %d bytes; it must be under the %d-byte shared floor to test the waiver",
+			len(short), internaltoken.DefaultMinBytes)
+	}
+	getenv := func(key string) string {
+		if key == internaltoken.NotifyInternalTokenEnv {
+			return short
+		}
+		return ""
+	}
+	if got := resolveOne(t, internaltoken.NotifyInternalTokenEnv, getenv); got != short {
+		t.Fatalf("token = %q, want the short value accepted under the legacy waiver", got)
+	}
+}
+
+func TestResolveNotifyTokenUnsetFailsClosed(t *testing.T) {
+	getenv := func(string) string { return "" }
+	for _, env := range []string{internaltoken.NotifyInternalTokenEnv, internaltoken.DocsNotifyTokenEnv} {
+		if got := resolveOne(t, env, getenv); got != "" {
+			t.Fatalf("%s unset resolved to %q; must be empty so authInternal rejects every request", env, got)
+		}
+	}
+}
+
+// TestResolveNotifyTokenCollisionDisablesTheJuniorCapability pins the
+// precedence rule for this module's own pair, which is also the behaviour the
+// hand-rolled check in New() had before the registry existed: with both envs
+// set to the same value, the legacy ingress keeps serving and the docs
+// capability — the newcomer that duplicated an existing secret — is the one
+// that goes dark.
+//
+// Disabling both would satisfy the invariant too, but it would take a working
+// production ingress offline on the next rolling deploy for a misconfiguration
+// whose damage is already contained once either side is off. Boot succeeds
+// either way; this is a module-local degradation, not a startup failure.
+func TestResolveNotifyTokenCollisionDisablesTheJuniorCapability(t *testing.T) {
+	const shared = "shared-internal-token-value-0000"
+	getenv := func(key string) string {
+		switch key {
+		case internaltoken.NotifyInternalTokenEnv, internaltoken.DocsNotifyTokenEnv:
+			return shared
+		default:
+			return ""
+		}
+	}
+	if got := resolveOne(t, internaltoken.NotifyInternalTokenEnv, getenv); got != shared {
+		t.Fatalf("legacy token = %q; the senior capability must keep serving", got)
+	}
+	if got := resolveOne(t, internaltoken.DocsNotifyTokenEnv, getenv); got != "" {
+		t.Fatalf("docs token = %q on collision; the junior capability must fail closed", got)
+	}
+}
+
+// TestResolveNotifyTokenCoversEverySibling is the coverage this module never
+// had: New() used to compare its two envs only against each other, so a value
+// shared with the bot-mention or drive capability went undetected here. Under
+// the registry's precedence rule the junior side yields, so OCTO_DOCS_NOTIFY_TOKEN
+// is now guarded against every env registered before it — and both of this
+// module's envs are guarded from the other direction too, by the junior module
+// disabling itself.
+func TestResolveNotifyTokenCoversEverySibling(t *testing.T) {
+	const shared = "shared-internal-token-value-0000"
+	envs := internaltoken.Envs()
+
+	index := func(target string) int {
+		for i, env := range envs {
+			if env == target {
+				return i
+			}
+		}
+		t.Fatalf("%s missing from internaltoken.Envs() = %v", target, envs)
+		return -1
+	}
+
+	for _, subject := range []string{internaltoken.NotifyInternalTokenEnv, internaltoken.DocsNotifyTokenEnv} {
+		subjectIndex := index(subject)
+		for siblingIndex, sibling := range envs {
+			if sibling == subject {
+				continue
+			}
+			getenv := func(key string) string {
+				if key == subject || key == sibling {
+					return shared
+				}
+				return ""
+			}
+			if siblingIndex < subjectIndex {
+				t.Run(subject+"_yields_to_"+sibling, func(t *testing.T) {
+					if got := resolveOne(t, subject, getenv); got != "" {
+						t.Fatalf("%s = %q while sharing a value with the senior env %s; want it disabled",
+							subject, got, sibling)
+					}
+				})
+				continue
+			}
+			t.Run(subject+"_outranks_"+sibling, func(t *testing.T) {
+				if got := resolveOne(t, subject, getenv); got != shared {
+					t.Fatalf("%s = %q while sharing a value with the junior env %s; the senior "+
+						"capability must keep serving (%s is the side that gets disabled)",
+						subject, got, sibling, sibling)
+				}
+			})
+		}
+	}
+}
+
+// TestNotifyOwnsItsEnvsInTheSharedRegistry keeps the module and the registry
+// from drifting apart: an env this module reads but nobody registered would
+// silently skip every cross-capability comparison.
+func TestNotifyOwnsItsEnvsInTheSharedRegistry(t *testing.T) {
+	for _, env := range []string{internaltoken.NotifyInternalTokenEnv, internaltoken.DocsNotifyTokenEnv} {
+		if !internaltoken.Registered(env) {
+			t.Fatalf("%s is not in pkg/internaltoken's registry; it would bypass every collision check", env)
+		}
+	}
+}

--- a/modules/notify/target_role_test.go
+++ b/modules/notify/target_role_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
 	"github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/Mininglamp-OSS/octo-server/pkg/internaltoken"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -780,7 +781,7 @@ const tokenB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 // modules/space runs the mirror-image comparison, so a shared value fails BOTH
 // capabilities closed rather than picking an arbitrary winner.
 func TestResolveInternalTokens_MarketplaceCollisionDisablesNotifyTokens(t *testing.T) {
-	foreign := marketplaceInternalTokenEnvForExclusion
+	foreign := internaltoken.MarketplaceInternalTokenEnv
 
 	t.Run("legacy vs "+foreign, func(t *testing.T) {
 		getenv := func(k string) string {
@@ -846,10 +847,14 @@ func TestResolveInternalTokens_PreExistingForeignEnvsAreNotExcluded(t *testing.T
 }
 
 // The marketplace env spelling must track modules/space's exported constant.
-// The literal is duplicated on purpose (no production import); this pins it.
+// It no longer needs a duplicated literal to track: both names now resolve to
+// the single entry in pkg/internaltoken, so this pins that they still do.
 func TestForeignTokenEnvSpellingsMatchOwningPackages(t *testing.T) {
-	assert.Equal(t, space.MarketplaceInternalTokenEnv, marketplaceInternalTokenEnvForExclusion,
-		"modules/space renamed its token env; update the literal in modules/notify/config.go")
+	assert.Equal(t, space.MarketplaceInternalTokenEnv, internaltoken.MarketplaceInternalTokenEnv,
+		"modules/space no longer sources its token env from pkg/internaltoken; the "+
+			"spelling can drift again")
+	assert.True(t, internaltoken.Registered(internaltoken.MarketplaceInternalTokenEnv),
+		"the marketplace env must stay registered, or its Mutual collision rule stops applying")
 }
 
 // The pre-existing intra-module tie-break is preserved verbatim: legacy wins,

--- a/modules/space/api_internal.go
+++ b/modules/space/api_internal.go
@@ -2,13 +2,13 @@ package space
 
 import (
 	"crypto/subtle"
-	"errors"
 	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/Mininglamp-OSS/octo-server/pkg/internaltoken"
 	"github.com/Mininglamp-OSS/octo-server/pkg/ratelimit"
 	"go.uber.org/zap"
 )
@@ -71,35 +71,18 @@ const (
 	// env name that describes a capability the process does not have is a
 	// standing invitation to misconfigure it. The name now matches its sibling
 	// OCTO_DRIVE_INTERNAL_TOKEN (one consumer, one internal capability set).
-	MarketplaceInternalTokenEnv = "OCTO_MARKETPLACE_INTERNAL_TOKEN"
-
-	// Sibling *fixed* internal-token envs we forbid intra-set collision with,
-	// so one leaked value can never grant two fixed capabilities. Mirrors the
-	// same local const set in modules/internal_resolve/config.go,
-	// modules/bot_mention/config.go and modules/notify/config.go — the names
-	// are duplicated on purpose rather than imported, so no module has to
-	// depend on another just to know a string. Every one of those modules runs
-	// the mirror-image comparison, so a shared value fails ALL the colliding
-	// capabilities closed instead of picking an arbitrary winner.
-	//
-	// Collision with the *dynamic* per-route notify tokens / callback secrets
-	// loaded from OCTO_CARD_ACTION_ROUTES cannot be seen from here; that check
-	// happens centrally in main.go (see MarketplaceInternalTokenEnv above).
-	notifyInternalTokenEnv            = "NOTIFY_INTERNAL_TOKEN"
-	docsNotifyInternalTokenEnv        = "OCTO_DOCS_NOTIFY_TOKEN"
-	botMentionInternalTokenEnv        = "OCTO_DOCS_BOT_MENTION_TOKEN"
-	driveInternalTokenEnvForExclusion = "OCTO_DRIVE_INTERNAL_TOKEN"
+	MarketplaceInternalTokenEnv = internaltoken.MarketplaceInternalTokenEnv
 
 	// marketplaceInternalTokenHeader is the wire header carrying the
 	// credential. Same value as modules/notify.InternalTokenHeader and
 	// modules/internal_resolve's internalTokenHeader — one convention across
 	// octo-server internal APIs.
-	marketplaceInternalTokenHeader = "X-Internal-Token"
+	marketplaceInternalTokenHeader = internaltoken.Header
 
 	// minMarketplaceInternalTokenBytes is the repository-wide 32-byte floor
 	// for internal-route credentials (see modules/internal_resolve and
 	// modules/notify). A one-byte value would otherwise enable the endpoint.
-	minMarketplaceInternalTokenBytes = 32
+	minMarketplaceInternalTokenBytes = internaltoken.DefaultMinBytes
 
 	// maxSpaceIDBytes matches the space.space_id / space_member.space_id
 	// column width (VARCHAR(40), modules/space/sql/20260307000002). Anything
@@ -149,41 +132,7 @@ const (
 //
 // Returned error messages are logger-safe: they never contain token values.
 func resolveMarketplaceInternalToken(getenv func(string) string) (string, error) {
-	if getenv == nil {
-		return "", errors.New(MarketplaceInternalTokenEnv +
-			" lookup unavailable; space internal API disabled")
-	}
-	token := getenv(MarketplaceInternalTokenEnv)
-	switch {
-	case token == "":
-		return "", errors.New(MarketplaceInternalTokenEnv +
-			" not set; space internal API will reject all requests")
-	case len(token) < minMarketplaceInternalTokenBytes:
-		// Length check goes BEFORE the collision checks: a short token is
-		// unusable regardless of whether it happens to collide, and we must
-		// not leak "your token collides with X" for a value that could never
-		// authenticate anyway.
-		return "", errors.New(MarketplaceInternalTokenEnv +
-			" must be at least 32 bytes; space internal API disabled")
-	case token == getenv(notifyInternalTokenEnv):
-		return "", errors.New(MarketplaceInternalTokenEnv +
-			" must differ from " + notifyInternalTokenEnv +
-			"; space internal API disabled")
-	case token == getenv(docsNotifyInternalTokenEnv):
-		return "", errors.New(MarketplaceInternalTokenEnv +
-			" must differ from " + docsNotifyInternalTokenEnv +
-			"; space internal API disabled")
-	case token == getenv(botMentionInternalTokenEnv):
-		return "", errors.New(MarketplaceInternalTokenEnv +
-			" must differ from " + botMentionInternalTokenEnv +
-			"; space internal API disabled")
-	case token == getenv(driveInternalTokenEnvForExclusion):
-		return "", errors.New(MarketplaceInternalTokenEnv +
-			" must differ from " + driveInternalTokenEnvForExclusion +
-			"; space internal API disabled")
-	default:
-		return token, nil
-	}
+	return internaltoken.Resolve(MarketplaceInternalTokenEnv, getenv)
 }
 
 // sanitizedSpaceMemberRoleRPS / sanitizedSpaceMemberRoleBurst resolve the

--- a/modules/space/api_internal_test.go
+++ b/modules/space/api_internal_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/Mininglamp-OSS/octo-server/pkg/internaltoken"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -322,29 +323,55 @@ func TestResolveMarketplaceInternalTokenChecksLengthBeforeCollision(t *testing.T
 }
 
 func TestResolveMarketplaceInternalTokenRejectsSiblingCollision(t *testing.T) {
+	// Enumerate the shared registry instead of a hand-written sibling list.
+	// This env is registered last AND marked Mutual, so it yields to every
+	// other entry — but the assertion asks internaltoken.Yields rather than
+	// assuming that, so it stays honest if the registry ever changes shape.
 	sharedSecret := strings.Repeat("s", minMarketplaceInternalTokenBytes)
-	cases := []struct {
-		name    string
-		sibling string
-	}{
-		{"notify", notifyInternalTokenEnv},
-		{"docs-notify", docsNotifyInternalTokenEnv},
-		{"bot-mention", botMentionInternalTokenEnv},
-		{"drive", driveInternalTokenEnvForExclusion},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+	yielding := 0
+	for _, sibling := range internaltoken.Envs() {
+		if sibling == MarketplaceInternalTokenEnv {
+			continue
+		}
+		if !internaltoken.Yields(MarketplaceInternalTokenEnv, sibling) {
+			continue
+		}
+		yielding++
+		t.Run(sibling, func(t *testing.T) {
 			getenv := func(k string) string {
-				if k == MarketplaceInternalTokenEnv || k == tc.sibling {
+				if k == MarketplaceInternalTokenEnv || k == sibling {
 					return sharedSecret
 				}
 				return ""
 			}
 			_, err := resolveMarketplaceInternalToken(getenv)
 			require.Error(t, err, "expected error when %s == %s",
-				MarketplaceInternalTokenEnv, tc.sibling)
+				MarketplaceInternalTokenEnv, sibling)
+			assert.Contains(t, err.Error(), sibling, "the reason must name the colliding env")
 			assert.NotContains(t, err.Error(), sharedSecret,
 				"error messages must never contain token values")
+		})
+	}
+	if yielding == 0 {
+		t.Fatal("this token yields to nothing; the cross-capability guard would be vacuous")
+	}
+}
+
+// The Mutual flag on this env is what makes its pairs symmetric: the four
+// pre-existing capabilities are registered BEFORE it, so precedence alone would
+// leave them serving on a shared value. #827 introduced that mirror-image
+// behaviour as four hand-written branches; this asserts the registry still
+// produces it from the one flag.
+func TestMarketplaceTokenCollisionAlsoDisablesTheSeniorCapability(t *testing.T) {
+	for _, senior := range internaltoken.Envs() {
+		if senior == MarketplaceInternalTokenEnv {
+			continue
+		}
+		t.Run(senior, func(t *testing.T) {
+			assert.True(t, internaltoken.Yields(senior, MarketplaceInternalTokenEnv),
+				"%s must yield to %s even though it is registered earlier — that is the "+
+					"Mutual flag, and dropping it silently leaves a leaked value serving here",
+				senior, MarketplaceInternalTokenEnv)
 		})
 	}
 }

--- a/pkg/internaltoken/internaltoken.go
+++ b/pkg/internaltoken/internaltoken.go
@@ -26,7 +26,9 @@
 // # Registration order is a precedence order
 //
 // Resolve compares the env being resolved against every env registered BEFORE
-// it, and the junior side is the one that yields. Two consequences:
+// it, and the junior side is the one that yields. (One env opts out — see
+// Spec.Mutual — but precedence is the default and the rest of this section
+// describes it.) Two consequences:
 //
 //   - Coverage is complete by construction. Every unordered pair {i, j} is
 //     compared exactly once — by whichever of the two was registered later — so
@@ -43,6 +45,15 @@
 //
 // So append new Specs to the END of the registry. Reordering it silently
 // changes which live capability a misconfigured deployment loses.
+//
+// A genuinely new capability may instead want its pairs symmetric — "fail both
+// closed rather than pick an arbitrary winner" — which is safe precisely
+// because no deployment can yet depend on the other side staying up. That is
+// what Spec.Mutual expresses, and OCTO_MARKETPLACE_INTERNAL_TOKEN (#827) is
+// the entry that made the case: it shipped the mirror-image branch in all four
+// existing modules by hand, while deliberately leaving every pre-existing pair
+// on precedence. Registering it here replaced five hand-written copies of that
+// decision with one field.
 //
 // # What a collision does
 //
@@ -92,6 +103,12 @@ const (
 	// modules/internal_resolve. The docs-auto-mount polling loop in octo-drive
 	// presents this token on every call.
 	DriveInternalTokenEnv = "OCTO_DRIVE_INTERNAL_TOKEN"
+
+	// MarketplaceInternalTokenEnv gates the Space role lookup in modules/space
+	// (GET /v1/internal/spaces/:space_id/members/:uid/role). It authorizes
+	// reading any uid's role in any Space, which is why its collisions are
+	// Mutual rather than precedence-ordered — see the Spec.Mutual doc.
+	MarketplaceInternalTokenEnv = "OCTO_MARKETPLACE_INTERNAL_TOKEN"
 )
 
 // DefaultMinBytes is the repository-wide length floor for internal-route
@@ -117,6 +134,27 @@ type Spec struct {
 	// into reasons as "<Env> ...; <Capability> disabled", so keep it a noun
 	// phrase.
 	Capability string
+	// Mutual makes this env's collisions symmetric: a shared value disables
+	// BOTH sides, not just the junior one.
+	//
+	// The default (false) is the precedence rule described above — the
+	// incumbent keeps serving, the newcomer yields — which is what the four
+	// original envs had already built by hand and what a refactor must not
+	// silently change for a live deployment.
+	//
+	// Mutual is for an env whose owner deliberately chose "fail both closed
+	// rather than pick an arbitrary winner" AND is new enough that no
+	// deployment can already be relying on the other side staying up. That is
+	// exactly the trade-off #827 made for MarketplaceInternalTokenEnv: it added
+	// the mirror-image branch to all four existing modules precisely because it
+	// was introducing the pair, while leaving every pre-existing pair alone for
+	// the same reason the default is precedence.
+	//
+	// Set it only with that justification. Flipping an existing entry from
+	// false to true takes a currently-serving ingress down on the next deploy
+	// of any installation carrying the collision.
+	Mutual bool
+
 	// MinBytes is the length floor enforced on the value. Zero means no floor.
 	//
 	// New capabilities MUST use DefaultMinBytes. The three legacy envs below
@@ -136,6 +174,7 @@ var registry = []Spec{
 	{Env: DocsNotifyTokenEnv, Capability: "docs notification capability", MinBytes: 0},
 	{Env: BotMentionTokenEnv, Capability: "bot mention capability", MinBytes: 0},
 	{Env: DriveInternalTokenEnv, Capability: "drive internal API", MinBytes: DefaultMinBytes},
+	{Env: MarketplaceInternalTokenEnv, Capability: "Space role lookup", MinBytes: DefaultMinBytes, Mutual: true},
 }
 
 // Reason classifies why Resolve refused a token, so callers can pick a log
@@ -203,10 +242,44 @@ func lookup(env string) (Spec, int, bool) {
 	return Spec{}, 0, false
 }
 
+// yieldsTo reports whether subject gives up its token on a shared value with
+// other. otherIsSenior says whether other is registered before subject.
+//
+// Precedence is the default: the junior yields, the incumbent keeps serving.
+// Either side being Mutual makes the pair symmetric instead, so both are
+// disabled — see Spec.Mutual for when that is the right choice.
+func yieldsTo(subject, other Spec, otherIsSenior bool) bool {
+	return otherIsSenior || subject.Mutual || other.Mutual
+}
+
+// Yields reports whether resolving subject is refused when its value is shared
+// with other — i.e. whether subject is the side that gets disabled.
+//
+// It exists so a module's own tests can branch on the rule instead of restating
+// it. A test that hard-codes "every other env disables me" passes only while
+// its subject happens to be registered last, and goes red the moment the
+// registry grows; one that asks Yields stays correct through an append and
+// through a Spec being marked Mutual.
+//
+// Unregistered names yield false: Resolve refuses them outright, so there is no
+// pair to speak of.
+func Yields(subject, other string) bool {
+	subjectSpec, subjectIndex, ok := lookup(subject)
+	if !ok {
+		return false
+	}
+	otherSpec, otherIndex, ok := lookup(other)
+	if !ok || subject == other {
+		return false
+	}
+	return yieldsTo(subjectSpec, otherSpec, otherIndex < subjectIndex)
+}
+
 // Resolve loads env and returns its value only when the value can grant
 // exactly one capability: it must be set, clear the spec's length floor, and
-// differ from the value of every env registered BEFORE it (see "Registration
-// order is a precedence order" in the package doc).
+// differ from the value of every env it yields to — by default the ones
+// registered BEFORE it (see "Registration order is a precedence order" in the
+// package doc), plus, in either direction, any env marked Mutual.
 //
 // On refusal it returns ("", *Error) — the empty token is what makes the
 // caller's auth middleware fail closed. Callers log the error and carry on;
@@ -249,14 +322,20 @@ func Resolve(env string, getenv func(string) string) (string, error) {
 				spec.Env, spec.MinBytes, spec.Capability),
 		}
 	}
-	for _, senior := range registry[:index] {
-		if token == getenv(senior.Env) {
+	for i, other := range registry {
+		if i == index {
+			continue
+		}
+		if !yieldsTo(spec, other, i < index) {
+			continue
+		}
+		if token == getenv(other.Env) {
 			return "", &Error{
 				Env:    env,
 				Reason: ReasonCollision,
-				Other:  senior.Env,
+				Other:  other.Env,
 				msg: fmt.Sprintf("%s must differ from %s; %s disabled",
-					spec.Env, senior.Env, spec.Capability),
+					spec.Env, other.Env, spec.Capability),
 			}
 		}
 	}

--- a/pkg/internaltoken/internaltoken.go
+++ b/pkg/internaltoken/internaltoken.go
@@ -1,0 +1,316 @@
+// Package internaltoken owns the registry of *fixed* internal-token
+// environment variables and the single resolve function every capability that
+// owns one goes through.
+//
+// # The invariant
+//
+// One credential grants exactly one capability. Each internal service-to-service
+// endpoint in octo-server is gated by its own X-Internal-Token value so that a
+// single leaked token cannot be replayed against a second, unrelated capability,
+// and so that one consumer can be rotated or revoked without disturbing the rest.
+//
+// # Why a registry instead of per-module checks
+//
+// Before this package every module hand-rolled its own "must differ from
+// sibling X" comparison, and each author only compared against the siblings
+// that existed when they wrote it: notify compared against nothing, docs-notify
+// against one, bot-mention against two, drive against three. That ladder
+// happens to cover all six of today's pairs, but it covers them by convention —
+// the Nth capability is protected only if its author remembers the full list,
+// and the N-1 modules already in the tree never learn the new env exists at all.
+// Coverage degrades silently as capabilities are added.
+//
+// The registry below makes the same ladder a property of the data instead of a
+// property of what each author remembered. Adding a Spec is the whole change.
+//
+// # Registration order is a precedence order
+//
+// Resolve compares the env being resolved against every env registered BEFORE
+// it, and the junior side is the one that yields. Two consequences:
+//
+//   - Coverage is complete by construction. Every unordered pair {i, j} is
+//     compared exactly once — by whichever of the two was registered later — so
+//     a newly appended Spec is guarded against all existing ones with no edit
+//     anywhere else, and no pair can be missed by an author forgetting a name.
+//
+//   - Which capability survives a collision is decided, not arbitrary. The
+//     incumbent keeps serving; the newcomer that duplicated an existing secret
+//     is the one that goes dark. That is the pre-existing behaviour of the
+//     hand-rolled checks, and it matters operationally: disabling BOTH sides
+//     would take a working production ingress offline on the next deploy, for a
+//     misconfiguration whose damage (one secret opening two doors) is already
+//     contained the moment either side is disabled.
+//
+// So append new Specs to the END of the registry. Reordering it silently
+// changes which live capability a misconfigured deployment loses.
+//
+// # What a collision does
+//
+// A collision disables the capability being resolved — Resolve returns an empty
+// token plus a logger-safe reason, and the caller's auth middleware then fails
+// closed because it has no token to compare against. Boot is NOT failed. That is
+// deliberate and pinned by TestCardActionDispatchScopesBotMentionTokenCollisionFailures
+// in main_carddispatch_test.go: a collision between two *fixed* internal-token
+// envs degrades module-locally, while a collision with a *dynamic* route
+// credential from OCTO_CARD_ACTION_ROUTES fails startup. Promoting fixed-vs-fixed
+// collisions to boot failures is a separate rollout decision.
+//
+// # Error strings never contain a token value
+//
+// Every message this package produces is assembled from env names and byte
+// counts only. Reasons are logged and, in some callers, surfaced at boot;
+// TestErrorsNeverContainTokenValue pins that no value can reach them.
+package internaltoken
+
+import "fmt"
+
+// Header is the wire header carrying an internal-service credential. One
+// convention across every internal API in octo-server, owned here alongside the
+// env names so a fourth capability cannot introduce a fourth spelling.
+const Header = "X-Internal-Token"
+
+// Fixed internal-token env names. Exported so callers pass a constant rather
+// than a literal that can drift out of sync with the registry.
+const (
+	// NotifyInternalTokenEnv gates the legacy text-notification ingress in
+	// modules/notify.
+	NotifyInternalTokenEnv = "NOTIFY_INTERNAL_TOKEN"
+
+	// DocsNotifyTokenEnv gates the docs-card notification ingress in
+	// modules/notify. Distinct from the legacy token so the docs consumer
+	// cannot mint arbitrary legacy notifications.
+	DocsNotifyTokenEnv = "OCTO_DOCS_NOTIFY_TOKEN"
+
+	// BotMentionTokenEnv gates the doc-comment bot-mention ingress in
+	// modules/bot_mention.
+	BotMentionTokenEnv = "OCTO_DOCS_BOT_MENTION_TOKEN"
+
+	// DriveInternalTokenEnv gates the drive-facing resolve endpoints in
+	// modules/internal_resolve. The docs-auto-mount polling loop in octo-drive
+	// presents this token on every call.
+	DriveInternalTokenEnv = "OCTO_DRIVE_INTERNAL_TOKEN"
+)
+
+// DefaultMinBytes is the repository-wide length floor for internal-route
+// credentials. internal/cardactiondispatch applies the same constant to the
+// dynamic per-route callback secrets and notify tokens, so operators have one
+// bar to remember and raising it here raises it everywhere.
+const DefaultMinBytes = 32
+
+// Spec describes one fixed internal-token env. Registry position is meaningful:
+// see "Registration order is a precedence order" in the package doc.
+type Spec struct {
+	// Env is the environment variable name.
+	Env string
+	// Capability names what the token unlocks, in prose. It is interpolated
+	// into reasons as "<Env> ...; <Capability> disabled", so keep it a noun
+	// phrase.
+	Capability string
+	// MinBytes is the length floor enforced on the value. Zero means no floor.
+	//
+	// New capabilities MUST use DefaultMinBytes. The three legacy envs below
+	// carry an explicit zero because they shipped without a floor: raising
+	// their bar would disable a live capability on the next deploy of any
+	// installation whose value is shorter, which is a rollout decision on the
+	// same footing as promoting collisions to boot failures — not something a
+	// refactor gets to do silently. Flipping one of these to DefaultMinBytes is
+	// a one-line change once that rollout happens.
+	MinBytes int
+}
+
+// registry is the source of truth, in precedence order: an entry yields to
+// every entry above it. APPEND new capabilities; do not reorder.
+var registry = []Spec{
+	{Env: NotifyInternalTokenEnv, Capability: "legacy internal notify API", MinBytes: 0},
+	{Env: DocsNotifyTokenEnv, Capability: "docs notification capability", MinBytes: 0},
+	{Env: BotMentionTokenEnv, Capability: "bot mention capability", MinBytes: 0},
+	{Env: DriveInternalTokenEnv, Capability: "drive internal API", MinBytes: DefaultMinBytes},
+}
+
+// Reason classifies why Resolve refused a token, so callers can pick a log
+// level (an unset env is a normal "capability not configured"; a collision is
+// an operator error worth an ERROR line) without string matching.
+type Reason string
+
+const (
+	// ReasonUnavailable: no getenv was supplied.
+	ReasonUnavailable Reason = "lookup_unavailable"
+	// ReasonUnregistered: the env asked for is not in the registry.
+	ReasonUnregistered Reason = "unregistered_env"
+	// ReasonUnset: the env is empty or absent.
+	ReasonUnset Reason = "unset"
+	// ReasonTooShort: the value is below the spec's length floor.
+	ReasonTooShort Reason = "too_short"
+	// ReasonCollision: the value equals the value of an env registered earlier.
+	ReasonCollision Reason = "collision"
+)
+
+// Error is the refusal returned by Resolve. Its message is built only from env
+// names and byte counts — never from a token value.
+type Error struct {
+	// Env is the env being resolved.
+	Env string
+	// Reason is why it was refused.
+	Reason Reason
+	// Other is the colliding env name; set only for ReasonCollision.
+	Other string
+
+	msg string
+}
+
+func (e *Error) Error() string { return e.msg }
+
+// Specs returns a copy of the registry, in precedence order.
+func Specs() []Spec {
+	out := make([]Spec, len(registry))
+	copy(out, registry)
+	return out
+}
+
+// Envs returns every registered env name, in precedence order.
+func Envs() []string {
+	out := make([]string, 0, len(registry))
+	for _, spec := range registry {
+		out = append(out, spec.Env)
+	}
+	return out
+}
+
+// Registered reports whether env is in the registry.
+func Registered(env string) bool {
+	_, _, ok := lookup(env)
+	return ok
+}
+
+// lookup returns the spec for env and its precedence index.
+func lookup(env string) (Spec, int, bool) {
+	for i, spec := range registry {
+		if spec.Env == env {
+			return spec, i, true
+		}
+	}
+	return Spec{}, 0, false
+}
+
+// Resolve loads env and returns its value only when the value can grant
+// exactly one capability: it must be set, clear the spec's length floor, and
+// differ from the value of every env registered BEFORE it (see "Registration
+// order is a precedence order" in the package doc).
+//
+// On refusal it returns ("", *Error) — the empty token is what makes the
+// caller's auth middleware fail closed. Callers log the error and carry on;
+// they must not fail boot on it (see the package doc).
+func Resolve(env string, getenv func(string) string) (string, error) {
+	spec, index, ok := lookup(env)
+	if !ok {
+		return "", &Error{
+			Env:    env,
+			Reason: ReasonUnregistered,
+			msg: fmt.Sprintf("%s is not a registered internal-token env; "+
+				"add it to pkg/internaltoken's registry — capability disabled", env),
+		}
+	}
+	if getenv == nil {
+		return "", &Error{
+			Env:    env,
+			Reason: ReasonUnavailable,
+			msg:    fmt.Sprintf("%s lookup unavailable; %s disabled", spec.Env, spec.Capability),
+		}
+	}
+	token := getenv(spec.Env)
+	if token == "" {
+		return "", &Error{
+			Env:    env,
+			Reason: ReasonUnset,
+			msg: fmt.Sprintf("%s not set; %s disabled and will reject all requests",
+				spec.Env, spec.Capability),
+		}
+	}
+	// The length gate runs before the collision gate because a value below the
+	// floor is unusable on its own terms: "lengthen this secret" is the whole
+	// fix, and naming a sibling env alongside it only adds a second thing for
+	// the operator to rule out.
+	if spec.MinBytes > 0 && len(token) < spec.MinBytes {
+		return "", &Error{
+			Env:    env,
+			Reason: ReasonTooShort,
+			msg: fmt.Sprintf("%s must be at least %d bytes; %s disabled",
+				spec.Env, spec.MinBytes, spec.Capability),
+		}
+	}
+	for _, senior := range registry[:index] {
+		if token == getenv(senior.Env) {
+			return "", &Error{
+				Env:    env,
+				Reason: ReasonCollision,
+				Other:  senior.Env,
+				msg: fmt.Sprintf("%s must differ from %s; %s disabled",
+					spec.Env, senior.Env, spec.Capability),
+			}
+		}
+	}
+	return token, nil
+}
+
+// Values returns the non-empty value of every registered env, in precedence
+// order.
+//
+// main.go feeds these into cardactiondispatch.Registry.ValidateNotifyTokenExclusions,
+// which is the only place that also sees the *dynamic* per-route notify tokens
+// and callback secrets loaded from OCTO_CARD_ACTION_ROUTES. Sourcing the list
+// from the registry means a newly registered capability joins that cross-check
+// automatically instead of waiting for someone to extend an argument list.
+//
+// A nil getenv panics rather than returning nothing. Returning an empty slice
+// would turn that boot gate — the one check here that ABORTS startup — into a
+// silent no-op, which is the single outcome a credential-exclusion gate must
+// never have. Same rationale as mustLookupSharedCode in the i18n helpers:
+// unrecoverable wiring mistakes fail loudly at boot.
+func Values(getenv func(string) string) []string {
+	if getenv == nil {
+		panic("internaltoken: Values requires a getenv; a nil lookup would silently disable the credential-exclusion gate")
+	}
+	out := make([]string, 0, len(registry))
+	for _, spec := range registry {
+		if value := getenv(spec.Env); value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+// Collision names one pair of registered envs sharing a value. Senior is the
+// env registered first (the one that keeps serving); Junior is the one Resolve
+// disables. Env names only — no value is ever carried.
+type Collision struct {
+	Senior string
+	Junior string
+}
+
+// Collisions reports every pair of registered envs that share a non-empty
+// value, in precedence order.
+//
+// Resolve already disables the junior side on its own. This exists so boot can
+// show the whole picture at once: an operator reading "docs capability
+// disabled" as a standalone line has to work out which other env it collided
+// with, and that the other one is still serving.
+//
+// A nil getenv panics, for the same reason as Values.
+func Collisions(getenv func(string) string) []Collision {
+	if getenv == nil {
+		panic("internaltoken: Collisions requires a getenv; a nil lookup would silently report no collisions")
+	}
+	var out []Collision
+	for i, junior := range registry {
+		value := getenv(junior.Env)
+		if value == "" {
+			continue
+		}
+		for _, senior := range registry[:i] {
+			if value == getenv(senior.Env) {
+				out = append(out, Collision{Senior: senior.Env, Junior: junior.Env})
+			}
+		}
+	}
+	return out
+}

--- a/pkg/internaltoken/internaltoken.go
+++ b/pkg/internaltoken/internaltoken.go
@@ -62,7 +62,10 @@
 // TestErrorsNeverContainTokenValue pins that no value can reach them.
 package internaltoken
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // Header is the wire header carrying an internal-service credential. One
 // convention across every internal API in octo-server, owned here alongside the
@@ -95,6 +98,14 @@ const (
 // credentials. internal/cardactiondispatch applies the same constant to the
 // dynamic per-route callback secrets and notify tokens, so operators have one
 // bar to remember and raising it here raises it everywhere.
+//
+// "Everywhere" is not one blast radius, though, and raising this constant is a
+// rollout decision on the same footing as the MinBytes waivers below. A FIXED
+// env below the floor is disabled module-locally and boot succeeds. A DYNAMIC
+// route credential below the floor fails validateRouteSpec, which propagates
+// out of installCardActionDispatch and PANICS main. So a bump from 32 to, say,
+// 48 would quietly disable a fixed ingress AND hard-fail boot for any
+// deployment whose route callback secret or route notify token is 32-47 bytes.
 const DefaultMinBytes = 32
 
 // Spec describes one fixed internal-token env. Registry position is meaningful:
@@ -279,21 +290,41 @@ func Values(getenv func(string) string) []string {
 	return out
 }
 
-// Collision names one pair of registered envs sharing a value. Senior is the
-// env registered first (the one that keeps serving); Junior is the one Resolve
-// disables. Env names only — no value is ever carried.
+// Collision names one env that Resolve disabled because its value duplicates an
+// env registered earlier. Env names only — no value is ever carried.
 type Collision struct {
+	// Senior is the earlier-registered env whose value the junior duplicated.
 	Senior string
+	// Junior is the env Resolve disabled over the shared value.
 	Junior string
+	// SeniorServing reports whether the senior itself resolves. It is normally
+	// true — that is the whole point of the precedence rule — but a senior can
+	// be dark for its own reason (a value below its floor), and a log line that
+	// says "this one is still serving" must not say it then.
+	SeniorServing bool
 }
 
-// Collisions reports every pair of registered envs that share a non-empty
-// value, in precedence order.
+// Collisions reports every capability Resolve disabled over a shared value, in
+// precedence order.
 //
-// Resolve already disables the junior side on its own. This exists so boot can
-// show the whole picture at once: an operator reading "docs capability
-// disabled" as a standalone line has to work out which other env it collided
-// with, and that the other one is still serving.
+// It is derived from Resolve rather than re-deriving the comparison, so the
+// boot report cannot contradict what actually happened. Two consequences worth
+// stating, because the obvious "compare every pair" implementation gets both
+// wrong:
+//
+//   - A value below its env's floor is refused for length, not collision, so no
+//     pair is reported for it. That preserves Resolve's deliberate ordering —
+//     "lengthen this secret" is the whole fix, and naming a sibling env
+//     alongside it only adds a second thing for the operator to rule out.
+//
+//   - When three envs share one value, only two lines appear, both naming the
+//     first env as the survivor. Reporting all three unordered pairs would name
+//     the middle env as a survivor while Resolve has it disabled, and an
+//     operator acting on that line rotates the wrong secret.
+//
+// Resolve already disables each junior on its own; this exists so boot can show
+// the whole picture at once, since a standalone "docs capability disabled" line
+// leaves the operator to work out which env it duplicated.
 //
 // A nil getenv panics, for the same reason as Values.
 func Collisions(getenv func(string) string) []Collision {
@@ -301,16 +332,18 @@ func Collisions(getenv func(string) string) []Collision {
 		panic("internaltoken: Collisions requires a getenv; a nil lookup would silently report no collisions")
 	}
 	var out []Collision
-	for i, junior := range registry {
-		value := getenv(junior.Env)
-		if value == "" {
+	for _, spec := range registry {
+		_, err := Resolve(spec.Env, getenv)
+		var resolveErr *Error
+		if !errors.As(err, &resolveErr) || resolveErr.Reason != ReasonCollision {
 			continue
 		}
-		for _, senior := range registry[:i] {
-			if value == getenv(senior.Env) {
-				out = append(out, Collision{Senior: senior.Env, Junior: junior.Env})
-			}
-		}
+		_, seniorErr := Resolve(resolveErr.Other, getenv)
+		out = append(out, Collision{
+			Senior:        resolveErr.Other,
+			Junior:        spec.Env,
+			SeniorServing: seniorErr == nil,
+		})
 	}
 	return out
 }

--- a/pkg/internaltoken/internaltoken_test.go
+++ b/pkg/internaltoken/internaltoken_test.go
@@ -317,7 +317,14 @@ func TestValuesPanicsOnNilGetenv(t *testing.T) {
 	}
 }
 
-func TestCollisionsReportEveryPairByEnvName(t *testing.T) {
+// TestCollisionsNeverNameADarkEnvAsTheSurvivor is the multi-way case the
+// obvious "report every unordered pair" implementation gets wrong. Three envs
+// sharing one secret is the single-secret-for-everything misconfiguration this
+// package exists to catch: Resolve disables the two juniors, so exactly two
+// lines are correct, both naming the first env — the one still serving. A third
+// line pairing the two juniors would advertise a dark env as the survivor, and
+// an operator acting on it rotates the wrong secret.
+func TestCollisionsNeverNameADarkEnvAsTheSurvivor(t *testing.T) {
 	shared := longEnough("s")
 	getenv := envMap(map[string]string{
 		NotifyInternalTokenEnv: shared,
@@ -327,28 +334,73 @@ func TestCollisionsReportEveryPairByEnvName(t *testing.T) {
 	})
 
 	got := Collisions(getenv)
-	// Three envs sharing one value ⇒ 3 unordered pairs.
-	if len(got) != 3 {
-		t.Fatalf("Collisions() = %v, want 3 pairs", got)
+	if len(got) != 2 {
+		t.Fatalf("Collisions() = %+v, want one line per DISABLED env (2), not one per unordered pair (3)", got)
 	}
 	for _, collision := range got {
-		if collision.Senior == "" || collision.Junior == "" || collision.Senior == collision.Junior {
-			t.Fatalf("malformed collision %+v", collision)
+		if collision.Senior != NotifyInternalTokenEnv {
+			t.Fatalf("collision %+v names %s as the survivor; only the first env of the "+
+				"equal-value group actually resolves", collision, collision.Senior)
 		}
-		if collision.Senior == DriveInternalTokenEnv || collision.Junior == DriveInternalTokenEnv {
-			t.Fatalf("%s holds a unique value but was reported in %+v", DriveInternalTokenEnv, collision)
+		if collision.Junior == NotifyInternalTokenEnv || collision.Junior == DriveInternalTokenEnv {
+			t.Fatalf("collision %+v disabled the wrong env", collision)
 		}
-		// Senior/Junior must match the precedence order Resolve acts on,
-		// otherwise the log line names the wrong survivor.
-		_, seniorIndex, _ := lookup(collision.Senior)
-		_, juniorIndex, _ := lookup(collision.Junior)
-		if seniorIndex >= juniorIndex {
-			t.Fatalf("collision %+v has the survivor and the disabled env the wrong way round", collision)
+		// Every reported survivor must really resolve — the property the log
+		// line at main.go claims.
+		if !collision.SeniorServing {
+			t.Fatalf("collision %+v reports its senior as dark, but %s resolves", collision, collision.Senior)
+		}
+		if _, err := Resolve(collision.Senior, getenv); err != nil {
+			t.Fatalf("reported survivor %s does not resolve: %v", collision.Senior, err)
+		}
+		if _, err := Resolve(collision.Junior, getenv); err == nil {
+			t.Fatalf("reported junior %s still resolves; it was not disabled", collision.Junior)
 		}
 	}
 
 	if Collisions(envMap(map[string]string{NotifyInternalTokenEnv: shared})) != nil {
 		t.Fatal("a single configured env cannot collide with anything")
+	}
+}
+
+// TestCollisionsRespectTheLengthFloor pins that the boot report does not undo
+// Resolve's length-before-collision ordering. A value below its floor is
+// refused for length, so naming a sibling env would hand the operator a second
+// cause to rule out for a token that could not authenticate either way.
+func TestCollisionsRespectTheLengthFloor(t *testing.T) {
+	short := strings.Repeat("x", DefaultMinBytes-1)
+	getenv := envMap(map[string]string{
+		NotifyInternalTokenEnv: short, // MinBytes 0 — legacy waiver, resolves fine
+		DriveInternalTokenEnv:  short, // MinBytes 32 — refused for length, not collision
+	})
+
+	if _, err := Resolve(DriveInternalTokenEnv, getenv); err == nil {
+		t.Fatal("precondition: the short drive token must be refused")
+	}
+	if got := Collisions(getenv); got != nil {
+		t.Fatalf("Collisions() = %+v; a too-short value must not be reported as a collision, "+
+			"or the boot report contradicts Resolve's own reason", got)
+	}
+}
+
+func TestCollisionsPairSurvivorWithDisabled(t *testing.T) {
+	shared := longEnough("s")
+	getenv := envMap(map[string]string{
+		NotifyInternalTokenEnv: shared,
+		DocsNotifyTokenEnv:     shared,
+	})
+	got := Collisions(getenv)
+	if len(got) != 1 {
+		t.Fatalf("Collisions() = %+v, want exactly one", got)
+	}
+	if got[0].Senior != NotifyInternalTokenEnv || got[0].Junior != DocsNotifyTokenEnv {
+		t.Fatalf("collision = %+v; the earlier-registered env is the survivor", got[0])
+	}
+	if !got[0].SeniorServing {
+		t.Fatalf("collision = %+v; %s resolves and must be reported as serving", got[0], got[0].Senior)
+	}
+	if strings.Contains(got[0].Senior+got[0].Junior, shared) {
+		t.Fatal("a collision must carry env names only, never a value")
 	}
 }
 

--- a/pkg/internaltoken/internaltoken_test.go
+++ b/pkg/internaltoken/internaltoken_test.go
@@ -1,0 +1,367 @@
+package internaltoken
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// longEnough clears DefaultMinBytes so length never masks the case under test.
+func longEnough(seed string) string {
+	return strings.Repeat(seed, DefaultMinBytes)[:DefaultMinBytes]
+}
+
+// envMap builds a getenv over an explicit map so a test can never accidentally
+// read the ambient process environment.
+func envMap(values map[string]string) func(string) string {
+	return func(key string) string { return values[key] }
+}
+
+// TestResolveCoversEveryRegisteredPair is the point of the package: every
+// unordered pair of registered envs is checked, exactly once, by whichever of
+// the two was registered later. A hand-rolled per-module check only ever covered
+// the siblings its author happened to know about; this enumerates the registry,
+// so appending an env covers it against all the existing ones with no test edit.
+//
+// It also pins the precedence rule that decides which side yields: the junior
+// env is disabled and the senior one keeps serving. Disabling both would take a
+// working ingress offline for a misconfiguration that is already contained once
+// either side is off.
+func TestResolveCoversEveryRegisteredPair(t *testing.T) {
+	envs := Envs()
+	if len(envs) < 2 {
+		t.Fatalf("registry has %d envs; the pairwise invariant needs at least 2", len(envs))
+	}
+	shared := longEnough("s")
+
+	pairs := 0
+	for juniorIndex, junior := range envs {
+		for _, senior := range envs[:juniorIndex] {
+			pairs++
+			t.Run(junior+"_yields_to_"+senior, func(t *testing.T) {
+				getenv := envMap(map[string]string{junior: shared, senior: shared})
+
+				token, err := Resolve(junior, getenv)
+				if err == nil {
+					t.Fatalf("Resolve(%s) = %q, nil; a value shared with the senior env %s must disable it",
+						junior, token, senior)
+				}
+				if token != "" {
+					t.Fatalf("Resolve(%s) token = %q; a refused token must be empty so auth fails closed",
+						junior, token)
+				}
+				var resolveErr *Error
+				if !errors.As(err, &resolveErr) {
+					t.Fatalf("Resolve(%s) error type = %T, want *internaltoken.Error", junior, err)
+				}
+				if resolveErr.Reason != ReasonCollision {
+					t.Fatalf("Resolve(%s) reason = %q, want %q", junior, resolveErr.Reason, ReasonCollision)
+				}
+				if resolveErr.Other != senior {
+					t.Fatalf("Resolve(%s) collided with %q, want %q", junior, resolveErr.Other, senior)
+				}
+				if !strings.Contains(err.Error(), senior) {
+					t.Fatalf("reason %q must name the colliding env %s so an operator can act on it",
+						err.Error(), senior)
+				}
+
+				// The senior capability keeps serving: it is the incumbent, and
+				// the invariant ("one credential, one capability") is satisfied
+				// the moment the junior one is off.
+				seniorToken, seniorErr := Resolve(senior, getenv)
+				if seniorErr != nil {
+					t.Fatalf("Resolve(%s) error = %v; the senior env must keep serving", senior, seniorErr)
+				}
+				if seniorToken != shared {
+					t.Fatalf("Resolve(%s) = %q, want the configured value", senior, seniorToken)
+				}
+			})
+		}
+	}
+	if want := len(envs) * (len(envs) - 1) / 2; pairs != want {
+		t.Fatalf("exercised %d unordered pairs, want %d — every pair must be covered exactly once", pairs, want)
+	}
+}
+
+// TestResolveAcceptsDistinctValues is the negative control for the test above:
+// with every env set to its own value, every capability stays enabled. Guards
+// against an overzealous check breaking clean deployments.
+func TestResolveAcceptsDistinctValues(t *testing.T) {
+	values := make(map[string]string, len(registry))
+	for i, spec := range registry {
+		values[spec.Env] = longEnough(string(rune('a' + i)))
+	}
+	getenv := envMap(values)
+
+	for _, spec := range registry {
+		token, err := Resolve(spec.Env, getenv)
+		if err != nil {
+			t.Fatalf("Resolve(%s) error = %v; distinct values must all resolve", spec.Env, err)
+		}
+		if token != values[spec.Env] {
+			t.Fatalf("Resolve(%s) = %q, want the configured value", spec.Env, token)
+		}
+	}
+}
+
+// TestErrorsNeverContainTokenValue pins the logging contract: a reason names
+// the ENV, never the secret. Reasons are logged at boot and, for some callers,
+// surfaced in startup output — a value reaching one of them is a credential
+// leak into the log pipeline.
+func TestErrorsNeverContainTokenValue(t *testing.T) {
+	const secret = "SUPER-SECRET-TOKEN-VALUE-DO-NOT-LOG-0000000000"
+	const shortSecret = "SHORT-SECRET-DO-NOT-LOG"
+
+	cases := []struct {
+		name   string
+		env    string
+		getenv func(string) string
+		value  string
+	}{
+		{
+			name:   "collision",
+			env:    DocsNotifyTokenEnv,
+			getenv: envMap(map[string]string{NotifyInternalTokenEnv: secret, DocsNotifyTokenEnv: secret}),
+			value:  secret,
+		},
+		{
+			name:   "too short",
+			env:    DriveInternalTokenEnv,
+			getenv: envMap(map[string]string{DriveInternalTokenEnv: shortSecret}),
+			value:  shortSecret,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Resolve(tc.env, tc.getenv)
+			if err == nil {
+				t.Fatal("expected a refusal")
+			}
+			if strings.Contains(err.Error(), tc.value) {
+				t.Fatalf("reason leaked the token value: %q", err.Error())
+			}
+			if !strings.Contains(err.Error(), tc.env) {
+				t.Fatalf("reason %q must name the env", err.Error())
+			}
+		})
+	}
+}
+
+func TestResolveRejectsUnsetAndUnavailable(t *testing.T) {
+	token, err := Resolve(DriveInternalTokenEnv, envMap(nil))
+	if err == nil || token != "" {
+		t.Fatalf("unset env = %q, %v; want a disabled capability", token, err)
+	}
+	var resolveErr *Error
+	if !errors.As(err, &resolveErr) || resolveErr.Reason != ReasonUnset {
+		t.Fatalf("unset reason = %+v, want %q", resolveErr, ReasonUnset)
+	}
+
+	token, err = Resolve(DriveInternalTokenEnv, nil)
+	if err == nil || token != "" {
+		t.Fatalf("nil getenv = %q, %v; want a disabled capability", token, err)
+	}
+	if !errors.As(err, &resolveErr) || resolveErr.Reason != ReasonUnavailable {
+		t.Fatalf("nil getenv reason = %+v, want %q", resolveErr, ReasonUnavailable)
+	}
+}
+
+// TestResolveRejectsUnregisteredEnv keeps a typo fail-closed: an env that is
+// not in the registry cannot be compared against anything, so it must not be
+// handed back as a usable credential.
+func TestResolveRejectsUnregisteredEnv(t *testing.T) {
+	const bogus = "OCTO_NOT_REGISTERED_TOKEN"
+	token, err := Resolve(bogus, envMap(map[string]string{bogus: longEnough("z")}))
+	if err == nil || token != "" {
+		t.Fatalf("unregistered env = %q, %v; want a disabled capability", token, err)
+	}
+	var resolveErr *Error
+	if !errors.As(err, &resolveErr) || resolveErr.Reason != ReasonUnregistered {
+		t.Fatalf("unregistered reason = %+v, want %q", resolveErr, ReasonUnregistered)
+	}
+}
+
+// TestLengthFloorRunsBeforeCollision pins the ordering documented in Resolve: a
+// value below the floor is unusable on its own terms, so "lengthen this secret"
+// is the whole fix and naming a sibling env only adds noise.
+func TestLengthFloorRunsBeforeCollision(t *testing.T) {
+	short := strings.Repeat("x", DefaultMinBytes-1)
+	getenv := envMap(map[string]string{
+		DriveInternalTokenEnv:  short,
+		NotifyInternalTokenEnv: short,
+	})
+	_, err := Resolve(DriveInternalTokenEnv, getenv)
+	var resolveErr *Error
+	if !errors.As(err, &resolveErr) {
+		t.Fatalf("error = %v, want *internaltoken.Error", err)
+	}
+	if resolveErr.Reason != ReasonTooShort {
+		t.Fatalf("reason = %q, want %q (length gate runs first)", resolveErr.Reason, ReasonTooShort)
+	}
+	if strings.Contains(err.Error(), NotifyInternalTokenEnv) {
+		t.Fatalf("a too-short value must not name a sibling env: %q", err.Error())
+	}
+}
+
+// TestLegacyLengthWaiversAreExplicit documents which envs currently ship
+// without the shared floor. Raising one is a deployment rollout decision (a
+// short live value would be disabled on the next deploy), so the waiver list is
+// pinned here rather than left to drift: adding a NEW env with MinBytes 0 fails
+// this test, and lifting a waiver is a deliberate one-line edit in both places.
+func TestLegacyLengthWaiversAreExplicit(t *testing.T) {
+	waived := map[string]bool{
+		NotifyInternalTokenEnv: true,
+		DocsNotifyTokenEnv:     true,
+		BotMentionTokenEnv:     true,
+	}
+	for _, spec := range Specs() {
+		switch {
+		case spec.MinBytes == 0 && !waived[spec.Env]:
+			t.Fatalf("%s has no length floor and is not a documented legacy waiver; "+
+				"new internal-token envs must use DefaultMinBytes", spec.Env)
+		case spec.MinBytes != 0 && waived[spec.Env]:
+			t.Fatalf("%s now enforces a floor of %d — drop it from this waiver list",
+				spec.Env, spec.MinBytes)
+		case spec.MinBytes != 0 && spec.MinBytes != DefaultMinBytes:
+			t.Fatalf("%s floor = %d, want DefaultMinBytes (%d); one bar for operators to remember",
+				spec.Env, spec.MinBytes, DefaultMinBytes)
+		}
+	}
+}
+
+// TestRegistryPrecedenceOrderIsStable pins the order itself. Position decides
+// which live capability a misconfigured deployment loses, so reordering or
+// inserting (rather than appending) is a behaviour change that must be
+// deliberate. Appending a new env is expected and only needs this list extended.
+func TestRegistryPrecedenceOrderIsStable(t *testing.T) {
+	want := []string{
+		NotifyInternalTokenEnv,
+		DocsNotifyTokenEnv,
+		BotMentionTokenEnv,
+		DriveInternalTokenEnv,
+	}
+	got := Envs()
+	if len(got) < len(want) {
+		t.Fatalf("registry lost entries: got %v, want it to start with %v", got, want)
+	}
+	for i, env := range want {
+		if got[i] != env {
+			t.Fatalf("registry position %d = %s, want %s — reordering changes which "+
+				"capability survives a collision; append new envs instead", i, got[i], env)
+		}
+	}
+}
+
+// TestSpecsAreWellFormed guards the registry itself: duplicate or unnamed
+// entries would silently weaken Resolve's pairwise sweep.
+func TestSpecsAreWellFormed(t *testing.T) {
+	seen := make(map[string]struct{}, len(registry))
+	for _, spec := range Specs() {
+		if spec.Env == "" || spec.Capability == "" {
+			t.Fatalf("spec %+v must name both an env and the capability it unlocks", spec)
+		}
+		if _, dup := seen[spec.Env]; dup {
+			t.Fatalf("%s registered twice", spec.Env)
+		}
+		seen[spec.Env] = struct{}{}
+		if !Registered(spec.Env) {
+			t.Fatalf("Registered(%s) = false for a registered env", spec.Env)
+		}
+	}
+	if Registered("OCTO_NOT_REGISTERED_TOKEN") {
+		t.Fatal("Registered() accepted an unregistered env")
+	}
+}
+
+func TestHeaderIsTheOneWireConvention(t *testing.T) {
+	if Header != "X-Internal-Token" {
+		t.Fatalf("Header = %q; every internal ingress in octo-server reads X-Internal-Token", Header)
+	}
+}
+
+func TestValuesFeedsTheCrossCheck(t *testing.T) {
+	first := longEnough("a")
+	second := longEnough("b")
+	getenv := envMap(map[string]string{
+		NotifyInternalTokenEnv: first,
+		BotMentionTokenEnv:     second,
+		// DocsNotifyTokenEnv / DriveInternalTokenEnv unset — empties are skipped.
+	})
+
+	got := Values(getenv)
+	if len(got) != 2 || got[0] != first || got[1] != second {
+		t.Fatalf("Values() = %v, want the two configured values in precedence order", got)
+	}
+}
+
+// TestValuesPanicsOnNilGetenv pins the fail-closed choice behind Values and
+// Collisions. Returning an empty slice would make
+// registry.ValidateNotifyTokenExclusions(Values(nil)...) a no-op — the one gate
+// here that aborts startup would silently pass a deployment where a fixed token
+// equals a dynamic route credential.
+func TestValuesPanicsOnNilGetenv(t *testing.T) {
+	for name, call := range map[string]func(){
+		"Values":     func() { Values(nil) },
+		"Collisions": func() { Collisions(nil) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatalf("%s(nil) returned normally; a nil lookup must not silently "+
+						"report an empty credential set", name)
+				}
+			}()
+			call()
+		})
+	}
+}
+
+func TestCollisionsReportEveryPairByEnvName(t *testing.T) {
+	shared := longEnough("s")
+	getenv := envMap(map[string]string{
+		NotifyInternalTokenEnv: shared,
+		DocsNotifyTokenEnv:     shared,
+		BotMentionTokenEnv:     shared,
+		DriveInternalTokenEnv:  longEnough("d"),
+	})
+
+	got := Collisions(getenv)
+	// Three envs sharing one value ⇒ 3 unordered pairs.
+	if len(got) != 3 {
+		t.Fatalf("Collisions() = %v, want 3 pairs", got)
+	}
+	for _, collision := range got {
+		if collision.Senior == "" || collision.Junior == "" || collision.Senior == collision.Junior {
+			t.Fatalf("malformed collision %+v", collision)
+		}
+		if collision.Senior == DriveInternalTokenEnv || collision.Junior == DriveInternalTokenEnv {
+			t.Fatalf("%s holds a unique value but was reported in %+v", DriveInternalTokenEnv, collision)
+		}
+		// Senior/Junior must match the precedence order Resolve acts on,
+		// otherwise the log line names the wrong survivor.
+		_, seniorIndex, _ := lookup(collision.Senior)
+		_, juniorIndex, _ := lookup(collision.Junior)
+		if seniorIndex >= juniorIndex {
+			t.Fatalf("collision %+v has the survivor and the disabled env the wrong way round", collision)
+		}
+	}
+
+	if Collisions(envMap(map[string]string{NotifyInternalTokenEnv: shared})) != nil {
+		t.Fatal("a single configured env cannot collide with anything")
+	}
+}
+
+// TestCollisionsIgnoreUnsetEnvs is the case that would otherwise make every
+// under-configured deployment look catastrophically broken: two envs that are
+// both absent share the empty value but are not a collision.
+func TestCollisionsIgnoreUnsetEnvs(t *testing.T) {
+	if got := Collisions(envMap(nil)); got != nil {
+		t.Fatalf("Collisions() = %v for an empty environment, want none", got)
+	}
+	for _, spec := range Specs() {
+		if _, err := Resolve(spec.Env, envMap(nil)); err == nil {
+			t.Fatalf("Resolve(%s) accepted an unset value", spec.Env)
+		}
+	}
+}

--- a/pkg/internaltoken/internaltoken_test.go
+++ b/pkg/internaltoken/internaltoken_test.go
@@ -38,6 +38,12 @@ func TestResolveCoversEveryRegisteredPair(t *testing.T) {
 	for juniorIndex, junior := range envs {
 		for _, senior := range envs[:juniorIndex] {
 			pairs++
+			if Yields(senior, junior) {
+				// A Mutual env makes the pair symmetric, so there is no
+				// survivor to assert; TestMutualCollisionsDisableBothSides
+				// covers those.
+				continue
+			}
 			t.Run(junior+"_yields_to_"+senior, func(t *testing.T) {
 				getenv := envMap(map[string]string{junior: shared, senior: shared})
 
@@ -79,7 +85,7 @@ func TestResolveCoversEveryRegisteredPair(t *testing.T) {
 		}
 	}
 	if want := len(envs) * (len(envs) - 1) / 2; pairs != want {
-		t.Fatalf("exercised %d unordered pairs, want %d — every pair must be covered exactly once", pairs, want)
+		t.Fatalf("visited %d unordered pairs, want %d — every pair must be covered exactly once", pairs, want)
 	}
 }
 
@@ -240,6 +246,7 @@ func TestRegistryPrecedenceOrderIsStable(t *testing.T) {
 		DocsNotifyTokenEnv,
 		BotMentionTokenEnv,
 		DriveInternalTokenEnv,
+		MarketplaceInternalTokenEnv,
 	}
 	got := Envs()
 	if len(got) < len(want) {
@@ -414,6 +421,62 @@ func TestCollisionsIgnoreUnsetEnvs(t *testing.T) {
 	for _, spec := range Specs() {
 		if _, err := Resolve(spec.Env, envMap(nil)); err == nil {
 			t.Fatalf("Resolve(%s) accepted an unset value", spec.Env)
+		}
+	}
+}
+
+// TestMutualCollisionsDisableBothSides pins the opt-out from precedence.
+//
+// A Mutual env's pairs are symmetric in both directions: it yields to every
+// other entry, and every other entry yields to it regardless of registration
+// order. That is the behaviour #827 shipped as a hand-written mirror branch in
+// four modules; expressing it as one flag is only correct if it reproduces both
+// halves, so both are asserted here.
+func TestMutualCollisionsDisableBothSides(t *testing.T) {
+	shared := longEnough("s")
+	mutual := 0
+	for _, spec := range Specs() {
+		if !spec.Mutual {
+			continue
+		}
+		mutual++
+		for _, other := range Envs() {
+			if other == spec.Env {
+				continue
+			}
+			getenv := envMap(map[string]string{spec.Env: shared, other: shared})
+			t.Run(spec.Env+"_and_"+other, func(t *testing.T) {
+				if !Yields(spec.Env, other) || !Yields(other, spec.Env) {
+					t.Fatalf("Yields is not symmetric for the Mutual pair (%s, %s)", spec.Env, other)
+				}
+				if token, err := Resolve(spec.Env, getenv); err == nil || token != "" {
+					t.Fatalf("Resolve(%s) = %q, %v; the Mutual env must be disabled", spec.Env, token, err)
+				}
+				if token, err := Resolve(other, getenv); err == nil || token != "" {
+					t.Fatalf("Resolve(%s) = %q, %v; a Mutual pair disables BOTH sides, "+
+						"including an env registered earlier", other, token, err)
+				}
+			})
+		}
+	}
+	if mutual == 0 {
+		t.Skip("no Mutual entry in the registry; nothing to assert")
+	}
+}
+
+// TestMutualIsOptInAndJustified keeps the flag from spreading by habit. Marking
+// a pre-existing env Mutual takes a currently-serving ingress down on the next
+// deploy of any installation carrying the collision, so the list is pinned.
+func TestMutualIsOptInAndJustified(t *testing.T) {
+	allowed := map[string]bool{MarketplaceInternalTokenEnv: true}
+	for _, spec := range Specs() {
+		if spec.Mutual && !allowed[spec.Env] {
+			t.Fatalf("%s is marked Mutual but is not in the reviewed list; flipping an existing "+
+				"env to Mutual disables a serving capability on the next deploy", spec.Env)
+		}
+		if !spec.Mutual && allowed[spec.Env] {
+			t.Fatalf("%s lost its Mutual flag; #827 requires that pair to fail BOTH sides closed",
+				spec.Env)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Four fixed internal-token envs each hand-rolled a "must differ from sibling X" check, and each author compared only against the siblings that existed when they wrote it: `NOTIFY_INTERNAL_TOKEN` against 0, `OCTO_DOCS_NOTIFY_TOKEN` against 1, `OCTO_DOCS_BOT_MENTION_TOKEN` against 2, `OCTO_DRIVE_INTERNAL_TOKEN` against 3.

That ladder does cover all six of today's pairs — but only by convention. The (N+1)th capability is protected solely if its author remembers the whole list, and the N modules already in the tree never learn the new env exists.

`pkg/internaltoken` keeps the ladder's semantics and makes it a property of the data. **Registration order is a precedence order**: `Resolve(env, getenv)` enforces the env's length floor and compares it against every env registered *before* it, so every unordered pair is checked exactly once — by whichever side was registered later — and appending a `Spec` guards it against all existing envs, and them against it, with no edit anywhere else.

Which side yields stays decided rather than arbitrary: the incumbent keeps serving, the newcomer that duplicated an existing secret goes dark. That is exactly what the hand-rolled checks did.

## Related Issue

None — self-initiated refactor. Task brief: `.octospec/tasks/internal-token-registry/brief.md`.

## Linked Spec

`.octospec/tasks/internal-token-registry/brief.md`

## Changes

- **`pkg/internaltoken` (new)** — owns the registry of fixed internal-token envs, `Resolve(env, getenv)`, the `X-Internal-Token` header name, and `DefaultMinBytes`. Refusal returns `("", *Error)` with a typed `Reason` (`unset` / `too_short` / `collision` / …); the empty token is what makes each caller's auth middleware fail closed. `Values`/`Collisions` **panic** on a nil `getenv` — returning an empty slice would turn the one gate that aborts startup into a silent no-op.
- **`modules/notify`, `modules/bot_mention`, `modules/internal_resolve`** — the three hand-rolled resolvers collapse to one call each. All three now split log level on `Reason` (unset → WARN, collision/too-short → ERROR); previously `internal_resolve` and `bot_mention` logged both at ERROR.
- **`internal/cardactiondispatch/registry.go`** — its two hardcoded `32` literals now read `internaltoken.DefaultMinBytes`, so "one bar for operators to remember" is one value instead of a claim in a doc comment.
- **`main.go`** — `ValidateNotifyTokenExclusions` is fed from `internaltoken.Values(os.Getenv)` instead of a hand-written argument list. New `reportFixedInternalTokenCollisions` logs one line per colliding pair naming the survivor and the disabled env, placed **before** the card-dispatch installers so a malformed `OCTO_CARD_ACTION_ROUTES` cannot swallow the diagnostic.
- **`docs/card-action-callback-dispatch.md`** — the hand-written exclusion list (which omitted two of the four envs) now points at the registry and states that reuse *aborts startup* rather than warns.
- **`ci/unit-packages.txt`** — `pkg/internaltoken` moved to the unit lane; `go list -deps` resolves to the standard library alone.
- **`.octospec/`** — task brief, shared journal, dated log entry, and one learning candidate in `learnings/pending/` (promotion into `rules/` is a separate reviewed PR).

### Behaviour preserved

A fixed-vs-fixed collision disables the junior capability module-locally and boot still succeeds; a collision with a dynamic route credential still fails startup — the contract pinned by `TestCardActionDispatchScopesBotMentionTokenCollisionFailures`. **No capability that was enabled before is disabled now, or vice versa.** Reasons name the ENV, never the value.

### Operator-visible

- Refusal reasons come from one template, so the wording changed. The unset case deliberately keeps the `will reject all requests` substring that three of the four previously shared, so log-based alerting keyed on that phrase still fires.
- An unset env now logs at WARN instead of ERROR in `internal_resolve` and `bot_mention`.

### Deliberately out of scope

- **Promoting fixed-vs-fixed collisions to boot failures** — a separate rollout decision; the current contract is pinned by `main_carddispatch_test.go`.
- **Raising the 32-byte floor on the three legacy envs** — it would disable a live ingress on the next deploy of any installation running a shorter secret, and `pilote2e` proves short values are in use. The waivers are explicit `MinBytes: 0` entries pinned by `TestLegacyLengthWaiversAreExplicit`, so lifting one is a deliberate one-line change in two places.

## Testing

Full suite run locally the way CI runs it (`ci/run-unit-tests.sh` + `ci/run-e2e-shard.sh 1 1`), against MySQL 8.0 / Redis 7 / WuKongIM `v2.2.4-20260313`, with `OCTO_MASTER_KEY` set and `max_connections = 1000` as the workflow does:

| Lane | Packages | Result |
|---|---|---|
| Unit | 52 | 0 failures |
| E2E | 50 | 0 failures |

Touched packages (all in the E2E lane): `modules/notify` 24.5s (incl. group/space welcome E2E), `internal/cardactiondispatch` 7.0s, `octo-server` (main) 9.5s, `modules/bot_mention` 1.3s (incl. MySQL+Redis+robot-queue integration), `modules/internal_resolve` 1.2s, `pkg/internaltoken` 1.0s.

`go build ./...`, `go vet ./...`, `golangci-lint run`, `make i18n-extract-check`, `make i18n-lint` all clean.

**Pre-existing, unrelated:** `go test -tags pilote2e ./pilote2e/` has 3 failing tests — `notify: cardtmpl registry/template unavailable (composition bug): default catalog not wired`, because the package has no TestMain wiring the cardtmpl registry the way `modules/notify/testmain_test.go` does. Token auth passes; the requests fail later, at delivery. Verified by checking out the parent commit `d5b091a` and reproducing the identical three failures (same test names, same timings). `pilote2e` is build-tagged and is not in either CI lane.

- [x] Unit tests added/updated
- [x] Manually verified

## COMPREHENSION

**1. What does this change actually do to the load-bearing path?**

It moves the "one credential grants exactly one capability" check from four independent call sites into one function, and turns the implicit ordering those four sites had built into an explicit precedence order.

Concretely, on every boot each of the four envs now resolves through `internaltoken.Resolve`, which (a) enforces that env's length floor, then (b) compares its value against every env registered before it. A refusal yields `""`, and every consumer's auth middleware already treats an empty configured token as "reject everything", so the capability fails closed. Boot is never failed by this path — that is deliberate and pinned.

The cross-capability gate against *dynamic* route credentials from `OCTO_CARD_ACTION_ROUTES` still lives in `main.go` and still aborts startup; the only change is that its argument list is derived from the registry rather than typed out, so a capability added later joins it automatically.

The set of envs disabled for any given environment is unchanged from before this PR. What changes is that the guarantee no longer depends on the next author remembering four names.

**2. What could break because of it (dependents + failure mode)?**

- **The precedence order is now load-bearing data.** Reordering `registry` or inserting rather than appending changes which live capability a misconfigured deployment loses. Failure mode: an operator who has (wrongly) set two envs equal loses a *different* ingress than before, silently, on deploy. Mitigated by `TestRegistryPrecedenceOrderIsStable`, which fails on any reorder, and by a doc comment saying append-only.
- **A new env registered with `MinBytes: 0`** would silently inherit the legacy waiver. `TestLegacyLengthWaiversAreExplicit` fails for any env outside the three documented ones.
- **`Values`/`Collisions` now panic on nil `getenv`.** Only `main.go` calls them, with `os.Getenv`. A future caller passing nil crashes at boot instead of silently disabling the exclusion gate — intended, and the same posture as `mustLookupSharedCode`.
- **Log-line wording changed**, so text-matching alerts could break. Mitigated by preserving the `will reject all requests` substring on the unset case; the level change (ERROR → WARN for unset) could silence an alert keyed on level in `internal_resolve`/`bot_mention`, which is the point — that line fires on every boot of any deployment not using those capabilities.
- **`internal/cardactiondispatch` now imports `pkg/internaltoken`.** It is a leaf package importing only `fmt`, so no cycle; raising `DefaultMinBytes` would now also raise the dynamic route-credential floor, which is the intended coupling and was previously a false claim in a comment.

**3. How do you know it works (specific test/repro/trace)?**

- `TestResolveCoversEveryRegisteredPair` enumerates the registry and, for every unordered pair, asserts the junior env is refused with `ReasonCollision` naming the senior, returns `""`, **and** that the senior still resolves to its value. It also asserts the pair count is exactly `n(n-1)/2`, so a rule that skipped comparisons would fail rather than pass quietly.
- `TestErrorsNeverContainTokenValue` feeds a distinctive secret through the collision and too-short paths and asserts it appears in no message.
- `TestValuesPanicsOnNilGetenv` pins the fail-closed choice on the one gate that aborts startup.
- Behaviour preservation: `TestCardActionDispatchScopesBotMentionTokenCollisionFailures` (unchanged) still passes — fixed-vs-fixed stays module-local, fixed-vs-dynamic still fails boot. `TestResolveNotifyTokenCollisionDisablesTheJuniorCapability` pins that `NOTIFY_INTERNAL_TOKEN` keeps serving when docs collides with it, which is exactly the pre-PR behaviour.
- Wiring: `main_wiring_test.go` pins that `main.go` passes `internaltoken.Values(os.Getenv)` — both halves, since `Values(` alone would still pass for a stub lookup — plus a runtime assertion that the registry contains the drive env.
- Per-module tests in `notify`, `bot_mention` and `internal_resolve` enumerate `internaltoken.Envs()` rather than a hand-written sibling list, so they extend automatically.
- End to end: 102 packages green through both CI lanes with real MySQL, Redis and WuKongIM.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)

---
_Generated by [Claude Code](https://claude.ai/code/session_018H4pMDBHFjYGfFdDmykCC5)_