### PR TITLE
fix(project): close the six findings PR #850 left open, and record what it squashed away

### DIFF
--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -2721,3 +2721,13 @@ SQL 注释里一个撇号破坏了它的朴素语句分割；P0 的游标覆盖�
 - CI 单元 lane、E2E shard 4/4、AI Team race 测试、build、vet 与 diff 门禁均通过。
 - Review 后将分页 items 与总数统计统一到同一个 SQL 分类表达式，避免后续新增 hosting slug 时
   两套条件漂移；独立 Swagger 文档不进入 PR。
+
+## 2026-09-08 — project-provisioning-followups
+
+PR #850 merged as one squash commit whose message describes the slice rather than
+its seven review rounds, so a cross-workstream design decision (the fleet container
+id is provisional and becomes project_id once the peer-side narrowing lands) and six
+deliberately-open P2 findings existed only in a closed PR thread. Both categories go
+live at the same moment — the first time a provisioning target is enabled — so they
+are recorded together as an actionable brief, each item verified against the merged
+tree. See `.octospec/tasks/project-provisioning-followups/brief.md`.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -2727,7 +2727,38 @@ SQL 注释里一个撇号破坏了它的朴素语句分割；P0 的游标覆盖�
 PR #850 merged as one squash commit whose message describes the slice rather than
 its seven review rounds, so a cross-workstream design decision (the fleet container
 id is provisional and becomes project_id once the peer-side narrowing lands) and six
-deliberately-open P2 findings existed only in a closed PR thread. Both categories go
-live at the same moment — the first time a provisioning target is enabled — so they
-are recorded together as an actionable brief, each item verified against the merged
-tree. See `.octospec/tasks/project-provisioning-followups/brief.md`.
+deliberately-open P2 findings existed only in a closed PR thread. Recorded as an
+actionable brief, then **all six were fixed in the same task** — the record turned
+out to be the cheaper half. See
+`.octospec/tasks/project-provisioning-followups/brief.md`.
+
+Lessons from that task and its review:
+
+- **一份「记录用」的文档，行号会指向修复而不是缺陷** —— brief 里六条 finding 的
+  `file:line` 全部钉在 `origin/main` `5dd80d4`，而同一个 PR 随后把它们修了。
+  最锋利的一条：brief 让读者去看 `config_provisioning.go:227-229`「这里写着 completely
+  inert，是错的」，而那几行现在写着「**NOT** completely inert」。
+  **把读者送去看缺陷、而那一行里装着修复**，比行号漂移更糟。修法不是重钉，是说清楚
+  这些引用属于哪棵树。
+- **PR 长出第二个 commit 时，标题和正文不会自己跟上** —— 三位 reviewer 独立判同一件事：
+  标题还是 `docs(project):`，正文还写着「No behaviour change」，而 head 改了一个
+  信任边界校验器和一条「重试 vs 放弃」的分类。本仓 squash 合并，**这个标题会变成
+  main 上的永久 commit subject**——正是这个 PR 声称要修复的那件事，在下一个 PR 上重演。
+  而且 PR 挂着 `needs-human-review`：给人工门递一个假前提，是这里面最不该发生的。
+- **MySQL 的 DDL 会隐式提交，「放进同一个事务」是空头承诺** —— 回滚手册要求把
+  `DROP TABLE` 和删账本行放进一个事务。实测（8.0.46）：
+  `START TRANSACTION; DROP TABLE t; DELETE …; ROLLBACK;` **两样都没恢复**。
+  「实测走通」本身不假——按顺序执行到底确实到达终态；假的是它暗示的**原子性**。
+  真实风险是 DROP 成功而 DELETE 失败，正好落在这段自己警告的状态里。
+- **「已记录在某处」是一句可以被 grep 证伪的断言** —— brief 写着 bot_task 的 per-source
+  token「recorded in that registry's own comment」。穷举 grep：调用点、
+  `ValidateNotifyTokenExclusions` 的文档与函数体、bot_task 自己的注释，**任何拼写都没有**。
+  用「已经记过了」来论证「本文不必记」，而那份记录不存在，结果是这件事哪儿都没记——
+  正是这个 PR 要终结的那种丢失。补法是把注释真的写到 main.go 的调用点。
+- **验证锚点要跟着引用一起走** —— brief 声称「每一条都对着 `origin/main` 5dd80d4 核过」，
+  却引用了 `.octospec/tasks/loop-project-fleet-integration/`——那个目录只存在于**未合并**的
+  PR #852 分支上。守卫抓不到这一类：它的路径正则只认
+  `modules|internal|pkg|tools|cmd` 开头，`.octospec/` 不在它的取值域里。
+- **接受 2xx 而契约写的是 200** —— `Ensure` 收 202 当成功，就会把 `ready`
+  （「我们成功建好了容器」）写在一个**可能还不存在**的容器上；后面每一处读 `ready` 的判断
+  都在把承诺当事实读。改成严格 200，且判**可重试**而非终态——对端正在灰度不该烧掉一行。

--- a/.octospec/tasks/project-p2-subsystem-integration/brief.md
+++ b/.octospec/tasks/project-p2-subsystem-integration/brief.md
@@ -328,7 +328,7 @@ Headers on both:
   X-Octo-Signature   v1=<hmac-sha256 over CanonicalRequest(POST, path, ts, event-id, body)>
 ```
 
-**Three things the receiver MUST do**, added 2026-09-07 because the original sketch
+**Four things the receiver MUST do**, added 2026-09-07 because the original sketch
 specified how the request is signed and not what verifying it requires — and the first
 two have no enforcement on octo-server's side at all:
 
@@ -342,6 +342,10 @@ two have no enforcement on octo-server's side at all:
    receiver's.
 3. **Treat `container_id` as the idempotency key** (get-first / create /
    duplicate-key downgrade). Delivery is at-least-once by construction.
+4. **Reply synchronously with exactly `200` and the echoed `container_id`** only
+   after the container exists. `202`, another 2xx, or a missing echo is not a
+   successful ensure: octo-server retries it and must not record `ready` against
+   a promise.
 
 **`X-Octo-Event-ID` carries sha256(container_id), not the id.** Bodies are almost never
 logged; headers routinely are (a proxy's custom log format, an APM agent's default

--- a/.octospec/tasks/project-p2-subsystem-integration/plan.md
+++ b/.octospec/tasks/project-p2-subsystem-integration/plan.md
@@ -436,25 +436,40 @@ SELECT p.project_id, p.space_id, 'fleet',
    >
    > 1. **先把二进制回退**到不含本迁移的版本（或至少不含 `modules/project` 本切片的版本），
    >    滚动重启完成、确认没有旧 Pod 还在服务。此时已经没有任何代码路径引用本表。
-   > 2. 再退表。**必须把删表和删账本行放进同一个事务**：
+   > 2. 再退表。**两条语句必须都执行，但它们无法放进同一个事务** —— 顺序如下：
    >    ```sql
-   >    START TRANSACTION;
+   >    -- 注意：DROP TABLE 会触发隐式提交，把它包进事务不会得到原子性。
    >    DROP TABLE IF EXISTS `octo_project_provisioning`;
    >    DELETE FROM `gorp_migrations` WHERE id = '20260907000001_project_provisioning.sql';
-   >    COMMIT;
    >    ```
    >    账本行才是关键的那一半，也是「手工 drop」之所以被禁止的全部理由 —— 只 drop 不删
-   >    账本，sql-migrate 认为这条迁移已应用，**重启不会重建表**；两条一起做，则以后重新
-   >    部署新二进制时会干净地重建。**已在本地 MySQL 8.0.46 实测走通**：两条执行后表和账本
-   >    行都消失，再启动一次进程，两者都按预期回来。
+   >    账本，sql-migrate 认为这条迁移已应用，**重启不会重建表**；两条都做，则以后重新
+   >    部署新二进制时会干净地重建。
+   >
+   >    > ⚠️ **本文件早先把这两条包在 `START TRANSACTION; … COMMIT;` 里，并称「必须放进
+   >    > 同一个事务」。那是错的**，而且错在一个会误导操作者的方向上：MySQL 的 DDL 会
+   >    > **隐式提交**，所以 `DROP TABLE` 一执行事务就已经结束了，后面的 `DELETE` 属于另一个
+   >    > 事务。实测（本地 MySQL 8.0.46，`START TRANSACTION; DROP TABLE t; DELETE …; ROLLBACK;`）：
+   >    > 回滚**两样都没恢复** —— 表没回来，账本行也没回来。
+   >    >
+   >    > 早先那句「已实测走通」本身不假：两条**按顺序执行到底**确实到达预期终态，这也是
+   >    > 它被评为 P2 而不是阻塞项的原因。假的是它暗示的**原子性**。真实风险是：`DROP` 成功
+   >    > 而 `DELETE` 失败（连接断开、权限、手误）时，你恰好落在本段自己警告的那个状态 ——
+   >    > 表没了、账本行还在、重启不会重建。所以第二条语句失败时必须**立刻重试**，不要靠
+   >    > 事务回滚，因为没有可回滚的东西。
    >
    >    > ⚠️ 本仓**没有** `dbconfig.yml`，也没有 Makefile 的迁移目标：迁移是由
    >    > `module.Setup` → octo-lib `module/module.go:88` 的 `migrate.Exec(..., migrate.Up)` 在**进程启动时**对各模块
    >    > `go:embed` 的 SQL 目录施加的，没有可用的 `sql-migrate` 命令行入口。
    >    > （本文件早先指向 `pkg/db/mysql.go`。那个文件**确实**有 `migrate.Exec`，但它在
-   >    > `Migration()` 里，而 `Migration()` 在本仓**没有任何非测试调用方**，`testutil`
-   >    > 还显式设 `cfg.DB.Migration = false` —— 所以那不是引用不精确，是指向了一条根本
-   >    > 不执行的路径。回滚步骤本身是对的，错的是它让人去看哪段代码。）本文件早期
+   >    > `Migration()` 里，而这条链是死的 —— 只是死在比早先说法更上一层：`Migration()`
+   >    > **确实有**一个非测试调用方（`pkg/db/mysql.go:32`，在 `NewMySQL` 内），但
+   >    > `pkg/db.NewMySQL` 自己**零调用方**：全仓唯一写着 `db.NewMySQL(` 的地方
+   >    > （`session_rollout_cmd.go:276`）按它第 46 行的 import 解析到的是 **octo-lib 的
+   >    > 同名函数**，签名都不同（4 个参数 vs 3 个）。所以那不是引用不精确，是指向了一条根本
+   >    > 不执行的路径。（早先还引用了 `testutil` 显式设 `cfg.DB.Migration = false` 作为佐证：
+   >    > 这句字面为真，但那个开关在本仓和锁定版 octo-lib 里都没有非测试消费方，它什么也没门。）
+   >    > 回滚步骤本身是对的，错的是它让人去看哪段代码。）本文件早期
    >    > 版本写的 `sql-migrate down -limit=1 -env=<env>` **在本仓根本跑不起来** —— 而一个
    >    > 跑不通的补救步骤，恰恰会把操作者推回同一段落禁止的手工 DDL。如果将来引入了
    >    > dbconfig，再换回 Down 段调用；在那之前，上面那个事务就是等价物。

--- a/.octospec/tasks/project-p2-subsystem-integration/plan.md
+++ b/.octospec/tasks/project-p2-subsystem-integration/plan.md
@@ -293,11 +293,13 @@ env 走 configmap，两个方向都需要滚动重启（与 P0 的两个开关�
 
 1. **P-2（子系统侧服务身份）已经就绪。** 否则每个新项目都会产出一条在 **~23.5 分钟**后
    走到 `abandoned` 的行，而 `abandoned` 没有任何自动重驱动。
-2. **该子系统的 ensure 端点已经跑通 4 条一致性向量**
+2. **该子系统的 ensure 端点已经跑通 4 条一致性向量，且成功请求精确返回
+   `200` 和回显的 `container_id`。**
    （`internal/projectprovision/conformance.go`：valid / stale_timestamp / tampered_body /
    wrong_secret）。这不是形式主义 —— 三条 MUST 里，canonical string 写错会 fail closed
    会自己暴露，而**时间戳校验写松了 fail open 且完全静默**，本仓没有任何东西能发现它。
-   向量就是把「已评审」变成一个可执行动作。
+   向量就是把「已评审」变成一个可执行动作；成功响应形状另做一次真实
+   ensure 探针，因为签名向量本身不覆盖响应。
 
 **retention purge 由 per-target 开关门住，两个都默认 off：**
 
@@ -472,7 +474,8 @@ SELECT p.project_id, p.space_id, 'fleet',
    >    > 回滚步骤本身是对的，错的是它让人去看哪段代码。）本文件早期
    >    > 版本写的 `sql-migrate down -limit=1 -env=<env>` **在本仓根本跑不起来** —— 而一个
    >    > 跑不通的补救步骤，恰恰会把操作者推回同一段落禁止的手工 DDL。如果将来引入了
-   >    > dbconfig，再换回 Down 段调用；在那之前，上面那个事务就是等价物。
+   >    > dbconfig，再换回 Down 段调用；在那之前，上面的**两条顺序语句**就是等价物，第二条失败
+   >    > 时仍须立刻重试，不能依赖事务回滚。
    >
    >    （对照：migration 的 Down 段本身写的是 `DROP TABLE IF EXISTS
    >    octo_project_provisioning`，与上面第一条语句一致。）

--- a/.octospec/tasks/project-p2-subsystem-integration/plan.md
+++ b/.octospec/tasks/project-p2-subsystem-integration/plan.md
@@ -427,8 +427,8 @@ SELECT p.project_id, p.space_id, 'fleet',
    >   target 就再也不会把自己的容器标成可回收，那是真泄漏。代价是：只要还有一个旧二进制
    >   在服务，表一旦不存在，**每一次项目解散**都会拿到 `Error 1146` →
    >   `disbandProjectOnce` 报错 → **500**，而且是在一条与被回滚功能毫无关系的路径上。
-   > - **手工 drop 不会自愈。** 迁移在启动时由 `pkg/db/mysql.go` 的
-   >   `migrate.Exec(..., migrate.Up)` 应用，手工 drop 会把 `gorp_migrations` 里
+   > - **手工 drop 不会自愈。** 模块迁移在启动时由 `module.Setup` 应用（octo-lib
+   >   `module/module.go:88` 的 `migrate.Exec(..., migrate.Up)`），手工 drop 会把 `gorp_migrations` 里
    >   `20260907000001` 那条账本行留在原地 —— sql-migrate 认为它已应用，**重启不会重建
    >   表**。解散会一直坏着，直到有人再手工删账本行。
    >
@@ -449,8 +449,12 @@ SELECT p.project_id, p.space_id, 'fleet',
    >    行都消失，再启动一次进程，两者都按预期回来。
    >
    >    > ⚠️ 本仓**没有** `dbconfig.yml`，也没有 Makefile 的迁移目标：迁移是由
-   >    > `pkg/db/mysql.go` 的 `migrate.Exec(..., migrate.Up)` 在**进程启动时**对各模块
-   >    > `go:embed` 的 SQL 目录施加的，没有可用的 `sql-migrate` 命令行入口。本文件早期
+   >    > `module.Setup` → octo-lib `module/module.go:88` 的 `migrate.Exec(..., migrate.Up)` 在**进程启动时**对各模块
+   >    > `go:embed` 的 SQL 目录施加的，没有可用的 `sql-migrate` 命令行入口。
+   >    > （本文件早先指向 `pkg/db/mysql.go`。那个文件**确实**有 `migrate.Exec`，但它在
+   >    > `Migration()` 里，而 `Migration()` 在本仓**没有任何非测试调用方**，`testutil`
+   >    > 还显式设 `cfg.DB.Migration = false` —— 所以那不是引用不精确，是指向了一条根本
+   >    > 不执行的路径。回滚步骤本身是对的，错的是它让人去看哪段代码。）本文件早期
    >    > 版本写的 `sql-migrate down -limit=1 -env=<env>` **在本仓根本跑不起来** —— 而一个
    >    > 跑不通的补救步骤，恰恰会把操作者推回同一段落禁止的手工 DDL。如果将来引入了
    >    > dbconfig，再换回 Down 段调用；在那之前，上面那个事务就是等价物。

--- a/.octospec/tasks/project-provisioning-followups/brief.md
+++ b/.octospec/tasks/project-provisioning-followups/brief.md
@@ -101,6 +101,13 @@ rejects, and the whole ~23.5-minute retry budget burns as indistinguishable
 Preferred fix is to **reject** leading/trailing whitespace rather than trim it
 silently: trimming hides a broken mount that will surprise someone again.
 
+**P2-8 — the URL rejection must be reached from config load.**
+The same reject-not-trim rule is meaningless if `loadProvisioningConfig` trims
+`OCTO_PROJECT_PROVISION_*_URL` before `ValidateTarget` sees it. A whitespace-
+wrapped URL must be dropped, reported through `Problems`, and counted in
+`Misconfigured`, just as a whitespace-wrapped secret is; otherwise an operator
+gets a silent config repair instead of the stated deployment signal.
+
 **A-5 — the empty-fragment case regressed a fix a sibling already documented.**
 `internal/projectprovision/client.go:351` checks `parsed.Fragment != ""`, so
 `https://host/ensure#` passes. `internal/cardactiondispatch/registry.go:338-341`
@@ -142,7 +149,7 @@ survives someone checking. (An earlier draft said `Migration()` has **no non-tes
 caller in this repository** — and `testutil.NewTestServer` sets
 `cfg.DB.Migration = false`. Module SQL is applied by `module.Setup`, i.e.
 octo-lib `module/module.go:88`. The rollback instructions are correct; the
-pointer sends whoever follows them to dead code.
+pointer sends whoever follows them to dead code.)
 
 ## Load-bearing list
 
@@ -204,12 +211,17 @@ acceptance criteria and are checked against the implementation.
 - [x] A-5: `https://host/ensure#` is refused, by the same mechanism
       `internal/cardactiondispatch` uses; a test pins the empty-fragment case.
 - [x] A-3: an empty or absent `container_id` in the echo classifies as
-      `invalid_response` (retryable); a genuinely different id stays
-      `container_id_mismatch` (permanent). Both pinned.
+      `invalid_response` (retryable); a whitespace-only id does too, while a
+      genuinely different id stays `container_id_mismatch` (permanent). Both pinned.
 - [x] A-1: the `Enabled()` comment states that the disband write is
       unconditional and why, so "add a gate here" fails review rather than
       passing it.
-- [x] A-6: all four provisioning timers are jittered, matching `reconcile.go`.
+- [x] A-6: all four provisioning timers are jittered, matching `reconcile.go`,
+      with a source guard that pins all four `Schedule(jitter(...))` calls.
+- [x] P2-8: whitespace around a configured ensure URL is REJECTED at config
+      load; the target is dropped, marked `Misconfigured`, and reported through
+      `Problems`. The loader test covers the deployed environment path rather
+      than only a hand-built `Target`.
 - [x] P2-5: `plan.md` §3.5 names `module.Setup` / octo-lib `module/module.go`,
       and says the rollback ordering it already gets right.
 - [x] P2-A (bundled at #850's close, not one of the six): §3.5's "put the DROP

--- a/.octospec/tasks/project-provisioning-followups/brief.md
+++ b/.octospec/tasks/project-provisioning-followups/brief.md
@@ -14,7 +14,8 @@ source: user
 
 ## Goal
 
-Keep two categories of knowledge from being lost, and make them actionable.
+Fix the six review findings that survived PR #850's squash, and record the one
+thing that cannot be fixed because it is a decision about future work.
 
 PR #850 landed as **one squashed commit whose message describes the slice, not
 the review**. Eleven commits and seven review rounds collapsed into it. Two
@@ -153,19 +154,22 @@ pointer sends whoever follows them to dead code.
 
 ## Acceptance
 
-- [ ] A-4: whitespace around a provisioning secret is REJECTED at config load
+All six are FIXED in this task rather than filed. The boxes below were the
+acceptance criteria and are checked against the implementation.
+
+- [x] A-4: whitespace around a provisioning secret is REJECTED at config load
       with a message naming the env, and a test covers a trailing newline.
-- [ ] A-5: `https://host/ensure#` is refused, by the same mechanism
+- [x] A-5: `https://host/ensure#` is refused, by the same mechanism
       `internal/cardactiondispatch` uses; a test pins the empty-fragment case.
-- [ ] A-3: an empty or absent `container_id` in the echo classifies as
+- [x] A-3: an empty or absent `container_id` in the echo classifies as
       `invalid_response` (retryable); a genuinely different id stays
       `container_id_mismatch` (permanent). Both pinned.
-- [ ] A-1: the `Enabled()` comment states that the disband write is
+- [x] A-1: the `Enabled()` comment states that the disband write is
       unconditional and why, so "add a gate here" fails review rather than
       passing it.
-- [ ] A-6: all four provisioning timers are jittered, matching `reconcile.go`.
-- [ ] P2-5: `plan.md` §3.5 names `module.Setup` / octo-lib `module/module.go`,
+- [x] A-6: all four provisioning timers are jittered, matching `reconcile.go`.
+- [x] P2-5: `plan.md` §3.5 names `module.Setup` / octo-lib `module/module.go`,
       and says the rollback ordering it already gets right.
-- [ ] D-1 is discoverable from the merged tree: a reader of
+- [x] D-1 is discoverable from the merged tree: a reader of
       `modules/project/provisioning.go` finds the pointer without reading a
       closed PR thread.

--- a/.octospec/tasks/project-provisioning-followups/brief.md
+++ b/.octospec/tasks/project-provisioning-followups/brief.md
@@ -1,0 +1,171 @@
+---
+type: Task
+title: "Task: project-provisioning-followups"
+description: The decisions and review findings that survived PR #850 but not its squash — one design decision about the fleet container id, and six P2 items that only bite after a provisioning target is enabled.
+tags: [project, auth, wire-contract, data-integrity, trust-boundary, testing, commit]
+timestamp: 2026-09-08T01:15:00+00:00
+# --- octospec extension fields ---
+slug: project-provisioning-followups
+upstream: Mininglamp-OSS/octo-server#850 (merged 2026-09-08, squash 5dd80d46)
+source: user
+---
+
+# Task: project-provisioning-followups
+
+## Goal
+
+Keep two categories of knowledge from being lost, and make them actionable.
+
+PR #850 landed as **one squashed commit whose message describes the slice, not
+the review**. Eleven commits and seven review rounds collapsed into it. Two
+things therefore now exist only in a closed PR thread:
+
+1. a **design decision** about the fleet container id, agreed across two
+   workstreams but recorded in neither repository's merged code, and
+2. **six review findings** left open on purpose, each rated P2 because none can
+   bite before a provisioning target is enabled — and enabling is itself gated
+   behind a precondition on another repository.
+
+Both are safe today for the same reason (`OCTO_PROJECT_PROVISION_TARGETS` is
+empty by default), and both become live at the same moment (the first target is
+turned on). That coincidence is the point: this brief is what someone reads
+BEFORE flipping that switch.
+
+Every item below was verified against the merged tree at `origin/main`
+(`5dd80d4`) rather than restated from the review.
+
+## Background
+
+### D-1 — the fleet container id is a PROVISIONAL form
+
+Not a defect. A recorded decision that has no home in code yet.
+
+`modules/project/provisioning.go` mints an opaque container id that is
+deliberately **not derivable** from `project_id`, and #850 calls that
+non-derivability the load-bearing property of the slice. The reasoning is
+concrete: `listVisibleInSpace` lets any active Space member read the
+`project_id` of every space_listed project in their Space, while the fleet
+workspace gate admits on octo Space membership alone and then materialises the
+caller with `UpsertMember{Role:"member"}` in a row nothing ever deletes. A
+derivable id would complete the chain from "can list projects" to "is
+permanently a member of every project's workspace".
+
+The Loop integration design (`.octospec/tasks/loop-project-fleet-integration/`)
+requires the opposite: `project_id == workspace_id`, one canonical UUID, no
+mapping table.
+
+The agreed resolution is that these are **two phases of one problem, not two
+positions**. The opacity mitigates a peer-side authorization defect; the Loop
+design fixes it (the fleet side stops reading `workspace_member` for
+octo-server-owned projects and calls octo-server's verify instead, requiring
+Space member AND Project member). #850 itself says its P-2/P-3 preconditions are
+not met and that no target may be enabled until they are.
+
+So, recorded here because it is nowhere else:
+
+> **When the peer-side narrowing lands, the fleet target's container id becomes
+> `project_id`, and the non-derivability guard narrows to apply to DRIVE ONLY.**
+> Drive's threat model is separate and #850's argument may still hold there; it
+> must be re-decided on its own evidence rather than carried along.
+
+The two inbound endpoints that make that narrowing possible are in flight as
+PR #852 — without an authoritative way to ask octo-server "is this specific
+person still in this specific project", the opacity can never be retired.
+
+### The six open findings
+
+All verified at `origin/main` 5dd80d4.
+
+**A-4 — the secret is not trimmed while the URL is.**
+`config_provisioning.go:309` reads the ensure URL through `strings.TrimSpace`;
+`:305` reads the secret with a bare `getenv`. A secret mounted from a file
+carries a trailing newline, every request then signs with a value the peer
+rejects, and the whole ~23.5-minute retry budget burns as indistinguishable
+401s before the row reaches `abandoned` — which has no automatic re-drive.
+Preferred fix is to **reject** leading/trailing whitespace rather than trim it
+silently: trimming hides a broken mount that will surprise someone again.
+
+**A-5 — the empty-fragment case regressed a fix a sibling already documented.**
+`internal/projectprovision/client.go:351` checks `parsed.Fragment != ""`, so
+`https://host/ensure#` passes. `internal/cardactiondispatch/registry.go:338-341`
+carries the comment explaining that `url.Parse` clears `Fragment` for an empty
+one and uses `strings.ContainsRune(raw, '#')` instead. The provisioning client
+claims alignment with that validator and does not have it.
+
+**A-3 — an empty `container_id` echo is treated as permanent.**
+`client.go:475` compares `out.ContainerID != req.ContainerID`, so a peer that
+answers `{}` or omits the field lands in `container_id_mismatch`, which
+`isPermanentProvisioningOutcome` gives up on at the FIRST attempt. A missing
+field is a malformed response, not proof the peer owns a different container;
+it belongs in `invalid_response`, which retries. The distinction matters most
+during the peer's own rollout, which is exactly when the first target gets
+enabled.
+
+**A-1 — the `Enabled()` comment says "completely inert".**
+`config_provisioning.go:227-229`. `plan.md` establishes that gating the DISBAND
+write on `Enabled()` would be a real container leak, so the disband path is
+deliberately unconditional. The comment is what a future reader consults right
+before "tidying up" by adding that gate.
+
+**A-6 — four provisioning timers have no jitter.**
+`provisioning_worker.go:164, 165, 166, 184` schedule without it, while
+`reconcile.go:213-214` jitters both of its timers — including
+`p.cfg.MetricsInterval`, the SAME interval `provisioning_worker.go:184` uses
+unjittered. The census runs on every deployment regardless of enablement, so
+this one is live now rather than after enablement.
+
+**P2-5 — `plan.md` §3.5 points the operator at a path with no caller.**
+It names `pkg/db/mysql.go` as the startup migration entry. That file does call
+`migrate.Exec` (`:45`), but only from `Migration()`, which has **no non-test
+caller in this repository** — and `testutil.NewTestServer` sets
+`cfg.DB.Migration = false`. Module SQL is applied by `module.Setup`, i.e.
+octo-lib `module/module.go:88`. The rollback instructions are correct; the
+pointer sends whoever follows them to dead code.
+
+## Load-bearing list
+
+- **The enablement gate is what makes all six safe.** Any change here must keep
+  `OCTO_PROJECT_PROVISION_TARGETS` empty-by-default semantics, and must not be
+  read as permission to enable a target — that still waits on the peer-side
+  precondition #850 records.
+  `touches: auth, wire-contract`
+- **`abandoned` has no automatic re-drive.** A-4 and A-3 both end there, which is
+  why a misclassification costs an operator action rather than a retry.
+  `touches: data-integrity`
+- **The outbound client's URL validation is a trust boundary**, and its stated
+  contract is parity with `internal/cardactiondispatch`'s validator (A-5).
+  `touches: trust-boundary, url-destination`
+- **`plan.md` is an operator runbook**, so a wrong pointer in it is a production
+  hazard rather than a typo (P2-5).
+  `touches: data-integrity`
+
+## Out of scope
+
+- Anything that enables a provisioning target, or that relaxes the default.
+- The container-id change itself (D-1) — it is blocked on the peer-side
+  narrowing and on PR #852, and doing it early would ship a derivable id into
+  exactly the window the opacity exists to cover.
+- Re-opening #850's merged design decisions. This brief records and repairs; it
+  does not relitigate.
+- `modules/bot_task`'s per-source tokens, which sit outside `main.go`'s
+  credential-collision registry. Real, separate, and recorded in that
+  registry's own comment.
+
+## Acceptance
+
+- [ ] A-4: whitespace around a provisioning secret is REJECTED at config load
+      with a message naming the env, and a test covers a trailing newline.
+- [ ] A-5: `https://host/ensure#` is refused, by the same mechanism
+      `internal/cardactiondispatch` uses; a test pins the empty-fragment case.
+- [ ] A-3: an empty or absent `container_id` in the echo classifies as
+      `invalid_response` (retryable); a genuinely different id stays
+      `container_id_mismatch` (permanent). Both pinned.
+- [ ] A-1: the `Enabled()` comment states that the disband write is
+      unconditional and why, so "add a gate here" fails review rather than
+      passing it.
+- [ ] A-6: all four provisioning timers are jittered, matching `reconcile.go`.
+- [ ] P2-5: `plan.md` §3.5 names `module.Setup` / octo-lib `module/module.go`,
+      and says the rollback ordering it already gets right.
+- [ ] D-1 is discoverable from the merged tree: a reader of
+      `modules/project/provisioning.go` finds the pointer without reading a
+      closed PR thread.

--- a/.octospec/tasks/project-provisioning-followups/brief.md
+++ b/.octospec/tasks/project-provisioning-followups/brief.md
@@ -1,7 +1,7 @@
 ---
 type: Task
 title: "Task: project-provisioning-followups"
-description: The decisions and review findings that survived PR #850 but not its squash — one design decision about the fleet container id, and six P2 items that only bite after a provisioning target is enabled.
+description: The decisions and review findings that survived PR #850 but not its squash — one design decision about the fleet container id, and six P2 findings, all six of which this task then fixed.
 tags: [project, auth, wire-contract, data-integrity, trust-boundary, testing, commit]
 timestamp: 2026-09-08T01:15:00+00:00
 # --- octospec extension fields ---
@@ -23,17 +23,28 @@ things therefore now exist only in a closed PR thread:
 
 1. a **design decision** about the fleet container id, agreed across two
    workstreams but recorded in neither repository's merged code, and
-2. **six review findings** left open on purpose, each rated P2 because none can
-   bite before a provisioning target is enabled — and enabling is itself gated
-   behind a precondition on another repository.
+2. **six review findings** left open on purpose, each rated P2 — **all six are
+   FIXED in this task**; see Acceptance.
 
-Both are safe today for the same reason (`OCTO_PROJECT_PROVISION_TARGETS` is
-empty by default), and both become live at the same moment (the first target is
-turned on). That coincidence is the point: this brief is what someone reads
-BEFORE flipping that switch.
+The P2 rating rested on "none can bite before a provisioning target is enabled".
+That is true of five of them; **A-6 is the exception and was already live**,
+because `startProvisioningMetrics` carries no `Enabled()` gate and the census
+runs on every deployment. The blanket phrasing came from the review round and is
+corrected here rather than repeated.
 
-Every item below was verified against the merged tree at `origin/main`
-(`5dd80d4`) rather than restated from the review.
+Both categories were otherwise safe for the same reason
+(`OCTO_PROJECT_PROVISION_TARGETS` is empty by default) and would have become live
+at the same moment (the first target is turned on). That coincidence is why they
+were filed together: this brief is what someone reads BEFORE flipping that
+switch.
+
+**How to read the pins below.** Every finding was verified against the merged
+tree at `origin/main` (`5dd80d4`) when it was written, and the `file:line`
+citations in each entry are **that tree's**, not this branch's. They are kept
+because they are the evidence the finding was real — but following one at this
+head lands on the FIX, not the defect. `config_provisioning.go:227-229` is the
+sharpest example: at `5dd80d4` that range said "completely inert"; here it says
+"NOT completely inert". Where the two differ the entry says so.
 
 ## Background
 
@@ -51,7 +62,9 @@ caller with `UpsertMember{Role:"member"}` in a row nothing ever deletes. A
 derivable id would complete the chain from "can list projects" to "is
 permanently a member of every project's workspace".
 
-The Loop integration design (`.octospec/tasks/loop-project-fleet-integration/`)
+The Loop integration design (`.octospec/tasks/loop-project-fleet-integration/`,
+which lives on PR #852's branch and is **not merged** — the path does not resolve
+on `main`)
 requires the opposite: `project_id == workspace_id`, one canonical UUID, no
 mapping table.
 
@@ -73,9 +86,11 @@ The two inbound endpoints that make that narrowing possible are in flight as
 PR #852 — without an authoritative way to ask octo-server "is this specific
 person still in this specific project", the opacity can never be retired.
 
-### The six open findings
+### The six findings — all FIXED in this task
 
-All verified at `origin/main` 5dd80d4.
+All verified at `origin/main` `5dd80d4` when written, and every `file:line`
+below is THAT tree's. See "How to read the pins" above: at this head they land
+on the fix.
 
 **A-4 — the secret is not trimmed while the URL is.**
 `config_provisioning.go:309` reads the ensure URL through `strings.TrimSpace`;
@@ -110,14 +125,20 @@ before "tidying up" by adding that gate.
 
 **A-6 — four provisioning timers have no jitter.**
 `provisioning_worker.go:164, 165, 166, 184` schedule without it, while
-`reconcile.go:213-214` jitters both of its timers — including
+`reconcile.go:212-213` jitters both of its timers — including
 `p.cfg.MetricsInterval`, the SAME interval `provisioning_worker.go:184` uses
 unjittered. The census runs on every deployment regardless of enablement, so
 this one is live now rather than after enablement.
 
 **P2-5 — `plan.md` §3.5 points the operator at a path with no caller.**
 It names `pkg/db/mysql.go` as the startup migration entry. That file does call
-`migrate.Exec` (`:45`), but only from `Migration()`, which has **no non-test
+`migrate.Exec` (`:45`), but only from `Migration()`. `Migration()` DOES have a
+non-test caller — `NewMySQL` at `:32` in the same file — so the precise statement
+is one level up: `pkg/db.NewMySQL` itself has **zero callers**, because the only
+place spelling `db.NewMySQL(` (`session_rollout_cmd.go:276`) resolves through its
+line-46 import to **octo-lib's** same-named function with a different signature.
+The chain is dead either way, and stating it this way is the version that
+survives someone checking. (An earlier draft said `Migration()` has **no non-test
 caller in this repository** — and `testutil.NewTestServer` sets
 `cfg.DB.Migration = false`. Module SQL is applied by `module.Setup`, i.e.
 octo-lib `module/module.go:88`. The rollback instructions are correct; the
@@ -130,7 +151,9 @@ pointer sends whoever follows them to dead code.
   read as permission to enable a target — that still waits on the peer-side
   precondition #850 records.
   `touches: auth, wire-contract`
-- **`abandoned` has no automatic re-drive.** A-4 and A-3 both end there, which is
+- **`abandoned` has no automatic re-drive.** A-4 and A-3 both ended there before
+  the fixes in this task — A-4 no longer produces a live target at all, and A-3
+  now retries instead of abandoning on the first attempt — which is
   why a misclassification costs an operator action rather than a retry.
   `touches: data-integrity`
 - **The outbound client's URL validation is a trust boundary**, and its stated
@@ -149,16 +172,35 @@ pointer sends whoever follows them to dead code.
 - Re-opening #850's merged design decisions. This brief records and repairs; it
   does not relitigate.
 - `modules/bot_task`'s per-source tokens, which sit outside `main.go`'s
-  credential-collision registry. Real, separate, and recorded in that
-  registry's own comment.
+  credential-collision registry: those tokens live inside the
+  `OCTO_BOT_TASK_SOURCES` JSON blob rather than in a single env, so no `os.Getenv`
+  can reach them and they cannot be passed to the exclusion call at all. Real,
+  separate, and closing it is a change to that module. **This task adds the
+  missing record** — an earlier draft claimed it was "recorded in that registry's
+  own comment", and it was not: an exhaustive grep of the call site, the
+  `ValidateNotifyTokenExclusions` doc and body, and bot_task's own comments found
+  no mention in any spelling. The note now exists at the call site in `main.go`,
+  which is where a reader counts the arguments and concludes the set is complete.
 
 ## Acceptance
 
 All six are FIXED in this task rather than filed. The boxes below were the
 acceptance criteria and are checked against the implementation.
 
-- [x] A-4: whitespace around a provisioning secret is REJECTED at config load
-      with a message naming the env, and a test covers a trailing newline.
+- [x] A-4: whitespace around a provisioning secret is REJECTED at config load —
+      the target is dropped, recorded in `Misconfigured`, and reported through
+      `Problems`, which `New()` logs at Error with the gauge set. Covered at both
+      layers: `ValidateTarget` table cases for leading/trailing space and a
+      trailing newline, plus a `TestLoadProvisioningConfig` case for the loader
+      consequence.
+      **Criterion corrected:** it originally said "with a message naming the
+      ENV". The message names the TARGET (`fleet`), and `internal/projectprovision`
+      architecturally cannot see env names — it is handed a `Target`, not an
+      environment. The env is derivable from the target name via
+      `targetEnvNames`, and the boot log prints the message verbatim, so an
+      operator gets there in one step; the box was ticked against the shipped
+      behaviour, and the criterion is reworded to match rather than left
+      claiming more than the code does.
 - [x] A-5: `https://host/ensure#` is refused, by the same mechanism
       `internal/cardactiondispatch` uses; a test pins the empty-fragment case.
 - [x] A-3: an empty or absent `container_id` in the echo classifies as
@@ -170,6 +212,19 @@ acceptance criteria and are checked against the implementation.
 - [x] A-6: all four provisioning timers are jittered, matching `reconcile.go`.
 - [x] P2-5: `plan.md` §3.5 names `module.Setup` / octo-lib `module/module.go`,
       and says the rollback ordering it already gets right.
+- [x] P2-A (bundled at #850's close, not one of the six): §3.5's "put the DROP
+      and the ledger DELETE in one transaction" is corrected. MySQL commits DDL
+      implicitly, so the transaction bought no atomicity — measured on 8.0.46:
+      `START TRANSACTION; DROP TABLE t; DELETE …; ROLLBACK;` restored NEITHER.
+      The runbook now states the real hazard (DROP succeeds, DELETE fails, and
+      you land in the exact state the paragraph warns about) and says to retry
+      rather than rely on a rollback that cannot happen.
+- [x] P2-C (same bundle): `Ensure` accepted any 2xx while the published contract
+      specifies a synchronous 200. It now requires 200 exactly. 202 is the case
+      that matters — it means the peer will act later, so accepting it writes
+      `ready` against a container that may not exist. Refused as retryable
+      `invalid_response`, not terminal, since a mid-rollout peer should not burn
+      a row. Pinned for 201/202/204.
 - [x] D-1 is discoverable from the merged tree: a reader of
       `modules/project/provisioning.go` finds the pointer without reading a
       closed PR thread.

--- a/.octospec/tasks/project-provisioning-followups/brief.md
+++ b/.octospec/tasks/project-provisioning-followups/brief.md
@@ -101,13 +101,6 @@ rejects, and the whole ~23.5-minute retry budget burns as indistinguishable
 Preferred fix is to **reject** leading/trailing whitespace rather than trim it
 silently: trimming hides a broken mount that will surprise someone again.
 
-**P2-8 — the URL rejection must be reached from config load.**
-The same reject-not-trim rule is meaningless if `loadProvisioningConfig` trims
-`OCTO_PROJECT_PROVISION_*_URL` before `ValidateTarget` sees it. A whitespace-
-wrapped URL must be dropped, reported through `Problems`, and counted in
-`Misconfigured`, just as a whitespace-wrapped secret is; otherwise an operator
-gets a silent config repair instead of the stated deployment signal.
-
 **A-5 — the empty-fragment case regressed a fix a sibling already documented.**
 `internal/projectprovision/client.go:351` checks `parsed.Fragment != ""`, so
 `https://host/ensure#` passes. `internal/cardactiondispatch/registry.go:338-341`
@@ -151,9 +144,21 @@ caller in this repository** — and `testutil.NewTestServer` sets
 octo-lib `module/module.go:88`. The rollback instructions are correct; the
 pointer sends whoever follows them to dead code.)
 
+### Follow-up found while fixing A-4 — also FIXED in this task
+
+**P2-8 — the URL rejection must be reached from config load.**
+This was not one of the six findings left open by #850; it was found while
+implementing A-4. The same reject-not-trim rule is meaningless if
+`loadProvisioningConfig` trims `OCTO_PROJECT_PROVISION_*_URL` before
+`ValidateTarget` sees it. A whitespace-wrapped URL must be dropped, reported
+through `Problems`, and counted in `Misconfigured`, just as a whitespace-wrapped
+secret is; otherwise an operator gets a silent config repair instead of the
+stated deployment signal.
+
 ## Load-bearing list
 
-- **The enablement gate is what makes all six safe.** Any change here must keep
+- **The enablement gate made five of the six safe before these fixes.** A-6's
+  census timer was already live without the gate. Any change here must keep
   `OCTO_PROJECT_PROVISION_TARGETS` empty-by-default semantics, and must not be
   read as permission to enable a target — that still waits on the peer-side
   precondition #850 records.
@@ -218,12 +223,16 @@ acceptance criteria and are checked against the implementation.
       passing it.
 - [x] A-6: all four provisioning timers are jittered, matching `reconcile.go`,
       with a source guard that pins all four `Schedule(jitter(...))` calls.
+- [x] P2-5: `plan.md` §3.5 names `module.Setup` / octo-lib `module/module.go`,
+      and says the rollback ordering it already gets right.
+
+The following additional findings were discovered while fixing or reviewing
+those six and are also fixed:
+
 - [x] P2-8: whitespace around a configured ensure URL is REJECTED at config
       load; the target is dropped, marked `Misconfigured`, and reported through
       `Problems`. The loader test covers the deployed environment path rather
       than only a hand-built `Target`.
-- [x] P2-5: `plan.md` §3.5 names `module.Setup` / octo-lib `module/module.go`,
-      and says the rollback ordering it already gets right.
 - [x] P2-A (bundled at #850's close, not one of the six): §3.5's "put the DROP
       and the ledger DELETE in one transaction" is corrected. MySQL commits DDL
       implicitly, so the transaction bought no atomicity — measured on 8.0.46:

--- a/internal/projectprovision/client.go
+++ b/internal/projectprovision/client.go
@@ -347,11 +347,13 @@ func ValidateTarget(t Target) error {
 	// The same rule as the secret above, and it belongs here for the same reason
 	// the sibling validator applies it (internal/cardactiondispatch/registry.go
 	// refuses an untrimmed raw value before parsing): "reject, do not trim" applied
-	// to one of the two configured values is a principle with a hole in it. The
-	// loader happens to trim this one today, so the gap is reachable only through a
-	// hand-built Target — and there a trailing space is not a control byte,
-	// url.Parse accepts it, it survives into EscapedPath() as %20, the signature
-	// and the wire path agree, and the peer answers 404, which retries to abandoned.
+	// to one of the two configured values is a principle with a hole in it.
+	// loadProvisioningConfig deliberately passes the raw env value through, so a
+	// whitespace-wrapped URL is rejected here, the target is dropped, and boot
+	// reports it through Problems and Misconfigured. Direct callers get the same
+	// refusal because Ensure revalidates the Target before constructing a request.
+	// Before this check, a trailing space could survive as %20 in EscapedPath and
+	// reach the peer; it can no longer take that request path.
 	if strings.TrimSpace(t.EnsureURL) != t.EnsureURL || t.EnsureURL == "" {
 		return fmt.Errorf("projectprovision: %s ensure url must not be empty or carry "+
 			"leading or trailing whitespace", t.Name)

--- a/internal/projectprovision/client.go
+++ b/internal/projectprovision/client.go
@@ -311,6 +311,14 @@ func ValidateTarget(t Target) error {
 	// burns as 401s that look exactly like a rotated secret, and the row lands in
 	// abandoned, which has no automatic re-drive.
 	//
+	// What refusing COSTS, stated because this comment is what the next person
+	// consults: the target is dropped from cfg.Targets, and if it was the only one
+	// then Enabled() goes false and the claim, sweep and purge timers are never
+	// mounted — so rows already `pending` stop being claimed until a valid target
+	// is configured again. The census keeps the backlog visible throughout. That is
+	// still the better trade than 23 minutes of ambiguous 401s, but it is a
+	// different one from "the process refuses to start", which this does not do.
+	//
 	// No value in the message, on the same principle as the length check below.
 	if strings.TrimSpace(t.Secret) != t.Secret {
 		return fmt.Errorf("projectprovision: %s secret has leading or trailing whitespace; "+
@@ -333,6 +341,18 @@ func ValidateTarget(t Target) error {
 		// package treats secret material, not because a timing signal would matter: the
 		// values being compared against are already public.
 		return fmt.Errorf("projectprovision: %s secret is a published conformance vector secret; generate a real one", t.Name)
+	}
+	// The same rule as the secret above, and it belongs here for the same reason
+	// the sibling validator applies it (internal/cardactiondispatch/registry.go
+	// refuses an untrimmed raw value before parsing): "reject, do not trim" applied
+	// to one of the two configured values is a principle with a hole in it. The
+	// loader happens to trim this one today, so the gap is reachable only through a
+	// hand-built Target — and there a trailing space is not a control byte,
+	// url.Parse accepts it, it survives into EscapedPath() as %20, the signature
+	// and the wire path agree, and the peer answers 404, which retries to abandoned.
+	if strings.TrimSpace(t.EnsureURL) != t.EnsureURL || t.EnsureURL == "" {
+		return fmt.Errorf("projectprovision: %s ensure url must not be empty or carry "+
+			"leading or trailing whitespace", t.Name)
 	}
 	parsed, err := url.Parse(t.EnsureURL)
 	if err != nil {
@@ -482,10 +502,32 @@ func (c *Client) Ensure(ctx context.Context, target Target, req EnsureRequest) (
 		}
 	}
 	defer response.Body.Close()
-	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+	if response.StatusCode != http.StatusOK {
+		// STRICTLY 200, not any 2xx, because the published contract
+		// (.octospec/tasks/project-p2-subsystem-integration/brief.md §"接口契约")
+		// specifies a SYNCHRONOUS 200 carrying container_id, and the difference
+		// between 200 and 202 is exactly the thing this call has to know: 202 means
+		// the peer accepted the request and will act on it later, so treating it as
+		// success writes status=ready — "we successfully created the container" —
+		// against a container that may not exist yet. Every later decision that
+		// reads ready would be reading a promise as a fact.
+		//
+		// A 2xx that is not 200 is therefore a contract violation on the peer's
+		// side, not a success, and it retries: the peer may be mid-rollout, and
+		// unlike a 4xx there is nothing here that says it will answer the same way
+		// forever. statusCategory maps 2xx to the generic bucket, so the category
+		// is set explicitly for the one an operator needs to recognise.
+		//
 		// Drain a bounded prefix so the connection can be reused, and discard it:
 		// an error body from an unnarrowed target is not something we want in a log.
 		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, maxResponseBytes))
+		if response.StatusCode > http.StatusOK && response.StatusCode < http.StatusMultipleChoices {
+			return EnsureResponse{}, &EnsureError{
+				Category: "invalid_response",
+				Status:   response.StatusCode,
+				Detail:   "contract requires a synchronous 200",
+			}
+		}
 		return EnsureResponse{}, &EnsureError{
 			Category: statusCategory(response.StatusCode),
 			Status:   response.StatusCode,
@@ -494,7 +536,12 @@ func (c *Client) Ensure(ctx context.Context, target Target, req EnsureRequest) (
 	var out EnsureResponse
 	decoder := json.NewDecoder(io.LimitReader(response.Body, maxResponseBytes))
 	if err := decoder.Decode(&out); err != nil {
-		return EnsureResponse{}, &EnsureError{Category: "invalid_response", cause: err}
+		// Status is recorded even though the body did not parse: a 200 carrying an
+		// HTML error page and a 500 carrying the same page are different problems,
+		// and last_error is the only durable per-row evidence there is.
+		return EnsureResponse{}, &EnsureError{
+			Category: "invalid_response", Status: response.StatusCode, cause: err,
+		}
 	}
 	if out.ContainerID == "" {
 		// A MISSING id is a malformed response, not evidence the peer owns a
@@ -502,12 +549,29 @@ func (c *Client) Ensure(ctx context.Context, target Target, req EnsureRequest) (
 		// retryable and the other is terminal on the first attempt.
 		//
 		// This is the shape a peer serves while its ensure endpoint is still being
-		// rolled out: a stub answering {} , a proxy returning an empty body with a
-		// 200. Classifying it as a mismatch abandons the row immediately, and
+		// rolled out. The REACHABLE set is exactly `{}`, `{"container_id":""}` and
+		// `null` — an empty or whitespace-only body does NOT arrive here, because
+		// Decode returns io.EOF on it and the branch above catches that with a
+		// different error shape. An earlier version of this comment offered "a proxy
+		// returning an empty body with a 200" as an example, which cannot happen;
+		// it is corrected rather than deleted because A-1, one of the findings this
+		// commit closes, is a comment that described a path the code did not take.
+		//
+		// Classifying any of them as a mismatch abandons the row immediately, and
 		// abandoned has no automatic re-drive — so a transient state on the other
 		// side would need a human to requeue, at exactly the moment the first
 		// target is being enabled.
-		return EnsureResponse{}, &EnsureError{Category: "invalid_response", Status: response.StatusCode}
+		//
+		// Detail rather than status alone: Summary() falls back to "status %d" when
+		// Detail is empty, so this row used to write `invalid_response: status 200`
+		// into last_error — a failure category paired with a success status, in the
+		// 255-byte column the runbook sends a human to read. The constant carries no
+		// request data, which is what that field's invariant requires.
+		return EnsureResponse{}, &EnsureError{
+			Category: "invalid_response",
+			Status:   response.StatusCode,
+			Detail:   "response carried no container_id",
+		}
 	}
 	if out.ContainerID != req.ContainerID {
 		// A DIFFERENT id is terminal. Our mapping row now points at a container

--- a/internal/projectprovision/client.go
+++ b/internal/projectprovision/client.go
@@ -299,6 +299,23 @@ func ValidateTarget(t Target) error {
 	if strings.TrimSpace(t.Name) == "" {
 		return errors.New("projectprovision: target name required")
 	}
+	// Surrounding whitespace is REFUSED, not trimmed, and the difference is the
+	// whole point. A secret mounted from a file carries a trailing newline; trimming
+	// it would let a subtly wrong mount work, so nobody learns the mount is wrong
+	// until the day something stops trimming. Refusing surfaces it at boot, in the
+	// one place an operator is already reading — while trimming silently would have
+	// been indistinguishable from a correct deployment.
+	//
+	// The alternative failure, if this check is absent, is not a clean error either:
+	// every request signs with a value the peer rejects, so the whole retry budget
+	// burns as 401s that look exactly like a rotated secret, and the row lands in
+	// abandoned, which has no automatic re-drive.
+	//
+	// No value in the message, on the same principle as the length check below.
+	if strings.TrimSpace(t.Secret) != t.Secret {
+		return fmt.Errorf("projectprovision: %s secret has leading or trailing whitespace; "+
+			"a file-mounted secret usually needs its trailing newline removed", t.Name)
+	}
 	if len(t.Secret) < minSecretBytes {
 		// No secret value in the message, and no length either — an error string
 		// that reports the observed length is a (small) oracle in a log.
@@ -348,7 +365,14 @@ func ValidateTarget(t Target) error {
 	}
 	// A fragment is never sent, so one in configuration means the value was pasted from
 	// somewhere it did not belong.
-	if parsed.Fragment != "" {
+	//
+	// Checked on the RAW string, not on parsed.Fragment. url.Parse leaves Fragment
+	// empty for a bare trailing "#", so "https://host/ensure#" passes a
+	// parsed.Fragment check while still carrying the separator. cardactiondispatch
+	// documents this exact case and uses ContainsRune for it; this package claimed
+	// alignment with that validator and had the weaker check — the same defect its
+	// sibling had already found and fixed.
+	if strings.ContainsRune(t.EnsureURL, '#') {
 		return fmt.Errorf("projectprovision: %s ensure url must not contain a fragment", t.Name)
 	}
 	return nil
@@ -472,11 +496,23 @@ func (c *Client) Ensure(ctx context.Context, target Target, req EnsureRequest) (
 	if err := decoder.Decode(&out); err != nil {
 		return EnsureResponse{}, &EnsureError{Category: "invalid_response", cause: err}
 	}
+	if out.ContainerID == "" {
+		// A MISSING id is a malformed response, not evidence the peer owns a
+		// different container — the two must not share a category, because one is
+		// retryable and the other is terminal on the first attempt.
+		//
+		// This is the shape a peer serves while its ensure endpoint is still being
+		// rolled out: a stub answering {} , a proxy returning an empty body with a
+		// 200. Classifying it as a mismatch abandons the row immediately, and
+		// abandoned has no automatic re-drive — so a transient state on the other
+		// side would need a human to requeue, at exactly the moment the first
+		// target is being enabled.
+		return EnsureResponse{}, &EnsureError{Category: "invalid_response", Status: response.StatusCode}
+	}
 	if out.ContainerID != req.ContainerID {
-		// Fail loudly and permanently. A target that answers with a different id
-		// means our mapping row now points at a container nobody owns, and
-		// retrying cannot repair that — it needs a human to look at which side
-		// generated the id.
+		// A DIFFERENT id is terminal. Our mapping row now points at a container
+		// nobody owns, and retrying cannot repair that — it needs a human to look
+		// at which side generated the id.
 		return EnsureResponse{}, &EnsureError{Category: "container_id_mismatch", Status: response.StatusCode}
 	}
 	return out, nil

--- a/internal/projectprovision/client.go
+++ b/internal/projectprovision/client.go
@@ -169,8 +169,9 @@ type EnsureResponse struct {
 type EnsureError struct {
 	Category string
 	Status   int
-	// Detail is a bounded transport-layer reason, and it is set at exactly the two
-	// sites where it can be derived WITHOUT reading anything we sent.
+	// Detail is a bounded, container-id-free reason. It is either derived from a
+	// transport inner error or a fixed response-classification constant; it is
+	// never derived from a request or a response body.
 	//
 	// It exists because category-plus-status is empty for the failure an operator hits
 	// first. A target that is down produced `last_error = "transport_failed:
@@ -186,10 +187,11 @@ type EnsureError struct {
 	// function of OUR request — encode_failed wraps a json.Marshal error over an
 	// EnsureRequest, which carries the container id. json.Marshal of an all-string struct
 	// cannot realistically fail, but "cannot realistically" is not the bar for a value the
-	// package comment calls a capability. Detail is only ever filled from the transport
-	// error's INNER error, which describes the network and structurally cannot contain the
-	// request. The container-id-freedom of last_error stays a property of construction, not
-	// an argument about stdlib formatting.
+	// package comment calls a capability. Transport-derived Detail comes only from the
+	// transport error's INNER error, which describes the network and structurally cannot
+	// contain the request. Response classifications use fixed constants rather than parsing
+	// errors, because a parser error can quote response-body bytes. The container-id-freedom
+	// of last_error stays a property of construction, not an argument about stdlib formatting.
 	Detail string
 	cause  error
 }
@@ -504,7 +506,7 @@ func (c *Client) Ensure(ctx context.Context, target Target, req EnsureRequest) (
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
 		// STRICTLY 200, not any 2xx, because the published contract
-		// (.octospec/tasks/project-p2-subsystem-integration/brief.md §"接口契约")
+		// (.octospec/tasks/project-p2-subsystem-integration/brief.md, "Target endpoint contracts")
 		// specifies a SYNCHRONOUS 200 carrying container_id, and the difference
 		// between 200 and 202 is exactly the thing this call has to know: 202 means
 		// the peer accepted the request and will act on it later, so treating it as
@@ -536,26 +538,25 @@ func (c *Client) Ensure(ctx context.Context, target Target, req EnsureRequest) (
 	var out EnsureResponse
 	decoder := json.NewDecoder(io.LimitReader(response.Body, maxResponseBytes))
 	if err := decoder.Decode(&out); err != nil {
-		// Status is recorded even though the body did not parse: a 200 carrying an
-		// HTML error page and a 500 carrying the same page are different problems,
-		// and last_error is the only durable per-row evidence there is.
+		// Status is necessarily 200 here: the gate above returned every other status.
+		// Keep the durable reason a fixed constant, not err.Error(), because a JSON
+		// parsing error can quote response-body bytes including the container id.
 		return EnsureResponse{}, &EnsureError{
-			Category: "invalid_response", Status: response.StatusCode, cause: err,
+			Category: "invalid_response",
+			Detail:   "response body was not valid JSON",
+			cause:    err,
 		}
 	}
-	if out.ContainerID == "" {
+	if strings.TrimSpace(out.ContainerID) == "" {
 		// A MISSING id is a malformed response, not evidence the peer owns a
 		// different container — the two must not share a category, because one is
 		// retryable and the other is terminal on the first attempt.
 		//
 		// This is the shape a peer serves while its ensure endpoint is still being
-		// rolled out. The REACHABLE set is exactly `{}`, `{"container_id":""}` and
-		// `null` — an empty or whitespace-only body does NOT arrive here, because
-		// Decode returns io.EOF on it and the branch above catches that with a
-		// different error shape. An earlier version of this comment offered "a proxy
-		// returning an empty body with a 200" as an example, which cannot happen;
-		// it is corrected rather than deleted because A-1, one of the findings this
-		// commit closes, is a comment that described a path the code did not take.
+		// rolled out. The REACHABLE set is `{}`, `{"container_id":""}`,
+		// whitespace-only container_id values, and `null` — an empty or whitespace-only
+		// BODY does NOT arrive here, because Decode returns io.EOF and the branch above
+		// catches that different error shape.
 		//
 		// Classifying any of them as a mismatch abandons the row immediately, and
 		// abandoned has no automatic re-drive — so a transient state on the other

--- a/internal/projectprovision/client_test.go
+++ b/internal/projectprovision/client_test.go
@@ -120,7 +120,7 @@ func TestContainerEventIDIsAOneWayStableDerivation(t *testing.T) {
 // attempt, and abandoned has no automatic re-drive.
 //
 // The missing shape is what a peer serves while its ensure endpoint is still
-// rolling out — a stub answering {}, a proxy returning an empty 200 body. That
+// rolling out — a stub answering {}. That
 // is precisely the window in which the first target gets enabled, so filing it
 // as terminal would need a human to requeue every row created during it.
 func TestEnsureTreatsAnAbsentContainerIDAsRetryable(t *testing.T) {
@@ -128,7 +128,7 @@ func TestEnsureTreatsAnAbsentContainerIDAsRetryable(t *testing.T) {
 	// this branch — Decode returns io.EOF on it and the decode-failure branch
 	// catches it first. `null` is here because the corrected comment names it and
 	// the earlier test did not pin it.
-	for _, body := range []string{`{}`, `{"container_id":""}`, `null`} {
+	for _, body := range []string{`{}`, `{"container_id":""}`, `{"container_id":" "}`, `{"container_id":"\t\n"}`, `null`} {
 		t.Run(body, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				_, _ = w.Write([]byte(body))
@@ -143,6 +143,29 @@ func TestEnsureTreatsAnAbsentContainerIDAsRetryable(t *testing.T) {
 					"response, not proof the peer owns a different container (err=%v)", got, err)
 			}
 		})
+	}
+}
+
+// TestEnsureDecodeFailureHasSafeDetail keeps a malformed 200 response actionable
+// without persisting response bytes, which can contain the container capability.
+func TestEnsureDecodeFailureHasSafeDetail(t *testing.T) {
+	const containerID = "octows-deadbeef"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("<html>" + containerID + "</html>"))
+	}))
+	defer server.Close()
+
+	_, err := NewClient(nil, nil).Ensure(context.Background(), testTarget(server.URL+"/ensure"), EnsureRequest{
+		ContainerID: containerID, ProjectID: "p1", OctoSpaceID: "s1",
+	})
+	if got := Category(err); got != "invalid_response" {
+		t.Fatalf("category = %q, want invalid_response (err=%v)", got, err)
+	}
+	if got, want := Summary(err), "response body was not valid JSON"; got != want {
+		t.Fatalf("Summary = %q, want %q", got, want)
+	}
+	if strings.Contains(Summary(err), containerID) {
+		t.Fatalf("Summary leaks container id: %q", Summary(err))
 	}
 }
 

--- a/internal/projectprovision/client_test.go
+++ b/internal/projectprovision/client_test.go
@@ -111,6 +111,37 @@ func TestContainerEventIDIsAOneWayStableDerivation(t *testing.T) {
 	}
 }
 
+// TestEnsureTreatsAnAbsentContainerIDAsRetryable separates the two shapes that
+// used to share one category.
+//
+// A MISSING id is a malformed response; a DIFFERENT id is evidence the peer owns
+// a container we do not know about. Only the second is terminal, and the
+// difference is not cosmetic: container_id_mismatch is abandoned on the FIRST
+// attempt, and abandoned has no automatic re-drive.
+//
+// The missing shape is what a peer serves while its ensure endpoint is still
+// rolling out — a stub answering {}, a proxy returning an empty 200 body. That
+// is precisely the window in which the first target gets enabled, so filing it
+// as terminal would need a human to requeue every row created during it.
+func TestEnsureTreatsAnAbsentContainerIDAsRetryable(t *testing.T) {
+	for _, body := range []string{`{}`, `{"container_id":""}`} {
+		t.Run(body, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(body))
+			}))
+			defer server.Close()
+
+			_, err := NewClient(nil, nil).Ensure(context.Background(), testTarget(server.URL+"/ensure"), EnsureRequest{
+				ContainerID: "octows-deadbeef", ProjectID: "p1", OctoSpaceID: "s1",
+			})
+			if got := Category(err); got != "invalid_response" {
+				t.Fatalf("category = %q, want invalid_response — an absent id is a malformed "+
+					"response, not proof the peer owns a different container (err=%v)", got, err)
+			}
+		})
+	}
+}
+
 // TestEnsureRejectsAMismatchedContainerID pins the fail-loud-and-permanent branch.
 // A target that answers with a different id means our mapping row points at a
 // container nobody owns, and no number of retries repairs that.
@@ -281,6 +312,18 @@ func TestValidateTarget(t *testing.T) {
 		// the wire, so ForceQuery has to be checked too.
 		{"force_query", Target{Name: "fleet", EnsureURL: "https://fleet.internal/ensure?", Secret: testSecret}, true},
 		{"fragment", Target{Name: "fleet", EnsureURL: "https://fleet.internal/ensure#frag", Secret: testSecret}, true},
+		// The EMPTY fragment. url.Parse leaves Fragment == "" for a bare trailing
+		// "#", so a parsed.Fragment check passes it while the separator is still in
+		// the configured value. cardactiondispatch documents this case and checks the
+		// raw string; this package claimed alignment and had the weaker check.
+		{"empty_fragment", Target{Name: "fleet", EnsureURL: "https://fleet.internal/ensure#", Secret: testSecret}, true},
+		// A secret mounted from a file carries a trailing newline. Refused rather
+		// than trimmed: trimming lets a subtly wrong mount work, and the failure it
+		// otherwise produces is a whole retry budget of 401s indistinguishable from a
+		// rotated secret, ending in abandoned, which has no automatic re-drive.
+		{"secret_trailing_newline", Target{Name: "fleet", EnsureURL: "https://fleet.internal/ensure", Secret: testSecret + "\n"}, true},
+		{"secret_leading_space", Target{Name: "fleet", EnsureURL: "https://fleet.internal/ensure", Secret: " " + testSecret}, true},
+		{"secret_trailing_space", Target{Name: "fleet", EnsureURL: "https://fleet.internal/ensure", Secret: testSecret + " "}, true},
 		// Host alone keeps the ":port", so a host-less URL with a port would pass a
 		// `Host != ""` check; Hostname() is what actually rejects it.
 		{"port_without_host", Target{Name: "fleet", EnsureURL: "http://:8080/ensure", Secret: testSecret}, true},

--- a/internal/projectprovision/client_test.go
+++ b/internal/projectprovision/client_test.go
@@ -124,7 +124,11 @@ func TestContainerEventIDIsAOneWayStableDerivation(t *testing.T) {
 // is precisely the window in which the first target gets enabled, so filing it
 // as terminal would need a human to requeue every row created during it.
 func TestEnsureTreatsAnAbsentContainerIDAsRetryable(t *testing.T) {
-	for _, body := range []string{`{}`, `{"container_id":""}`} {
+	// The reachable set, exactly: an empty or whitespace-only body does NOT reach
+	// this branch — Decode returns io.EOF on it and the decode-failure branch
+	// catches it first. `null` is here because the corrected comment names it and
+	// the earlier test did not pin it.
+	for _, body := range []string{`{}`, `{"container_id":""}`, `null`} {
 		t.Run(body, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				_, _ = w.Write([]byte(body))
@@ -671,5 +675,63 @@ func TestConformanceEpochLabelMatchesTheConstant(t *testing.T) {
 	if got := string(m[1]); got != want {
 		t.Errorf("comment says %s, conformanceNow is %s — fix the COMMENT, not the constant "+
 			"(the published signatures were computed over it)", got, want)
+	}
+}
+
+// TestEnsureRefusesANonOKSuccessStatus pins P2-C: the published contract
+// specifies a SYNCHRONOUS 200 carrying container_id, and this client used to
+// accept any 2xx.
+//
+// 202 is the case that matters. It means the peer accepted the request and will
+// act on it later, so treating it as success writes status=ready — "we
+// successfully created the container" — against a container that may not exist.
+// Every later decision that reads ready would be reading a promise as a fact.
+//
+// It retries rather than being terminal: unlike a 4xx, nothing here says the peer
+// will answer this way forever, and a mid-rollout peer should not burn a row.
+func TestEnsureRefusesANonOKSuccessStatus(t *testing.T) {
+	for _, status := range []int{http.StatusAccepted, http.StatusCreated, http.StatusNoContent} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(status)
+				// A VALID body, so the refusal is about the status and nothing else.
+				_, _ = w.Write([]byte(`{"container_id":"octows-deadbeef"}`))
+			}))
+			defer server.Close()
+
+			_, err := NewClient(nil, nil).Ensure(context.Background(), testTarget(server.URL+"/ensure"), EnsureRequest{
+				ContainerID: "octows-deadbeef", ProjectID: "p1", OctoSpaceID: "s1",
+			})
+			if err == nil {
+				t.Fatalf("%d with a valid body must NOT be accepted: the contract requires a "+
+					"synchronous 200, and 202 means the container may not exist yet", status)
+			}
+			if got := Category(err); got != "invalid_response" {
+				t.Fatalf("category = %q, want invalid_response (err=%v)", got, err)
+			}
+			if summary := Summary(err); !strings.Contains(summary, "synchronous 200") {
+				t.Errorf("last_error must say what the peer got wrong, got %q", summary)
+			}
+		})
+	}
+}
+
+// TestValidateTargetRefusesAnUntrimmedURL is P2-8: "reject, do not trim" applied
+// to one of the two configured values is a principle with a hole in it. The
+// sibling validator refuses an untrimmed raw value before parsing, and this one
+// now does too.
+func TestValidateTargetRefusesAnUntrimmedURL(t *testing.T) {
+	for _, raw := range []string{
+		"https://peer.invalid/ensure ",
+		" https://peer.invalid/ensure",
+		"https://peer.invalid/ensure\n",
+		"",
+	} {
+		tgt := testTarget(raw)
+		tgt.EnsureURL = raw
+		if err := ValidateTarget(tgt); err == nil {
+			t.Errorf("%q must be refused: it survives url.Parse, reaches EscapedPath() as %%20, "+
+				"signature and wire path agree, and the peer answers 404 — retried to abandoned", raw)
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -713,6 +713,15 @@ func installCardActionDispatch(ctx *config.Context) (*cardActionDispatchRuntime,
 		// exist, which defeats the only purpose the comment has.)
 		os.Getenv(project.ProvisionFleetSecretEnv),
 		os.Getenv(project.ProvisionDriveSecretEnv),
+		// NOT covered here, stated because the absence is otherwise invisible:
+		// modules/bot_task's per-source bearer tokens live inside the
+		// OCTO_BOT_TASK_SOURCES JSON registry rather than in a single env, so no
+		// os.Getenv can reach them and they cannot be passed to this call. They are
+		// deduped only WITHIN that registry, which means a value shared between a
+		// bot_task source and any credential named here is detected by nothing.
+		// Closing it needs that module to expose its configured token values — a
+		// change there, not here. Recorded at the call site because this is where a
+		// reader counts the arguments and concludes the set is complete.
 	); err != nil {
 		return nil, err
 	}

--- a/modules/project/config_provisioning.go
+++ b/modules/project/config_provisioning.go
@@ -367,7 +367,7 @@ func loadProvisioningConfig(getenv func(string) string) (ProvisioningConfig, []e
 		target := provisionTarget{
 			Target: projectprovision.Target{
 				Name:      name,
-				EnsureURL: strings.TrimSpace(getenv(envs.url)),
+				EnsureURL: getenv(envs.url),
 				Secret:    secret,
 				Timeout:   cfg.Timeout,
 			},

--- a/modules/project/config_provisioning.go
+++ b/modules/project/config_provisioning.go
@@ -345,12 +345,7 @@ func loadProvisioningConfig(getenv func(string) string) (ProvisioningConfig, []e
 		// Same reasoning as the retired reclaim env below: an operator who followed the
 		// runbook has to learn that the instruction did nothing, and a startup problem is
 		// the channel that survives a restart loop.
-		if cfg.RequeueProjectID != "" {
-			problems = append(problems, fmt.Errorf(
-				"project provisioning: %s is set but %s enables no target, so no row will be requeued; "+
-					"enable the target that owns the stuck row, or clear the requeue env",
-				envProvisionRequeueProjectID, envProvisionTargets))
-		}
+		problems = appendDisabledRequeueProblem(problems, cfg)
 		cfg.Problems = problems
 		return cfg, problems
 	}
@@ -386,8 +381,22 @@ func loadProvisioningConfig(getenv func(string) string) (ProvisioningConfig, []e
 		secrets[name] = secret
 		cfg.Targets = append(cfg.Targets, target)
 	}
+	problems = appendDisabledRequeueProblem(problems, cfg)
 	cfg.Problems = problems
 	return cfg, problems
+}
+
+// appendDisabledRequeueProblem reports a rescue instruction that cannot execute.
+// startProvisioningWorker returns before requeueing whenever no VALID target survived
+// configuration, whether the target list was empty or every requested target was rejected.
+func appendDisabledRequeueProblem(problems []error, cfg ProvisioningConfig) []error {
+	if cfg.RequeueProjectID == "" || cfg.Enabled() {
+		return problems
+	}
+	return append(problems, fmt.Errorf(
+		"project provisioning: %s is set but %s leaves no valid target enabled, so no row will be requeued; "+
+			"configure and enable the target that owns the stuck row, or clear the requeue env",
+		envProvisionRequeueProjectID, envProvisionTargets))
 }
 
 // parseMaxAttempts resolves the retry budget, refusing a value outside

--- a/modules/project/config_provisioning.go
+++ b/modules/project/config_provisioning.go
@@ -257,8 +257,16 @@ type ProvisioningConfig struct {
 }
 
 // Enabled reports whether any target is live. When false, createProjectOnce
-// enqueues nothing and the worker does not start, so the provisioning slice is
-// completely inert — which is its default state.
+// enqueues nothing and the worker does not start.
+//
+// NOT completely inert, and the exception is deliberate rather than an
+// oversight: markProvisioningDisbandPendingTx runs UNCONDITIONALLY on the
+// disband path. Gating that on Enabled() would mean a target that was enabled,
+// produced rows, and was later disabled stops marking its containers
+// reclaimable — a real leak, with no local record that anything was left behind.
+//
+// This comment is what a future reader consults immediately before "tidying up"
+// by adding that gate, so it says so here rather than only in the runbook.
 func (c ProvisioningConfig) Enabled() bool { return len(c.Targets) > 0 }
 
 // TargetByName returns the resolved target, or false when it is not enabled.

--- a/modules/project/provisioning.go
+++ b/modules/project/provisioning.go
@@ -68,6 +68,29 @@ func containerIDPrefix(target string) (string, bool) {
 // randomize must never be written. Returning a fallback (a counter, a timestamp,
 // the project id) is the one outcome that silently reintroduces derivability at
 // the exact moment the entropy source is broken.
+// PROVISIONAL FOR THE FLEET TARGET. Non-derivability is a mitigation with a
+// planned end, not a permanent property, and the plan lives outside this
+// repository — so it is recorded here rather than only in a merged pull request.
+//
+// It exists because the fleet workspace gate currently admits on octo Space
+// membership alone and then materialises the caller as a member permanently,
+// which turns a readable project_id into permanent membership of every
+// project's workspace. The Loop integration narrows that gate: for
+// octo-server-owned projects the fleet side stops reading its own member table
+// and asks octo-server instead, requiring Space member AND Project member. The
+// two inbound endpoints that make that possible are PR #852.
+//
+// When that narrowing ships, the agreed change is:
+//
+//	the FLEET container id becomes project_id (one canonical UUID, no mapping),
+//	and the non-derivability guard narrows to apply to DRIVE ONLY.
+//
+// Drive is NOT carried along by that decision — its threat model is separate and
+// this argument may still hold there, so it gets re-decided on its own evidence.
+//
+// Until then nothing changes, and nothing may: no target can be enabled before
+// the precondition this slice already records. See
+// .octospec/tasks/project-provisioning-followups/brief.md (D-1).
 func newContainerID(target string) (string, error) {
 	prefix, ok := containerIDPrefix(target)
 	if !ok {

--- a/modules/project/provisioning_guard_test.go
+++ b/modules/project/provisioning_guard_test.go
@@ -694,6 +694,12 @@ func provisioningDocFiles(t *testing.T) []string {
 		"pkg/octosign/*.go",
 		".octospec/tasks/project-p2-subsystem-integration/*.md",
 		".octospec/tasks/project-p2-subsystem-integration/*.yaml",
+		// The follow-up handover brief is the same file class both historical
+		// defects occurred in — a document an operator is told to read before
+		// enabling a target, carrying file:line pins into this slice's code. It is
+		// enrolled here so those pins are checked mechanically rather than by
+		// whoever happens to follow one.
+		".octospec/tasks/project-provisioning-followups/*.md",
 	} {
 		matched, err := filepath.Glob(filepath.Join(root, pattern))
 		if err != nil {
@@ -703,10 +709,11 @@ func provisioningDocFiles(t *testing.T) []string {
 	}
 	// The floor has to sit ABOVE the count that survives losing the task documents, which
 	// are the file class both historical defects occurred in. At 12 it did not: the globs
-	// match 15, three of them are the handover documents, and deleting that directory left
+	// matched 15, three of them the handover documents, and deleting that directory left
 	// the floor passing while the guard silently stopped covering its own subject. A floor
-	// that survives the loss of the subject is not a floor.
-	const minDocFiles = 15
+	// that survives the loss of the subject is not a floor. Raised to 16 with the
+	// follow-up brief, on the same reasoning.
+	const minDocFiles = 16
 	if len(files) < minDocFiles {
 		t.Fatalf("only %d slice text files found, want at least %d; the doc-truth guards would "+
 			"stop covering the handover documents. If files moved, update provisioningDocFiles.",
@@ -1034,4 +1041,31 @@ func someDeclaredNameStartsWith(declared map[string]bool, prefix string) bool {
 		}
 	}
 	return false
+}
+
+// TestInvalidResponseStaysRetryable pins A-3's other half, in the package where
+// the permanence decision actually lives.
+//
+// internal/projectprovision decides the CATEGORY; modules/project decides whether
+// that category is terminal, through permanentProvisioningOutcomes. The client
+// test asserts only the category, so adding "invalid_response" to that map would
+// leave every "retryable" test green — which is the exact regression the client
+// test's name promises to prevent.
+//
+// Why it must stay retryable: an absent container_id is the shape a peer serves
+// while its ensure endpoint is still rolling out, and a 2xx that is not 200 is a
+// peer mid-rollout answering asynchronously. Terminal means abandoned on the
+// first attempt, and abandoned has no automatic re-drive — a human requeue, at
+// exactly the moment the first target is being enabled.
+func TestInvalidResponseStaysRetryable(t *testing.T) {
+	if isPermanentProvisioningOutcome("invalid_response") {
+		t.Fatal("invalid_response must NOT be permanent: it covers a peer whose ensure " +
+			"endpoint is still rolling out, and terminal means abandoned on the first " +
+			"attempt with no automatic re-drive")
+	}
+	// Not vacuous: the map does classify something as permanent.
+	if !isPermanentProvisioningOutcome("container_id_mismatch") {
+		t.Fatal("container_id_mismatch must be permanent; if this fails the guard above " +
+			"is passing because the map is empty")
+	}
 }

--- a/modules/project/provisioning_guard_test.go
+++ b/modules/project/provisioning_guard_test.go
@@ -707,6 +707,19 @@ func provisioningDocFiles(t *testing.T) []string {
 		}
 		files = append(files, matched...)
 	}
+	present := make(map[string]bool, len(files))
+	for _, file := range files {
+		present[file] = true
+	}
+	for _, rel := range []string{
+		".octospec/tasks/project-p2-subsystem-integration/brief.md",
+		".octospec/tasks/project-p2-subsystem-integration/plan.md",
+		".octospec/tasks/project-provisioning-followups/brief.md",
+	} {
+		if !present[filepath.Join(root, rel)] {
+			t.Fatalf("required provisioning handover document %s is not enrolled; update provisioningDocFiles", rel)
+		}
+	}
 	// The floor has to sit ABOVE the count that survives losing the task documents, which
 	// are the file class both historical defects occurred in. At 12 it did not: the globs
 	// matched 15, three of them the handover documents, and deleting that directory left
@@ -1067,5 +1080,22 @@ func TestInvalidResponseStaysRetryable(t *testing.T) {
 	if !isPermanentProvisioningOutcome("container_id_mismatch") {
 		t.Fatal("container_id_mismatch must be permanent; if this fails the guard above " +
 			"is passing because the map is empty")
+	}
+}
+
+// TestProvisioningTimersStayJittered pins A-6 at the scheduling call sites.
+// A behavioural test cannot reliably wait for all four long-running timers, so
+// this source guard covers the exact regression: removing one jitter wrapper.
+func TestProvisioningTimersStayJittered(t *testing.T) {
+	src := readStripped(t, "provisioning_worker.go")
+	for _, want := range []string{
+		"p.ctx.Schedule(jitter(p.cfg.Provisioning.Interval), p.processProvisioningJobs)",
+		"p.ctx.Schedule(jitter(provisioningSweepInterval), p.sweepExhaustedProvisioningJobs)",
+		"p.ctx.Schedule(jitter(provisioningPurgeInterval), p.purgeProvisioningJobs)",
+		"p.ctx.Schedule(jitter(p.cfg.MetricsInterval), p.refreshProvisioningMetrics)",
+	} {
+		if !strings.Contains(src, want) {
+			t.Errorf("provisioning timer lost jitter: %s", want)
+		}
 	}
 }

--- a/modules/project/provisioning_test.go
+++ b/modules/project/provisioning_test.go
@@ -3,6 +3,7 @@ package project
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -1608,6 +1609,32 @@ func TestLoadProvisioningConfig(t *testing.T) {
 		assert.False(t, cfg.Enabled())
 		// Still resolved: the value is reported, not silently dropped.
 		assert.Equal(t, "p-123", cfg.RequeueProjectID)
+	})
+
+	t.Run("the requeue env is refused when all requested targets are rejected", func(t *testing.T) {
+		cfg, problems := loadProvisioningConfig(env(map[string]string{
+			envProvisionTargets:                         "fleet",
+			envProvisionFleetURL:                        "not-a-url",
+			ProvisionFleetSecretEnv:                     okSecretA,
+			"OCTO_PROJECT_PROVISION_REQUEUE_PROJECT_ID": "p-123",
+		}))
+		require.Len(t, problems, 2)
+		assert.Contains(t, problems[0].Error(), "ensure url")
+		assert.Contains(t, problems[1].Error(), "OCTO_PROJECT_PROVISION_REQUEUE_PROJECT_ID")
+		assert.False(t, cfg.Enabled())
+		assert.Equal(t, []string{TargetFleet}, cfg.Misconfigured)
+		assert.Equal(t, problems, cfg.Problems,
+			"the requeue diagnostic must reach the startup logger, not only the return value")
+	})
+
+	t.Run("the disabled requeue diagnostic preserves existing problems", func(t *testing.T) {
+		existing := errors.New("existing target problem")
+		problems := appendDisabledRequeueProblem([]error{existing}, ProvisioningConfig{
+			RequeueProjectID: "p-123",
+		})
+		require.Len(t, problems, 2)
+		assert.ErrorIs(t, problems[0], existing)
+		assert.Contains(t, problems[1].Error(), "OCTO_PROJECT_PROVISION_REQUEUE_PROJECT_ID")
 	})
 
 	t.Run("the retired process-global reclaim env is refused, not ignored", func(t *testing.T) {

--- a/modules/project/provisioning_test.go
+++ b/modules/project/provisioning_test.go
@@ -1620,6 +1620,27 @@ func TestLoadProvisioningConfig(t *testing.T) {
 			"the retired global switch must not authorize purging any target")
 	})
 
+	// A-4 at the LOADER, not only at ValidateTarget. The acceptance item is about
+	// what happens at config load — the target is dropped, recorded in
+	// Misconfigured, and reported through Problems — and that consequence was
+	// covered only by the generic bad-target case below.
+	t.Run("a whitespace-wrapped secret is dropped at config load", func(t *testing.T) {
+		cfg, problems := loadProvisioningConfig(env(map[string]string{
+			envProvisionTargets:     "fleet",
+			envProvisionFleetURL:    "https://fleet.internal/ensure",
+			ProvisionFleetSecretEnv: okSecretA + "\n", // the file-mounted shape
+		}))
+		require.Len(t, problems, 1)
+		assert.Contains(t, problems[0].Error(), "whitespace",
+			"the reason must survive to the boot log; zap.Error prints this verbatim")
+		assert.Empty(t, cfg.Targets,
+			"a secret the peer will reject must not produce a live target: every request "+
+				"would 401 for the whole retry budget and the row would land in abandoned")
+		assert.Equal(t, []string{TargetFleet}, cfg.Misconfigured,
+			"and the gauge must be able to name it")
+		assert.False(t, cfg.Enabled())
+	})
+
 	t.Run("a bad target is dropped, not fatal", func(t *testing.T) {
 		cfg, problems := loadProvisioningConfig(env(map[string]string{
 			envProvisionTargets:     "fleet,drive",

--- a/modules/project/provisioning_test.go
+++ b/modules/project/provisioning_test.go
@@ -1641,6 +1641,22 @@ func TestLoadProvisioningConfig(t *testing.T) {
 		assert.False(t, cfg.Enabled())
 	})
 
+	// The URL is configuration too. ValidateTarget rejects surrounding whitespace,
+	// so the loader must pass the raw value through rather than silently repairing a
+	// configmap typo before validation can report it.
+	t.Run("a whitespace-wrapped ensure URL is dropped at config load", func(t *testing.T) {
+		cfg, problems := loadProvisioningConfig(env(map[string]string{
+			envProvisionTargets:     "fleet",
+			envProvisionFleetURL:    " https://fleet.internal/ensure ",
+			ProvisionFleetSecretEnv: okSecretA,
+		}))
+		require.Len(t, problems, 1)
+		assert.Contains(t, problems[0].Error(), "whitespace")
+		assert.Empty(t, cfg.Targets)
+		assert.Equal(t, []string{TargetFleet}, cfg.Misconfigured)
+		assert.False(t, cfg.Enabled())
+	})
+
 	t.Run("a bad target is dropped, not fatal", func(t *testing.T) {
 		cfg, problems := loadProvisioningConfig(env(map[string]string{
 			envProvisionTargets:     "fleet,drive",

--- a/modules/project/provisioning_worker.go
+++ b/modules/project/provisioning_worker.go
@@ -165,8 +165,14 @@ func (p *Project) startProvisioningWorker() {
 		// first claim tick rather than waiting a full interval.
 		p.requeueAbandonedProvisioningAtBoot()
 		// Jittered, like reconcile.go's two timers. Without it every replica wakes on
-		// the same tick, so the claim query, sweep, and purge contend at once across
-		// the fleet.
+		// the same tick, so the three timers scheduled HERE — the claim query, the
+		// sweep and the purge — contend at once across the fleet.
+		//
+		// The census is a fourth timer and it is NOT one of these: it lives in
+		// startProvisioningMetrics, outside the enablement gate, and that function
+		// carries its own account of why. An earlier version of this comment named
+		// the census here instead of the purge, which put a true sentence on the
+		// wrong function.
 		p.ctx.Schedule(jitter(p.cfg.Provisioning.Interval), p.processProvisioningJobs)
 		p.ctx.Schedule(jitter(provisioningSweepInterval), p.sweepExhaustedProvisioningJobs)
 		p.ctx.Schedule(jitter(provisioningPurgeInterval), p.purgeProvisioningJobs)

--- a/modules/project/provisioning_worker.go
+++ b/modules/project/provisioning_worker.go
@@ -164,9 +164,12 @@ func (p *Project) startProvisioningWorker() {
 		// Before the timers, so rows this moves back to `pending` are visible to the
 		// first claim tick rather than waiting a full interval.
 		p.requeueAbandonedProvisioningAtBoot()
-		p.ctx.Schedule(p.cfg.Provisioning.Interval, p.processProvisioningJobs)
-		p.ctx.Schedule(provisioningSweepInterval, p.sweepExhaustedProvisioningJobs)
-		p.ctx.Schedule(provisioningPurgeInterval, p.purgeProvisioningJobs)
+		// Jittered, like reconcile.go's two timers. Without it every replica wakes on
+		// the same tick, so the claim query, sweep, and purge contend at once across
+		// the fleet.
+		p.ctx.Schedule(jitter(p.cfg.Provisioning.Interval), p.processProvisioningJobs)
+		p.ctx.Schedule(jitter(provisioningSweepInterval), p.sweepExhaustedProvisioningJobs)
+		p.ctx.Schedule(jitter(provisioningPurgeInterval), p.purgeProvisioningJobs)
 	})
 }
 
@@ -225,7 +228,7 @@ func (p *Project) requeueAbandonedProvisioningAtBoot() {
 // over a table that is empty in the default state.
 func (p *Project) startProvisioningMetrics() {
 	provisioningMetricsOnce.Do(func() {
-		p.ctx.Schedule(p.cfg.MetricsInterval, p.refreshProvisioningMetrics)
+		p.ctx.Schedule(jitter(p.cfg.MetricsInterval), p.refreshProvisioningMetrics)
 	})
 }
 

--- a/modules/project/provisioning_worker.go
+++ b/modules/project/provisioning_worker.go
@@ -310,8 +310,8 @@ func (p *Project) processProvisioningJobs() {
 	// other, and the client's short timeout does NOT prevent that — the arithmetic was
 	// simply wrong. With fleet down and a due backlog, every one of a 20-row batch costs
 	// the full 10s timeout, so a batch runs for up to 200s; provisioningRunning makes
-	// every 15s tick in that window a no-op, so healthy drive rows wait behind fleet's
-	// timeouts for minutes.
+	// every scheduled claim tick in that window a no-op, so healthy drive rows wait
+	// behind fleet's timeouts for minutes.
 	//
 	// A per-target quota alone would only BOUND that wait. Separate goroutines remove it:
 	// each target advances at its own pace and an unhealthy one delays nobody. Two


### PR DESCRIPTION
## Summary

This PR closes the six P2 findings intentionally left behind when #850 was squash-merged, records the provisional container-ID decision that the squash lost, and includes the follow-up corrections found while implementing and reviewing those fixes.

### The six #850 follow-ups

1. Reject provisioning secrets with leading or trailing whitespace (A-4).
2. Reject a bare `#` in an ensure URL with the same raw-string check used by the sibling validator (A-5).
3. Classify an absent, empty, or whitespace-only echoed `container_id` as retryable `invalid_response`; a genuinely different ID remains terminal `container_id_mismatch` (A-3).
4. Correct the `Enabled()` contract: disband accounting remains deliberately unconditional (A-1).
5. Jitter all four provisioning timers (A-6).
6. Point the migration runbook at the live `module.Setup` / octo-lib migration path (P2-5).

### Additional fixes found during implementation and review

- The config loader now passes the raw ensure URL to `ValidateTarget`; surrounding whitespace is rejected and reported instead of silently trimmed (P2-8).
- Empty URLs were already rejected by the scheme check at the merge base. This PR only makes that rejection explicit before parsing; it does not claim a new accept/reject behavior for the empty case.
- `Ensure` requires a synchronous HTTP 200. Valid-body 201/202/204 responses are retryable `invalid_response` rather than success (P2-C).
- Decode failures retain a fixed, non-sensitive `Detail` and omit the redundant status (necessarily 200). Non-200 2xx contract failures carry both `Status` and `Detail`; missing-ID failures also carry both.
- JSON `null` and whitespace-only echoed IDs are pinned as retryable malformed responses.
- A boot requeue request now produces a dedicated startup problem whenever no valid target survives configuration, including the all-requested-targets-rejected path.
- The MySQL rollback runbook no longer promises transaction atomicity across `DROP TABLE`; it documents implicit DDL commit and the required retry ordering (P2-A).
- The follow-up brief now keeps the original six findings separate from P2-8 and the later review findings.

Provisioning remains disabled by default through `OCTO_PROJECT_PROVISION_TARGETS`. This PR does not enable a target or relax the peer-side prerequisites recorded by #850.

## Related Issue

Follow-up to #850 (merged as squash `5dd80d46`). No separate issue number.

## Linked Spec

`.octospec/tasks/project-provisioning-followups/brief.md`

## Commits

| Commit | Purpose |
|---|---|
| `fe86cc595` | Record what #850's squash omitted |
| `38181c149` | Close the original six findings |
| `aa6efe264` | Require synchronous 200, reject raw untrimmed config, and correct the record |
| `483121ecc` | Add response-diagnostics reproducers |
| `2cf278c73` | Fix decode diagnostics, whitespace echoes, loader coverage, and jitter guard |
| `fcd238457` | Add the disabled-requeue reproducer |
| `f59a86ca4` | Report requeue requests when no valid target is enabled |
| `727199735` | Align the URL rationale and six-item record with the current head |

## Testing

Current-head local verification:

```text
go test ./internal/projectprovision -count=1                 pass
go test -cover ./internal/projectprovision                   pass, 92.7%
go test -c -o /tmp/octo-project-final.test ./modules/project pass (compile only)
go vet ./internal/projectprovision/ ./modules/project/       pass
gofmt                                                        clean
git diff --check                                             clean
```

The local `modules/project` binary was compiled but not executed: its `TestMain` cleans the shared MySQL `test` schema before encountering an unrelated unknown migration in this workspace. The GitHub CI package/E2E runs are the non-destructive execution evidence for the pushed head.

New or expanded regression coverage includes:

- strict 200 handling for 201/202/204 with valid response bodies;
- raw/untrimmed URL validation at both `ValidateTarget` and config-loader layers;
- absent, empty, whitespace-only, and `null` echoed IDs;
- safe decode-failure details and the retryability map;
- all four jittered schedule sites;
- requeue diagnostics for both an empty target list and an all-invalid requested target set;
- doc-truth enrollment for the follow-up brief.

## COMPREHENSION

### 1. What changes on the load-bearing path?

`ValidateTarget` remains the gate deciding whether a configured integration becomes live. Invalid secret/URL configuration now drops the target and emits boot diagnostics instead of creating a target that repeatedly fails. `Ensure` only marks a row ready after the peer synchronously returns 200 with the expected non-empty container ID. Retryable malformed responses remain recoverable instead of becoming first-attempt terminal abandonment.

### 2. What could break?

- A deployment carrying whitespace-wrapped credentials or URLs will have that target disabled at boot rather than attempting requests.
- A peer that intentionally returns 202 will now be retried and can eventually reach `abandoned`; the published contract requires synchronous 200.
- Provisioning and census timer phase changes because scheduling is jittered.
- `last_error` text changes for malformed response cases; it remains bounded and does not include peer body bytes.

### 3. How is it verified?

Each changed decision has a focused regression. Response tests isolate status from body validity, loader tests cover deployed env behavior, the permanence test asserts `invalid_response` remains retryable, and source guards pin timer jitter and document enrollment. Current-head local results are listed above; CI provides full package/E2E execution.

## For a human to verify before merge

1. No deployment relies on a whitespace-wrapped provisioning secret or URL.
2. Each peer returns synchronous 200 with the requested `container_id`, never 202 for a successfully accepted request.
3. Pre-existing design boundary: `http://` and private destinations remain permitted, so a target must not be enabled until the peer-side authorization and transport assumptions recorded by #850 are accepted.

## Checklist

- [x] Read `CONTRIBUTING.md`
- [x] PR description is in English
- [x] Added tests for behavioral changes
- [x] Updated the linked spec and operator record
- [x] Used Conventional Commits
