### PR TITLE
feat(auth): expose bot hosting and owner project context

### DIFF
--- a/.octospec/tasks/eva-loop-assistants/brief.md
+++ b/.octospec/tasks/eva-loop-assistants/brief.md
@@ -1,0 +1,61 @@
+# EVA Loop assistants — identity facts for local assistants
+
+## Goal
+
+Expose the identity facts Fleet needs to authorize a human's own self_hosted
+assistants, regardless of execution platform. Assistants do not join Projects.
+
+Related issue: Mininglamp-OSS/octo-server#857.
+
+## Load-bearing list
+
+- Session robot/owned_bots adds agent_hosting directly to its existing four fields;
+  no include=agent_metadata switch and no agent_platform dependency.
+- verify-bot opt-in owner_context, bound to the actual Bot credential.
+- Separate Bot/owner identity and current Space/Project facts; fail closed on lookup errors.
+
+## Out of scope
+
+- Changing generic bot-task transport into a Loop-specific service.
+- Project membership/role/cascade/governance changes and migrations.
+- Fleet Agent/Runtime/installation creation for assistants.
+- Shared-service deployments and changes to user credentials.
+
+## Acceptance
+
+- Existing owned Bot display fields and Session authentication stay available;
+  the default list includes hosting and excludes disabled Bot accounts.
+- Default verify-bot keeps its five fields. Only include=owner_context enables
+  the credential-bound owner/Project facts; do not split this callback into a new API.
+- Explicit owner queries bind identity, validate accounts/Space and expose only
+  requested Project facts; absent/failed context grants nothing.
+- Queries do not read agent_platform; existing IM storage/reporting is untouched.
+  Fleet, not Server, classifies Loop assistants.
+- Focused regression tests and broader auth/project/group checks are recorded in
+  the workspace implementation report.
+
+## Files and verification
+
+Project policy remains unchanged; identity context stays in modules/user and robot.
+Reuse existing DB sessions, membership queries, errors and test helpers.
+
+### API contract
+
+- `GET /v1/robot/owned_bots?space_id=...` uses the authenticated owner and the
+  requested Space. Every item contains `uid`, `name`, `description`,
+  `bot_commands`, and `agent_hosting`; no metadata query switch is required.
+- `POST /v1/auth/verify-bot?include=owner_context` accepts `bot_token`,
+  `space_id`, and a bounded list of `project_ids`. It derives the owner from
+  the validated credential and rejects a caller-supplied `owner_uid`.
+- The extension returns `bot_context` (identity, active state, hosting and
+  Space membership) separately from `owner_context` (identity, active state,
+  Space membership and answers for the requested Projects). Owner membership
+  must never be represented as the Bot's own Project membership.
+- A failed context lookup sets `context_error` and omits both contexts;
+  inactive identities or missing Space membership disclose no Project roles.
+- Without `include=owner_context`, the original verifier's five fields and
+  legacy `space_id` remain unchanged. Hosting is returned as a fact, not used
+  here to classify or authorize downstream assistant operations.
+
+Tests cover default compatibility, account/Space isolation, spoofed owner
+rejection, Project bounds, lookup failures, and independence from platform data.

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -1976,22 +1976,24 @@ func (rb *Robot) ownedBots(c *wkhttp.Context) {
 	}
 
 	// creator_uid=loginUID 与 space_id 双重过滤即 space 隔离点，均为占位符，不可绕过。
-	// 仅暴露 uid/name/description/bot_commands，绝不返回 token/凭据。
+	// 托管类型是通用 Bot 事实；由消费方决定用途，绝不返回 token/凭据。
 	type ownedBotRow struct {
-		UID         string `db:"uid"`
-		Name        string `db:"name"`
-		Description string `db:"description"`
-		BotCommands string `db:"bot_commands"`
+		UID          string `db:"uid"`
+		Name         string `db:"name"`
+		Description  string `db:"description"`
+		BotCommands  string `db:"bot_commands"`
+		AgentHosting string `db:"agent_hosting"`
 	}
 	var bots []ownedBotRow
 	_, err = rb.ctx.DB().SelectBySql(`
 		SELECT r.robot_id as uid, IFNULL(u.name,'') as name,
 			IFNULL(r.description,'') as description,
-			IFNULL(r.bot_commands,'') as bot_commands
+			IFNULL(r.bot_commands,'') as bot_commands,
+			IFNULL(r.agent_hosting,'') as agent_hosting
 		FROM robot r
 		INNER JOIN user u ON u.uid = r.robot_id AND u.robot = 1
 		INNER JOIN space_member sm ON sm.uid = r.robot_id AND sm.space_id = ? AND sm.status = 1
-		WHERE r.creator_uid = ? AND r.status = 1
+		WHERE r.creator_uid = ? AND r.status = 1 AND u.status = 1
 		ORDER BY r.created_at DESC
 	`, spaceID, loginUID).Load(&bots)
 	if err != nil {
@@ -2002,12 +2004,14 @@ func (rb *Robot) ownedBots(c *wkhttp.Context) {
 
 	results := make([]map[string]interface{}, 0, len(bots))
 	for _, b := range bots {
-		results = append(results, map[string]interface{}{
-			"uid":          b.UID,
-			"name":         b.Name,
-			"description":  b.Description,
-			"bot_commands": b.BotCommands,
-		})
+		item := map[string]interface{}{
+			"uid":           b.UID,
+			"name":          b.Name,
+			"description":   b.Description,
+			"bot_commands":  b.BotCommands,
+			"agent_hosting": b.AgentHosting,
+		}
+		results = append(results, item)
 	}
 	c.Response(results)
 }

--- a/modules/robot/api_owned_bots_metadata_test.go
+++ b/modules/robot/api_owned_bots_metadata_test.go
@@ -1,0 +1,154 @@
+package robot
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// Exercises the actual handler and MySQL joins. Authentication is deliberately
+// injected: this is not a replacement for the Session/Redis middleware suite.
+// Only the randomly named database created here is changed or dropped.
+func TestOwnedBotsMetadataMySQLContract(t *testing.T) {
+	dsn := os.Getenv("OCTO_ASSISTANT_TEST_MYSQL_DSN")
+	if dsn == "" {
+		t.Skip("set OCTO_ASSISTANT_TEST_MYSQL_DSN for an isolated MySQL server")
+	}
+	dbConfig, err := mysql.ParseDSN(dsn)
+	require.NoError(t, err)
+	dbConfig.DBName = "information_schema"
+	bootstrap, err := sql.Open("mysql", dbConfig.FormatDSN())
+	require.NoError(t, err)
+	bootstrap.SetMaxOpenConns(2)
+	bootstrap.SetMaxIdleConns(1)
+	t.Cleanup(func() { require.NoError(t, bootstrap.Close()) })
+	require.NoError(t, bootstrap.Ping())
+	databaseName := "octo_assistant_" + util.GenerUUID()[:12]
+	_, err = bootstrap.Exec("CREATE DATABASE `" + databaseName + "` CHARACTER SET utf8mb4")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, err := bootstrap.Exec("DROP DATABASE `" + databaseName + "`")
+		require.NoError(t, err)
+	})
+	dbConfig.DBName = databaseName
+	cfg := config.New()
+	cfg.DB.MySQLAddr = dbConfig.FormatDSN()
+	cfg.DB.MySQLMaxOpenConns = 2
+	cfg.DB.MySQLMaxIdleConns = 1
+	ctx := testutil.NewTestContext(cfg)
+	database := ctx.DB().DB
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	exec := func(query string, args ...any) {
+		t.Helper()
+		_, err := database.Exec(query, args...)
+		require.NoError(t, err)
+	}
+	// Minimal projections of the production tables; migration coverage is a
+	// separate concern. No shared schema or testutil.CleanAllTables is used.
+	exec("CREATE TABLE space (space_id VARCHAR(40) PRIMARY KEY, status INT NOT NULL)")
+	exec("CREATE TABLE space_member (space_id VARCHAR(40), uid VARCHAR(40), status INT NOT NULL, PRIMARY KEY(space_id,uid))")
+	exec("CREATE TABLE user (uid VARCHAR(40) PRIMARY KEY, name VARCHAR(40), robot INT NOT NULL, status INT NOT NULL)")
+	exec("CREATE TABLE robot (robot_id VARCHAR(40) PRIMARY KEY, creator_uid VARCHAR(40), status INT NOT NULL, description TEXT, bot_commands TEXT, agent_platform VARCHAR(40), agent_hosting VARCHAR(40), created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)")
+	exec("INSERT INTO space VALUES ('space-a',1),('space-b',1)")
+	exec("INSERT INTO space_member VALUES ('space-a','owner',1),('space-b','owner',1),('space-a','other-owner',1)")
+	for _, bot := range []struct {
+		uid, owner, space, platform, hosting         string
+		userStatus, robotStatus, memberStatus, robot int
+	}{
+		{"local", "owner", "space-a", "OpenClaw", "self_hosted", 1, 1, 1, 1},
+		{"cloud", "owner", "space-a", "OpenClaw", "octo_hosted", 1, 1, 1, 1},
+		{"other-platform", "owner", "space-a", "Codex", "self_hosted", 1, 1, 1, 1},
+		{"no-platform", "owner", "space-a", "", "self_hosted", 1, 1, 1, 1},
+		{"unknown-platform", "owner", "space-a", "custom-runtime", "self_hosted", 1, 1, 1, 1},
+		{"foreign", "other-owner", "space-a", "OpenClaw", "self_hosted", 1, 1, 1, 1},
+		{"other-space", "owner", "space-b", "OpenClaw", "self_hosted", 1, 1, 1, 1},
+		{"disabled-user", "owner", "space-a", "OpenClaw", "self_hosted", 0, 1, 1, 1},
+		{"disabled-robot", "owner", "space-a", "OpenClaw", "self_hosted", 1, 0, 1, 1},
+		{"removed-bot", "owner", "space-a", "OpenClaw", "self_hosted", 1, 1, 0, 1},
+		{"human", "owner", "space-a", "OpenClaw", "self_hosted", 1, 1, 1, 0},
+	} {
+		exec("INSERT INTO user VALUES (?,?,?,?)", bot.uid, bot.uid, bot.robot, bot.userStatus)
+		exec("INSERT INTO robot(robot_id,creator_uid,status,description,bot_commands,agent_platform,agent_hosting) VALUES (?,?,?,'description','[]',?,?)", bot.uid, bot.owner, bot.robotStatus, bot.platform, bot.hosting)
+		exec("INSERT INTO space_member VALUES (?,?,?)", bot.space, bot.uid, bot.memberStatus)
+	}
+	// Prove the entire endpoint works without querying the unrelated platform column.
+	exec("ALTER TABLE robot DROP COLUMN agent_platform")
+	rb := &Robot{ctx: ctx, Log: log.NewTLog("OwnedBotsMetadataTest")}
+	router := wkhttp.New()
+	router.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	loginUID := "owner"
+	router.GET("/v1/robot/owned_bots", func(c *wkhttp.Context) {
+		c.Set("uid", loginUID)
+		rb.ownedBots(c)
+	})
+	get := func(query string) *httptest.ResponseRecorder {
+		t.Helper()
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, httptest.NewRequest("GET", "/v1/robot/owned_bots"+query, nil))
+		return w
+	}
+	for _, tc := range []struct {
+		name, query string
+		want        []string
+	}{
+		{"default includes hosting", "?space_id=space-a", []string{"local", "cloud", "other-platform", "no-platform", "unknown-platform"}},
+		{"unknown include is ignored", "?space_id=space-a&include=future", []string{"local", "cloud", "other-platform", "no-platform", "unknown-platform"}},
+		{"old include cannot change owner", "?space_id=space-a&include=agent_metadata&owner_uid=other-owner", []string{"local", "cloud", "other-platform", "no-platform", "unknown-platform"}},
+		{"space-bound", "?space_id=space-b", []string{"other-space"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := get(tc.query)
+			require.Equal(t, 200, w.Code, w.Body.String())
+			var rows []map[string]any
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &rows))
+			var ids []string
+			for _, row := range rows {
+				require.Len(t, row, 5)
+				ids = append(ids, row["uid"].(string))
+				for _, field := range []string{"uid", "name", "description", "bot_commands"} {
+					require.Contains(t, row, field)
+				}
+				require.NotContains(t, row, "agent_platform")
+				require.NotEmpty(t, row["agent_hosting"])
+			}
+			require.ElementsMatch(t, tc.want, ids)
+		})
+	}
+	assertDenied := func(query string, semanticStatus int) {
+		t.Helper()
+		w := get(query)
+		require.Equal(t, 400, w.Code, w.Body.String()) // Legacy D14 envelope.
+		var envelope struct {
+			Error struct {
+				HTTPStatus int `json:"http_status"`
+			} `json:"error"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+		require.Equal(t, semanticStatus, envelope.Error.HTTPStatus, w.Body.String())
+		require.NotContains(t, w.Body.String(), "agent_hosting")
+	}
+	assertDenied("", 400)
+	assertDenied("?space_id=unknown", 403)
+	loginUID = "outsider"
+	assertDenied("?space_id=space-a", 403)
+	loginUID = "owner"
+	exec("UPDATE space_member SET status=0 WHERE space_id='space-a' AND uid='owner'")
+	assertDenied("?space_id=space-a", 403)
+	exec("UPDATE space_member SET status=1 WHERE space_id='space-a' AND uid='owner'")
+	exec("UPDATE space SET status=0 WHERE space_id='space-a'")
+	assertDenied("?space_id=space-a", 403)
+	exec("UPDATE space SET status=1 WHERE space_id='space-a'")
+	exec("ALTER TABLE robot RENAME COLUMN agent_hosting TO missing_hosting")
+	assertDenied("?space_id=space-a", 500)
+}

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -5090,15 +5090,22 @@ func (u *User) queryUserSpaceContext(uid string) ([]string, map[string][]string,
 }
 
 type authVerifyBotReq struct {
-	BotToken string `json:"bot_token"`
+	BotToken   string   `json:"bot_token"`
+	SpaceID    string   `json:"space_id"`
+	ProjectIDs []string `json:"project_ids"`
+	OwnerUID   string   `json:"owner_uid"` // Rejected on the opt-in path; never an authority.
 }
 
 type authVerifyBotResp struct {
-	BotUID    string `json:"bot_uid"`
-	BotName   string `json:"bot_name"`
-	OwnerUID  string `json:"owner_uid"`
-	OwnerName string `json:"owner_name"`
-	SpaceID   string `json:"space_id"`
+	BotUID          string                 `json:"bot_uid"`
+	BotName         string                 `json:"bot_name"`
+	OwnerUID        string                 `json:"owner_uid"`
+	OwnerName       string                 `json:"owner_name"`
+	SpaceID         string                 `json:"space_id"`
+	ContextIncluded bool                   `json:"context_included,omitempty"`
+	ContextError    bool                   `json:"context_error,omitempty"`
+	BotContext      *verifyBotContext      `json:"bot_context,omitempty"`
+	OwnerContext    *verifyBotOwnerContext `json:"owner_context,omitempty"`
 }
 
 // authVerifyBot validates a Bot token (BotFather Bearer token) and returns bot + owner info.
@@ -5111,6 +5118,11 @@ func (u *User) authVerifyBot(c *wkhttp.Context) {
 	}
 	if req.BotToken == "" {
 		respondUserTokenRequired(c, "bot_token")
+		return
+	}
+	if c.Query("include") == "owner_context" &&
+		(req.SpaceID == "" || req.OwnerUID != "" || len(req.ProjectIDs) > maxVerifyProjectIDs) {
+		respondUserRequestInvalid(c, "owner_context")
 		return
 	}
 
@@ -5152,13 +5164,26 @@ func (u *User) authVerifyBot(c *wkhttp.Context) {
 		Limit(1).
 		LoadOne(&spaceID)
 
-	c.Response(authVerifyBotResp{
+	resp := authVerifyBotResp{
 		BotUID:    botInfo.RobotID,
 		BotName:   botName,
 		OwnerUID:  botInfo.CreatorUID,
 		OwnerName: ownerName,
 		SpaceID:   spaceID,
-	})
+	}
+	if c.Query("include") == "owner_context" {
+		if err := u.fillBotProjectContext(&resp, req); err != nil {
+			if errors.Is(err, errTooManyProjectIDs) {
+				respondUserRequestInvalid(c, "project_ids")
+				return
+			}
+			u.Warn("authVerifyBot context lookup failed", zap.Error(err))
+			resp.ContextError = true
+			resp.BotContext = nil
+			resp.OwnerContext = nil
+		}
+	}
+	c.Response(resp)
 }
 
 type authVerifyAPIKeyReq struct {

--- a/modules/user/api_bot_project_context.go
+++ b/modules/user/api_bot_project_context.go
@@ -1,0 +1,72 @@
+package user
+
+import "github.com/gocraft/dbr/v2"
+
+// These are identity/membership facts, not delegated permissions. Owner projects
+// are not the Bot's seats and are never emitted as top-level projects.
+type verifyBotContext struct {
+	UID          string `json:"uid"`
+	Active       bool   `json:"active"`
+	AgentHosting string `json:"agent_hosting"`
+	SpaceID      string `json:"space_id"`
+	SpaceMember  bool   `json:"space_member"`
+}
+
+type verifyBotOwnerContext struct {
+	UID         string                `json:"uid"`
+	Active      bool                  `json:"active"`
+	SpaceID     string                `json:"space_id"`
+	SpaceMember bool                  `json:"space_member"`
+	Projects    []verifyProjectAnswer `json:"projects"`
+}
+
+// Deliberately uncached. No platform/hosting filter belongs in a general identity query.
+func (u *User) fillBotProjectContext(resp *authVerifyBotResp, req authVerifyBotReq) error {
+	resp.ContextIncluded = true
+	if len(req.ProjectIDs) > maxVerifyProjectIDs {
+		return errTooManyProjectIDs
+	}
+	bot := &verifyBotContext{UID: resp.BotUID, SpaceID: req.SpaceID}
+	owner := &verifyBotOwnerContext{UID: resp.OwnerUID, SpaceID: req.SpaceID}
+	resp.BotContext, resp.OwnerContext = bot, owner
+	var facts struct {
+		Hosting     string `db:"hosting"`
+		BotActive   bool   `db:"bot_active"`
+		OwnerActive bool   `db:"owner_active"`
+		BotMember   bool   `db:"bot_member"`
+		OwnerMember bool   `db:"owner_member"`
+	}
+	err := u.db.session.SelectBySql(
+		"SELECT IFNULL(r.agent_hosting,'') AS hosting, "+
+			"(bu.status = 1 AND bu.robot = 1) AS bot_active, (ou.status = 1 AND ou.robot = 0) AS owner_active, "+
+			"(s.space_id IS NOT NULL AND bm.uid IS NOT NULL) AS bot_member, "+
+			"(s.space_id IS NOT NULL AND om.uid IS NOT NULL) AS owner_member "+
+			"FROM robot r JOIN `user` bu ON bu.uid = r.robot_id JOIN `user` ou ON ou.uid = r.creator_uid "+
+			"LEFT JOIN space s ON s.space_id = ? AND s.status = 1 "+
+			"LEFT JOIN space_member bm ON bm.space_id = s.space_id AND bm.uid = bu.uid AND bm.status = 1 "+
+			"LEFT JOIN space_member om ON om.space_id = s.space_id AND om.uid = ou.uid AND om.status = 1 "+
+			"WHERE r.robot_id = ? AND r.creator_uid = ? AND r.bot_token = ? AND r.status = 1 LIMIT 1",
+		req.SpaceID, resp.BotUID, resp.OwnerUID, req.BotToken,
+	).LoadOne(&facts)
+	if err != nil && err != dbr.ErrNotFound {
+		return err
+	}
+	bot.Active, bot.AgentHosting = facts.BotActive, facts.Hosting
+	owner.Active = facts.OwnerActive
+	bot.SpaceMember = bot.Active && facts.BotMember
+	owner.SpaceMember = owner.Active && facts.OwnerMember
+	if bot.SpaceMember && owner.SpaceMember {
+		owner.Projects, err = u.answerProjectMembership(owner.UID, req.SpaceID, req.ProjectIDs)
+		return err
+	}
+	// No role/epoch disclosure when either identity cannot access the named Space.
+	owner.Projects = make([]verifyProjectAnswer, 0, len(req.ProjectIDs))
+	seen := make(map[string]bool, len(req.ProjectIDs))
+	for _, id := range req.ProjectIDs {
+		if id != "" && !seen[id] {
+			seen[id] = true
+			owner.Projects = append(owner.Projects, verifyProjectAnswer{ProjectID: id})
+		}
+	}
+	return nil
+}

--- a/modules/user/api_bot_project_context_test.go
+++ b/modules/user/api_bot_project_context_test.go
@@ -1,0 +1,158 @@
+package user
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/stretchr/testify/require"
+)
+
+type botContextUserNames struct{ IService }
+
+func (botContextUserNames) GetUser(uid string) (*Resp, error) {
+	return &Resp{Name: uid + " name"}, nil
+}
+
+// Real HTTP handler and SQL contract; this does not replace MySQL integration.
+// Opt-in fields must never change default verifier clients.
+func TestBotOwnerContextHTTPContract(t *testing.T) {
+	for _, tc := range []struct {
+		name, query, body          string
+		invalid, extended, dbError bool
+	}{
+		{"default", "", `{"bot_token":"bf_test"}`, false, false, false},
+		{"legacy context", "?include=context", `{"bot_token":"bf_test","owner_uid":"ignored"}`, false, false, false},
+		{"scoped", "?include=owner_context", `{"bot_token":"bf_test","space_id":"space","project_ids":["p"]}`, false, true, false},
+		{"unavailable", "?include=owner_context", `{"bot_token":"bf_test","space_id":"space","project_ids":["p"]}`, false, true, true},
+		{"missing space", "?include=owner_context", `{"bot_token":"bf_test"}`, true, false, false},
+		{"forged owner", "?include=owner_context", `{"bot_token":"bf_test","space_id":"space","owner_uid":"victim"}`, true, false, false},
+		{"too many projects", "?include=owner_context", `{"bot_token":"bf_test","space_id":"space","project_ids":[` + strings.Repeat(`"p",`, maxVerifyProjectIDs) + `"p"]}`, true, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock := newPhoneLookupMock(t)
+			u := &User{db: db, userService: botContextUserNames{}, Log: log.NewTLog("bot-context-test")}
+			if !tc.invalid {
+				mock.ExpectQuery("SELECT.*FROM robot.*bot_token = 'bf_test'").WillReturnRows(sqlmock.NewRows([]string{"robot_id", "creator_uid"}).AddRow("bot", "owner"))
+				mock.ExpectQuery("SELECT.*FROM space_member.*uid = 'bot'").WillReturnRows(sqlmock.NewRows([]string{"space_id"}).AddRow("first-space"))
+				if tc.extended {
+					q := mock.ExpectQuery("SELECT IFNULL.*WHERE r.robot_id = 'bot' AND r.creator_uid = 'owner' AND r.bot_token = 'bf_test'")
+					if tc.dbError {
+						q.WillReturnError(errors.New("database unavailable"))
+					} else {
+						q.WillReturnRows(sqlmock.NewRows([]string{"hosting", "bot_active", "owner_active", "bot_member", "owner_member"}).AddRow("self_hosted", true, true, true, true))
+						mock.ExpectQuery("SELECT pm.project_id.*WHERE pm.uid = 'owner'.*pm.space_id = 'space'").WillReturnRows(sqlmock.NewRows([]string{"project_id", "role", "member_epoch"}).AddRow("p", 2, 7))
+					}
+				}
+			}
+			r := wkhttp.New()
+			r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+			r.POST("/v1/auth/verify-bot", u.authVerifyBot)
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/v1/auth/verify-bot"+tc.query, strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			r.ServeHTTP(w, req)
+			var response map[string]any
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+			if tc.invalid {
+				require.Equal(t, http.StatusBadRequest, w.Code)
+				require.Contains(t, response, "error")
+			} else {
+				require.Equal(t, http.StatusOK, w.Code)
+				require.Equal(t, "first-space", response["space_id"])
+				require.NotContains(t, response, "projects")
+				require.NotContains(t, w.Body.String(), "bf_test")
+				if !tc.extended {
+					require.Len(t, response, 5)
+				} else if tc.dbError {
+					require.Equal(t, true, response["context_error"])
+					require.NotContains(t, response, "bot_context")
+					require.NotContains(t, response, "owner_context")
+				} else {
+					require.Equal(t, true, response["context_included"])
+					require.Contains(t, response, "bot_context")
+					require.Contains(t, response, "owner_context")
+					require.NotContains(t, response["bot_context"], "agent_platform")
+					require.Equal(t, "self_hosted", response["bot_context"].(map[string]any)["agent_hosting"])
+				}
+			}
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestBotOwnerContextDefaultSchema(t *testing.T) {
+	data, err := json.Marshal(authVerifyBotResp{BotUID: "bot", BotName: "Bot", OwnerUID: "owner", OwnerName: "Owner", SpaceID: "legacy-first-space"})
+	require.NoError(t, err)
+	var fields map[string]any
+	require.NoError(t, json.Unmarshal(data, &fields))
+	require.Len(t, fields, 5)
+	for _, key := range []string{"bot_uid", "bot_name", "owner_uid", "owner_name", "space_id"} {
+		require.Contains(t, fields, key)
+	}
+	data, err = json.Marshal(ownedBot{UID: "bot", Name: "Bot"})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"uid":"bot","name":"Bot"}`, string(data))
+}
+
+func TestBotOwnerContextPlatformNeutralAndSpaceScoped(t *testing.T) {
+	for _, tc := range []struct {
+		name, hosting                                  string
+		botActive, ownerActive, botMember, ownerMember bool
+	}{
+		{"assistant without platform", "self_hosted", true, true, true, true},
+		{"cloud facts are not filtered by Server", "octo_hosted", true, true, true, true},
+		{"unknown hosting remains an identity fact", "", true, true, true, true},
+		{"bot disabled", "self_hosted", false, true, true, true},
+		{"owner disabled", "self_hosted", true, false, true, true},
+		{"bot removed from Space", "self_hosted", true, true, false, true},
+		{"owner removed from Space", "self_hosted", true, true, true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock := newPhoneLookupMock(t)
+			mock.ExpectQuery("SELECT IFNULL.*WHERE r.robot_id = 'bot' AND r.creator_uid = 'owner' AND r.bot_token = 'bf_test' AND r.status = 1").
+				WillReturnRows(sqlmock.NewRows([]string{"hosting", "bot_active", "owner_active", "bot_member", "owner_member"}).AddRow(tc.hosting, tc.botActive, tc.ownerActive, tc.botMember, tc.ownerMember))
+			allowed := tc.botActive && tc.ownerActive && tc.botMember && tc.ownerMember
+			if allowed {
+				mock.ExpectQuery("SELECT pm.project_id.*WHERE pm.uid = 'owner'.*pm.space_id = 'space'").
+					WillReturnRows(sqlmock.NewRows([]string{"project_id", "role", "member_epoch"}).AddRow("p", 2, 7))
+			}
+			resp := authVerifyBotResp{BotUID: "bot", OwnerUID: "owner", SpaceID: "legacy-first-space"}
+			err := (&User{db: db}).fillBotProjectContext(&resp, authVerifyBotReq{BotToken: "bf_test", SpaceID: "space", ProjectIDs: []string{"p", "unknown", "p"}})
+			require.NoError(t, err)
+			require.Equal(t, "legacy-first-space", resp.SpaceID)
+			require.True(t, resp.ContextIncluded)
+			require.Len(t, resp.OwnerContext.Projects, 2)
+			require.Equal(t, allowed, resp.OwnerContext.Projects[0].Member)
+			require.False(t, resp.OwnerContext.Projects[1].Member)
+			require.Nil(t, resp.OwnerContext.Projects[1].Role)
+			require.Nil(t, resp.OwnerContext.Projects[1].MemberEpoch)
+			if !allowed {
+				require.Nil(t, resp.OwnerContext.Projects[0].Role)
+				require.Nil(t, resp.OwnerContext.Projects[0].MemberEpoch)
+			}
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestBotOwnerContextFailsClosed(t *testing.T) {
+	db, mock := newPhoneLookupMock(t)
+	mock.ExpectQuery("SELECT IFNULL").WillReturnError(errors.New("database unavailable"))
+	resp := authVerifyBotResp{BotUID: "bot", OwnerUID: "owner", SpaceID: "legacy"}
+	err := (&User{db: db}).fillBotProjectContext(&resp, authVerifyBotReq{BotToken: "bf_test", SpaceID: "space", ProjectIDs: []string{"p"}})
+	require.Error(t, err)
+	require.Empty(t, resp.OwnerContext.Projects)
+	require.False(t, resp.BotContext.SpaceMember)
+	require.Equal(t, "legacy", resp.SpaceID)
+	require.NoError(t, mock.ExpectationsWereMet())
+	err = (&User{}).fillBotProjectContext(&resp, authVerifyBotReq{ProjectIDs: make([]string, maxVerifyProjectIDs+1)})
+	require.ErrorIs(t, err, errTooManyProjectIDs)
+}

--- a/modules/user/api_project_context.go
+++ b/modules/user/api_project_context.go
@@ -62,7 +62,7 @@ func (u *User) answerProjectMembership(uid, spaceID string, projectIDs []string)
 
 	// One bounded query for the whole batch, not one per id (C9: this endpoint
 	// runs on every request of every subsystem that fronts octo-server).
-	rows, err := projectpkg.MembershipsInSpace(u.ctx.DB(), spaceID, uid, projectIDs)
+	rows, err := projectpkg.MembershipsInSpace(u.db.session, spaceID, uid, projectIDs)
 	if err != nil {
 		return nil, fmt.Errorf("user: project membership lookup: %w", err)
 	}


### PR DESCRIPTION
## Summary

Expose Bot hosting and credential-bound owner Project facts through two
existing Server endpoints, without introducing platform-specific eligibility
rules or assigning Project membership to Bots.

## Related Issue

Closes #857

## Linked Spec

[Implementation brief](https://github.com/MrAladdin/octo-server/blob/6c9b59457d3a2f02c3c1ffa1931e6344f044f419/.octospec/tasks/eva-loop-assistants/brief.md)

## Changes

- Include `agent_hosting` in the default `owned_bots` response and exclude
  disabled Bot accounts while preserving owner/Space isolation.
- Add opt-in `owner_context` to `verify-bot`, deriving the owner from the Bot
  credential and returning separate Bot/owner facts and scoped Project answers.
- Preserve the default verifier's five fields and legacy Space response.
- Reuse the existing Project membership query and module DB session; add no
  new route, schema migration, platform dependency or Project membership.
- Add MySQL-backed owned-Bot contract tests and HTTP/SQL-mock verification tests.

## Testing

- [x] `owned_bots` actual-handler/MySQL contract tests passed three shuffled
  runs on an isolated database after syncing with `main` at `38da0695`.
- [x] `verify-bot` HTTP/SQL-mock contract tests passed three shuffled runs,
  including default compatibility, owner spoofing, Project bounds and failures.
- [x] Robot and User legacy-error-response source guards passed three runs.
- [x] Edited Go files pass `gofmt`; staged changes pass `git diff --check`.

Local commands used Go 1.25.0 with a Windows-only test overlay for the existing
disk-space implementation; the User unit run also bypassed the integration
TestMain. The overlay files are not part of this PR.

```text
go test -overlay <windows-overlay.json> ./modules/robot -run '^Test(OwnedBotsMetadataMySQLContract|RobotNoLegacyResponseError)' -shuffle=on -count=3 -v
go test -overlay <unit-overlay.json> ./modules/user -run '^Test(BotOwnerContext|UserAPINoLegacyResponseError|ManagerAPINoLegacyResponseError|MigratedUserFilesNoLegacyResponseError)' -shuffle=on -count=3 -v
```

The MySQL test uses `OCTO_ASSISTANT_TEST_MYSQL_DSN` and creates/removes only its
own randomly named database. Reported query errors are intentional failure
injections with passing assertions.

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   It supplies authoritative identity and current owner membership facts to
   downstream authorization. The supplied Bot credential determines the owner;
   a caller cannot choose an owner UID. Server does not grant delegated actions.

2. **What could break** because of it (dependents + failure mode)?

   Strict owned-Bot response decoders must tolerate the added hosting field.
   Incorrect identity or Space binding could disclose Project facts, so the
   extension rechecks active accounts and both Space memberships and fails
   closed on lookup errors. Existing verifier clients retain their default
   response unless they explicitly request the extension.

3. **How do you know it works** (specific test/repro/trace)?

   Contract tests exercise default/extended JSON responses, forged-owner
   rejection, bounded Project queries and failure paths. An isolated MySQL
   test verifies the actual owned-Bot joins and continues to pass after removing
   the unrelated platform column from its temporary test schema.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
