### PR TITLE
fix: address AI team review findings

### DIFF
--- a/.octospec/journal/shared/my-ai-team-sessions.md
+++ b/.octospec/journal/shared/my-ai-team-sessions.md
@@ -126,3 +126,16 @@ source: self
 - The deprecated recent-conversation response and operational analytics now hide
   protected parents and session threads too, including stale analytics dimensions
   created before a group acquired the protected purpose.
+
+## Review-fix stacked PR
+
+- Applied the hidden-container predicate to the two shared group aggregates used
+  by the manager list and statistics dashboard, keeping enumeration and totals on
+  the same population.
+- Initialized both page result slices so a zero-row query preserves the wire
+  contract as `items: []` rather than `items: null`.
+- Kept soft-deleted sessions in the durable idempotency ledger and made same-key
+  replay return the existing conflict response explicitly.
+- Restricted automatic title extraction to text messages. Structured content now
+  uses established content-type display text, so media metadata cannot become a
+  session title.

--- a/.octospec/learnings/pending/my-ai-team-sessions.md
+++ b/.octospec/learnings/pending/my-ai-team-sessions.md
@@ -27,3 +27,19 @@ When one handler set is mounted on multiple authentication faces or resource
 scopes, enforce protected-resource policy inside the shared authorization
 funnel, after the caller's membership is established. This covers the whole
 route family and avoids leaking the protected purpose to unaffiliated callers.
+
+# Keep paired contracts aligned
+
+When a product predicate hides rows from an enumeration, trace every aggregate
+used beside or above that enumeration. A filtered list with an unfiltered count
+creates impossible pages and misleading dashboards even though each query is
+locally valid.
+
+Durable idempotency keys also need an explicit terminal-state replay contract.
+If deletion keeps the ledger row, detect its tombstoned resource and return a
+stable conflict; do not let replay fall through to a lookup that necessarily
+returns not found.
+
+For JSON paging contracts, initialize empty result slices before ORM loading.
+Many ORMs leave a nil destination unchanged on zero rows, turning `[]` into
+`null` at the wire.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -2552,3 +2552,11 @@ SQL 注释里一个撇号破坏了它的朴素语句分割；P0 的游标覆盖�
 - 继续关闭第六轮发现的路由族缺口：四组 incoming-webhook 管理挂载统一在成员鉴权后拒绝
   AI 容器；旧版最近会话和运营看板也不再展示容器、thread 或成员明细。
 - 完整 `incomingwebhook`、`message`、`opanalytics` 套件通过。
+
+## 2026-09-08 — my-ai-team-sessions（PR #848 独立 review-fix）
+
+- 管理列表与统计面板的群总数统一排除 AI 容器，修复可见列表与聚合口径不一致。
+- 空 agent/session 页固定输出 `items: []`；软删除 session 的幂等 key 重放明确返回 409。
+- 非文本消息不再把原始结构化 payload 写入 session 标题，改用已有内容类型展示文案。
+- build、全仓 vet、AI Team 全包和 Robot 聚焦测试通过；Group DB 回归保留给干净数据库 CI，
+  本机共享库的 migration 账本包含当前分支不存在的旧迁移，未为跑绿而破坏共享状态。

--- a/.octospec/tasks/my-ai-team-sessions/verification.md
+++ b/.octospec/tasks/my-ai-team-sessions/verification.md
@@ -165,3 +165,30 @@ verified by this server checkout.
 
 `golangci-lint` is not installed in the local environment; `go vet ./...` and the
 repository's build/test/i18n checks were used instead.
+
+## Stacked review-fix verification on 2026-09-08
+
+The follow-up branch closes the four findings reported against `808f1257`:
+
+- manager and statistics group totals now apply the same AI-container predicate
+  as their visible rows;
+- empty agent and session pages encode `items` as `[]`;
+- replaying a retained idempotency key after soft deletion returns the existing
+  409 idempotency-conflict envelope instead of a permanent 404;
+- automatic titles use raw `content` only for text and established display text
+  for structured message types.
+
+Final gates:
+
+- `go build ./...`: PASS.
+- `go vet ./...`: PASS.
+- `go test ./modules/ai_team -count=1`: PASS.
+- focused AI-title tests in `modules/robot`: PASS.
+- `go test ./modules/group ./modules/statistics -run '^$' -count=1`: PASS.
+- `git diff --check`: PASS.
+- The DB-backed `TestManagerGroupQueriesExcludeAIContainers` could not execute
+  locally because the shared `test.gorp_migrations` ledger contains migrations
+  absent from this PR branch (`robot_legacy01.sql`). The package compiles, the
+  new assertions are retained for clean-database CI, and no shared database state
+  was destructively rewritten to hide the environment mismatch.
+- `golangci-lint` is unavailable in this environment.

--- a/modules/ai_team/api_test.go
+++ b/modules/ai_team/api_test.go
@@ -129,8 +129,11 @@ func decodeJSON(t *testing.T, w *httptest.ResponseRecorder, out any) {
 
 func TestAITeamAgentLifecycleAndSessionIdempotency(t *testing.T) {
 	f := seedFixture(t)
+	w := request(t, f, http.MethodGet, "/v1/ai-team/agents", "", nil)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), `"items":[]`)
 
-	w := request(t, f, http.MethodPost, "/v1/ai-team/agents/"+f.botID, "", nil)
+	w = request(t, f, http.MethodPost, "/v1/ai-team/agents/"+f.botID, "", nil)
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 	var first struct {
 		BotID   string `json:"bot_id"`
@@ -142,6 +145,9 @@ func TestAITeamAgentLifecycleAndSessionIdempotency(t *testing.T) {
 
 	w = request(t, f, http.MethodPost, "/v1/ai-team/agents/"+f.botID, "", nil)
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	w = request(t, f, http.MethodGet, "/v1/ai-team/agents/"+f.botID+"/sessions", "", nil)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), `"items":[]`)
 
 	w = request(t, f, http.MethodPost, "/v1/ai-team/agents/"+f.botID+"/sessions", "idem-1", map[string]string{"name": "First"})
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
@@ -399,6 +405,9 @@ func TestAITeamSessionPersonalControls(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 	w = request(t, f, http.MethodGet, "/v1/ai-team/sessions/"+first.SessionID, "", nil)
 	assert.Equal(t, http.StatusNotFound, w.Code, w.Body.String())
+	w = request(t, f, http.MethodPost, "/v1/ai-team/agents/"+f.botID+"/sessions", "controls-1", map[string]string{"name": "First"})
+	assert.Equal(t, http.StatusConflict, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "err.server.ai_team.idempotency_conflict")
 	var status int
 	require.NoError(t, testContext.DB().Select("status").From("thread").Where("short_id=?", first.SessionID).LoadOne(&status))
 	assert.Equal(t, 3, status, "session deletion must remain a recoverable DB soft delete")

--- a/modules/ai_team/service.go
+++ b/modules/ai_team/service.go
@@ -202,7 +202,7 @@ func (s *Service) ListAgents(spaceID, userUID string, beforeID int64, limit int)
 	if beforeID > 0 {
 		q = q.Where("a.id<?", beforeID)
 	}
-	var rows []*Agent
+	rows := make([]*Agent, 0)
 	_, err := q.Load(&rows)
 	if err != nil {
 		return nil, err
@@ -302,6 +302,12 @@ func (s *Service) CreateSession(spaceID, userUID, botID, idempotencyKey, name st
 		return nil, err
 	}
 	if existing != nil && existing.RequestHash != requestHash {
+		return nil, errIdempotencyConflict
+	}
+	// A deleted thread remains part of the durable idempotency ledger. Reusing
+	// its key must fail explicitly instead of falling through to GetSession and
+	// turning a create replay into a permanent not-found response.
+	if existing != nil && existing.Status == thread.ThreadStatusDeleted {
 		return nil, errIdempotencyConflict
 	}
 	if existing == nil {
@@ -465,7 +471,7 @@ func (s *Service) ListSessions(spaceID, userUID, botID string, statuses []int, p
 	if len(statuses) == 0 {
 		statuses = []int{thread.ThreadStatusActive}
 	}
-	var rows []*Session
+	rows := make([]*Session, 0)
 	_, err := s.ctx.DB().Select(
 		"ats.id", "ats.agent_id", "ats.short_id", "ats.state", "ats.manual_title",
 		"t.group_no", "t.name", "t.status", "t.message_count", "t.last_message_content",

--- a/modules/group/api_manager_test.go
+++ b/modules/group/api_manager_test.go
@@ -40,6 +40,9 @@ func TestManagerGroupQueriesExcludeAIContainers(t *testing.T) {
 	count, err := managerDB.queryGroupCountWithKeyWord("manager query")
 	require.NoError(t, err)
 	assert.EqualValues(t, 1, count)
+	count, err = db.queryGroupCount()
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, count)
 	count, err = managerDB.queryGroupCountWithStatus(GroupStatusNormal)
 	require.NoError(t, err)
 	assert.EqualValues(t, 1, count)
@@ -54,6 +57,17 @@ func TestManagerGroupQueriesExcludeAIContainers(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, list, 1)
 	assert.Equal(t, "manager-visible", list[0].GroupNo)
+	count, err = db.queryCreatedCountWithDate(today)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, count)
+
+	service := NewService(ctx)
+	count, err = service.GetAllGroupCount()
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, count, "statistics total must use the product-visible group population")
+	count, err = service.GetCreatedCountWithDate(today)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, count, "statistics daily total must use the product-visible group population")
 }
 
 func TestGroupList(t *testing.T) {

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/db"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	aiteampkg "github.com/Mininglamp-OSS/octo-server/pkg/aiteam"
 	"github.com/gocraft/dbr/v2"
 )
 
@@ -731,14 +732,14 @@ func (d *DB) QueryMemberCount(groupNo string) (int64, error) {
 // 查询群总数
 func (d *DB) queryGroupCount() (int64, error) {
 	var count int64
-	_, err := d.session.Select("count(*)").From("`group`").Load(&count)
+	_, err := d.session.Select("count(*)").From("`group`").Where("purpose<>?", aiteampkg.GroupPurpose).Load(&count)
 	return count, err
 }
 
 // 查询某天的新建群数量
 func (d *DB) queryCreatedCountWithDate(date string) (int64, error) {
 	var count int64
-	_, err := d.session.Select("count(*)").From("`group`").Where("date_format(created_at,'%Y-%m-%d')=?", date).Load(&count)
+	_, err := d.session.Select("count(*)").From("`group`").Where("date_format(created_at,'%Y-%m-%d')=? and purpose<>?", date, aiteampkg.GroupPurpose).Load(&count)
 	return count, err
 }
 

--- a/modules/robot/event.go
+++ b/modules/robot/event.go
@@ -158,7 +158,7 @@ func (rb *Robot) robotMessageListen(messages []*config.MessageResp) {
 			} else if resolved != nil {
 				aiTarget = resolved
 				robotID = resolved.BotID
-				rb.maybeSetAISessionTitle(resolved, payloadValue.Get("content").String())
+				rb.maybeSetAISessionTitle(resolved, aiSessionTitleFromPayload(message.Payload, payloadValue.Get("type").Int()))
 			}
 		}
 		// aisBroadcastSet captures the robotIDs that were added to
@@ -495,6 +495,16 @@ func isAITeamUserContentType(contentType int64) bool {
 		return true
 	}
 	return contentType == int64(cardmsg.InteractiveCard)
+}
+
+func aiSessionTitleFromPayload(payload []byte, contentType int64) string {
+	if contentType == int64(common.Text) {
+		return gjson.GetBytes(payload, "content").String()
+	}
+	if contentType == int64(cardmsg.InteractiveCard) {
+		return cardmsg.DisplayText()
+	}
+	return common.GetDisplayText(int(contentType))
 }
 
 func (rb *Robot) maybeSetAISessionTitle(target *aiteampkg.SessionTarget, content string) {

--- a/modules/robot/event_test.go
+++ b/modules/robot/event_test.go
@@ -35,6 +35,25 @@ func TestAITeamUserContentTypeAllowlist(t *testing.T) {
 	}
 }
 
+func TestAISessionTitleFromPayloadDoesNotUseStructuredContent(t *testing.T) {
+	tests := []struct {
+		name        string
+		payload     string
+		contentType int64
+		want        string
+	}{
+		{name: "text uses content", payload: `{"type":1,"content":"First question"}`, contentType: int64(common.Text), want: "First question"},
+		{name: "image uses display text", payload: `{"type":2,"content":{"url":"https://example.com/private.png"}}`, contentType: int64(common.Image), want: common.GetDisplayText(common.Image.Int())},
+		{name: "interactive card uses placeholder", payload: `{"type":17,"plain":"untrusted title"}`, contentType: int64(cardmsg.InteractiveCard), want: cardmsg.DisplayText()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, aiSessionTitleFromPayload([]byte(tt.payload), tt.contentType))
+		})
+	}
+}
+
 // TestExtractBotCommand tests the bot command extraction logic with bounds checking.
 // This test addresses issue #251 where malformed offset/length values could cause panic.
 func TestExtractBotCommand(t *testing.T) {


### PR DESCRIPTION
## Summary

Close all four actionable findings from the automated review of #848 in a separate follow-up branch and PR. The original PR head remains unchanged.

## Related Issue

- Follow-up to #848.
- Closes #849.

## Linked Spec

- `.octospec/tasks/my-ai-team-sessions/brief.md`

## Changes

- Keep manager and statistics group counts aligned with AI-container-filtered lists.
- Serialize empty agent/session pages as arrays.
- Return an explicit idempotency conflict when replaying a key whose session was soft-deleted.
- Derive non-text automatic session titles from established display text instead of raw payload data.
- Add regression coverage and verification records.

## Testing

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./modules/ai_team -count=1`
- [x] Focused AI-title tests in `modules/robot`
- [x] Group and statistics packages compile
- [ ] DB-backed group regression locally (blocked by a stale shared `test.gorp_migrations` ledger; retained for clean-database CI)
- [ ] `golangci-lint` (not installed locally)

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**

   It aligns hidden-container aggregates with their enumerations, preserves JSON collection shape, makes retained idempotency keys return a deterministic 409 after session deletion, and prevents structured payloads from becoming session titles.

2. **What could break because of it (dependents + failure mode)?**

   Manager/statistics totals intentionally decrease by the number of protected containers. Clients reusing a deleted session key now receive 409 instead of 404. Non-text session titles become stable type labels rather than payload-derived strings.

3. **How do you know it works (specific test/repro/trace)?**

   API integration tests cover empty pages and deleted-key replay; Robot unit tests cover text/image/card title derivation; group regressions assert both DB aggregates and their statistics-facing service methods exclude protected containers. Build and vet pass across the repository.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated verification and octospec records
- [x] Followed commit message conventions (Conventional Commits)