### PR TITLE
feat(auth): expose bot hosting and owner project context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,10 @@ jobs:
       # 32-char value here so re-runs are reproducible (the value is
       # ephemeral CI-only and never used outside tests).
       OCTO_MASTER_KEY: 0123456789abcdef0123456789abcdef
+      # Opt-in MySQL contract tests create and drop only randomly named
+      # databases. Wiring the existing service DSN here keeps those tests in
+      # the merge queue instead of silently skipping them.
+      OCTO_ASSISTANT_TEST_MYSQL_DSN: root:demo@tcp(127.0.0.1:3306)/?charset=utf8mb4&parseTime=true
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.octospec/journal/shared/eva-loop-assistants.md
+++ b/.octospec/journal/shared/eva-loop-assistants.md
@@ -19,9 +19,9 @@ source: user
 - `verify-bot?include=owner_context` derives the owner from the validated Bot
   credential, returns Bot and owner facts separately, and answers only the
   requested Project IDs.
-- Disabled, terminally destroyed, removed-from-Space, and disbanded-Space cases
-  all deny Project facts. Context lookup errors and a row disappearing between
-  credential verification and context lookup fail closed.
+- Disabled, cooling-off, terminally destroyed, removed-from-Space, and
+  disbanded-Space cases all deny Project facts. Context lookup errors and a row
+  disappearing between credential verification and context lookup fail closed.
 - The default five-field `verify-bot` response remains unchanged.
 
 ## Structural learnings
@@ -42,8 +42,9 @@ source: user
 ## Gotchas
 
 - A SQL mock that injects already-computed booleans does not prove the SQL that
-  computes them. The query expectation now pins every account, Space, and
-  membership predicate, while table cases exercise the downstream conjunction.
+  computes them. The query expectation pins every account, Space, and
+  membership predicate, and an isolated MySQL matrix executes those predicates
+  for disabled/destroyed principals, revoked memberships, and inactive scopes.
 - The CI package runner recreates the shared `test` database before every
   package because migration ledgers differ by linked module set. Local
   verification used fresh isolated service containers for the same reason.

--- a/.octospec/journal/shared/eva-loop-assistants.md
+++ b/.octospec/journal/shared/eva-loop-assistants.md
@@ -18,10 +18,12 @@ source: user
   owner/Space/account filtering in the SQL predicate.
 - `verify-bot?include=owner_context` derives the owner from the validated Bot
   credential, returns Bot and owner facts separately, and answers only the
-  requested Project IDs.
+  requested Project IDs. Cross-principal Project answers expose membership and
+  role only, never owner capabilities or membership epochs.
 - Disabled, cooling-off, terminally destroyed, removed-from-Space, and
   disbanded-Space cases all deny Project facts. Context lookup errors and a row
-  disappearing between credential verification and context lookup fail closed.
+  disappearing between credential verification and context lookup fail closed
+  while preserving present-but-empty contexts and `projects: []`.
 - The default five-field `verify-bot` response remains unchanged.
 
 ## Structural learnings
@@ -32,6 +34,9 @@ source: user
   test both fields.
 - Account activity and Space membership are independent facts. Keep them
   separate on the wire, then require their conjunction before disclosing roles.
+- A Bot credential proves the Bot, not its human owner. Returning the owner's
+  role can describe routing context, but exporting the owner's executable
+  capabilities or membership epoch would cross that credential boundary.
 - A module test binary does not automatically register migrations owned by a
   sibling module. When production SQL gains such a dependency, import the
   migration owner from an external test package to avoid an import cycle.

--- a/.octospec/journal/shared/eva-loop-assistants.md
+++ b/.octospec/journal/shared/eva-loop-assistants.md
@@ -1,0 +1,49 @@
+---
+type: Journal
+title: "Journal: eva-loop-assistants"
+description: Credential-bound Bot owner context and owner-facing hosting metadata, with fail-closed account and Space checks.
+tags: ["auth", "bot-api", "space", "project", "trust-boundary", "testing"]
+timestamp: 2026-09-08T14:10:08+08:00
+# --- octospec extension fields ---
+task: eva-loop-assistants
+upstream: "Mininglamp-OSS/octo-server#857"
+source: user
+---
+
+# Journal: eva-loop-assistants
+
+## Result
+
+- `owned_bots` now returns hosting together with its report timestamp and keeps
+  owner/Space/account filtering in the SQL predicate.
+- `verify-bot?include=owner_context` derives the owner from the validated Bot
+  credential, returns Bot and owner facts separately, and answers only the
+  requested Project IDs.
+- Disabled, terminally destroyed, removed-from-Space, and disbanded-Space cases
+  all deny Project facts. Context lookup errors and a row disappearing between
+  credential verification and context lookup fail closed.
+- The default five-field `verify-bot` response remains unchanged.
+
+## Structural learnings
+
+- `user.status=1` is not sufficient liveness for a human account. Final account
+  deletion sets `is_destroy=2` without clearing `status`, and Space/Project
+  cascade cleanup is intentionally deferred. Authorization-shaped reads must
+  test both fields.
+- Account activity and Space membership are independent facts. Keep them
+  separate on the wire, then require their conjunction before disclosing roles.
+- A module test binary does not automatically register migrations owned by a
+  sibling module. When production SQL gains such a dependency, import the
+  migration owner from an external test package to avoid an import cycle.
+- `agent_hosting` is caller-reported telemetry. Any response that carries it
+  must also carry `agent_reported_hosting_at`, and neither field may become an
+  authorization or quota signal.
+
+## Gotchas
+
+- A SQL mock that injects already-computed booleans does not prove the SQL that
+  computes them. The query expectation now pins every account, Space, and
+  membership predicate, while table cases exercise the downstream conjunction.
+- The CI package runner recreates the shared `test` database before every
+  package because migration ledgers differ by linked module set. Local
+  verification used fresh isolated service containers for the same reason.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -2560,3 +2560,13 @@ SQL 注释里一个撇号破坏了它的朴素语句分割；P0 的游标覆盖�
 - 非文本消息不再把原始结构化 payload 写入 session 标题，改用已有内容类型展示文案。
 - build、全仓 vet、AI Team 全包和 Robot 聚焦测试通过；Group DB 回归保留给干净数据库 CI，
   本机共享库的 migration 账本包含当前分支不存在的旧迁移，未为跑绿而破坏共享状态。
+
+## 2026-09-08 — eva-loop-assistants（PR #858 blocker 收敛）
+
+- `owned_bots` 的测试包通过外部测试包注册 botfather 迁移，修复 CI 中
+  `agent_hosting` 缺列；全新隔离 MySQL/Redis/WuKongIM 环境下原回归通过。
+- Bot/owner active 判定补上 `is_destroy=0`，并保持 active 与 Space membership
+  两个事实正交；只有双方均 active 且仍在 Space 时才返回 owner Project 角色。
+- hosting 与上报时间成对返回，并恢复「自报遥测不可用于鉴权/配额」的信任边界。
+- SQL mock 直接钉住账户、Space、membership 全部权限谓词；user/robot 定向测试、
+  Project helper、Group/Robot/User error guards、build、vet、diff 检查通过。

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -2570,3 +2570,6 @@ SQL 注释里一个撇号破坏了它的朴素语句分割；P0 的游标覆盖�
 - hosting 与上报时间成对返回，并恢复「自报遥测不可用于鉴权/配额」的信任边界。
 - SQL mock 直接钉住账户、Space、membership 全部权限谓词；user/robot 定向测试、
   Project helper、Group/Robot/User error guards、build、vet、diff 检查通过。
+- 后续 review 将 Bot 凭据可见的 owner Project 答案收窄为 `member` / `role`，不再
+  跨主体暴露 capabilities 与 member epoch；DB 异常保留空的 fail-secure contexts，
+  `owned_bots` 同时排除 destroying/destroyed 用户，均补充回归覆盖。

--- a/.octospec/tasks/eva-loop-assistants/brief.md
+++ b/.octospec/tasks/eva-loop-assistants/brief.md
@@ -2,15 +2,17 @@
 
 ## Goal
 
-Expose the identity facts Fleet needs to authorize a human's own self_hosted
-assistants, regardless of execution platform. Assistants do not join Projects.
+Expose credential-bound owner/Project facts for Fleet and separately surface
+self-reported Bot hosting telemetry. Hosting is not an authorization signal,
+and assistants do not join Projects.
 
 Related issue: Mininglamp-OSS/octo-server#857.
 
 ## Load-bearing list
 
-- Session robot/owned_bots adds agent_hosting directly to its existing four fields;
-  no include=agent_metadata switch and no agent_platform dependency.
+- Session robot/owned_bots adds agent_hosting and agent_reported_hosting_at
+  directly to its existing four fields; no include=agent_metadata switch and
+  no agent_platform dependency.
 - verify-bot opt-in owner_context, bound to the actual Bot credential.
 - Separate Bot/owner identity and current Space/Project facts; fail closed on lookup errors.
 
@@ -30,7 +32,7 @@ Related issue: Mininglamp-OSS/octo-server#857.
 - Explicit owner queries bind identity, validate accounts/Space and expose only
   requested Project facts; absent/failed context grants nothing.
 - Queries do not read agent_platform; existing IM storage/reporting is untouched.
-  Fleet, not Server, classifies Loop assistants.
+  Hosting remains self-reported observability metadata and must not feed authz.
 - Focused regression tests and broader auth/project/group checks are recorded in
   the workspace implementation report.
 
@@ -43,19 +45,21 @@ Reuse existing DB sessions, membership queries, errors and test helpers.
 
 - `GET /v1/robot/owned_bots?space_id=...` uses the authenticated owner and the
   requested Space. Every item contains `uid`, `name`, `description`,
-  `bot_commands`, and `agent_hosting`; no metadata query switch is required.
+  `bot_commands`, `agent_hosting`, and `agent_reported_hosting_at`; no metadata
+  query switch is required.
 - `POST /v1/auth/verify-bot?include=owner_context` accepts `bot_token`,
   `space_id`, and a bounded list of `project_ids`. It derives the owner from
   the validated credential and rejects a caller-supplied `owner_uid`.
-- The extension returns `bot_context` (identity, active state, hosting and
-  Space membership) separately from `owner_context` (identity, active state,
-  Space membership and answers for the requested Projects). Owner membership
-  must never be represented as the Bot's own Project membership.
+- The extension returns `bot_context` (identity, active state, self-reported
+  hosting plus report time, and Space membership) separately from
+  `owner_context` (identity, active state, Space membership and answers for the
+  requested Projects). Owner membership must never be represented as the Bot's
+  own Project membership.
 - A failed context lookup sets `context_error` and omits both contexts;
   inactive identities or missing Space membership disclose no Project roles.
 - Without `include=owner_context`, the original verifier's five fields and
-  legacy `space_id` remain unchanged. Hosting is returned as a fact, not used
-  here to classify or authorize downstream assistant operations.
+  legacy `space_id` remain unchanged. Hosting is telemetry, not authority;
+  consumers must not use it to classify authorization eligibility.
 
 Tests cover default compatibility, account/Space isolation, spoofed owner
 rejection, Project bounds, lookup failures, and independence from platform data.

--- a/.octospec/tasks/eva-loop-assistants/brief.md
+++ b/.octospec/tasks/eva-loop-assistants/brief.md
@@ -56,10 +56,13 @@ Reuse existing DB sessions, membership queries, errors and test helpers.
   requested Projects). Owner membership must never be represented as the Bot's
   own Project membership.
 - A failed context lookup sets `context_error` and omits both contexts;
-  inactive identities or missing Space membership disclose no Project roles.
+  disabled, cooling-off, or destroyed identities and missing Space membership
+  disclose no Project roles.
 - Without `include=owner_context`, the original verifier's five fields and
   legacy `space_id` remain unchanged. Hosting is telemetry, not authority;
   consumers must not use it to classify authorization eligibility.
 
 Tests cover default compatibility, account/Space isolation, spoofed owner
 rejection, Project bounds, lookup failures, and independence from platform data.
+The account and membership predicates execute against MySQL in the E2E lane;
+they are not covered only through pre-computed SQL-mock booleans.

--- a/.octospec/tasks/eva-loop-assistants/brief.md
+++ b/.octospec/tasks/eva-loop-assistants/brief.md
@@ -53,9 +53,12 @@ Reuse existing DB sessions, membership queries, errors and test helpers.
 - The extension returns `bot_context` (identity, active state, self-reported
   hosting plus report time, and Space membership) separately from
   `owner_context` (identity, active state, Space membership and answers for the
-  requested Projects). Owner membership must never be represented as the Bot's
-  own Project membership.
-- A failed context lookup sets `context_error` and omits both contexts;
+  requested Projects). Both contexts call the nested request scope
+  `requested_space_id`. Owner membership must never be represented as the Bot's
+  own Project membership, and the Bot credential may receive only the owner's
+  Project `member` and `role` facts—not capabilities or membership epochs.
+- A failed context lookup sets `context_error` and returns both contexts in an
+  empty, fail-secure form (including `projects: []`);
   disabled, cooling-off, or destroyed identities and missing Space membership
   disclose no Project roles.
 - Without `include=owner_context`, the original verifier's five fields and

--- a/.octospec/tasks/eva-loop-assistants/brief.md
+++ b/.octospec/tasks/eva-loop-assistants/brief.md
@@ -1,0 +1,61 @@
+# EVA Loop assistants — identity facts for local assistants
+
+## Goal
+
+Expose the identity facts Fleet needs to authorize a human's own self_hosted
+assistants, regardless of execution platform. Assistants do not join Projects.
+
+Related issue: Mininglamp-OSS/octo-server#857.
+
+## Load-bearing list
+
+- Session robot/owned_bots adds agent_hosting directly to its existing four fields;
+  no include=agent_metadata switch and no agent_platform dependency.
+- verify-bot opt-in owner_context, bound to the actual Bot credential.
+- Separate Bot/owner identity and current Space/Project facts; fail closed on lookup errors.
+
+## Out of scope
+
+- Changing generic bot-task transport into a Loop-specific service.
+- Project membership/role/cascade/governance changes and migrations.
+- Fleet Agent/Runtime/installation creation for assistants.
+- Shared-service deployments and changes to user credentials.
+
+## Acceptance
+
+- Existing owned Bot display fields and Session authentication stay available;
+  the default list includes hosting and excludes disabled Bot accounts.
+- Default verify-bot keeps its five fields. Only include=owner_context enables
+  the credential-bound owner/Project facts; do not split this callback into a new API.
+- Explicit owner queries bind identity, validate accounts/Space and expose only
+  requested Project facts; absent/failed context grants nothing.
+- Queries do not read agent_platform; existing IM storage/reporting is untouched.
+  Fleet, not Server, classifies Loop assistants.
+- Focused regression tests and broader auth/project/group checks are recorded in
+  the workspace implementation report.
+
+## Files and verification
+
+Project policy remains unchanged; identity context stays in modules/user and robot.
+Reuse existing DB sessions, membership queries, errors and test helpers.
+
+### API contract
+
+- `GET /v1/robot/owned_bots?space_id=...` uses the authenticated owner and the
+  requested Space. Every item contains `uid`, `name`, `description`,
+  `bot_commands`, and `agent_hosting`; no metadata query switch is required.
+- `POST /v1/auth/verify-bot?include=owner_context` accepts `bot_token`,
+  `space_id`, and a bounded list of `project_ids`. It derives the owner from
+  the validated credential and rejects a caller-supplied `owner_uid`.
+- The extension returns `bot_context` (identity, active state, hosting and
+  Space membership) separately from `owner_context` (identity, active state,
+  Space membership and answers for the requested Projects). Owner membership
+  must never be represented as the Bot's own Project membership.
+- A failed context lookup sets `context_error` and omits both contexts;
+  inactive identities or missing Space membership disclose no Project roles.
+- Without `include=owner_context`, the original verifier's five fields and
+  legacy `space_id` remain unchanged. Hosting is returned as a fact, not used
+  here to classify or authorize downstream assistant operations.
+
+Tests cover default compatibility, account/Space isolation, spoofed owner
+rejection, Project bounds, lookup failures, and independence from platform data.

--- a/.octospec/tasks/eva-loop-assistants/context.yaml
+++ b/.octospec/tasks/eva-loop-assistants/context.yaml
@@ -1,0 +1,12 @@
+injected:
+  - id: space-isolation
+    source: repo
+  - id: error-handling
+    source: repo
+  - id: rate-limit
+    source: repo
+  - id: testing
+    source: repo
+  - id: commit-style
+    source: repo
+brief: .octospec/tasks/eva-loop-assistants/brief.md

--- a/.octospec/tasks/eva-loop-assistants/implementation.md
+++ b/.octospec/tasks/eva-loop-assistants/implementation.md
@@ -7,14 +7,15 @@
   `agent_reported_hosting_at` without introducing an import cycle.
 - Kept hosting explicitly self-reported and non-authoritative, and paired it
   with `agent_reported_hosting_at` on both new response surfaces.
-- Treated terminally destroyed Bot/owner accounts as inactive even when their
-  legacy `status` and membership rows remain active.
+- Treated cooling-off and terminally destroyed Bot/owner accounts as inactive
+  even when their legacy `status` and membership rows remain active.
 - Kept account activity and Space membership as separate facts while requiring
   both identities to be active members before returning owner Project roles.
 - Turned a context row disappearing after credential verification into a
   fail-closed `context_error` path.
-- Strengthened the existing owned-Bot integration test and pinned every SQL
-  predicate that gates owner Project facts.
+- Strengthened the existing owned-Bot integration test, pinned every SQL
+  predicate that gates owner Project facts, and added an isolated MySQL matrix
+  for disabled/destroyed principals, revoked memberships, and inactive scopes.
 
 ## Verification
 
@@ -23,6 +24,7 @@ Passed locally:
 ```text
 go test ./modules/user -run '^TestBotOwnerContext' -count=1
 OCTO_ASSISTANT_TEST_MYSQL_DSN='root:demo@tcp(127.0.0.1:3306)/?charset=utf8mb4&parseTime=true' go test ./modules/robot -run '^TestOwnedBotsMetadataMySQLContract$' -count=1
+OCTO_ASSISTANT_TEST_MYSQL_DSN='root:demo@tcp(127.0.0.1:3306)/?charset=utf8mb4&parseTime=true' go test ./modules/user -run '^TestBotOwnerContextMySQLLivenessContract$' -count=1
 go test ./modules/robot -run '^TestOwnedBots$' -count=1 # fresh isolated MySQL/Redis/WuKongIM containers
 go test ./modules/robot -run '^TestRobotNoLegacyResponseError$' -count=1
 go test ./modules/user -run '^Test(UserAPINoLegacyResponseError|ManagerAPINoLegacyResponseError|MigratedUserFilesNoLegacyResponseError)$' -count=1

--- a/.octospec/tasks/eva-loop-assistants/implementation.md
+++ b/.octospec/tasks/eva-loop-assistants/implementation.md
@@ -12,7 +12,14 @@
 - Kept account activity and Space membership as separate facts while requiring
   both identities to be active members before returning owner Project roles.
 - Turned a context row disappearing after credential verification into a
-  fail-closed `context_error` path.
+  fail-closed `context_error` path that preserves present-but-empty Bot and
+  owner contexts, including `projects: []`.
+- Narrowed cross-principal Project answers exposed to a Bot credential to
+  `member` and `role`; owner capabilities and membership epochs remain private
+  to owner-authenticated APIs. Renamed the nested scope echo to
+  `requested_space_id`.
+- Excluded destroying and destroyed Bot user rows from `owned_bots`, with both
+  fixture-level and real-MySQL coverage.
 - Strengthened the existing owned-Bot integration test, pinned every SQL
   predicate that gates owner Project facts, and added an isolated MySQL matrix
   for disabled/destroyed principals, revoked memberships, and inactive scopes.

--- a/.octospec/tasks/eva-loop-assistants/implementation.md
+++ b/.octospec/tasks/eva-loop-assistants/implementation.md
@@ -1,0 +1,36 @@
+# Implementation report
+
+## Review fixes
+
+- Loaded the botfather migrations in the external robot test package so the
+  existing `TestOwnedBots` schema contains `agent_hosting` and
+  `agent_reported_hosting_at` without introducing an import cycle.
+- Kept hosting explicitly self-reported and non-authoritative, and paired it
+  with `agent_reported_hosting_at` on both new response surfaces.
+- Treated terminally destroyed Bot/owner accounts as inactive even when their
+  legacy `status` and membership rows remain active.
+- Kept account activity and Space membership as separate facts while requiring
+  both identities to be active members before returning owner Project roles.
+- Turned a context row disappearing after credential verification into a
+  fail-closed `context_error` path.
+- Strengthened the existing owned-Bot integration test and pinned every SQL
+  predicate that gates owner Project facts.
+
+## Verification
+
+Passed locally:
+
+```text
+go test ./modules/user -run '^TestBotOwnerContext' -count=1
+OCTO_ASSISTANT_TEST_MYSQL_DSN='root:demo@tcp(127.0.0.1:3306)/?charset=utf8mb4&parseTime=true' go test ./modules/robot -run '^TestOwnedBotsMetadataMySQLContract$' -count=1
+go test ./modules/robot -run '^TestOwnedBots$' -count=1 # fresh isolated MySQL/Redis/WuKongIM containers
+go test ./modules/robot -run '^TestRobotNoLegacyResponseError$' -count=1
+go test ./modules/user -run '^Test(UserAPINoLegacyResponseError|ManagerAPINoLegacyResponseError|MigratedUserFilesNoLegacyResponseError)$' -count=1
+go test ./modules/group -run '^TestGroupNoLegacyResponseError$' -count=1
+go test ./pkg/project -count=1
+go vet ./modules/robot ./modules/user ./modules/group
+go test -c ./modules/robot
+go test -c ./modules/user
+go test -c ./modules/group
+git diff --check
+```

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -1997,6 +1997,7 @@ func (rb *Robot) ownedBots(c *wkhttp.Context) {
 		INNER JOIN user u ON u.uid = r.robot_id AND u.robot = 1
 		INNER JOIN space_member sm ON sm.uid = r.robot_id AND sm.space_id = ? AND sm.status = 1
 		WHERE r.creator_uid = ? AND r.status = 1 AND u.status = 1
+			AND COALESCE(u.is_destroy, 0) = 0
 		ORDER BY r.created_at DESC
 	`, spaceID, loginUID).Load(&bots)
 	if err != nil {

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -1976,20 +1976,23 @@ func (rb *Robot) ownedBots(c *wkhttp.Context) {
 	}
 
 	// creator_uid=loginUID 与 space_id 双重过滤即 space 隔离点，均为占位符，不可绕过。
-	// 托管类型是通用 Bot 事实；由消费方决定用途，绝不返回 token/凭据。
+	// 托管类型是 Bot 自报遥测，只可用于展示与排障，不得用于鉴权或配额；
+	// 与上报时间一起返回以便调用方判断新鲜度。绝不返回 token/凭据。
 	type ownedBotRow struct {
-		UID          string `db:"uid"`
-		Name         string `db:"name"`
-		Description  string `db:"description"`
-		BotCommands  string `db:"bot_commands"`
-		AgentHosting string `db:"agent_hosting"`
+		UID                    string       `db:"uid"`
+		Name                   string       `db:"name"`
+		Description            string       `db:"description"`
+		BotCommands            string       `db:"bot_commands"`
+		AgentHosting           string       `db:"agent_hosting"`
+		AgentReportedHostingAt dbr.NullTime `db:"agent_reported_hosting_at"`
 	}
 	var bots []ownedBotRow
 	_, err = rb.ctx.DB().SelectBySql(`
 		SELECT r.robot_id as uid, IFNULL(u.name,'') as name,
 			IFNULL(r.description,'') as description,
 			IFNULL(r.bot_commands,'') as bot_commands,
-			IFNULL(r.agent_hosting,'') as agent_hosting
+			IFNULL(r.agent_hosting,'') as agent_hosting,
+			r.agent_reported_hosting_at as agent_reported_hosting_at
 		FROM robot r
 		INNER JOIN user u ON u.uid = r.robot_id AND u.robot = 1
 		INNER JOIN space_member sm ON sm.uid = r.robot_id AND sm.space_id = ? AND sm.status = 1
@@ -2004,12 +2007,18 @@ func (rb *Robot) ownedBots(c *wkhttp.Context) {
 
 	results := make([]map[string]interface{}, 0, len(bots))
 	for _, b := range bots {
+		var agentReportedHostingAt *string
+		if b.AgentReportedHostingAt.Valid {
+			formatted := b.AgentReportedHostingAt.Time.Format(time.DateTime)
+			agentReportedHostingAt = &formatted
+		}
 		item := map[string]interface{}{
-			"uid":           b.UID,
-			"name":          b.Name,
-			"description":   b.Description,
-			"bot_commands":  b.BotCommands,
-			"agent_hosting": b.AgentHosting,
+			"uid":                       b.UID,
+			"name":                      b.Name,
+			"description":               b.Description,
+			"bot_commands":              b.BotCommands,
+			"agent_hosting":             b.AgentHosting,
+			"agent_reported_hosting_at": agentReportedHostingAt,
 		}
 		results = append(results, item)
 	}

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -1976,22 +1976,24 @@ func (rb *Robot) ownedBots(c *wkhttp.Context) {
 	}
 
 	// creator_uid=loginUID 与 space_id 双重过滤即 space 隔离点，均为占位符，不可绕过。
-	// 仅暴露 uid/name/description/bot_commands，绝不返回 token/凭据。
+	// 托管类型是通用 Bot 事实；由消费方决定用途，绝不返回 token/凭据。
 	type ownedBotRow struct {
-		UID         string `db:"uid"`
-		Name        string `db:"name"`
-		Description string `db:"description"`
-		BotCommands string `db:"bot_commands"`
+		UID          string `db:"uid"`
+		Name         string `db:"name"`
+		Description  string `db:"description"`
+		BotCommands  string `db:"bot_commands"`
+		AgentHosting string `db:"agent_hosting"`
 	}
 	var bots []ownedBotRow
 	_, err = rb.ctx.DB().SelectBySql(`
 		SELECT r.robot_id as uid, IFNULL(u.name,'') as name,
 			IFNULL(r.description,'') as description,
-			IFNULL(r.bot_commands,'') as bot_commands
+			IFNULL(r.bot_commands,'') as bot_commands,
+			IFNULL(r.agent_hosting,'') as agent_hosting
 		FROM robot r
 		INNER JOIN user u ON u.uid = r.robot_id AND u.robot = 1
 		INNER JOIN space_member sm ON sm.uid = r.robot_id AND sm.space_id = ? AND sm.status = 1
-		WHERE r.creator_uid = ? AND r.status = 1
+		WHERE r.creator_uid = ? AND r.status = 1 AND u.status = 1
 		ORDER BY r.created_at DESC
 	`, spaceID, loginUID).Load(&bots)
 	if err != nil {
@@ -2002,12 +2004,14 @@ func (rb *Robot) ownedBots(c *wkhttp.Context) {
 
 	results := make([]map[string]interface{}, 0, len(bots))
 	for _, b := range bots {
-		results = append(results, map[string]interface{}{
-			"uid":          b.UID,
-			"name":         b.Name,
-			"description":  b.Description,
-			"bot_commands": b.BotCommands,
-		})
+		item := map[string]interface{}{
+			"uid":           b.UID,
+			"name":          b.Name,
+			"description":   b.Description,
+			"bot_commands":  b.BotCommands,
+			"agent_hosting": b.AgentHosting,
+		}
+		results = append(results, item)
 	}
 	c.Response(results)
 }

--- a/modules/robot/api_owned_bots_metadata_test.go
+++ b/modules/robot/api_owned_bots_metadata_test.go
@@ -59,7 +59,7 @@ func TestOwnedBotsMetadataMySQLContract(t *testing.T) {
 	exec("CREATE TABLE space (space_id VARCHAR(40) PRIMARY KEY, status INT NOT NULL)")
 	exec("CREATE TABLE space_member (space_id VARCHAR(40), uid VARCHAR(40), status INT NOT NULL, PRIMARY KEY(space_id,uid))")
 	exec("CREATE TABLE user (uid VARCHAR(40) PRIMARY KEY, name VARCHAR(40), robot INT NOT NULL, status INT NOT NULL)")
-	exec("CREATE TABLE robot (robot_id VARCHAR(40) PRIMARY KEY, creator_uid VARCHAR(40), status INT NOT NULL, description TEXT, bot_commands TEXT, agent_platform VARCHAR(40), agent_hosting VARCHAR(40), created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)")
+	exec("CREATE TABLE robot (robot_id VARCHAR(40) PRIMARY KEY, creator_uid VARCHAR(40), status INT NOT NULL, description TEXT, bot_commands TEXT, agent_platform VARCHAR(40), agent_hosting VARCHAR(40), agent_reported_hosting_at TIMESTAMP NULL, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)")
 	exec("INSERT INTO space VALUES ('space-a',1),('space-b',1)")
 	exec("INSERT INTO space_member VALUES ('space-a','owner',1),('space-b','owner',1),('space-a','other-owner',1)")
 	for _, bot := range []struct {
@@ -79,7 +79,7 @@ func TestOwnedBotsMetadataMySQLContract(t *testing.T) {
 		{"human", "owner", "space-a", "OpenClaw", "self_hosted", 1, 1, 1, 0},
 	} {
 		exec("INSERT INTO user VALUES (?,?,?,?)", bot.uid, bot.uid, bot.robot, bot.userStatus)
-		exec("INSERT INTO robot(robot_id,creator_uid,status,description,bot_commands,agent_platform,agent_hosting) VALUES (?,?,?,'description','[]',?,?)", bot.uid, bot.owner, bot.robotStatus, bot.platform, bot.hosting)
+		exec("INSERT INTO robot(robot_id,creator_uid,status,description,bot_commands,agent_platform,agent_hosting,agent_reported_hosting_at) VALUES (?,?,?,'description','[]',?,?,UTC_TIMESTAMP())", bot.uid, bot.owner, bot.robotStatus, bot.platform, bot.hosting)
 		exec("INSERT INTO space_member VALUES (?,?,?)", bot.space, bot.uid, bot.memberStatus)
 	}
 	// Prove the entire endpoint works without querying the unrelated platform column.
@@ -114,13 +114,14 @@ func TestOwnedBotsMetadataMySQLContract(t *testing.T) {
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &rows))
 			var ids []string
 			for _, row := range rows {
-				require.Len(t, row, 5)
+				require.Len(t, row, 6)
 				ids = append(ids, row["uid"].(string))
 				for _, field := range []string{"uid", "name", "description", "bot_commands"} {
 					require.Contains(t, row, field)
 				}
 				require.NotContains(t, row, "agent_platform")
 				require.NotEmpty(t, row["agent_hosting"])
+				require.NotEmpty(t, row["agent_reported_hosting_at"])
 			}
 			require.ElementsMatch(t, tc.want, ids)
 		})

--- a/modules/robot/api_owned_bots_metadata_test.go
+++ b/modules/robot/api_owned_bots_metadata_test.go
@@ -1,0 +1,154 @@
+package robot
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// Exercises the actual handler and MySQL joins. Authentication is deliberately
+// injected: this is not a replacement for the Session/Redis middleware suite.
+// Only the randomly named database created here is changed or dropped.
+func TestOwnedBotsMetadataMySQLContract(t *testing.T) {
+	dsn := os.Getenv("OCTO_ASSISTANT_TEST_MYSQL_DSN")
+	if dsn == "" {
+		t.Skip("set OCTO_ASSISTANT_TEST_MYSQL_DSN for an isolated MySQL server")
+	}
+	dbConfig, err := mysql.ParseDSN(dsn)
+	require.NoError(t, err)
+	dbConfig.DBName = "information_schema"
+	bootstrap, err := sql.Open("mysql", dbConfig.FormatDSN())
+	require.NoError(t, err)
+	bootstrap.SetMaxOpenConns(2)
+	bootstrap.SetMaxIdleConns(1)
+	t.Cleanup(func() { require.NoError(t, bootstrap.Close()) })
+	require.NoError(t, bootstrap.Ping())
+	databaseName := "octo_assistant_" + util.GenerUUID()[:12]
+	_, err = bootstrap.Exec("CREATE DATABASE `" + databaseName + "` CHARACTER SET utf8mb4")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, err := bootstrap.Exec("DROP DATABASE `" + databaseName + "`")
+		require.NoError(t, err)
+	})
+	dbConfig.DBName = databaseName
+	cfg := config.New()
+	cfg.DB.MySQLAddr = dbConfig.FormatDSN()
+	cfg.DB.MySQLMaxOpenConns = 2
+	cfg.DB.MySQLMaxIdleConns = 1
+	ctx := testutil.NewTestContext(cfg)
+	database := ctx.DB().DB
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	exec := func(query string, args ...any) {
+		t.Helper()
+		_, err := database.Exec(query, args...)
+		require.NoError(t, err)
+	}
+	// Minimal projections of the production tables; migration coverage is a
+	// separate concern. No shared schema or testutil.CleanAllTables is used.
+	exec("CREATE TABLE space (space_id VARCHAR(40) PRIMARY KEY, status INT NOT NULL)")
+	exec("CREATE TABLE space_member (space_id VARCHAR(40), uid VARCHAR(40), status INT NOT NULL, PRIMARY KEY(space_id,uid))")
+	exec("CREATE TABLE user (uid VARCHAR(40) PRIMARY KEY, name VARCHAR(40), robot INT NOT NULL, status INT NOT NULL)")
+	exec("CREATE TABLE robot (robot_id VARCHAR(40) PRIMARY KEY, creator_uid VARCHAR(40), status INT NOT NULL, description TEXT, bot_commands TEXT, agent_platform VARCHAR(40), agent_hosting VARCHAR(40), created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)")
+	exec("INSERT INTO space VALUES ('space-a',1),('space-b',1)")
+	exec("INSERT INTO space_member VALUES ('space-a','owner',1),('space-b','owner',1),('space-a','other-owner',1)")
+	for _, bot := range []struct {
+		uid, owner, space, platform, hosting         string
+		userStatus, robotStatus, memberStatus, robot int
+	}{
+		{"local", "owner", "space-a", "OpenClaw", "self_hosted", 1, 1, 1, 1},
+		{"cloud", "owner", "space-a", "OpenClaw", "octo_hosted", 1, 1, 1, 1},
+		{"other-platform", "owner", "space-a", "Codex", "self_hosted", 1, 1, 1, 1},
+		{"no-platform", "owner", "space-a", "", "self_hosted", 1, 1, 1, 1},
+		{"unknown-platform", "owner", "space-a", "custom-runtime", "self_hosted", 1, 1, 1, 1},
+		{"foreign", "other-owner", "space-a", "OpenClaw", "self_hosted", 1, 1, 1, 1},
+		{"other-space", "owner", "space-b", "OpenClaw", "self_hosted", 1, 1, 1, 1},
+		{"disabled-user", "owner", "space-a", "OpenClaw", "self_hosted", 0, 1, 1, 1},
+		{"disabled-robot", "owner", "space-a", "OpenClaw", "self_hosted", 1, 0, 1, 1},
+		{"removed-bot", "owner", "space-a", "OpenClaw", "self_hosted", 1, 1, 0, 1},
+		{"human", "owner", "space-a", "OpenClaw", "self_hosted", 1, 1, 1, 0},
+	} {
+		exec("INSERT INTO user VALUES (?,?,?,?)", bot.uid, bot.uid, bot.robot, bot.userStatus)
+		exec("INSERT INTO robot(robot_id,creator_uid,status,description,bot_commands,agent_platform,agent_hosting) VALUES (?,?,?,'description','[]',?,?)", bot.uid, bot.owner, bot.robotStatus, bot.platform, bot.hosting)
+		exec("INSERT INTO space_member VALUES (?,?,?)", bot.space, bot.uid, bot.memberStatus)
+	}
+	// Prove the entire endpoint works without querying the unrelated platform column.
+	exec("ALTER TABLE robot DROP COLUMN agent_platform")
+	rb := &Robot{ctx: ctx, Log: log.NewTLog("OwnedBotsMetadataTest")}
+	router := wkhttp.New()
+	router.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	loginUID := "owner"
+	router.GET("/v1/robot/owned_bots", func(c *wkhttp.Context) {
+		c.Set("uid", loginUID)
+		rb.ownedBots(c)
+	})
+	get := func(query string) *httptest.ResponseRecorder {
+		t.Helper()
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, httptest.NewRequest("GET", "/v1/robot/owned_bots"+query, nil))
+		return w
+	}
+	for _, tc := range []struct {
+		name, query string
+		want        []string
+	}{
+		{"default includes hosting", "?space_id=space-a", []string{"local", "cloud", "other-platform", "no-platform", "unknown-platform"}},
+		{"unknown include is ignored", "?space_id=space-a&include=future", []string{"local", "cloud", "other-platform", "no-platform", "unknown-platform"}},
+		{"old include cannot change owner", "?space_id=space-a&include=agent_metadata&owner_uid=other-owner", []string{"local", "cloud", "other-platform", "no-platform", "unknown-platform"}},
+		{"space-bound", "?space_id=space-b", []string{"other-space"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := get(tc.query)
+			require.Equal(t, 200, w.Code, w.Body.String())
+			var rows []map[string]any
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &rows))
+			var ids []string
+			for _, row := range rows {
+				require.Len(t, row, 5)
+				ids = append(ids, row["uid"].(string))
+				for _, field := range []string{"uid", "name", "description", "bot_commands"} {
+					require.Contains(t, row, field)
+				}
+				require.NotContains(t, row, "agent_platform")
+				require.NotEmpty(t, row["agent_hosting"])
+			}
+			require.ElementsMatch(t, tc.want, ids)
+		})
+	}
+	assertDenied := func(query string, semanticStatus int) {
+		t.Helper()
+		w := get(query)
+		require.Equal(t, 400, w.Code, w.Body.String()) // Legacy D14 envelope.
+		var envelope struct {
+			Error struct {
+				HTTPStatus int `json:"http_status"`
+			} `json:"error"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+		require.Equal(t, semanticStatus, envelope.Error.HTTPStatus, w.Body.String())
+		require.NotContains(t, w.Body.String(), "agent_hosting")
+	}
+	assertDenied("", 400)
+	assertDenied("?space_id=unknown", 403)
+	loginUID = "outsider"
+	assertDenied("?space_id=space-a", 403)
+	loginUID = "owner"
+	exec("UPDATE space_member SET status=0 WHERE space_id='space-a' AND uid='owner'")
+	assertDenied("?space_id=space-a", 403)
+	exec("UPDATE space_member SET status=1 WHERE space_id='space-a' AND uid='owner'")
+	exec("UPDATE space SET status=0 WHERE space_id='space-a'")
+	assertDenied("?space_id=space-a", 403)
+	exec("UPDATE space SET status=1 WHERE space_id='space-a'")
+	exec("ALTER TABLE robot RENAME COLUMN agent_hosting TO missing_hosting")
+	assertDenied("?space_id=space-a", 500)
+}

--- a/modules/robot/api_owned_bots_metadata_test.go
+++ b/modules/robot/api_owned_bots_metadata_test.go
@@ -58,27 +58,29 @@ func TestOwnedBotsMetadataMySQLContract(t *testing.T) {
 	// separate concern. No shared schema or testutil.CleanAllTables is used.
 	exec("CREATE TABLE space (space_id VARCHAR(40) PRIMARY KEY, status INT NOT NULL)")
 	exec("CREATE TABLE space_member (space_id VARCHAR(40), uid VARCHAR(40), status INT NOT NULL, PRIMARY KEY(space_id,uid))")
-	exec("CREATE TABLE user (uid VARCHAR(40) PRIMARY KEY, name VARCHAR(40), robot INT NOT NULL, status INT NOT NULL)")
+	exec("CREATE TABLE user (uid VARCHAR(40) PRIMARY KEY, name VARCHAR(40), robot INT NOT NULL, status INT NOT NULL, is_destroy INT NOT NULL DEFAULT 0)")
 	exec("CREATE TABLE robot (robot_id VARCHAR(40) PRIMARY KEY, creator_uid VARCHAR(40), status INT NOT NULL, description TEXT, bot_commands TEXT, agent_platform VARCHAR(40), agent_hosting VARCHAR(40), agent_reported_hosting_at TIMESTAMP NULL, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)")
 	exec("INSERT INTO space VALUES ('space-a',1),('space-b',1)")
 	exec("INSERT INTO space_member VALUES ('space-a','owner',1),('space-b','owner',1),('space-a','other-owner',1)")
 	for _, bot := range []struct {
-		uid, owner, space, platform, hosting         string
-		userStatus, robotStatus, memberStatus, robot int
+		uid, owner, space, platform, hosting                      string
+		userStatus, userDestroy, robotStatus, memberStatus, robot int
 	}{
-		{"local", "owner", "space-a", "OpenClaw", "self_hosted", 1, 1, 1, 1},
-		{"cloud", "owner", "space-a", "OpenClaw", "octo_hosted", 1, 1, 1, 1},
-		{"other-platform", "owner", "space-a", "Codex", "self_hosted", 1, 1, 1, 1},
-		{"no-platform", "owner", "space-a", "", "self_hosted", 1, 1, 1, 1},
-		{"unknown-platform", "owner", "space-a", "custom-runtime", "self_hosted", 1, 1, 1, 1},
-		{"foreign", "other-owner", "space-a", "OpenClaw", "self_hosted", 1, 1, 1, 1},
-		{"other-space", "owner", "space-b", "OpenClaw", "self_hosted", 1, 1, 1, 1},
-		{"disabled-user", "owner", "space-a", "OpenClaw", "self_hosted", 0, 1, 1, 1},
-		{"disabled-robot", "owner", "space-a", "OpenClaw", "self_hosted", 1, 0, 1, 1},
-		{"removed-bot", "owner", "space-a", "OpenClaw", "self_hosted", 1, 1, 0, 1},
-		{"human", "owner", "space-a", "OpenClaw", "self_hosted", 1, 1, 1, 0},
+		{"local", "owner", "space-a", "OpenClaw", "self_hosted", 1, 0, 1, 1, 1},
+		{"cloud", "owner", "space-a", "OpenClaw", "octo_hosted", 1, 0, 1, 1, 1},
+		{"other-platform", "owner", "space-a", "Codex", "self_hosted", 1, 0, 1, 1, 1},
+		{"no-platform", "owner", "space-a", "", "self_hosted", 1, 0, 1, 1, 1},
+		{"unknown-platform", "owner", "space-a", "custom-runtime", "self_hosted", 1, 0, 1, 1, 1},
+		{"foreign", "other-owner", "space-a", "OpenClaw", "self_hosted", 1, 0, 1, 1, 1},
+		{"other-space", "owner", "space-b", "OpenClaw", "self_hosted", 1, 0, 1, 1, 1},
+		{"disabled-user", "owner", "space-a", "OpenClaw", "self_hosted", 0, 0, 1, 1, 1},
+		{"destroying-user", "owner", "space-a", "OpenClaw", "self_hosted", 1, 1, 1, 1, 1},
+		{"destroyed-user", "owner", "space-a", "OpenClaw", "self_hosted", 1, 2, 1, 1, 1},
+		{"disabled-robot", "owner", "space-a", "OpenClaw", "self_hosted", 1, 0, 0, 1, 1},
+		{"removed-bot", "owner", "space-a", "OpenClaw", "self_hosted", 1, 0, 1, 0, 1},
+		{"human", "owner", "space-a", "OpenClaw", "self_hosted", 1, 0, 1, 1, 0},
 	} {
-		exec("INSERT INTO user VALUES (?,?,?,?)", bot.uid, bot.uid, bot.robot, bot.userStatus)
+		exec("INSERT INTO user VALUES (?,?,?,?,?)", bot.uid, bot.uid, bot.robot, bot.userStatus, bot.userDestroy)
 		exec("INSERT INTO robot(robot_id,creator_uid,status,description,bot_commands,agent_platform,agent_hosting,agent_reported_hosting_at) VALUES (?,?,?,'description','[]',?,?,UTC_TIMESTAMP())", bot.uid, bot.owner, bot.robotStatus, bot.platform, bot.hosting)
 		exec("INSERT INTO space_member VALUES (?,?,?)", bot.space, bot.uid, bot.memberStatus)
 	}

--- a/modules/robot/api_test.go
+++ b/modules/robot/api_test.go
@@ -315,6 +315,7 @@ func TestOwnedBots(t *testing.T) {
 	friendBot := "owned_friend_836"
 	deletedBot := "owned_deleted_836"
 	disabledUserBot := "owned_disabled_user_858"
+	destroyedUserBot := "owned_destroyed_user_859"
 	removedBot := "owned_removed_836"
 
 	spaceIDs := []string{testSpaceID, otherSpaceID, nonMemberSpaceID, removedMemberSpaceID, disabledSpaceID}
@@ -374,6 +375,9 @@ func TestOwnedBots(t *testing.T) {
 	mkBot(deletedBot, "DeletedBot", 0, uid, testSpaceID, 1)
 	mkBot(disabledUserBot, "DisabledUserBot", 1, uid, testSpaceID, 1)
 	_, err = db.Update("user").Set("status", 0).Where("uid = ?", disabledUserBot).Exec()
+	require.NoError(t, err)
+	mkBot(destroyedUserBot, "DestroyedUserBot", 1, uid, testSpaceID, 1)
+	_, err = db.Update("user").Set("is_destroy", 2).Where("uid = ?", destroyedUserBot).Exec()
 	require.NoError(t, err)
 	mkBot(removedBot, "RemovedBot", 1, uid, testSpaceID, 0)
 

--- a/modules/robot/api_test.go
+++ b/modules/robot/api_test.go
@@ -291,10 +291,10 @@ func TestRobotProxyFileNewPath(t *testing.T) {
 }
 
 // TestOwnedBots verifies /robot/owned_bots only returns bots created by the
-// login user, with robot.status=1 and an active space_member row in the given
-// Space. It must not leak bots from other spaces, bots created by others (even
-// if befriended), soft-deleted bots, or removed space members. Missing
-// space_id must be a request-invalid error.
+// login user, with active robot/user rows and an active space_member row in the
+// given Space. It must not leak bots from other spaces, bots created by others
+// (even if befriended), soft-deleted/disabled bots, or removed space members.
+// Missing space_id must be a request-invalid error.
 func TestOwnedBots(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
 	s.GetRoute().SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
@@ -314,6 +314,7 @@ func TestOwnedBots(t *testing.T) {
 	mineOther := "owned_other_sp_836"
 	friendBot := "owned_friend_836"
 	deletedBot := "owned_deleted_836"
+	disabledUserBot := "owned_disabled_user_858"
 	removedBot := "owned_removed_836"
 
 	spaceIDs := []string{testSpaceID, otherSpaceID, nonMemberSpaceID, removedMemberSpaceID, disabledSpaceID}
@@ -360,8 +361,8 @@ func TestOwnedBots(t *testing.T) {
 	mkBot := func(botUID, name string, robotStatus int, creator, spaceID string, memberStatus int) {
 		_, err := db.InsertInto("user").Columns("uid", "name", "short_no", "robot", "status").Values(botUID, name, botUID, 1, 1).Exec()
 		require.NoError(t, err)
-		_, err = db.InsertInto("robot").Columns("robot_id", "status", "creator_uid", "description", "bot_commands").
-			Values(botUID, robotStatus, creator, name+" desc", "/start").Exec()
+		_, err = db.InsertInto("robot").Columns("robot_id", "status", "creator_uid", "description", "bot_commands", "agent_hosting").
+			Values(botUID, robotStatus, creator, name+" desc", "/start", "self_hosted").Exec()
 		require.NoError(t, err)
 		_, err = db.InsertInto("space_member").Columns("space_id", "uid", "status").Values(spaceID, botUID, memberStatus).Exec()
 		require.NoError(t, err)
@@ -371,6 +372,9 @@ func TestOwnedBots(t *testing.T) {
 	mkBot(mineOther, "MineOtherSpace", 1, uid, otherSpaceID, 1)
 	mkBot(friendBot, "FriendBot", 1, other, testSpaceID, 1)
 	mkBot(deletedBot, "DeletedBot", 0, uid, testSpaceID, 1)
+	mkBot(disabledUserBot, "DisabledUserBot", 1, uid, testSpaceID, 1)
+	_, err = db.Update("user").Set("status", 0).Where("uid = ?", disabledUserBot).Exec()
+	require.NoError(t, err)
 	mkBot(removedBot, "RemovedBot", 1, uid, testSpaceID, 0)
 
 	_, err = db.InsertInto("friend").Columns("uid", "to_uid", "is_deleted").Values(uid, friendBot, 0).Exec()
@@ -423,6 +427,10 @@ func TestOwnedBots(t *testing.T) {
 	assert.Equal(t, mine, results[0]["uid"])
 	assert.Equal(t, "MineBot", results[0]["name"])
 	assert.Equal(t, "/start", results[0]["bot_commands"])
+	assert.Equal(t, "self_hosted", results[0]["agent_hosting"])
+	_, hasHostingReportedAt := results[0]["agent_reported_hosting_at"]
+	assert.True(t, hasHostingReportedAt)
+	assert.Nil(t, results[0]["agent_reported_hosting_at"])
 	_, hasToken := results[0]["token"]
 	assert.False(t, hasToken)
 	_, hasBotToken := results[0]["bot_token"]

--- a/modules/robot/zz_migrations_test.go
+++ b/modules/robot/zz_migrations_test.go
@@ -1,0 +1,6 @@
+package robot_test
+
+// The owned_bots query reads agent_hosting, whose schema migration is owned by
+// botfather. Import it from the external test package so robot's integration
+// test database receives that migration without creating an import cycle.
+import _ "github.com/Mininglamp-OSS/octo-server/modules/botfather"

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -5177,10 +5177,11 @@ func (u *User) authVerifyBot(c *wkhttp.Context) {
 				respondUserRequestInvalid(c, "project_ids")
 				return
 			}
-			u.Warn("authVerifyBot context lookup failed", zap.Error(err))
+			u.Warn("authVerifyBot context lookup failed",
+				zap.String("bot_uid", resp.BotUID),
+				zap.String("space_id", req.SpaceID),
+				zap.Error(err))
 			resp.ContextError = true
-			resp.BotContext = nil
-			resp.OwnerContext = nil
 		}
 	}
 	c.Response(resp)

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -5090,15 +5090,22 @@ func (u *User) queryUserSpaceContext(uid string) ([]string, map[string][]string,
 }
 
 type authVerifyBotReq struct {
-	BotToken string `json:"bot_token"`
+	BotToken   string   `json:"bot_token"`
+	SpaceID    string   `json:"space_id"`
+	ProjectIDs []string `json:"project_ids"`
+	OwnerUID   string   `json:"owner_uid"` // Rejected on the opt-in path; never an authority.
 }
 
 type authVerifyBotResp struct {
-	BotUID    string `json:"bot_uid"`
-	BotName   string `json:"bot_name"`
-	OwnerUID  string `json:"owner_uid"`
-	OwnerName string `json:"owner_name"`
-	SpaceID   string `json:"space_id"`
+	BotUID          string                 `json:"bot_uid"`
+	BotName         string                 `json:"bot_name"`
+	OwnerUID        string                 `json:"owner_uid"`
+	OwnerName       string                 `json:"owner_name"`
+	SpaceID         string                 `json:"space_id"`
+	ContextIncluded bool                   `json:"context_included,omitempty"`
+	ContextError    bool                   `json:"context_error,omitempty"`
+	BotContext      *verifyBotContext      `json:"bot_context,omitempty"`
+	OwnerContext    *verifyBotOwnerContext `json:"owner_context,omitempty"`
 }
 
 // authVerifyBot validates a Bot token (BotFather Bearer token) and returns bot + owner info.
@@ -5111,6 +5118,11 @@ func (u *User) authVerifyBot(c *wkhttp.Context) {
 	}
 	if req.BotToken == "" {
 		respondUserTokenRequired(c, "bot_token")
+		return
+	}
+	if c.Query("include") == "owner_context" &&
+		(req.SpaceID == "" || req.OwnerUID != "" || len(req.ProjectIDs) > maxVerifyProjectIDs) {
+		respondUserRequestInvalid(c, "owner_context")
 		return
 	}
 
@@ -5152,13 +5164,26 @@ func (u *User) authVerifyBot(c *wkhttp.Context) {
 		Limit(1).
 		LoadOne(&spaceID)
 
-	c.Response(authVerifyBotResp{
+	resp := authVerifyBotResp{
 		BotUID:    botInfo.RobotID,
 		BotName:   botName,
 		OwnerUID:  botInfo.CreatorUID,
 		OwnerName: ownerName,
 		SpaceID:   spaceID,
-	})
+	}
+	if c.Query("include") == "owner_context" {
+		if err := u.fillBotProjectContext(&resp, req); err != nil {
+			if errors.Is(err, errTooManyProjectIDs) {
+				respondUserRequestInvalid(c, "project_ids")
+				return
+			}
+			u.Warn("authVerifyBot context lookup failed", zap.Error(err))
+			resp.ContextError = true
+			resp.BotContext = nil
+			resp.OwnerContext = nil
+		}
+	}
+	c.Response(resp)
 }
 
 type authVerifyAPIKeyReq struct {

--- a/modules/user/api_bot_project_context.go
+++ b/modules/user/api_bot_project_context.go
@@ -1,15 +1,24 @@
 package user
 
-import "github.com/gocraft/dbr/v2"
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/gocraft/dbr/v2"
+)
 
 // These are identity/membership facts, not delegated permissions. Owner projects
 // are not the Bot's seats and are never emitted as top-level projects.
 type verifyBotContext struct {
-	UID          string `json:"uid"`
-	Active       bool   `json:"active"`
-	AgentHosting string `json:"agent_hosting"`
-	SpaceID      string `json:"space_id"`
-	SpaceMember  bool   `json:"space_member"`
+	UID    string `json:"uid"`
+	Active bool   `json:"active"`
+	// AgentHosting is self-reported telemetry. Consumers must not use it as an
+	// authorization or quota signal.
+	AgentHosting           string  `json:"agent_hosting"`
+	AgentReportedHostingAt *string `json:"agent_reported_hosting_at"`
+	SpaceID                string  `json:"space_id"`
+	SpaceMember            bool    `json:"space_member"`
 }
 
 type verifyBotOwnerContext struct {
@@ -30,15 +39,17 @@ func (u *User) fillBotProjectContext(resp *authVerifyBotResp, req authVerifyBotR
 	owner := &verifyBotOwnerContext{UID: resp.OwnerUID, SpaceID: req.SpaceID}
 	resp.BotContext, resp.OwnerContext = bot, owner
 	var facts struct {
-		Hosting     string `db:"hosting"`
-		BotActive   bool   `db:"bot_active"`
-		OwnerActive bool   `db:"owner_active"`
-		BotMember   bool   `db:"bot_member"`
-		OwnerMember bool   `db:"owner_member"`
+		Hosting         string       `db:"hosting"`
+		HostingReported dbr.NullTime `db:"hosting_reported_at"`
+		BotActive       bool         `db:"bot_active"`
+		OwnerActive     bool         `db:"owner_active"`
+		BotMember       bool         `db:"bot_member"`
+		OwnerMember     bool         `db:"owner_member"`
 	}
 	err := u.db.session.SelectBySql(
-		"SELECT IFNULL(r.agent_hosting,'') AS hosting, "+
-			"(bu.status = 1 AND bu.robot = 1) AS bot_active, (ou.status = 1 AND ou.robot = 0) AS owner_active, "+
+		"SELECT IFNULL(r.agent_hosting,'') AS hosting, r.agent_reported_hosting_at AS hosting_reported_at, "+
+			"(bu.status = 1 AND bu.robot = 1 AND COALESCE(bu.is_destroy, 0) <> 2) AS bot_active, "+
+			"(ou.status = 1 AND ou.robot = 0 AND COALESCE(ou.is_destroy, 0) <> 2) AS owner_active, "+
 			"(s.space_id IS NOT NULL AND bm.uid IS NOT NULL) AS bot_member, "+
 			"(s.space_id IS NOT NULL AND om.uid IS NOT NULL) AS owner_member "+
 			"FROM robot r JOIN `user` bu ON bu.uid = r.robot_id JOIN `user` ou ON ou.uid = r.creator_uid "+
@@ -48,14 +59,21 @@ func (u *User) fillBotProjectContext(resp *authVerifyBotResp, req authVerifyBotR
 			"WHERE r.robot_id = ? AND r.creator_uid = ? AND r.bot_token = ? AND r.status = 1 LIMIT 1",
 		req.SpaceID, resp.BotUID, resp.OwnerUID, req.BotToken,
 	).LoadOne(&facts)
-	if err != nil && err != dbr.ErrNotFound {
+	if err != nil {
+		if errors.Is(err, dbr.ErrNotFound) {
+			return fmt.Errorf("user: bot owner context disappeared after credential verification: %w", err)
+		}
 		return err
 	}
 	bot.Active, bot.AgentHosting = facts.BotActive, facts.Hosting
+	if facts.HostingReported.Valid {
+		formatted := facts.HostingReported.Time.Format(time.DateTime)
+		bot.AgentReportedHostingAt = &formatted
+	}
 	owner.Active = facts.OwnerActive
-	bot.SpaceMember = bot.Active && facts.BotMember
-	owner.SpaceMember = owner.Active && facts.OwnerMember
-	if bot.SpaceMember && owner.SpaceMember {
+	bot.SpaceMember = facts.BotMember
+	owner.SpaceMember = facts.OwnerMember
+	if bot.Active && owner.Active && bot.SpaceMember && owner.SpaceMember {
 		owner.Projects, err = u.answerProjectMembership(owner.UID, req.SpaceID, req.ProjectIDs)
 		return err
 	}

--- a/modules/user/api_bot_project_context.go
+++ b/modules/user/api_bot_project_context.go
@@ -17,16 +17,26 @@ type verifyBotContext struct {
 	// authorization or quota signal.
 	AgentHosting           string  `json:"agent_hosting"`
 	AgentReportedHostingAt *string `json:"agent_reported_hosting_at"`
-	SpaceID                string  `json:"space_id"`
+	RequestedSpaceID       string  `json:"requested_space_id"`
 	SpaceMember            bool    `json:"space_member"`
 }
 
 type verifyBotOwnerContext struct {
-	UID         string                `json:"uid"`
-	Active      bool                  `json:"active"`
-	SpaceID     string                `json:"space_id"`
-	SpaceMember bool                  `json:"space_member"`
-	Projects    []verifyProjectAnswer `json:"projects"`
+	UID              string                   `json:"uid"`
+	Active           bool                     `json:"active"`
+	RequestedSpaceID string                   `json:"requested_space_id"`
+	SpaceMember      bool                     `json:"space_member"`
+	Projects         []verifyBotProjectAnswer `json:"projects"`
+}
+
+// verifyBotProjectAnswer intentionally omits capabilities and member_epoch.
+// The Bot credential is not the owner's delegated credential, so this callback
+// may report the owner's membership role but must not export an executable
+// capability list or lifecycle metadata for that other principal.
+type verifyBotProjectAnswer struct {
+	ProjectID string `json:"project_id"`
+	Member    bool   `json:"member"`
+	Role      *int   `json:"role,omitempty"`
 }
 
 // Deliberately uncached. No platform/hosting filter belongs in a general identity query.
@@ -35,8 +45,11 @@ func (u *User) fillBotProjectContext(resp *authVerifyBotResp, req authVerifyBotR
 	if len(req.ProjectIDs) > maxVerifyProjectIDs {
 		return errTooManyProjectIDs
 	}
-	bot := &verifyBotContext{UID: resp.BotUID, SpaceID: req.SpaceID}
-	owner := &verifyBotOwnerContext{UID: resp.OwnerUID, SpaceID: req.SpaceID}
+	bot := &verifyBotContext{UID: resp.BotUID, RequestedSpaceID: req.SpaceID}
+	owner := &verifyBotOwnerContext{
+		UID: resp.OwnerUID, RequestedSpaceID: req.SpaceID,
+		Projects: make([]verifyBotProjectAnswer, 0),
+	}
 	resp.BotContext, resp.OwnerContext = bot, owner
 	var facts struct {
 		Hosting         string       `db:"hosting"`
@@ -48,8 +61,8 @@ func (u *User) fillBotProjectContext(resp *authVerifyBotResp, req authVerifyBotR
 	}
 	err := u.db.session.SelectBySql(
 		"SELECT IFNULL(r.agent_hosting,'') AS hosting, r.agent_reported_hosting_at AS hosting_reported_at, "+
-			"(bu.status = 1 AND bu.robot = 1 AND COALESCE(bu.is_destroy, 0) = 0) AS bot_active, "+
-			"(ou.status = 1 AND ou.robot = 0 AND COALESCE(ou.is_destroy, 0) = 0) AS owner_active, "+
+			"(COALESCE(bu.status, 0) = 1 AND COALESCE(bu.robot, 0) = 1 AND COALESCE(bu.is_destroy, 0) = 0) AS bot_active, "+
+			"(COALESCE(ou.status, 0) = 1 AND COALESCE(ou.robot, 0) = 0 AND COALESCE(ou.is_destroy, 0) = 0) AS owner_active, "+
 			"(s.space_id IS NOT NULL AND bm.uid IS NOT NULL) AS bot_member, "+
 			"(s.space_id IS NOT NULL AND om.uid IS NOT NULL) AS owner_member "+
 			"FROM robot r JOIN `user` bu ON bu.uid = r.robot_id JOIN `user` ou ON ou.uid = r.creator_uid "+
@@ -74,17 +87,36 @@ func (u *User) fillBotProjectContext(resp *authVerifyBotResp, req authVerifyBotR
 	bot.SpaceMember = facts.BotMember
 	owner.SpaceMember = facts.OwnerMember
 	if bot.Active && owner.Active && bot.SpaceMember && owner.SpaceMember {
-		owner.Projects, err = u.answerProjectMembership(owner.UID, req.SpaceID, req.ProjectIDs)
+		var answers []verifyProjectAnswer
+		answers, err = u.answerProjectMembership(owner.UID, req.SpaceID, req.ProjectIDs)
+		owner.Projects = narrowBotProjectAnswers(answers)
 		return err
 	}
-	// No role/epoch disclosure when either identity cannot access the named Space.
-	owner.Projects = make([]verifyProjectAnswer, 0, len(req.ProjectIDs))
+	// No role disclosure when either identity cannot access the named Space.
+	owner.Projects = make([]verifyBotProjectAnswer, 0, len(req.ProjectIDs))
 	seen := make(map[string]bool, len(req.ProjectIDs))
 	for _, id := range req.ProjectIDs {
 		if id != "" && !seen[id] {
 			seen[id] = true
-			owner.Projects = append(owner.Projects, verifyProjectAnswer{ProjectID: id})
+			owner.Projects = append(owner.Projects, verifyBotProjectAnswer{ProjectID: id})
 		}
 	}
 	return nil
+}
+
+func narrowBotProjectAnswers(answers []verifyProjectAnswer) []verifyBotProjectAnswer {
+	result := make([]verifyBotProjectAnswer, 0, len(answers))
+	for _, answer := range answers {
+		var role *int
+		if answer.Role != nil {
+			value := *answer.Role
+			role = &value
+		}
+		result = append(result, verifyBotProjectAnswer{
+			ProjectID: answer.ProjectID,
+			Member:    answer.Member,
+			Role:      role,
+		})
+	}
+	return result
 }

--- a/modules/user/api_bot_project_context.go
+++ b/modules/user/api_bot_project_context.go
@@ -48,8 +48,8 @@ func (u *User) fillBotProjectContext(resp *authVerifyBotResp, req authVerifyBotR
 	}
 	err := u.db.session.SelectBySql(
 		"SELECT IFNULL(r.agent_hosting,'') AS hosting, r.agent_reported_hosting_at AS hosting_reported_at, "+
-			"(bu.status = 1 AND bu.robot = 1 AND COALESCE(bu.is_destroy, 0) <> 2) AS bot_active, "+
-			"(ou.status = 1 AND ou.robot = 0 AND COALESCE(ou.is_destroy, 0) <> 2) AS owner_active, "+
+			"(bu.status = 1 AND bu.robot = 1 AND COALESCE(bu.is_destroy, 0) = 0) AS bot_active, "+
+			"(ou.status = 1 AND ou.robot = 0 AND COALESCE(ou.is_destroy, 0) = 0) AS owner_active, "+
 			"(s.space_id IS NOT NULL AND bm.uid IS NOT NULL) AS bot_member, "+
 			"(s.space_id IS NOT NULL AND om.uid IS NOT NULL) AS owner_member "+
 			"FROM robot r JOIN `user` bu ON bu.uid = r.robot_id JOIN `user` ou ON ou.uid = r.creator_uid "+

--- a/modules/user/api_bot_project_context.go
+++ b/modules/user/api_bot_project_context.go
@@ -1,0 +1,72 @@
+package user
+
+import "github.com/gocraft/dbr/v2"
+
+// These are identity/membership facts, not delegated permissions. Owner projects
+// are not the Bot's seats and are never emitted as top-level projects.
+type verifyBotContext struct {
+	UID          string `json:"uid"`
+	Active       bool   `json:"active"`
+	AgentHosting string `json:"agent_hosting"`
+	SpaceID      string `json:"space_id"`
+	SpaceMember  bool   `json:"space_member"`
+}
+
+type verifyBotOwnerContext struct {
+	UID         string                `json:"uid"`
+	Active      bool                  `json:"active"`
+	SpaceID     string                `json:"space_id"`
+	SpaceMember bool                  `json:"space_member"`
+	Projects    []verifyProjectAnswer `json:"projects"`
+}
+
+// Deliberately uncached. No platform/hosting filter belongs in a general identity query.
+func (u *User) fillBotProjectContext(resp *authVerifyBotResp, req authVerifyBotReq) error {
+	resp.ContextIncluded = true
+	if len(req.ProjectIDs) > maxVerifyProjectIDs {
+		return errTooManyProjectIDs
+	}
+	bot := &verifyBotContext{UID: resp.BotUID, SpaceID: req.SpaceID}
+	owner := &verifyBotOwnerContext{UID: resp.OwnerUID, SpaceID: req.SpaceID}
+	resp.BotContext, resp.OwnerContext = bot, owner
+	var facts struct {
+		Hosting     string `db:"hosting"`
+		BotActive   bool   `db:"bot_active"`
+		OwnerActive bool   `db:"owner_active"`
+		BotMember   bool   `db:"bot_member"`
+		OwnerMember bool   `db:"owner_member"`
+	}
+	err := u.db.session.SelectBySql(
+		"SELECT IFNULL(r.agent_hosting,'') AS hosting, "+
+			"(bu.status = 1 AND bu.robot = 1) AS bot_active, (ou.status = 1 AND ou.robot = 0) AS owner_active, "+
+			"(s.space_id IS NOT NULL AND bm.uid IS NOT NULL) AS bot_member, "+
+			"(s.space_id IS NOT NULL AND om.uid IS NOT NULL) AS owner_member "+
+			"FROM robot r JOIN `user` bu ON bu.uid = r.robot_id JOIN `user` ou ON ou.uid = r.creator_uid "+
+			"LEFT JOIN space s ON s.space_id = ? AND s.status = 1 "+
+			"LEFT JOIN space_member bm ON bm.space_id = s.space_id AND bm.uid = bu.uid AND bm.status = 1 "+
+			"LEFT JOIN space_member om ON om.space_id = s.space_id AND om.uid = ou.uid AND om.status = 1 "+
+			"WHERE r.robot_id = ? AND r.creator_uid = ? AND r.bot_token = ? AND r.status = 1 LIMIT 1",
+		req.SpaceID, resp.BotUID, resp.OwnerUID, req.BotToken,
+	).LoadOne(&facts)
+	if err != nil && err != dbr.ErrNotFound {
+		return err
+	}
+	bot.Active, bot.AgentHosting = facts.BotActive, facts.Hosting
+	owner.Active = facts.OwnerActive
+	bot.SpaceMember = bot.Active && facts.BotMember
+	owner.SpaceMember = owner.Active && facts.OwnerMember
+	if bot.SpaceMember && owner.SpaceMember {
+		owner.Projects, err = u.answerProjectMembership(owner.UID, req.SpaceID, req.ProjectIDs)
+		return err
+	}
+	// No role/epoch disclosure when either identity cannot access the named Space.
+	owner.Projects = make([]verifyProjectAnswer, 0, len(req.ProjectIDs))
+	seen := make(map[string]bool, len(req.ProjectIDs))
+	for _, id := range req.ProjectIDs {
+		if id != "" && !seen[id] {
+			seen[id] = true
+			owner.Projects = append(owner.Projects, verifyProjectAnswer{ProjectID: id})
+		}
+	}
+	return nil
+}

--- a/modules/user/api_bot_project_context_test.go
+++ b/modules/user/api_bot_project_context_test.go
@@ -1,25 +1,32 @@
 package user
 
 import (
+	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 )
 
 // Pin every SQL predicate that gates owner Project facts. The tests below also
 // inject each computed boolean to exercise the Go-level fail-closed logic.
 const botContextQueryPattern = `(?s)SELECT IFNULL.*` +
-	`bu.status = 1 AND bu.robot = 1 AND COALESCE\(bu.is_destroy, 0\) <> 2.*` +
-	`ou.status = 1 AND ou.robot = 0 AND COALESCE\(ou.is_destroy, 0\) <> 2.*` +
+	`bu.status = 1 AND bu.robot = 1 AND COALESCE\(bu.is_destroy, 0\) = 0.*` +
+	`ou.status = 1 AND ou.robot = 0 AND COALESCE\(ou.is_destroy, 0\) = 0.*` +
 	`s.space_id = 'space' AND s.status = 1.*` +
 	`bm.uid = bu.uid AND bm.status = 1.*` +
 	`om.uid = ou.uid AND om.status = 1.*` +
@@ -184,4 +191,100 @@ func TestBotOwnerContextMissingFactsIsAnError(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "disappeared after credential verification")
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestBotOwnerContextMySQLLivenessContract executes the authorization-shaped
+// predicates in MySQL instead of injecting their already-computed booleans.
+// Every case gets distinct rows in a randomly named database; no shared schema
+// or testutil.CleanAllTables call is involved.
+func TestBotOwnerContextMySQLLivenessContract(t *testing.T) {
+	dsn := os.Getenv("OCTO_ASSISTANT_TEST_MYSQL_DSN")
+	if dsn == "" {
+		t.Skip("set OCTO_ASSISTANT_TEST_MYSQL_DSN for an isolated MySQL server")
+	}
+	dbConfig, err := mysql.ParseDSN(dsn)
+	require.NoError(t, err)
+	dbConfig.DBName = "information_schema"
+	bootstrap, err := sql.Open("mysql", dbConfig.FormatDSN())
+	require.NoError(t, err)
+	bootstrap.SetMaxOpenConns(2)
+	bootstrap.SetMaxIdleConns(1)
+	t.Cleanup(func() { require.NoError(t, bootstrap.Close()) })
+	require.NoError(t, bootstrap.Ping())
+	databaseName := "octo_bot_context_" + util.GenerUUID()[:12]
+	_, err = bootstrap.Exec("CREATE DATABASE `" + databaseName + "` CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, err := bootstrap.Exec("DROP DATABASE `" + databaseName + "`")
+		require.NoError(t, err)
+	})
+	dbConfig.DBName = databaseName
+	cfg := config.New()
+	cfg.DB.MySQLAddr = dbConfig.FormatDSN()
+	cfg.DB.MySQLMaxOpenConns = 2
+	cfg.DB.MySQLMaxIdleConns = 1
+	ctx := testutil.NewTestContext(cfg)
+	database := ctx.DB().DB
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	exec := func(query string, args ...any) {
+		t.Helper()
+		_, err := database.Exec(query, args...)
+		require.NoError(t, err)
+	}
+	exec("CREATE TABLE `user` (uid VARCHAR(40) PRIMARY KEY, status INT NOT NULL, robot INT NOT NULL, is_destroy INT NULL)")
+	exec("CREATE TABLE robot (robot_id VARCHAR(40) PRIMARY KEY, creator_uid VARCHAR(40) NOT NULL, bot_token VARCHAR(80) NOT NULL, status INT NOT NULL, agent_hosting VARCHAR(40) NOT NULL DEFAULT '', agent_reported_hosting_at TIMESTAMP NULL)")
+	exec("CREATE TABLE space (space_id VARCHAR(40) PRIMARY KEY, status INT NOT NULL)")
+	exec("CREATE TABLE space_member (space_id VARCHAR(40), uid VARCHAR(40), status INT NOT NULL, PRIMARY KEY(space_id,uid))")
+	exec("CREATE TABLE octo_project (project_id VARCHAR(40) PRIMARY KEY, status INT NOT NULL, member_epoch BIGINT NOT NULL)")
+	exec("CREATE TABLE octo_project_member (project_id VARCHAR(40), uid VARCHAR(40), space_id VARCHAR(40), role INT NOT NULL, status INT NOT NULL, removing INT NOT NULL, PRIMARY KEY(project_id,uid))")
+
+	for i, tc := range []struct {
+		name                                                           string
+		botStatus, botDestroy, ownerStatus, ownerDestroy               int
+		botMemberStatus, ownerMemberStatus, spaceStatus, projectStatus int
+		wantMember                                                     bool
+	}{
+		{"live principals", 1, 0, 1, 0, 1, 1, 1, 1, true},
+		{"disabled bot", 0, 0, 1, 0, 1, 1, 1, 1, false},
+		{"destroying bot", 1, 1, 1, 0, 1, 1, 1, 1, false},
+		{"destroyed bot", 1, 2, 1, 0, 1, 1, 1, 1, false},
+		{"disabled owner", 1, 0, 0, 0, 1, 1, 1, 1, false},
+		{"destroying owner", 1, 0, 1, 1, 1, 1, 1, 1, false},
+		{"destroyed owner", 1, 0, 1, 2, 1, 1, 1, 1, false},
+		{"bot removed from Space", 1, 0, 1, 0, 0, 1, 1, 1, false},
+		{"owner removed from Space", 1, 0, 1, 0, 1, 0, 1, 1, false},
+		{"disbanded Space", 1, 0, 1, 0, 1, 1, 0, 1, false},
+		{"disbanded Project", 1, 0, 1, 0, 1, 1, 1, 0, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			suffix := fmt.Sprintf("%02d", i)
+			botID, ownerID := "bot"+suffix, "owner"+suffix
+			spaceID, projectID, token := "space"+suffix, "project"+suffix, "bf_"+suffix
+			exec("INSERT INTO `user` VALUES (?,?,1,?),(?,?,0,?)", botID, tc.botStatus, tc.botDestroy, ownerID, tc.ownerStatus, tc.ownerDestroy)
+			exec("INSERT INTO robot VALUES (?,?,?,1,'self_hosted',UTC_TIMESTAMP())", botID, ownerID, token)
+			exec("INSERT INTO space VALUES (?,?)", spaceID, tc.spaceStatus)
+			exec("INSERT INTO space_member VALUES (?,?,?),(?,?,?)", spaceID, botID, tc.botMemberStatus, spaceID, ownerID, tc.ownerMemberStatus)
+			exec("INSERT INTO octo_project VALUES (?,?,7)", projectID, tc.projectStatus)
+			exec("INSERT INTO octo_project_member VALUES (?,?,?,2,1,0)", projectID, ownerID, spaceID)
+
+			resp := authVerifyBotResp{BotUID: botID, OwnerUID: ownerID}
+			err := (&User{db: NewDB(ctx)}).fillBotProjectContext(&resp, authVerifyBotReq{
+				BotToken: token, SpaceID: spaceID, ProjectIDs: []string{projectID},
+			})
+			require.NoError(t, err)
+			require.Len(t, resp.OwnerContext.Projects, 1)
+			require.Equal(t, tc.wantMember, resp.OwnerContext.Projects[0].Member)
+			if tc.wantMember {
+				require.True(t, resp.BotContext.Active)
+				require.True(t, resp.OwnerContext.Active)
+				require.True(t, resp.BotContext.SpaceMember)
+				require.True(t, resp.OwnerContext.SpaceMember)
+				require.NotNil(t, resp.OwnerContext.Projects[0].Role)
+			} else {
+				require.Nil(t, resp.OwnerContext.Projects[0].Role)
+				require.Nil(t, resp.OwnerContext.Projects[0].MemberEpoch)
+				require.Empty(t, resp.OwnerContext.Projects[0].Capabilities)
+			}
+		})
+	}
 }

--- a/modules/user/api_bot_project_context_test.go
+++ b/modules/user/api_bot_project_context_test.go
@@ -1,0 +1,158 @@
+package user
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/stretchr/testify/require"
+)
+
+type botContextUserNames struct{ IService }
+
+func (botContextUserNames) GetUser(uid string) (*Resp, error) {
+	return &Resp{Name: uid + " name"}, nil
+}
+
+// Real HTTP handler and SQL contract; this does not replace MySQL integration.
+// Opt-in fields must never change default verifier clients.
+func TestBotOwnerContextHTTPContract(t *testing.T) {
+	for _, tc := range []struct {
+		name, query, body          string
+		invalid, extended, dbError bool
+	}{
+		{"default", "", `{"bot_token":"bf_test"}`, false, false, false},
+		{"legacy context", "?include=context", `{"bot_token":"bf_test","owner_uid":"ignored"}`, false, false, false},
+		{"scoped", "?include=owner_context", `{"bot_token":"bf_test","space_id":"space","project_ids":["p"]}`, false, true, false},
+		{"unavailable", "?include=owner_context", `{"bot_token":"bf_test","space_id":"space","project_ids":["p"]}`, false, true, true},
+		{"missing space", "?include=owner_context", `{"bot_token":"bf_test"}`, true, false, false},
+		{"forged owner", "?include=owner_context", `{"bot_token":"bf_test","space_id":"space","owner_uid":"victim"}`, true, false, false},
+		{"too many projects", "?include=owner_context", `{"bot_token":"bf_test","space_id":"space","project_ids":[` + strings.Repeat(`"p",`, maxVerifyProjectIDs) + `"p"]}`, true, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock := newPhoneLookupMock(t)
+			u := &User{db: db, userService: botContextUserNames{}, Log: log.NewTLog("bot-context-test")}
+			if !tc.invalid {
+				mock.ExpectQuery("SELECT.*FROM robot.*bot_token = 'bf_test'").WillReturnRows(sqlmock.NewRows([]string{"robot_id", "creator_uid"}).AddRow("bot", "owner"))
+				mock.ExpectQuery("SELECT.*FROM space_member.*uid = 'bot'").WillReturnRows(sqlmock.NewRows([]string{"space_id"}).AddRow("first-space"))
+				if tc.extended {
+					q := mock.ExpectQuery("SELECT IFNULL.*WHERE r.robot_id = 'bot' AND r.creator_uid = 'owner' AND r.bot_token = 'bf_test'")
+					if tc.dbError {
+						q.WillReturnError(errors.New("database unavailable"))
+					} else {
+						q.WillReturnRows(sqlmock.NewRows([]string{"hosting", "bot_active", "owner_active", "bot_member", "owner_member"}).AddRow("self_hosted", true, true, true, true))
+						mock.ExpectQuery("SELECT pm.project_id.*WHERE pm.uid = 'owner'.*pm.space_id = 'space'").WillReturnRows(sqlmock.NewRows([]string{"project_id", "role", "member_epoch"}).AddRow("p", 2, 7))
+					}
+				}
+			}
+			r := wkhttp.New()
+			r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+			r.POST("/v1/auth/verify-bot", u.authVerifyBot)
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/v1/auth/verify-bot"+tc.query, strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			r.ServeHTTP(w, req)
+			var response map[string]any
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+			if tc.invalid {
+				require.Equal(t, http.StatusBadRequest, w.Code)
+				require.Contains(t, response, "error")
+			} else {
+				require.Equal(t, http.StatusOK, w.Code)
+				require.Equal(t, "first-space", response["space_id"])
+				require.NotContains(t, response, "projects")
+				require.NotContains(t, w.Body.String(), "bf_test")
+				if !tc.extended {
+					require.Len(t, response, 5)
+				} else if tc.dbError {
+					require.Equal(t, true, response["context_error"])
+					require.NotContains(t, response, "bot_context")
+					require.NotContains(t, response, "owner_context")
+				} else {
+					require.Equal(t, true, response["context_included"])
+					require.Contains(t, response, "bot_context")
+					require.Contains(t, response, "owner_context")
+					require.NotContains(t, response["bot_context"], "agent_platform")
+					require.Equal(t, "self_hosted", response["bot_context"].(map[string]any)["agent_hosting"])
+				}
+			}
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestBotOwnerContextDefaultSchema(t *testing.T) {
+	data, err := json.Marshal(authVerifyBotResp{BotUID: "bot", BotName: "Bot", OwnerUID: "owner", OwnerName: "Owner", SpaceID: "legacy-first-space"})
+	require.NoError(t, err)
+	var fields map[string]any
+	require.NoError(t, json.Unmarshal(data, &fields))
+	require.Len(t, fields, 5)
+	for _, key := range []string{"bot_uid", "bot_name", "owner_uid", "owner_name", "space_id"} {
+		require.Contains(t, fields, key)
+	}
+	data, err = json.Marshal(ownedBot{UID: "bot", Name: "Bot"})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"uid":"bot","name":"Bot"}`, string(data))
+}
+
+func TestBotOwnerContextPlatformNeutralAndSpaceScoped(t *testing.T) {
+	for _, tc := range []struct {
+		name, hosting                                  string
+		botActive, ownerActive, botMember, ownerMember bool
+	}{
+		{"assistant without platform", "self_hosted", true, true, true, true},
+		{"cloud facts are not filtered by Server", "octo_hosted", true, true, true, true},
+		{"unknown hosting remains an identity fact", "", true, true, true, true},
+		{"bot disabled", "self_hosted", false, true, true, true},
+		{"owner disabled", "self_hosted", true, false, true, true},
+		{"bot removed from Space", "self_hosted", true, true, false, true},
+		{"owner removed from Space", "self_hosted", true, true, true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock := newPhoneLookupMock(t)
+			mock.ExpectQuery("SELECT IFNULL.*WHERE r.robot_id = 'bot' AND r.creator_uid = 'owner' AND r.bot_token = 'bf_test' AND r.status = 1").
+				WillReturnRows(sqlmock.NewRows([]string{"hosting", "bot_active", "owner_active", "bot_member", "owner_member"}).AddRow(tc.hosting, tc.botActive, tc.ownerActive, tc.botMember, tc.ownerMember))
+			allowed := tc.botActive && tc.ownerActive && tc.botMember && tc.ownerMember
+			if allowed {
+				mock.ExpectQuery("SELECT pm.project_id.*WHERE pm.uid = 'owner'.*pm.space_id = 'space'").
+					WillReturnRows(sqlmock.NewRows([]string{"project_id", "role", "member_epoch"}).AddRow("p", 2, 7))
+			}
+			resp := authVerifyBotResp{BotUID: "bot", OwnerUID: "owner", SpaceID: "legacy-first-space"}
+			err := (&User{db: db}).fillBotProjectContext(&resp, authVerifyBotReq{BotToken: "bf_test", SpaceID: "space", ProjectIDs: []string{"p", "unknown", "p"}})
+			require.NoError(t, err)
+			require.Equal(t, "legacy-first-space", resp.SpaceID)
+			require.True(t, resp.ContextIncluded)
+			require.Len(t, resp.OwnerContext.Projects, 2)
+			require.Equal(t, allowed, resp.OwnerContext.Projects[0].Member)
+			require.False(t, resp.OwnerContext.Projects[1].Member)
+			require.Nil(t, resp.OwnerContext.Projects[1].Role)
+			require.Nil(t, resp.OwnerContext.Projects[1].MemberEpoch)
+			if !allowed {
+				require.Nil(t, resp.OwnerContext.Projects[0].Role)
+				require.Nil(t, resp.OwnerContext.Projects[0].MemberEpoch)
+			}
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestBotOwnerContextFailsClosed(t *testing.T) {
+	db, mock := newPhoneLookupMock(t)
+	mock.ExpectQuery("SELECT IFNULL").WillReturnError(errors.New("database unavailable"))
+	resp := authVerifyBotResp{BotUID: "bot", OwnerUID: "owner", SpaceID: "legacy"}
+	err := (&User{db: db}).fillBotProjectContext(&resp, authVerifyBotReq{BotToken: "bf_test", SpaceID: "space", ProjectIDs: []string{"p"}})
+	require.Error(t, err)
+	require.Empty(t, resp.OwnerContext.Projects)
+	require.False(t, resp.BotContext.SpaceMember)
+	require.Equal(t, "legacy", resp.SpaceID)
+	require.NoError(t, mock.ExpectationsWereMet())
+	err = (&User{}).fillBotProjectContext(&resp, authVerifyBotReq{ProjectIDs: make([]string, maxVerifyProjectIDs+1)})
+	require.ErrorIs(t, err, errTooManyProjectIDs)
+}

--- a/modules/user/api_bot_project_context_test.go
+++ b/modules/user/api_bot_project_context_test.go
@@ -25,8 +25,8 @@ import (
 // Pin every SQL predicate that gates owner Project facts. The tests below also
 // inject each computed boolean to exercise the Go-level fail-closed logic.
 const botContextQueryPattern = `(?s)SELECT IFNULL.*` +
-	`bu.status = 1 AND bu.robot = 1 AND COALESCE\(bu.is_destroy, 0\) = 0.*` +
-	`ou.status = 1 AND ou.robot = 0 AND COALESCE\(ou.is_destroy, 0\) = 0.*` +
+	`COALESCE\(bu.status, 0\) = 1 AND COALESCE\(bu.robot, 0\) = 1 AND COALESCE\(bu.is_destroy, 0\) = 0.*` +
+	`COALESCE\(ou.status, 0\) = 1 AND COALESCE\(ou.robot, 0\) = 0 AND COALESCE\(ou.is_destroy, 0\) = 0.*` +
 	`s.space_id = 'space' AND s.status = 1.*` +
 	`bm.uid = bu.uid AND bm.status = 1.*` +
 	`om.uid = ou.uid AND om.status = 1.*` +
@@ -91,8 +91,10 @@ func TestBotOwnerContextHTTPContract(t *testing.T) {
 				} else if tc.dbError {
 					require.Equal(t, true, response["context_included"])
 					require.Equal(t, true, response["context_error"])
-					require.NotContains(t, response, "bot_context")
-					require.NotContains(t, response, "owner_context")
+					require.Contains(t, response, "bot_context")
+					require.Contains(t, response, "owner_context")
+					ownerContext := response["owner_context"].(map[string]any)
+					require.Empty(t, ownerContext["projects"])
 				} else {
 					require.Equal(t, true, response["context_included"])
 					require.Contains(t, response, "bot_context")
@@ -102,6 +104,16 @@ func TestBotOwnerContextHTTPContract(t *testing.T) {
 					require.Equal(t, "self_hosted", botContext["agent_hosting"])
 					require.Contains(t, botContext, "agent_reported_hosting_at")
 					require.Nil(t, botContext["agent_reported_hosting_at"])
+					require.Equal(t, "space", botContext["requested_space_id"])
+					require.NotContains(t, botContext, "space_id")
+					ownerContext := response["owner_context"].(map[string]any)
+					require.Equal(t, "space", ownerContext["requested_space_id"])
+					projects := ownerContext["projects"].([]any)
+					require.Len(t, projects, 1)
+					project := projects[0].(map[string]any)
+					require.Equal(t, float64(2), project["role"])
+					require.NotContains(t, project, "capabilities")
+					require.NotContains(t, project, "member_epoch")
 				}
 			}
 			require.NoError(t, mock.ExpectationsWereMet())
@@ -156,10 +168,8 @@ func TestBotOwnerContextPlatformNeutralAndSpaceScoped(t *testing.T) {
 			require.Equal(t, allowed, resp.OwnerContext.Projects[0].Member)
 			require.False(t, resp.OwnerContext.Projects[1].Member)
 			require.Nil(t, resp.OwnerContext.Projects[1].Role)
-			require.Nil(t, resp.OwnerContext.Projects[1].MemberEpoch)
 			if !allowed {
 				require.Nil(t, resp.OwnerContext.Projects[0].Role)
-				require.Nil(t, resp.OwnerContext.Projects[0].MemberEpoch)
 			}
 			require.NoError(t, mock.ExpectationsWereMet())
 		})
@@ -282,8 +292,6 @@ func TestBotOwnerContextMySQLLivenessContract(t *testing.T) {
 				require.NotNil(t, resp.OwnerContext.Projects[0].Role)
 			} else {
 				require.Nil(t, resp.OwnerContext.Projects[0].Role)
-				require.Nil(t, resp.OwnerContext.Projects[0].MemberEpoch)
-				require.Empty(t, resp.OwnerContext.Projects[0].Capabilities)
 			}
 		})
 	}

--- a/modules/user/api_bot_project_context_test.go
+++ b/modules/user/api_bot_project_context_test.go
@@ -15,6 +15,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Pin every SQL predicate that gates owner Project facts. The tests below also
+// inject each computed boolean to exercise the Go-level fail-closed logic.
+const botContextQueryPattern = `(?s)SELECT IFNULL.*` +
+	`bu.status = 1 AND bu.robot = 1 AND COALESCE\(bu.is_destroy, 0\) <> 2.*` +
+	`ou.status = 1 AND ou.robot = 0 AND COALESCE\(ou.is_destroy, 0\) <> 2.*` +
+	`s.space_id = 'space' AND s.status = 1.*` +
+	`bm.uid = bu.uid AND bm.status = 1.*` +
+	`om.uid = ou.uid AND om.status = 1.*` +
+	`WHERE r.robot_id = 'bot' AND r.creator_uid = 'owner' AND r.bot_token = 'bf_test' AND r.status = 1`
+
 type botContextUserNames struct{ IService }
 
 func (botContextUserNames) GetUser(uid string) (*Resp, error) {
@@ -43,11 +53,11 @@ func TestBotOwnerContextHTTPContract(t *testing.T) {
 				mock.ExpectQuery("SELECT.*FROM robot.*bot_token = 'bf_test'").WillReturnRows(sqlmock.NewRows([]string{"robot_id", "creator_uid"}).AddRow("bot", "owner"))
 				mock.ExpectQuery("SELECT.*FROM space_member.*uid = 'bot'").WillReturnRows(sqlmock.NewRows([]string{"space_id"}).AddRow("first-space"))
 				if tc.extended {
-					q := mock.ExpectQuery("SELECT IFNULL.*WHERE r.robot_id = 'bot' AND r.creator_uid = 'owner' AND r.bot_token = 'bf_test'")
+					q := mock.ExpectQuery(botContextQueryPattern)
 					if tc.dbError {
 						q.WillReturnError(errors.New("database unavailable"))
 					} else {
-						q.WillReturnRows(sqlmock.NewRows([]string{"hosting", "bot_active", "owner_active", "bot_member", "owner_member"}).AddRow("self_hosted", true, true, true, true))
+						q.WillReturnRows(sqlmock.NewRows([]string{"hosting", "hosting_reported_at", "bot_active", "owner_active", "bot_member", "owner_member"}).AddRow("self_hosted", nil, true, true, true, true))
 						mock.ExpectQuery("SELECT pm.project_id.*WHERE pm.uid = 'owner'.*pm.space_id = 'space'").WillReturnRows(sqlmock.NewRows([]string{"project_id", "role", "member_epoch"}).AddRow("p", 2, 7))
 					}
 				}
@@ -72,6 +82,7 @@ func TestBotOwnerContextHTTPContract(t *testing.T) {
 				if !tc.extended {
 					require.Len(t, response, 5)
 				} else if tc.dbError {
+					require.Equal(t, true, response["context_included"])
 					require.Equal(t, true, response["context_error"])
 					require.NotContains(t, response, "bot_context")
 					require.NotContains(t, response, "owner_context")
@@ -80,7 +91,10 @@ func TestBotOwnerContextHTTPContract(t *testing.T) {
 					require.Contains(t, response, "bot_context")
 					require.Contains(t, response, "owner_context")
 					require.NotContains(t, response["bot_context"], "agent_platform")
-					require.Equal(t, "self_hosted", response["bot_context"].(map[string]any)["agent_hosting"])
+					botContext := response["bot_context"].(map[string]any)
+					require.Equal(t, "self_hosted", botContext["agent_hosting"])
+					require.Contains(t, botContext, "agent_reported_hosting_at")
+					require.Nil(t, botContext["agent_reported_hosting_at"])
 				}
 			}
 			require.NoError(t, mock.ExpectationsWereMet())
@@ -117,8 +131,8 @@ func TestBotOwnerContextPlatformNeutralAndSpaceScoped(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			db, mock := newPhoneLookupMock(t)
-			mock.ExpectQuery("SELECT IFNULL.*WHERE r.robot_id = 'bot' AND r.creator_uid = 'owner' AND r.bot_token = 'bf_test' AND r.status = 1").
-				WillReturnRows(sqlmock.NewRows([]string{"hosting", "bot_active", "owner_active", "bot_member", "owner_member"}).AddRow(tc.hosting, tc.botActive, tc.ownerActive, tc.botMember, tc.ownerMember))
+			mock.ExpectQuery(botContextQueryPattern).
+				WillReturnRows(sqlmock.NewRows([]string{"hosting", "hosting_reported_at", "bot_active", "owner_active", "bot_member", "owner_member"}).AddRow(tc.hosting, nil, tc.botActive, tc.ownerActive, tc.botMember, tc.ownerMember))
 			allowed := tc.botActive && tc.ownerActive && tc.botMember && tc.ownerMember
 			if allowed {
 				mock.ExpectQuery("SELECT pm.project_id.*WHERE pm.uid = 'owner'.*pm.space_id = 'space'").
@@ -129,6 +143,8 @@ func TestBotOwnerContextPlatformNeutralAndSpaceScoped(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, "legacy-first-space", resp.SpaceID)
 			require.True(t, resp.ContextIncluded)
+			require.Equal(t, tc.botMember, resp.BotContext.SpaceMember)
+			require.Equal(t, tc.ownerMember, resp.OwnerContext.SpaceMember)
 			require.Len(t, resp.OwnerContext.Projects, 2)
 			require.Equal(t, allowed, resp.OwnerContext.Projects[0].Member)
 			require.False(t, resp.OwnerContext.Projects[1].Member)
@@ -145,7 +161,7 @@ func TestBotOwnerContextPlatformNeutralAndSpaceScoped(t *testing.T) {
 
 func TestBotOwnerContextFailsClosed(t *testing.T) {
 	db, mock := newPhoneLookupMock(t)
-	mock.ExpectQuery("SELECT IFNULL").WillReturnError(errors.New("database unavailable"))
+	mock.ExpectQuery(botContextQueryPattern).WillReturnError(errors.New("database unavailable"))
 	resp := authVerifyBotResp{BotUID: "bot", OwnerUID: "owner", SpaceID: "legacy"}
 	err := (&User{db: db}).fillBotProjectContext(&resp, authVerifyBotReq{BotToken: "bf_test", SpaceID: "space", ProjectIDs: []string{"p"}})
 	require.Error(t, err)
@@ -155,4 +171,17 @@ func TestBotOwnerContextFailsClosed(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 	err = (&User{}).fillBotProjectContext(&resp, authVerifyBotReq{ProjectIDs: make([]string, maxVerifyProjectIDs+1)})
 	require.ErrorIs(t, err, errTooManyProjectIDs)
+}
+
+func TestBotOwnerContextMissingFactsIsAnError(t *testing.T) {
+	db, mock := newPhoneLookupMock(t)
+	mock.ExpectQuery(botContextQueryPattern).
+		WillReturnRows(sqlmock.NewRows([]string{"hosting", "hosting_reported_at", "bot_active", "owner_active", "bot_member", "owner_member"}))
+	resp := authVerifyBotResp{BotUID: "bot", OwnerUID: "owner"}
+	err := (&User{db: db}).fillBotProjectContext(&resp, authVerifyBotReq{
+		BotToken: "bf_test", SpaceID: "space", ProjectIDs: []string{"p"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "disappeared after credential verification")
+	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/modules/user/api_project_context.go
+++ b/modules/user/api_project_context.go
@@ -62,7 +62,7 @@ func (u *User) answerProjectMembership(uid, spaceID string, projectIDs []string)
 
 	// One bounded query for the whole batch, not one per id (C9: this endpoint
 	// runs on every request of every subsystem that fronts octo-server).
-	rows, err := projectpkg.MembershipsInSpace(u.ctx.DB(), spaceID, uid, projectIDs)
+	rows, err := projectpkg.MembershipsInSpace(u.db.session, spaceID, uid, projectIDs)
 	if err != nil {
 		return nil, fmt.Errorf("user: project membership lookup: %w", err)
 	}


### PR DESCRIPTION
## Summary

Supersedes #858 with all three reviewers' blocking findings fixed. The original
head branch is not writable by this account, so this PR targets the official
repository directly with the complete change.

Expose credential-bound owner/Project facts through the existing verify-bot
endpoint and add Bot hosting metadata to the existing owned-bots endpoint,
without assigning Project membership to Bots.

## Related Issue

Closes #857

## Changes

- Keep the default verify-bot five-field response compatible; expose the new
  context only for `include=owner_context`.
- Derive the owner from the validated Bot credential and reject caller-supplied
  owner identity.
- Require active, non-destroying Bot and owner accounts plus active membership
  in the requested active Space before returning owner Project roles.
- Treat `agent_hosting` as self-reported telemetry only, never authz/quota, and
  pair it with `agent_reported_hosting_at` on both response surfaces.
- Register the botfather migration owner in the robot package test binary so the
  existing `TestOwnedBots` schema contains the hosting columns.
- Execute the liveness/membership gates in an isolated MySQL matrix and wire both
  MySQL contract tests into the E2E merge queue instead of silently skipping.

## Review blockers addressed

- #858 review blocker 1: robot test migration ownership / E2E failure.
- #858 review blocker 2: missing `is_destroy` liveness checks.
- #858 review blocker 3: hosting trust-boundary contradiction and bare value.
- #858 review blocker 4: SQL gates not executed by CI-backed real-MySQL tests.

## Testing

- [x] `go test ./modules/user -run '^TestBotOwnerContext' -count=1`
- [x] isolated MySQL `TestBotOwnerContextMySQLLivenessContract`
- [x] isolated MySQL `TestOwnedBotsMetadataMySQLContract`
- [x] fresh-schema `TestOwnedBots`
- [x] robot/user/group legacy-error guards
- [x] `go test ./pkg/project -count=1`
- [x] `go vet ./modules/robot ./modules/user ./modules/group`
- [x] robot/user/group compile gates
- [x] `git diff --check`

## Compatibility

No new route or schema migration is introduced here. Existing clients that do
not request `owner_context` keep the original verify-bot response shape.
Production databases still need the pre-existing botfather migration that adds
`agent_hosting` and `agent_reported_hosting_at`.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions
