### PR TITLE
feat(project): the group list, project_id on the sidebar, and project pinning (P2 product surfaces, PR-1 + PR-2 + PR-5)

### DIFF
--- a/.octospec/journal/shared/project-p2-product-surfaces.md
+++ b/.octospec/journal/shared/project-p2-product-surfaces.md
@@ -1,0 +1,149 @@
+---
+type: Journal
+title: "Learning: the project group list, and a predicate that is only interesting in the one case nobody wrote down"
+description: "A membership-scoped read whose access control IS its WHERE clause; the discovery that the repo's two group-membership predicates differ in exactly one reachable state — the blacklist — which no comment on either side mentioned; a Q2 I resolved from a config flag that turned out to gate nothing, refuted by actually running the suite; and two documentation defects that only a client team would ever have hit."
+tags: ["octospec-learning", "space", "isolation", "acl", "wire-contract", "testing", "mysql", "documentation"]
+timestamp: 2026-09-08T10:00:00Z
+source: self
+---
+
+# Learning: project-p2-product-surfaces (PR-1)
+
+## What changed
+
+`GET /v1/projects/:project_id/groups` — the caller's own live groups within one
+project. Before it, nothing in the tree could answer "which groups does this
+project have": `modules/project` registered nine routes and none returned a
+group, `GET /v1/group/my` filters on `space_id` alone, and the query that answers
+it already existed unexported, reachable only from the member-removal cascade
+worker.
+
+The task brief (`project-p2-product-surfaces`) covers four surfaces that P0, P1
+and P2 all deferred to "a sibling brief" nobody had written. This is PR-1 of it.
+
+## What we learned
+
+### A read whose access control is its WHERE clause needs no gate — and adding one makes it worse
+
+The list is scoped to the caller's own group membership. That is not a filter
+applied after an authorization decision; it **is** the decision, and the
+consequence is counter-intuitive enough to be worth stating: this endpoint
+deliberately has **no** role check beyond `projectMiddleware`.
+
+`listMembersHandler` next to it needs `canViewMembers`, because the roster is a
+fact *about other people*: a `space_listed` project shows its metadata to any
+Space member, but who is in it is not part of that. This endpoint returns only
+rows the caller is already a member of, so there is nothing to withhold. A Space
+admin who never joined gets `[]`.
+
+Adding a 403 there would be worse than redundant. It would answer a refusal to a
+caller whose correct answer is an empty list, and in doing so make "you are not a
+member of this project" **observable** on a route that currently discloses
+nothing — reintroducing, on a new route, exactly the oracle
+`projectMiddleware`'s three folded refusals exist to close.
+
+### The repo has two group-membership predicates, and they differ in exactly one reachable state
+
+`is_deleted = 0` versus `is_deleted = 0 AND status = GroupMemberStatusNormal`.
+Both are in wide use. Neither side's comments said where they disagree, and the
+abstract framing ("a read must not over-select") hides it.
+
+Removal sets `is_deleted = 1`, so the two agree there. The **only** reachable
+state where they disagree is the group blacklist, which sets `status = 2` and
+deliberately leaves `is_deleted = 0`. So the choice of predicate is, in practice,
+exactly one question: *does a group that blacklisted you still appear in your
+list?*
+
+Written that way it answers itself — `ExistMemberActive` is the hardening line
+(#343/#345) in front of group and thread reads for precisely that uid, so listing
+the group advertises a room the caller cannot open — but nothing on the page
+posed the question until a review did. Two older surfaces (`GET /v1/group/my`,
+the group detail) still show it, and `member_count` differs by one for the same
+reason. Both divergences are now argued in the source and pinned by a test that
+asserts **both halves**, so the day the older surfaces are hardened the comment
+cannot quietly become wrong.
+
+**Generalisable:** when two predicates for one concept coexist, the useful
+question is not which is stricter but *enumerate the states where they disagree*.
+There is usually exactly one, and it is usually a product decision wearing a SQL
+costume.
+
+### A config flag that gates nothing, believed for three commits
+
+Resolving an open question about a supposed `group` stub table, I read
+`testutil.NewTestServer` setting `cfg.DB.Migration = false` and concluded "tests
+never run migrations". Wrong: `module.Setup` calls `executeSQL` unconditionally
+(octo-lib `module/module.go:29`). The flag gates nothing on this path.
+
+It survived a self-review and two commits because it was *load-bearing for
+nothing yet* — the claim only had to be right the day someone acted on it.
+Running the suite refuted it within a minute, and did so in the most direct way
+available: `./modules/group/` against a database `./modules/project/` had just
+migrated dies at startup with `unknown migration in database`, because
+`modules/project`'s test binary registers all 40 modules (its external test
+package blank-imports `octo-server/internal`) and `modules/group`'s registers
+fewer. **Each package needs its own fresh `test` database** — worth knowing
+before you burn twenty minutes on a "failure" your change did not cause.
+
+The conclusion held and got better evidence: that divergence produces a
+**missing** table, not a differently-shaped one, so a binary without
+`modules/group` fails loudly with 1146 rather than quietly loading a NULL into a
+Go bool. No stub exists in this repo; if one exists at all it lives in
+`octo-deployment`'s `init-db.sql`.
+
+### Two documentation defects that only a client team would ever have hit
+
+Both survived the implementation and were caught in review. Both are the kind
+where the code is right and the prose sends someone else somewhere wrong.
+
+- **`is_named` documented with the meaning the column used to have.**
+  `20260629000002_refresh_avatar_comments.sql` retired 「用户显式起名」 for 「改版前老群」,
+  and `modules/group` hardcodes `0` on every create — so on this endpoint the
+  value is *always* 0. A client implementing to the old text branches on a
+  condition that is never true and expects an avatar fallback that never fires.
+  A field whose doc describes a superseded meaning is worse than an undocumented
+  field: it is confidently wrong.
+- **An ordering comment that claimed "always".** `ORDER BY g.id ASC` usually puts
+  the all-member group first because #855 provisions it with the project — but
+  `ensureAllMemberGroup` rebuilds it on a later write path when the first
+  provisioning failed, and the rebuild takes a fresh, higher id. The ordering
+  stays (it is the only *total* order available, and a non-total ORDER BY under
+  OFFSET pagination drops and duplicates rows between pages); the claim about
+  position became "a convenience, never the contract".
+
+### A pagination bounds test is not a pagination test
+
+The first cut had `?page=9223372036854775807` and an empty far page, and no case
+that read page 2. A swapped `LIMIT ? OFFSET ?` pair — adjacent ints, no compiler
+check — reads **correctly on page 1** and only breaks from page 2 on, so every
+existing assertion would have passed. The overflow regression and the
+correctness property are different tests; having the first does not imply the
+second.
+
+### The house rule beat the brief's own acceptance list
+
+The brief asked for `TestListProjectGroupsIsUIDRateLimited`. `TestAuthChainOrder`
+in the same module argues *against* exactly that: `SharedUIDRateLimiter` fails
+open without a uid, so a route mounted in the wrong order looks rate-limited and
+is not, and a hammer test passes either way. The chain is checked where it is
+declared; this PR adds only what that guard cannot see — that the new route went
+onto the authenticated group rather than a new bare one. **An acceptance item
+written before reading the module's own guards is a hypothesis, not a
+requirement.**
+
+## Gotchas worth remembering
+
+- `modules/project` may read the `group` **table** but must never import
+  `modules/group` (`pkg/project/import_guard_test.go` pins it at zero;
+  `modules/group` imports project, so there is only one legal direction).
+  Reverse-registration is the right shape for **writes** and the wrong shape for
+  a synchronous **read**: an unregistered read provider answers an empty list,
+  indistinguishable from "no rows".
+- A statement joining `group` ⋈ `group_member` needs **no** COLLATE (both legacy);
+  coercing either side gives up the index on `group_member.group_no` for a
+  mismatch that does not exist. Say so in the source — "has no COLLATE" and
+  "forgot its COLLATE" look identical in a diff — and register the statement in
+  `TestP2StatementsSurviveCollationDrift` so the claim is not free.
+- Running the integration suite locally needs MySQL 8, Redis and WuKongIM
+  (`WK_TOKENAUTHON=false`, health on `:5001`), plus a **fresh `test` database per
+  package**.

--- a/.octospec/learnings/pending/enumerate-where-two-predicates-disagree.md
+++ b/.octospec/learnings/pending/enumerate-where-two-predicates-disagree.md
@@ -1,0 +1,74 @@
+---
+type: Learning
+title: "When two predicates for one concept coexist, enumerate the states where they disagree"
+description: "Picking the stricter of two membership predicates is not a decision until you name the states that separate them. There is usually exactly one reachable state, it is usually a product decision wearing a SQL costume, and a comment that argues in the abstract ('a read must not over-select') hides it from every later reader."
+tags: ["acl", "isolation", "wire-contract", "documentation", "testing", "mysql"]
+timestamp: 2026-09-08T10:00:00Z
+source: self
+status: pending
+---
+
+# When two predicates for one concept coexist, enumerate the states where they disagree
+
+## The rule
+
+A codebase that has more than one way to ask "is this uid a member of this thing"
+has a decision to make on every new query. Choosing "the stricter one" or "the
+canonical one" is **not** that decision — it is a way of not making it.
+
+Make it by enumerating the rows the two predicates classify differently:
+
+1. Write down both predicates as sets.
+2. Compute the difference and name every state in it that is **reachable** —
+   which write path produces it, in which module.
+3. For each such state, answer the product question directly: should this row
+   appear on this surface?
+4. Put that answer, not the abstract argument, in the comment. Pin it with a test
+   that asserts **both** sides of the divergence, so the day the other surface
+   changes, the comment cannot quietly become wrong.
+
+Step 2 usually terminates with exactly one state. When it does, the choice of
+predicate is that single product question and nothing else.
+
+## Why
+
+Abstract framing conceals the case. In octo-server the two predicates are
+`is_deleted = 0` and `is_deleted = 0 AND status = GroupMemberStatusNormal`, and
+the reasoning offered for the second — *"the canonical predicate; a read must not
+over-select"* — is true, unfalsifiable, and tells a reader nothing about what it
+does.
+
+Enumerating: removal sets `is_deleted = 1`, so the two agree there. The only
+reachable divergence is the **group blacklist**, which sets `status` and
+deliberately leaves `is_deleted = 0`. So the whole choice is one question: *does
+a group that blacklisted you still appear in your list?* That question has an
+obvious answer (the access gates already refuse that uid, so listing it
+advertises a room they cannot open) — but nobody had asked it. The comment
+justifying the predicate never mentioned blacklisting, the surfaces using the
+looser predicate never mentioned that they show such groups, and the two
+`member_count` implementations silently returned different numbers for the same
+group.
+
+The cost of not enumerating is not usually a bug on the day. It is that the
+divergence is undocumented, so the next person to touch either side has no way to
+know one exists — and a divergence nobody recorded gets "fixed" in whichever
+direction the next reader happens to prefer.
+
+## Smells that this rule applies
+
+- Two functions whose names differ only by a qualifier (`ExistMember` /
+  `ExistMemberActive`, `queryXWithMember` / `queryXWithActiveMember`).
+- A comment justifying a predicate by its provenance ("the canonical one", "same
+  as the reconcile scan") rather than by its effect.
+- A status column where one value is written by a path that deliberately does
+  **not** touch the tombstone column — blacklists, mutes, suspensions, "pending
+  removal" flags. That path is where the two sets separate.
+- The same count exposed from two endpoints via two different helpers.
+
+## Counter-case
+
+This is not an argument for unifying the predicates. The looser one is correct
+where it is used — a cascade whose job is to delete rows can over-select
+harmlessly — and forcing one predicate everywhere would put the blacklist
+decision on paths that have no business making it. The rule is to **know and
+record** the divergence, not to remove it.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -2638,6 +2638,41 @@ SQL 注释里一个撇号破坏了它的朴素语句分割；P0 的游标覆盖�
   实测走通的等价物：`DROP TABLE` 与删 `gorp_migrations` 账本行**放在同一事务**。
 - **不实的功效声称会让下一个人跳过验证** —— 详见当日前一条与 journal。
 
+## 2026-09-08 — project-p2-product-surfaces（PR-1：项目视角群聊列表）
+
+`GET /v1/projects/:project_id/groups`。此前树上没有任何接口能回答「这个项目有哪些群」：
+`modules/project` 注册九条路由无一返回群，`GET /v1/group/my` 只按 space_id 过滤，而能答这
+个问题的查询早就存在、未导出，只有成员移除级联 worker 调它。
+
+- **访问控制就是 WHERE 子句，因此这个接口刻意没有角色门。** 旁边的 `listMembersHandler` 需要
+  `canViewMembers`，因为名册是「关于别人的事实」；这个接口只返回调用者已经在的行，没有可扣的
+  东西。没加入项目的 Space 管理员拿到 `[]`。**在这里加 403 比冗余更糟**——它会对一个正确答案
+  是空列表的调用者答拒绝，从而让「你不是本项目成员」在一条本来什么都不透露的路由上变得可观测，
+  等于在新路由上重新打开 `projectMiddleware` 三合一拒绝所要关掉的那个枚举通道。
+- **仓库里两个成员谓词，只在一个可达状态上分歧，而两边注释都没写。** `is_deleted = 0` 与
+  `is_deleted = 0 AND status = Normal`：移除置 `is_deleted = 1`，两者一致；**唯一**分歧是群
+  黑名单——只置 status、保留 `is_deleted = 0`。于是选谓词这件事实际上只有一个问题：*把你拉黑
+  的群还要不要出现在你的列表里*。这么问答案是自明的（`ExistMemberActive` 就是挡这个 uid 读群/
+  子区的加固线），但在 review 之前没人提出过这个问题。现已写进源码，并用**同时断言两半**的测试
+  钉住：既断言这里看不到，也断言 `/v1/group/my` 还看得到。
+- **一个什么都不 gate 的配置开关，被我信了三个 commit。** 为了结掉「group 桩表」那个悬问，我读到
+  `testutil` 里 `cfg.DB.Migration = false` 就断言「测试不跑迁移」。错：`module.Setup` 是无条件
+  调 `executeSQL` 的（octo-lib `module/module.go:29`）。它能活下来是因为**当时还不承重**——这个
+  断言只需要在有人依据它行动的那天为真。跑一遍套件一分钟就推翻了，而且推翻方式最直接：
+  `./modules/group/` 打在 `./modules/project/` 刚迁移过的库上，启动即死于
+  `unknown migration in database`（project 的测试二进制注册全部 40 个模块，group 的更少）。
+  **每个包要各自的干净 `test` 库。**
+- **两处只有客户端团队才会踩到的文档缺陷。** `is_named` 我写的是这一列**曾经**的含义
+  （`20260629000002` 已把「用户显式起名」改成「改版前老群」，且新群恒为 0，所以这个接口上它恒为
+  0）；排序注释写了「全员群**永远**最老」，而 `ensureAllMemberGroup` 会在补建时给它一个更大的
+  id。**文档描述一个已废弃的含义，比没有文档更糟：它是自信地错。**
+- **分页边界测试不是分页测试。** 第一版只有 `?page=<int64max>` 和一个越界空页。`LIMIT ? OFFSET ?`
+  两个参数写反——相邻 int、编译器不管——**第 1 页照样正确**，只有第 2 页起才崩，所有既有断言都会
+  通过。溢出回归和正确性是两个测试。
+- **模块自己的守卫压过了 brief 的验收清单。** brief 要求 `TestListProjectGroupsIsUIDRateLimited`；
+  同模块的 `TestAuthChainOrder` 恰恰论证了这种测试没用（`SharedUIDRateLimiter` 无 uid 时 fail
+  open，挂错顺序的路由两种情况都通过）。**在读模块自身守卫之前写下的验收项是假设，不是要求。**
+
 ## 2026-09-08 — my-ai-team-sessions（PR #848 CI 异步测试收敛）
 
 - **认领不是完成** —— `space_member_removal_cleanup.attempts` 在 worker 认领工单时就自增，早于任何

--- a/.octospec/tasks/project-p2-product-surfaces/brief.md
+++ b/.octospec/tasks/project-p2-product-surfaces/brief.md
@@ -229,10 +229,10 @@ one changes. This endpoint answers one question — *which groups in this projec
 it returns the identity fields the tree renders and nothing else, and the client fetches full
 state through the routes it already calls (`GET /v1/groups/:group_no`, `GET /v1/group/my`).
 
-Proposed field set, to confirm against the prototype and against Q2: `group_no`, `name`,
-`is_named`, `avatar_text`, `avatar_color`, `is_upload_avatar`, `member_count`. Anything beyond
-that needs an argument, and every field must be checked against the stub schema before it is
-frozen.
+Proposed field set, to confirm against the prototype: `group_no`, `name`, `is_named`,
+`avatar_text`, `avatar_color`, `is_upload_avatar`, `member_count`. Anything beyond that needs an
+argument. Q2 is resolved and does not narrow this — the columns are all on the one real `group`
+table, and the test suite is what proves it.
 
 **D4 — Threads are NOT nested in the response.**
 
@@ -345,13 +345,31 @@ admission transaction」, which P1 called a separate task and nobody has opened.
   `modules/group/api_manager.go:50`), or a Space admin. **Recommendation: manager console**, on
   the grounding that the badge's value is that its subject cannot grant it to themselves. Gates
   PR-4 only.
-- **Q2 — What is the `group` stub schema, exactly?** `reconcile_p1.go:191-198` asserts it exists
-  and differs, but the brief's author did not locate its DDL (`grep -ri 'create table.*\`group\`'`
-  over `modules/*/sql` finds only `modules/group/sql/20191106000002_group_legacy01.sql:5`; the
-  Go module cache was unavailable in this environment, so `octo-lib` was not searched). Resolve
-  before freezing D3's field set: if the stub carries only `group_no` / `name` / `status` /
-  `space_id` / `project_id`, the avatar fields cannot be selected from `modules/project`, and D2
-  is back on the table.
+- ~~**Q2 — What is the `group` stub schema?**~~ **RESOLVED: there is no stub in this repo, and
+  it does not constrain D3.** `reconcile_p1.go:191-198` claims that 「binaries whose migration
+  set does not include `modules/group` get a `group` STUB instead, and that one declares status
+  nullable」, and adds a defensive `g.status IS NOT NULL` on the strength of it. Chased down:
+
+  - The repo contains exactly **one** `group` DDL — `modules/group/sql/20191106000002_group_legacy01.sql:5`
+    — and it declares `status smallint not null DEFAULT 0`.
+  - `octo-lib@v0.0.0-20260811160929` contains **no `.sql` files at all** and no table-creating Go
+    code.
+  - `testutil.NewTestServer` sets `cfg.DB.Migration = false`. **Tests never run migrations**;
+    every package runs against the same externally-provisioned `test` database and
+    `CleanAllTables` only truncates. So the "binary with a partial migration set" scenario does
+    not arise in tests, which is where the divergence would have to bite.
+  - Production is a single binary: `main.go` → `internal/modules.go` blank-imports 40 modules, so
+    every migration always runs together.
+
+  The only place such a divergence could live is **another repository** — `init-db.sql` in
+  `octo-deployment` (`tools/migrate-rename/rewrite_initdb.go:15`), which is outside this repo and
+  was not inspected. If it turns out to define `group` differently from the migrations, that is a
+  deployment-seed drift bug and its own task, not a constraint on a response shape.
+
+  **Consequence for D3:** pick the field set from what the client needs, and let the test suite
+  prove the columns exist — `modules/project`'s existing tests already insert full `group` rows
+  (`reconcile_i2_test.go:36`) and pass. Leave `reconcile_p1.go`'s defensive predicate alone;
+  it is harmless and removing it is not this task's business.
 - **Q3 — Does the prototype's 群聊 tab need groups the caller is not in?** D1 says no and is
   reversible. Confirm with product before PR-1 merges, because widening later is additive while
   narrowing later is a breaking change.

--- a/.octospec/tasks/project-p2-product-surfaces/brief.md
+++ b/.octospec/tasks/project-p2-product-surfaces/brief.md
@@ -274,6 +274,27 @@ At `5dd80d4` that handler builds its response as a hand-written `gin.H`
 (`modules/group/api.go:5040-5100`) rather than through `GroupResp`, so it is not exposed by
 #855's change and must not be "tidied up" onto `GroupResp` by this one. A test pins that.
 
+**D6 amendment (post-review, requester-approved).** The paragraph above is wrong about one
+population and the review found it. `SidebarItem`s are NOT uniformly built from channels the
+caller is a current member of: without an `X-Space-ID` the handler skips Space filtering
+entirely, and only `COMMUNITY_TOPIC` items get the fail-closed parent-membership check
+(`filterThreadConvsByParentMembership`, which runs on every path). Plain `GROUP` items get no
+membership predicate there, so a removed member whose IM conversation row outlives the removal
+still receives the item. The disclosure argument D6 inherited from #855 therefore does not
+cover that path.
+
+Two options were put to the requester: keep the field everywhere (the marginal disclosure is an
+opaque id no route will resolve for that caller), or ship it only where Space filtering ran.
+The requester chose the gate. So `project_id` is emitted **only on the Space-scoped path**, for
+every target type including the one that was checked — gating per type would let a topic and its
+own parent group disagree inside one response, which is the property PR-2 exists to preserve.
+
+Consequence to hand to the client teams: on the no-`X-Space-ID` path `""` means "not
+evaluated", not "直属 Space", and the two are indistinguishable in the payload. It is written
+into the `SidebarItem.ProjectID` comment. The underlying hole is NOT closed here — closing it
+means a membership predicate for every group item — and belongs to
+`project-p2-read-path-hardening`.
+
 **D7 — `join_mode = 0` self-join (PR-3) needs a writer before it needs an endpoint.**
 
 `join_mode` today has no writer, no reader, and no wire field — `CreateReq` / `UpdateReq` /
@@ -483,11 +504,16 @@ golangci-lint run ./...
 
 **PR-2 — `project_id` on the sidebar** (the rest landed in #855) — SHIPPED as implemented below:
 
-- `project_id` present and correct on the `/v1/sidebar/*` payload for a project group, `""`
-  (omitted) for a Space-direct group, and `""` for a DM — the same three-way split
-  `SidebarItem.SpaceID` already documents at `modules/message/api_sidebar.go:112-119`.
-- For a COMMUNITY_TOPIC item, `project_id` is the **parent group's**, matching how `SpaceID` is
-  resolved for that target type. Asserted, not assumed.
+- **On a request carrying `X-Space-ID`**: `project_id` present and correct on the
+  `/v1/sidebar/*` payload for a project group, `""` (omitted) for a Space-direct group, and
+  `""` for a DM — the same three-way split `SidebarItem.SpaceID` already documents.
+- **On a request WITHOUT `X-Space-ID`**: `""` for every item, deliberately. See the amendment
+  to D6 — this was not in the brief as written and is a requester-approved narrowing, added
+  after review. Stated here rather than only in D6's rationale, because this section is what a
+  future contributor implements against, and read without it the gate looks like a bug to
+  remove.
+- For a COMMUNITY_TOPIC item on the Space-scoped path, `project_id` is the **parent group's**,
+  matching how `SpaceID` is resolved for that target type. Asserted, not assumed.
 - No extra per-item query: the value must come from the batch the sidebar already runs, not a
   per-group round-trip on the hot read path.
 - `project_id` still absent from the public invite-preview response (D6), pinned by a test.

--- a/.octospec/tasks/project-p2-product-surfaces/brief.md
+++ b/.octospec/tasks/project-p2-product-surfaces/brief.md
@@ -370,9 +370,11 @@ admission transaction」, which P1 called a separate task and nobody has opened.
   prove the columns exist — `modules/project`'s existing tests already insert full `group` rows
   (`reconcile_i2_test.go:36`) and pass. Leave `reconcile_p1.go`'s defensive predicate alone;
   it is harmless and removing it is not this task's business.
-- **Q3 — Does the prototype's 群聊 tab need groups the caller is not in?** D1 says no and is
-  reversible. Confirm with product before PR-1 merges, because widening later is additive while
-  narrowing later is a breaking change.
+- ~~**Q3 — Does the prototype's 群聊 tab need groups the caller is not in?**~~ **RESOLVED
+  2026-09-08: no — the list is the caller's own groups.** D1 stands as written and is
+  implemented as the query predicate rather than as a filter over a wider result. Still
+  reversible in the additive direction only: a `?scope=all` variant can be argued later on its
+  own merits; narrowing after shipping the wider set could not.
 
 ## Out of scope
 

--- a/.octospec/tasks/project-p2-product-surfaces/brief.md
+++ b/.octospec/tasks/project-p2-product-surfaces/brief.md
@@ -354,10 +354,21 @@ admission transaction」, which P1 called a separate task and nobody has opened.
     — and it declares `status smallint not null DEFAULT 0`.
   - `octo-lib@v0.0.0-20260811160929` contains **no `.sql` files at all** and no table-creating Go
     code.
-  - `testutil.NewTestServer` sets `cfg.DB.Migration = false`. **Tests never run migrations**;
-    every package runs against the same externally-provisioned `test` database and
-    `CleanAllTables` only truncates. So the "binary with a partial migration set" scenario does
-    not arise in tests, which is where the divergence would have to bite.
+  - Tests DO run migrations, per test binary, from whatever module set is registered.
+    `testutil.NewTestServer` sets `cfg.DB.Migration = false`, but that flag gates nothing here:
+    `module.Setup` calls `executeSQL` unconditionally (octo-lib `module/module.go:29`). An
+    earlier draft of this entry read the flag and concluded the opposite; running the suite
+    refuted it directly. **The per-binary divergence is real and observable**: running
+    `./modules/group/` against a database that `./modules/project/` had just migrated fails at
+    startup with `Unable to create migration plan because of 20191106000001_event_legacy01.sql:
+    unknown migration in database` — modules/project's test binary registers all 40 modules (its
+    external test package blank-imports `octo-server/internal`), modules/group's registers
+    fewer, and sql-migrate refuses a database carrying records its own source does not know.
+    Each package therefore needs a fresh `test` database.
+  - But that divergence produces a MISSING TABLE, not a different one. A binary without
+    modules/group's migrations has no `group` table at all, so a query against it fails loudly
+    with 1146 rather than quietly loading a NULL into a Go bool. The stub the comment describes
+    is a third thing, and nothing in this repo creates it.
   - Production is a single binary: `main.go` → `internal/modules.go` blank-imports 40 modules, so
     every migration always runs together.
 
@@ -367,9 +378,10 @@ admission transaction」, which P1 called a separate task and nobody has opened.
   deployment-seed drift bug and its own task, not a constraint on a response shape.
 
   **Consequence for D3:** pick the field set from what the client needs, and let the test suite
-  prove the columns exist — `modules/project`'s existing tests already insert full `group` rows
-  (`reconcile_i2_test.go:36`) and pass. Leave `reconcile_p1.go`'s defensive predicate alone;
-  it is harmless and removing it is not this task's business.
+  prove the columns exist. It now has: PR-1 selects `is_named` / `avatar_text` / `avatar_color` /
+  `is_upload_avatar` from `modules/project` and `go test -race -shuffle=on ./modules/project/`
+  is green. Leave `reconcile_p1.go`'s defensive predicate alone; it is harmless and removing it
+  is not this task's business.
 - ~~**Q3 — Does the prototype's 群聊 tab need groups the caller is not in?**~~ **RESOLVED
   2026-09-08: no — the list is the caller's own groups.** D1 stands as written and is
   implemented as the query predicate rather than as a filter over a wider result. Still

--- a/.octospec/tasks/project-p2-product-surfaces/brief.md
+++ b/.octospec/tasks/project-p2-product-surfaces/brief.md
@@ -57,7 +57,11 @@ Four surfaces, in the order they unblock things:
 1. **`GET /v1/projects/:project_id/groups`** — the caller's groups within one project (PR-1).
 2. **`project_id` on the sidebar** — the last hop of the passthrough #855 starts (PR-2).
 3. **`join_mode = 0` self-join** — a column P0 shipped with no writer and no reader (PR-3).
-4. **`is_official` management** and **per-user project pinning** (PR-4, PR-5).
+4. **`is_official` management** (PR-4) and **per-user project pinning** (PR-5).
+
+PR-1 and PR-5 ship together in #861 at the requester's direction (2026-09-08). They are
+independent features sharing a branch, which is a review cost paid deliberately, not a
+dependency.
 
 PR-1 and PR-2 are independently shippable and are the whole of the unblock. PR-3 to PR-5
 carry their own product questions and must not hold PR-1 up.
@@ -291,7 +295,7 @@ so `SharedUIDRateLimiter` is the right layer, but it is a *membership write* dri
 alone, which is a new shape for this module. Quota interaction with
 `ErrProjectQuotaPerSpace` / `ErrProjectQuotaDailyCreate` must be spelled out in the PR.
 
-**D8 — Per-user project pinning (PR-5) is a new table, not a column.**
+**D8 — Per-user project pinning (PR-5) is a new table, not a column. SHIPPED, with a cap.**
 
 `octo_project_user_setting (project_id, uid, pinned, pinned_at, created_at, updated_at)`,
 `UNIQUE (project_id, uid)`, `octo_` prefix, `utf8mb4_general_ci`, application-written UTC times
@@ -304,6 +308,33 @@ A column on `octo_project_member` was considered and rejected: pinning is not a 
 (a Space admin can see a `space_listed` project they have not joined, and could reasonably pin
 it), and every write to `octo_project_member` is on the epoch-bumping path — a pin is not a
 membership change and must not bump `member_epoch`.
+
+*As implemented*, three things the draft did not settle:
+
+- **The write is a settings bag, not `/pin` + `/unpin`.** `PUT /v1/projects/:project_id/setting`
+  with a pointer field, following `PUT /v1/groups/:group_no/setting` (top / mute / save /
+  remark through one route onto `group_setting (group_no, uid)`). Two verb routes are simpler
+  only while there is one preference; the second costs two routes and two handlers where this
+  costs a key. PUT is also idempotent by contract, so "pin an already-pinned project" needs no
+  answer invented for it.
+- **The read is a field on the existing list, not a second endpoint.** A separate "my pinned
+  projects" route would make the client fetch twice and merge — and the *order* has to be the
+  server's, because OFFSET pagination needs a total order that a client-side merge cannot
+  reconstruct. `ORDER BY IFNULL(s.pinned,0) DESC, s.pinned_at DESC, p.id DESC` keeps the
+  pre-existing tail order byte-identical.
+- **A cap of 6 pinned projects PER SPACE** (`OCTO_PROJECT_MAX_PINNED`, requester's call,
+  2026-09-08), refused with `err.server.project.quota_pinned` carrying `max` in details.
+  Per Space rather than per user because the pinned section is rendered inside one Space's
+  list: a global budget would refuse a pin in the Space the caller is looking at because of
+  pins in a Space they cannot see. Unpinning is never refused (it is the operation that frees
+  a slot), re-pinning something already pinned is never refused (it adds no row), and a
+  disbanded project releases its slot (its owner can no longer see it to unpin it).
+
+The count and the write share a transaction so the check reads the snapshot the write lands in.
+That is NOT atomicity against a concurrent pin by the same uid: two requests that both count 5
+both insert, leaving 7. The window is a double-click inside a 2 rps shared bucket and its worst
+outcome is one extra row the user can remove, so it does not justify serialising every pin
+behind a lock. Recorded because "there is a transaction here" reads like "this is atomic".
 
 ### Also parked by P0/P1, still unowned at HEAD
 

--- a/.octospec/tasks/project-p2-product-surfaces/brief.md
+++ b/.octospec/tasks/project-p2-product-surfaces/brief.md
@@ -1,7 +1,7 @@
 ---
 type: Task
 title: "Task: project-p2-product-surfaces"
-description: The four product surfaces P1 and P2 both deferred to a sibling brief — the project-scoped group list a client needs to render the 群聊 tab, `project_id` passthrough on the group reads that already exist, `join_mode = 0` self-join, `is_official` management, and per-user project pinning. P1 and P2 built a Project that owns groups and enforces I2 on the write side; nothing on the read side lets a client discover that a group belongs to a project at all.
+description: The four product surfaces P0, P1 and P2 all deferred to a sibling brief that was never written — the project-scoped group list a client needs to render the 群聊 tab, `project_id` on the sidebar (the half #855 does not cover), `join_mode = 0` self-join, `is_official` management, and per-user project pinning. P1 gave a Project groups and enforced I2 on the write side; #855 gives it an all-member group; neither ships a way to ask which groups a project has.
 tags: ["space", "isolation", "acl", "wire-contract", "error-response", "i18n", "rate-limit", "testing", "commit", "migration"]
 timestamp: 2026-09-08T00:00:00Z
 # --- octospec extension fields ---
@@ -18,6 +18,13 @@ source: self
 > **Status: DRAFT.** Q1 (`is_official` ownership) is open and gates PR-4 only.
 > Named by `.octospec/tasks/project-p2-subsystem-integration/brief.md:1023-1024`,
 > which is where these four items were parked.
+>
+> **Depends on #855** (`feat(project): give every project an all-member group (P2)`,
+> OPEN, in review, base `5dd80d4`). Every line reference below is measured at
+> `main@5dd80d4`; #855 touches 61 files including `modules/group/service.go`,
+> `modules/group/db.go`, `modules/project/{api,db,model,service}.go`, so they will
+> move. Two of its changes are load-bearing for this brief and are folded in below:
+> it ships the all-member group, and it ships **most of PR-2 already**.
 
 ## Goal
 
@@ -35,7 +42,8 @@ group read admit which project it belongs to. Measured at HEAD:
   parameter.
 - `GroupResp` (`modules/group/service.go:905-951`) carries `space_id` and **not**
   `project_id`. `Model.ProjectID` (`modules/group/db.go:858`) exists and is never
-  serialized.
+  serialized. (#855 fixes exactly this one — see below. The sidebar's own item struct,
+  which #855 does not touch, still cannot say it.)
 - The query the endpoint needs already exists and is unexported:
   `queryProjectGroupNosWithActiveMember` (`modules/group/db.go:1316`), whose only caller
   is the member-removal cascade worker (`modules/group/project_cascade.go:101`).
@@ -47,12 +55,33 @@ expressible against HEAD. That is the gap this task closes.
 Four surfaces, in the order they unblock things:
 
 1. **`GET /v1/projects/:project_id/groups`** — the caller's groups within one project (PR-1).
-2. **`project_id` passthrough** on the group reads that already exist (PR-2).
+2. **`project_id` on the sidebar** — the last hop of the passthrough #855 starts (PR-2).
 3. **`join_mode = 0` self-join** — a column P0 shipped with no writer and no reader (PR-3).
 4. **`is_official` management** and **per-user project pinning** (PR-4, PR-5).
 
 PR-1 and PR-2 are independently shippable and are the whole of the unblock. PR-3 to PR-5
 carry their own product questions and must not hold PR-1 up.
+
+### What #855 already does, so this brief does not
+
+- **`GroupResp.ProjectID`** — added, with the disclosure argument written out in the field's
+  own comment (「客户端要靠它把项目群归到项目名下展示」), and populated in **both** mappers
+  (`from` and `fromModel`). That covers `GET /v1/group/my` on both branches and the group
+  detail. Nothing is left for this brief there.
+- **The all-member group** — provisioned with the project, `octo_project.all_member_group_no`
+  on the project `Resp`, invariant I4 (the group's active member set *equals* the project's)
+  and two reconcile scans behind it. So the prototype's 全员群 row is real, and PR-1 will list
+  it like any other project group. The client can label it by comparing `group_no` against the
+  `all_member_group_no` it already has from the project detail — PR-1 adds no flag for that.
+- **The import ban is now a test.** `pkg/project/import_guard_test.go` pins
+  `modules/project → modules/group` at zero, and #855's own group-side work is registered
+  *into* project through `modules/project/all_member_group_registry.go`. D2 below is
+  unchanged by this — it gets stricter.
+
+What #855 leaves for PR-2 is the **sidebar**: `modules/message/api_sidebar.go` is not in its
+61 files, and `SidebarItem` (`:107-137`) carries `space_id` / `my_source_space_id` and no
+`project_id`. So a client rendering the 消息 list still cannot tell which of those
+conversations belong to a project — the one remaining half of 「拿到一个群，问它属于哪个项目」.
 
 ## Background
 
@@ -99,11 +128,12 @@ This is that brief.
   verified Space via `spacepkg.SetSpaceID` — *after* the Space membership check, never before
   (`middleware.go:315-319`). A new handler that reads `GetSpaceID` without that ordering gets a
   Space the caller has no seat in.
-- **`wire-contract` — `GroupResp` gains a field (PR-2).** `modules/group/service.go:905-951` is
-  consumed by `GET /v1/group/my`, group detail, and the sidebar. An added field is additive,
-  but it is a wire contract with existing clients and both mappers must populate it
-  (`from` at `:953`, `fromModel` at `:1000`) or the field silently reads `""` on one path and
-  correctly on the other — worse than absent.
+- **`wire-contract` — `SidebarItem` gains a field (PR-2).** `modules/message/api_sidebar.go:107-137`
+  is one of the hottest read payloads in the product, and its existing `SpaceID` comment
+  (`:112-119`) already fixes the per-target-type contract a new `project_id` must match. #855
+  makes the equivalent change on `GroupResp` and shows the failure mode to avoid: a field
+  populated in one mapper and not the other reads `""` on one path and correctly on the other,
+  which is worse than absent.
 - **`error-response` / `i18n` — the envelope.** `httperr.ResponseErrorL` + a registered
   `pkg/errcode` code only. The per-module helpers already exist
   (`modules/project/api_i18n.go`: `respondProjectNotFound`, `respondQueryFailed`,
@@ -162,8 +192,10 @@ project, not every group in it.**
 
 I2 is a ceiling, not a floor: being in the project does not put you in its groups. Returning
 every group would hand a project member the names of groups they hold no seat in, and there
-is nothing they could do with that — there is no self-join path into a group, and the
-all-hands group (P2 PR-0) is unshipped. A name is the most sensitive field a group has at
+is nothing they could do with that — there is no self-join path into a group. The
+all-member group is not a counter-example: every project member is already in it (#855's I4),
+so it shows up in a membership-scoped list for everyone anyway, without the list having to
+disclose anything. A name is the most sensitive field a group has at
 list granularity (「关键供应商来料异常」 tells you the incident exists), so the default is
 membership-scoped.
 
@@ -217,18 +249,21 @@ The prototype's red badges come from the conversation layer (`sidebar/sync`). Se
 here would make a second source of truth for a number that changes on every message, read
 through a route with a 60-second membership cache. Out.
 
-**D6 — PR-2 adds `project_id` to `GroupResp`, and that is a disclosure argument, not a
-formality.**
+**D6 — PR-2 is the sidebar only, and it inherits #855's disclosure argument rather than
+re-deciding it.**
 
-Who learns what: only an existing member of the group learns which project it belongs to. By
-I2 they are already an active member of that project, so the field tells them nothing their
-own project roster does not. It does **not** go on any unauthenticated or pre-admission
-surface — specifically not the public invite preview
-(`GET /v1/group/invite/detail`, `modules/group/api.go:191`), where a `project_id` would leak
-project existence to an unauthenticated caller holding only an invite code.
+#855 already settled who may learn a group's `project_id`: a member of the group, who by I2 is
+already an active member of that project, so the field tells them nothing their own project
+roster does not. The sidebar is the same population — `SidebarItem`s are built from the
+IM-returned conversation list, which only contains channels the caller is a current member of
+(`modules/message/api_sidebar.go:560-578`). So the field carries no new disclosure there.
 
-Both mappers must populate it (`from` at `service.go:953`, `fromModel` at `:1000`). One
-populated and one not is the failure mode this decision exists to prevent.
+It must still stay off every unauthenticated or pre-admission surface. The one to check is the
+public invite preview (`GET /v1/group/invite/detail`, `modules/group/api.go:191`), where a
+`project_id` would leak project existence to an anonymous caller holding only an invite code.
+At `5dd80d4` that handler builds its response as a hand-written `gin.H`
+(`modules/group/api.go:5040-5100`) rather than through `GroupResp`, so it is not exposed by
+#855's change and must not be "tidied up" onto `GroupResp` by this one. A test pins that.
 
 **D7 — `join_mode = 0` self-join (PR-3) needs a writer before it needs an endpoint.**
 
@@ -275,7 +310,8 @@ membership change and must not bump `member_epoch`.
 P0 (`project-p0-foundation/brief.md:215`) and P1 (`project-p1-group-binding/brief.md:279-282`)
 parked **seven** items as "P2". P2's brief reassigned only four of them to this task
 (`project-p2-subsystem-integration/brief.md:1023-1024`). Of the remaining three, one is
-decided here (the nested tree — D4) and one is PR-2 (`project_id` passthrough). **Two were
+decided here (the nested tree — D4) and one is `project_id` passthrough, which #855 lands for
+`GroupResp` and PR-2 finishes on the sidebar. **Two were
 never given a home by any brief, and are recorded here so they stop being invisible rather
 than because this task claims them:**
 
@@ -322,19 +358,21 @@ admission transaction」, which P1 called a separate task and nobody has opened.
 
 ## Out of scope
 
-- **The all-hands group (全员群).** Creating a group with the project is P2 PR-0
-  (`project-p2-subsystem-integration/brief.md` D10) and is unshipped at HEAD — there is no
-  `全员群` / `all_hands` anywhere in `modules/`. PR-1 lists whatever groups exist; it does not
-  create one. The prototype's first row stays empty until PR-0 lands, and that is expected, not
-  a defect in this task.
+- **The all-member group (全员群) itself.** #855 creates it, owns invariant I4, and exposes
+  `all_member_group_no` on the project `Resp`. PR-1 **lists** it — it is a project group like
+  any other — and creates, names, protects and repairs nothing about it. In particular the five
+  operations #855's D7 refuses on an all-member group (disband, exit, member removal, owner
+  transfer, blacklist) are refused in `modules/group`'s handlers and stay there; PR-1 must not
+  grow a second copy of that verdict just because it happens to be listing the group.
 - **Listing groups the caller is not a member of.** D1, pending Q3.
 - **Nested threads in the group-list response.** D4.
 - **Unread / badge state.** D5.
 - **Read-path hardening** — `sidebar/sync`'s `ExistMembersActive` backstop, the deprecated
   `/v1/coversations` filter, the group-avatar enumeration oracle, `querySavedGroups` after
   leaving. Its own brief, named `project-p2-read-path-hardening` by
-  `project-p2-subsystem-integration/brief.md:1015-1022`. PR-2 adds a field to an existing
-  response; it does not touch those gates.
+  `project-p2-subsystem-integration/brief.md:1015-1022`. PR-2 adds a field to the sidebar
+  payload; it does not touch the `ExistMembersActive` question, and must not be read as having
+  settled it.
 - **Re-parenting a group between projects.** I3 forbids it; the source guard
   (`TestNoProjectIDRewritesOutsideTheDetachStep`, `modules/group/admission_guard_test.go:134`) must keep passing untouched.
 - **Pending invitations** (`octo_project_invitation`, P2 D8) and **ownership transfer** — P2's,
@@ -375,13 +413,17 @@ golangci-lint run ./...
   with it.
 - `TestProjectNoLegacyResponseError` still green (automatic — the file list is dynamic).
 
-**PR-2 — `project_id` passthrough:**
+**PR-2 — `project_id` on the sidebar** (the rest landed in #855):
 
-- `project_id` present and correct on `GET /v1/group/my?space_id=`, on group detail, and on the
-  sidebar payload, asserted for a project group **and** asserted as `""` for a Space-direct
-  group.
-- Both mappers covered: a test that would fail if only `from` or only `fromModel` were changed.
-- `project_id` absent from the public invite-preview response (D6), pinned by a test.
+- `project_id` present and correct on the `/v1/sidebar/*` payload for a project group, `""`
+  (omitted) for a Space-direct group, and `""` for a DM — the same three-way split
+  `SidebarItem.SpaceID` already documents at `modules/message/api_sidebar.go:112-119`.
+- For a COMMUNITY_TOPIC item, `project_id` is the **parent group's**, matching how `SpaceID` is
+  resolved for that target type. Asserted, not assumed.
+- No extra per-item query: the value must come from the batch the sidebar already runs, not a
+  per-group round-trip on the hot read path.
+- `project_id` still absent from the public invite-preview response (D6), pinned by a test.
+- Regression: `GroupResp.project_id` from #855 still correct on both mappers after the rebase.
 - `TestGroupNoLegacyResponseError`'s fixed file list updated if `modules/group` gains a file.
 
 **PR-3 — `join_mode = 0` self-join:**

--- a/.octospec/tasks/project-p2-product-surfaces/brief.md
+++ b/.octospec/tasks/project-p2-product-surfaces/brief.md
@@ -55,7 +55,7 @@ expressible against HEAD. That is the gap this task closes.
 Four surfaces, in the order they unblock things:
 
 1. **`GET /v1/projects/:project_id/groups`** — the caller's groups within one project (PR-1).
-2. **`project_id` on the sidebar** — the last hop of the passthrough #855 starts (PR-2).
+2. **`project_id` on the sidebar** — the last hop of the passthrough #855 starts (PR-2). SHIPPED.
 3. **`join_mode = 0` self-join** — a column P0 shipped with no writer and no reader (PR-3).
 4. **`is_official` management** (PR-4) and **per-user project pinning** (PR-5).
 
@@ -132,6 +132,11 @@ This is that brief.
   verified Space via `spacepkg.SetSpaceID` — *after* the Space membership check, never before
   (`middleware.go:315-319`). A new handler that reads `GetSpaceID` without that ordering gets a
   Space the caller has no seat in.
+- **`wire-contract` — `SidebarItem` gains a field (PR-2), and so does `group.InfoResp`.**
+  `InfoResp` is the cross-module batch read shape (`GetGroups`), and adding `project_id` there is
+  what makes the sidebar's copy free: the value was already in the row `QueryWithGroupNos`
+  selects, it was simply never mapped out. Without it the sidebar would need a second batch on
+  the hottest read path for a field already in the response.
 - **`wire-contract` — `SidebarItem` gains a field (PR-2).** `modules/message/api_sidebar.go:107-137`
   is one of the hottest read payloads in the product, and its existing `SpaceID` comment
   (`:112-119`) already fixes the per-target-type contract a new `project_id` must match. #855
@@ -476,7 +481,7 @@ golangci-lint run ./...
   with it.
 - `TestProjectNoLegacyResponseError` still green (automatic — the file list is dynamic).
 
-**PR-2 — `project_id` on the sidebar** (the rest landed in #855):
+**PR-2 — `project_id` on the sidebar** (the rest landed in #855) — SHIPPED as implemented below:
 
 - `project_id` present and correct on the `/v1/sidebar/*` payload for a project group, `""`
   (omitted) for a Space-direct group, and `""` for a DM — the same three-way split
@@ -487,7 +492,11 @@ golangci-lint run ./...
   per-group round-trip on the hot read path.
 - `project_id` still absent from the public invite-preview response (D6), pinned by a test.
 - Regression: `GroupResp.project_id` from #855 still correct on both mappers after the rebase.
-- `TestGroupNoLegacyResponseError`'s fixed file list updated if `modules/group` gains a file.
+- ~~`TestGroupNoLegacyResponseError`'s fixed file list updated~~ — **no longer applies.** That
+  guard now DISCOVERS its file list from the package directory (`modules/group/api_i18n_test.go:45`),
+  changed with the note that "a hard-coded list cannot see a new file — which is the failure mode
+  that matters, because nobody adds a handler by editing api.go". The brief's load-bearing list
+  said otherwise and was correct when written; recorded here rather than silently dropped.
 
 **PR-3 — `join_mode = 0` self-join:**
 

--- a/.octospec/tasks/project-p2-product-surfaces/brief.md
+++ b/.octospec/tasks/project-p2-product-surfaces/brief.md
@@ -470,6 +470,29 @@ admission transaction」, which P1 called a separate task and nobody has opened.
   they all filter within a Space the caller already holds a seat in.
 - **Any change to `group.project_id`'s two writers**, to the I2 admission entry, or to the
   cascade.
+- **Swagger for `modules/project`, and with it the client-facing contract notes.** Raised in
+  review and worth its own task: 20+ modules carry a `swagger/api.yaml` and this one carries
+  none across all twelve routes. The consequence is not tidiness — the two things client teams
+  actually need are written only in Go doc comments they will never read: that `member_count`
+  counts humans on the project row (#855's D16) and humans **plus agents** on this PR's group
+  list, differing by one for a group holding a blacklisted member; and that the sidebar's
+  `project_id` is withheld entirely on the no-`X-Space-ID` path. `sidebar.yaml`'s `sidebarItem`
+  is three fields behind as well (`project_id`, `space_id`, `my_source_space_id`) — declined
+  here as pre-existing drift from #153, which is a scoping call in favour of that task rather
+  than against it.
+- **`SidebarItem.ProjectID` as `*string` — considered and declined, recorded so it is not
+  re-litigated by accident.** The suggestion was to copy `CategoryID *string` two lines below
+  it, so `nil` means "not evaluated" and a pointer to `""` means 直属 Space, removing the
+  ambiguity the Space-scope gate creates. Declined for two reasons. First, the disambiguator
+  already exists and is not in the payload: a client knows whether it sent `X-Space-ID`, and on
+  the path where it did, an absent field is unambiguous. Second, the ambiguity is temporary by
+  construction — it exists only because that path lacks a membership predicate, and
+  `project-p2-read-path-hardening` removes the gate along with the hole. A pointer is a
+  permanent wire shape; emitting `"project_id": ""` on every Space-direct group of the hottest
+  read path is a real cost to describe a state that is meant to stop existing. The reviewer is
+  right that this is the cheap moment to decide, which is why the decision is written here
+  rather than left implicit — if hardening slips or a client ships against the ambiguity, the
+  trade changes and this is where to reopen it.
 
 ## Acceptance
 

--- a/.octospec/tasks/project-p2-product-surfaces/brief.md
+++ b/.octospec/tasks/project-p2-product-surfaces/brief.md
@@ -1,0 +1,408 @@
+---
+type: Task
+title: "Task: project-p2-product-surfaces"
+description: The four product surfaces P1 and P2 both deferred to a sibling brief — the project-scoped group list a client needs to render the 群聊 tab, `project_id` passthrough on the group reads that already exist, `join_mode = 0` self-join, `is_official` management, and per-user project pinning. P1 and P2 built a Project that owns groups and enforces I2 on the write side; nothing on the read side lets a client discover that a group belongs to a project at all.
+tags: ["space", "isolation", "acl", "wire-contract", "error-response", "i18n", "rate-limit", "testing", "commit", "migration"]
+timestamp: 2026-09-08T00:00:00Z
+# --- octospec extension fields ---
+slug: project-p2-product-surfaces
+upstream: self
+source: self
+---
+
+# Task: project-p2-product-surfaces
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+>
+> **Status: DRAFT.** Q1 (`is_official` ownership) is open and gates PR-4 only.
+> Named by `.octospec/tasks/project-p2-subsystem-integration/brief.md:1023-1024`,
+> which is where these four items were parked.
+
+## Goal
+
+Make a Project's groups **readable**.
+
+P1 (#846) gave a group an owner — `group.project_id`, one admission entry, and
+invariant I2 behind it. P2 PR-5 (#850) provisioned the subsystem containers. Neither
+shipped a way to ask *which groups belong to a project*, and neither made an existing
+group read admit which project it belongs to. Measured at HEAD:
+
+- `modules/project/api.go:175-201` registers nine routes. All nine are the project row
+  and its member roster. None returns a group.
+- `GET /v1/group/my` (`modules/group/api.go:967`) branches on `c.Query("space_id")` only.
+  Repo-wide there is **zero** occurrence of a handler reading a `project_id` query
+  parameter.
+- `GroupResp` (`modules/group/service.go:905-951`) carries `space_id` and **not**
+  `project_id`. `Model.ProjectID` (`modules/group/db.go:858`) exists and is never
+  serialized.
+- The query the endpoint needs already exists and is unexported:
+  `queryProjectGroupNosWithActiveMember` (`modules/group/db.go:1316`), whose only caller
+  is the member-removal cascade worker (`modules/group/project_cascade.go:101`).
+
+So a client cannot list a project's group chats, and cannot even tell that a group it
+*can* already see belongs to a project. The 群聊 tab of the 2026-09-07 prototype is not
+expressible against HEAD. That is the gap this task closes.
+
+Four surfaces, in the order they unblock things:
+
+1. **`GET /v1/projects/:project_id/groups`** — the caller's groups within one project (PR-1).
+2. **`project_id` passthrough** on the group reads that already exist (PR-2).
+3. **`join_mode = 0` self-join** — a column P0 shipped with no writer and no reader (PR-3).
+4. **`is_official` management** and **per-user project pinning** (PR-4, PR-5).
+
+PR-1 and PR-2 are independently shippable and are the whole of the unblock. PR-3 to PR-5
+carry their own product questions and must not hold PR-1 up.
+
+## Background
+
+### What P0/P1/P2 already decided, that this brief must not re-open
+
+- **Space is the only security boundary.** `pkg/authtree/authtree.go:101-113` records it
+  in as many words: 「Project is explicitly not a read boundary — Space remains the only
+  security boundary」. Every route here is gated on the caller's own Space membership
+  first; the Project dimension is a **filter**, never the gate. A group list that reads
+  as "Project is now a read boundary" is the wrong shape even if it returns the right rows.
+- **Anti-enumeration is uniform.** `projectMiddleware` (`modules/project/middleware.go:258-340`)
+  folds three refusals into one indistinguishable response: the project does not exist; it
+  is in a Space the caller has no seat in; it is unlisted and the caller is neither a member
+  nor a Space admin. Any new project-scoped route inherits that, unchanged.
+- **I2 is a ceiling, not a floor.** A project group's active members are a *subset* of the
+  project's active members. Project membership does **not** imply membership of any
+  particular group in it. D1 below is the direct consequence.
+- **I3 makes attribution immutable.** `group.project_id` is written exactly twice in the
+  tree — the create path and the disband detach (`modules/group/db.go:1444-1450`), pinned by
+  a source guard (`TestNoProjectIDRewritesOutsideTheDetachStep`, `modules/group/admission_guard_test.go:134`). Nothing here writes it.
+- **Three P0 columns still have no writer**: `join_mode`, `is_official`, and
+  `discoverability`'s unlisted value (`modules/project/sql/20260904000001_project_core.sql:86-89`).
+  Their own comments assign them here. P2 explicitly claimed none of them
+  (`project-p2-subsystem-integration/brief.md:70-74`).
+
+### Where these four items were parked
+
+- P0 and P1, identically: 「**`GET /v1/projects/:project_id/groups`**, the nested
+  Project → Group → Thread response, `project_id` passthrough in sidebar / group detail /
+  group list, project pinning, the `is_official` management endpoint, Project-level
+  auto-join, and the member-picker data source — all **P2**」
+  (`project-p1-group-binding/brief.md:279-282`; `project-p0-foundation/brief.md:215`).
+- P2: 「**The product surfaces**: `join_mode = 0` self-join, `is_official` management,
+  per-user pinning, `GET /v1/projects/:project_id/groups`. Own brief.」
+  (`project-p2-subsystem-integration/brief.md:218-219`, repeated at `:1023-1024`).
+
+This is that brief.
+
+## Load-bearing list
+
+- **`space` / `isolation` / `acl` — the Space gate and the anti-enumeration contract.**
+  Every route added here mounts `AuthMiddleware` → `SharedUIDRateLimiter` → `projectMiddleware`,
+  in that order (`modules/project/api.go:185-189`), and `projectMiddleware` is what writes the
+  verified Space via `spacepkg.SetSpaceID` — *after* the Space membership check, never before
+  (`middleware.go:315-319`). A new handler that reads `GetSpaceID` without that ordering gets a
+  Space the caller has no seat in.
+- **`wire-contract` — `GroupResp` gains a field (PR-2).** `modules/group/service.go:905-951` is
+  consumed by `GET /v1/group/my`, group detail, and the sidebar. An added field is additive,
+  but it is a wire contract with existing clients and both mappers must populate it
+  (`from` at `:953`, `fromModel` at `:1000`) or the field silently reads `""` on one path and
+  correctly on the other — worse than absent.
+- **`error-response` / `i18n` — the envelope.** `httperr.ResponseErrorL` + a registered
+  `pkg/errcode` code only. The per-module helpers already exist
+  (`modules/project/api_i18n.go`: `respondProjectNotFound`, `respondQueryFailed`,
+  `respondForbidden`, `respondParamInvalid`). `TestProjectNoLegacyResponseError`
+  (`api_i18n_test.go:96`) globs the module dynamically via `moduleSourceFiles`, so a new
+  project file is covered automatically. **`TestGroupNoLegacyResponseError`
+  (`modules/group/api_i18n_test.go:30`) does NOT — it scans a fixed file list**, so any new
+  file under `modules/group` must be added to it by hand.
+- **`rate-limit` — `SharedUIDRateLimiter`, mounted after `AuthMiddleware`.** Already on both
+  project route groups. Tests that hit these routes must reset `ratelimit:uid:*` in setup;
+  `CleanAllTables` does not clear it.
+- **The `group_space_project` index.** `(space_id, project_id)` on `group`
+  (`modules/space/sql/20260906000001_group_project_binding.sql:78`) is the index PR-1's query
+  must actually use. It is also the first index ever to serve `group.space_id`, so it already
+  changed the plan for `queryGroupsWithMemberUIDAndSpaceID` and `modules/bot_api/groups.go:51`.
+  A new query that filters `project_id` without `space_id` cannot use it at all — the leading
+  column is `space_id`, which is why `queryProjectGroupNos` takes both
+  (`modules/group/db.go:1276-1285`).
+- **Collation.** `group` / `group_member` are legacy (server default; production measured at
+  `utf8mb4_0900_ai_ci`), `octo_project*` is pinned `utf8mb4_general_ci`. Any join that crosses
+  the two needs an explicit `COLLATE utf8mb4_general_ci` on the legacy side or it is MySQL
+  error 1267 in production while passing in CI — the exact failure
+  `reconcile_p1.go:206-218` documents and `reconcile_p1_collation_test.go` pins. A join *within*
+  the legacy side (`group` ⋈ `group_member`) must **not** be coerced: it would cost the index.
+- **The `group` stub schema.** `reconcile_p1.go:191-198` records that binaries whose migration
+  set excludes `modules/group` see a **stub** `group` table with a different shape (its `status`
+  is nullable). A query from `modules/project` may only rely on columns present in both. Which
+  columns those are must be established before the response field set is frozen (see Q2).
+- **Import direction.** `modules/group` imports `modules/project`
+  (`modules/group/project_cascade.go:8`). The reverse must never happen —
+  `modules/project/cascade_registry.go:10-15` states it and the cascade registry exists to keep
+  it true. `modules/project` reading the `group` **table** directly is already established
+  practice (`reconcile_p1.go:200,311`) and is not the same thing as importing the package.
+- **Disbanded groups.** `group.status = 2` rows keep their `group_member` rows on purpose —
+  disband flips status only, and there is no endpoint that cleans them up
+  (`modules/group/db.go:1287-1305`). A membership-driven list that omits the status filter
+  returns dead groups.
+- **`member_epoch` monotonicity (PR-3).** Every member/role write bumps it by exactly 1 in the
+  same transaction, pinned by `TestMemberEpochOnlyEverIncrements` (`api_i18n_test.go:119`). A
+  self-join is a member write and inherits that.
+- **I1 (PR-3).** An active `octo_project_member` uid must hold an active `space_member` seat in
+  the same Space. A self-join must re-check it inside the admission transaction, not from the
+  cached middleware verdict.
+- **`migration` (PR-5).** Pinning needs a new table. Placement rule, from
+  `modules/space/sql/20260906000001_group_project_binding.sql:5-42`: a column ships from a
+  migration directory present in every binary that reads it. Only `modules/project` reads a
+  project-user setting, so `modules/project/sql/` is correct — the same reasoning that keeps
+  `octo_project_member.removing` there. Time columns are application-written UTC with no
+  `DEFAULT CURRENT_TIMESTAMP` and no `ON UPDATE`.
+- **`testing` / `commit`** — repo conventions; Conventional Commits, English.
+
+## Decisions
+
+**D1 — `GET /v1/projects/:project_id/groups` returns the caller's OWN groups in that
+project, not every group in it.**
+
+I2 is a ceiling, not a floor: being in the project does not put you in its groups. Returning
+every group would hand a project member the names of groups they hold no seat in, and there
+is nothing they could do with that — there is no self-join path into a group, and the
+all-hands group (P2 PR-0) is unshipped. A name is the most sensitive field a group has at
+list granularity (「关键供应商来料异常」 tells you the incident exists), so the default is
+membership-scoped.
+
+The predicate already exists, disbanded-group filter included, as
+`queryProjectGroupNosWithActiveMember` (`modules/group/db.go:1316-1329`). PR-1 reimplements
+that shape in `modules/project` (D2) rather than exporting it across the forbidden import
+direction.
+
+Reversible on purpose: an admin-visible `?scope=all` is additive, and can be argued on its own
+merits when a product surface needs it. Shipping the wider set first cannot be taken back.
+
+**D2 — The handler lives in `modules/project` and queries `group` directly. No new registry.**
+
+`modules/project` must never import `modules/group` (`cascade_registry.go:10-15`), and the
+reverse import already exists, so the package dependency is settled. But reading the **table**
+is not importing the package, and `modules/project` already does exactly that in production
+code: the I2/I3 reconcile scans join `group` ⋈ `group_member` ⋈ `octo_project_member`
+(`reconcile_p1.go:200,311`), and the module's own tests insert into `group`
+(`reconcile_i2_test.go:36`). So the read view needs no cascade-registry-style indirection, and
+a synchronous request path is the worst place for one anyway: an unregistered provider would
+answer an empty list, which is indistinguishable from "this project has no groups".
+
+The cost, recorded because it is real: `modules/project` cannot reuse `GroupResp`. That is
+what D3 turns into a feature rather than a workaround.
+
+**D3 — A narrow, purpose-built response — not a second `GroupResp`.**
+
+`GroupResp` is 40-odd fields of per-user group state (`service.go:905-951`). Cloning it here
+would create a second wire contract for the same state, and the two would drift the first time
+one changes. This endpoint answers one question — *which groups in this project am I in* — so
+it returns the identity fields the tree renders and nothing else, and the client fetches full
+state through the routes it already calls (`GET /v1/groups/:group_no`, `GET /v1/group/my`).
+
+Proposed field set, to confirm against the prototype and against Q2: `group_no`, `name`,
+`is_named`, `avatar_text`, `avatar_color`, `is_upload_avatar`, `member_count`. Anything beyond
+that needs an argument, and every field must be checked against the stub schema before it is
+frozen.
+
+**D4 — Threads are NOT nested in the response.**
+
+P1's out-of-scope entry calls it 「the nested Project → Group → Thread response」, and the
+nesting belongs to the client. `GET /v1/groups/:group_no/threads` already exists
+(`modules/thread/api.go:185`) with its own pagination and its own access gate
+(`modules/thread/api.go:349,429,519,643,941` gate on `ExistMemberActive` against the parent
+group). A nested response would be `O(groups × threads)` with two pagination axes that cannot
+both be expressed in one cursor, and it would fork thread access control into a second place.
+
+**D5 — No unread counts, no badge state.**
+
+The prototype's red badges come from the conversation layer (`sidebar/sync`). Serving them
+here would make a second source of truth for a number that changes on every message, read
+through a route with a 60-second membership cache. Out.
+
+**D6 — PR-2 adds `project_id` to `GroupResp`, and that is a disclosure argument, not a
+formality.**
+
+Who learns what: only an existing member of the group learns which project it belongs to. By
+I2 they are already an active member of that project, so the field tells them nothing their
+own project roster does not. It does **not** go on any unauthenticated or pre-admission
+surface — specifically not the public invite preview
+(`GET /v1/group/invite/detail`, `modules/group/api.go:191`), where a `project_id` would leak
+project existence to an unauthenticated caller holding only an invite code.
+
+Both mappers must populate it (`from` at `service.go:953`, `fromModel` at `:1000`). One
+populated and one not is the failure mode this decision exists to prevent.
+
+**D7 — `join_mode = 0` self-join (PR-3) needs a writer before it needs an endpoint.**
+
+`join_mode` today has no writer, no reader, and no wire field — `CreateReq` / `UpdateReq` /
+`Resp` (`modules/project/model.go:141-153,193-211`) do not mention it. So PR-3 is three things,
+and shipping only the third is the hazard P0's comment warns about: 「自助加入是 P2，本列在 P0
+无消费方」.
+
+1. `join_mode` becomes settable on create/update (owner-only, same capability as
+   `discoverability`) and readable on `Resp`.
+2. `POST /v1/projects/:project_id/join`, admitted only when `join_mode = 0` **and**
+   `discoverability = space_listed` — an unlisted project is invisible to a non-member by
+   `projectMiddleware`'s own rules, so a join route that answered it would be a new
+   enumeration oracle on a surface that has none.
+3. The admission goes through the existing entry, `admitMemberTx` (`modules/project/db.go:595`),
+   inside a transaction that re-checks I1, the per-project member cap, and bumps `member_epoch`
+   by exactly 1. Not a second write path.
+
+No retro-consent problem exists: every row on disk is `join_mode = 1` (the DDL default) and
+nothing has ever written the column, so enabling the semantics cannot silently open an existing
+project. State that in the PR body — it is the question a reviewer will ask.
+
+The self-join route also needs `StrictIPRateLimitMiddleware`-grade thinking: it is authenticated,
+so `SharedUIDRateLimiter` is the right layer, but it is a *membership write* driven by the caller
+alone, which is a new shape for this module. Quota interaction with
+`ErrProjectQuotaPerSpace` / `ErrProjectQuotaDailyCreate` must be spelled out in the PR.
+
+**D8 — Per-user project pinning (PR-5) is a new table, not a column.**
+
+`octo_project_user_setting (project_id, uid, pinned, pinned_at, created_at, updated_at)`,
+`UNIQUE (project_id, uid)`, `octo_` prefix, `utf8mb4_general_ci`, application-written UTC times
+with no MySQL-side defaults. It lands in `modules/project/sql/` because only `modules/project`
+reads it. It changes the ordering of `GET /v1/space/:space_id/projects`
+(`listVisibleInSpace`), which is a wire-visible behaviour change to an endpoint that already
+ships — pinned first, then existing order, and the existing order must not otherwise move.
+
+A column on `octo_project_member` was considered and rejected: pinning is not a membership fact
+(a Space admin can see a `space_listed` project they have not joined, and could reasonably pin
+it), and every write to `octo_project_member` is on the epoch-bumping path — a pin is not a
+membership change and must not bump `member_epoch`.
+
+### Also parked by P0/P1, still unowned at HEAD
+
+P0 (`project-p0-foundation/brief.md:215`) and P1 (`project-p1-group-binding/brief.md:279-282`)
+parked **seven** items as "P2". P2's brief reassigned only four of them to this task
+(`project-p2-subsystem-integration/brief.md:1023-1024`). Of the remaining three, one is
+decided here (the nested tree — D4) and one is PR-2 (`project_id` passthrough). **Two were
+never given a home by any brief, and are recorded here so they stop being invisible rather
+than because this task claims them:**
+
+- **Project-level auto-join.** Named identically in P0 and P1, and *not* obviously the same
+  thing as P2's 「`join_mode = 0` self-join」 (PR-3 / D7). Two readings: (a) self-service join,
+  in which case PR-3 already covers it and the two names should be merged; (b) new Space
+  members are auto-admitted to designated projects — the Project analogue of Space preset
+  groups (`joinPresetGroups`, `modules/space/api.go:1366`), which is a different feature with a
+  different consent question. **Q4 below.**
+- **The member-picker data source.** I2 means the "add members to this project group" picker
+  must be scoped to the project's roster, not the Space's. `GET /v1/projects/:project_id/members`
+  (`modules/project/api.go:420`) is that roster and is already members-only — but it takes
+  offset/limit and **no keyword** (`p.db.listMembers(row.ProjectID, offset, limit)`), so a
+  picker over a 1000-member project has to page the whole roster client-side to search it. The
+  gap is one filter parameter on an endpoint that already exists, not a new surface. Small
+  enough to fold into PR-1's PR if the human confirms; listed, not claimed.
+
+Two further P1 out-of-scope entries also remain unowned and are **not** this brief's:
+read-path hardening (named `project-p2-read-path-hardening` by P2 but never written — the
+`sidebar/sync` comment P2 said must be rewritten is unchanged at
+`modules/message/api_sidebar.go:555-580`), and 「tightening the Space membership check into the
+admission transaction」, which P1 called a separate task and nobody has opened.
+
+## Open questions
+
+- **Q4 — Which feature is 「Project-level auto-join」?** See above. If (a), delete the name and
+  fold it into D7. If (b), it needs its own consent argument and does not belong in this brief.
+- **Q1 — Who may set `is_official`, and what does it assert?** 「官方项目徽标」 reads as a
+  platform assertion, not a Space one. If a project owner can set it on their own project the
+  badge means nothing. Two candidates: the manager console (`api_manager.go` pattern, e.g.
+  `modules/group/api_manager.go:50`), or a Space admin. **Recommendation: manager console**, on
+  the grounding that the badge's value is that its subject cannot grant it to themselves. Gates
+  PR-4 only.
+- **Q2 — What is the `group` stub schema, exactly?** `reconcile_p1.go:191-198` asserts it exists
+  and differs, but the brief's author did not locate its DDL (`grep -ri 'create table.*\`group\`'`
+  over `modules/*/sql` finds only `modules/group/sql/20191106000002_group_legacy01.sql:5`; the
+  Go module cache was unavailable in this environment, so `octo-lib` was not searched). Resolve
+  before freezing D3's field set: if the stub carries only `group_no` / `name` / `status` /
+  `space_id` / `project_id`, the avatar fields cannot be selected from `modules/project`, and D2
+  is back on the table.
+- **Q3 — Does the prototype's 群聊 tab need groups the caller is not in?** D1 says no and is
+  reversible. Confirm with product before PR-1 merges, because widening later is additive while
+  narrowing later is a breaking change.
+
+## Out of scope
+
+- **The all-hands group (全员群).** Creating a group with the project is P2 PR-0
+  (`project-p2-subsystem-integration/brief.md` D10) and is unshipped at HEAD — there is no
+  `全员群` / `all_hands` anywhere in `modules/`. PR-1 lists whatever groups exist; it does not
+  create one. The prototype's first row stays empty until PR-0 lands, and that is expected, not
+  a defect in this task.
+- **Listing groups the caller is not a member of.** D1, pending Q3.
+- **Nested threads in the group-list response.** D4.
+- **Unread / badge state.** D5.
+- **Read-path hardening** — `sidebar/sync`'s `ExistMembersActive` backstop, the deprecated
+  `/v1/coversations` filter, the group-avatar enumeration oracle, `querySavedGroups` after
+  leaving. Its own brief, named `project-p2-read-path-hardening` by
+  `project-p2-subsystem-integration/brief.md:1015-1022`. PR-2 adds a field to an existing
+  response; it does not touch those gates.
+- **Re-parenting a group between projects.** I3 forbids it; the source guard
+  (`TestNoProjectIDRewritesOutsideTheDetachStep`, `modules/group/admission_guard_test.go:134`) must keep passing untouched.
+- **Pending invitations** (`octo_project_invitation`, P2 D8) and **ownership transfer** — P2's,
+  not this brief's.
+- **Making Project a read boundary.** `authtree.go:101-113`. No route here changes the gate;
+  they all filter within a Space the caller already holds a seat in.
+- **Any change to `group.project_id`'s two writers**, to the I2 admission entry, or to the
+  cascade.
+
+## Acceptance
+
+**Gates (all must pass):**
+
+```bash
+go test ./modules/project/... ./modules/group/... ./modules/thread/... ./modules/space/...
+make i18n-extract && make i18n-extract-check && make i18n-lint
+golangci-lint run ./...
+```
+
+**PR-1 — `GET /v1/projects/:project_id/groups`:**
+
+- `TestListProjectGroupsReturnsOnlyMyGroups` — project member in 1 of 3 project groups gets
+  exactly 1 row.
+- `TestListProjectGroupsExcludesDisbandedGroups` — a `status = 2` group the caller is still a
+  `group_member` of does not appear.
+- `TestListProjectGroupsExcludesSpaceDirectGroups` — a group with `project_id = ''` in the same
+  Space does not appear.
+- `TestListProjectGroupsUnknownProjectIsNotFound`,
+  `...CrossSpaceProjectIsNotFound`, `...UnlistedNonMemberIsNotFound` — all three produce the
+  **byte-identical** envelope, asserted against each other, not merely against a status code.
+- `TestListProjectGroupsIsUIDRateLimited` — with `ratelimit:uid:*` reset in setup.
+- `TestListProjectGroupsPaginationIsBounded` — reuses `pageParams`; `?page=9223372036854775807`
+  returns an empty page, not a 5xx (the defect `pageParams`' comment records).
+- An `EXPLAIN` assertion that the query uses `group_space_project`, in the shape of
+  `TestReconcileQueriesAreBounded`.
+- A collation-drift case extending `reconcile_p1_collation_test.go`'s rig: the new statement
+  must survive a legacy side at `utf8mb4_0900_ai_ci`, i.e. fail without the `COLLATE` and pass
+  with it.
+- `TestProjectNoLegacyResponseError` still green (automatic — the file list is dynamic).
+
+**PR-2 — `project_id` passthrough:**
+
+- `project_id` present and correct on `GET /v1/group/my?space_id=`, on group detail, and on the
+  sidebar payload, asserted for a project group **and** asserted as `""` for a Space-direct
+  group.
+- Both mappers covered: a test that would fail if only `from` or only `fromModel` were changed.
+- `project_id` absent from the public invite-preview response (D6), pinned by a test.
+- `TestGroupNoLegacyResponseError`'s fixed file list updated if `modules/group` gains a file.
+
+**PR-3 — `join_mode = 0` self-join:**
+
+- `join_mode` round-trips through create → read → update → read; a non-owner cannot set it.
+- Self-join succeeds only for `join_mode = 0` **and** `discoverability = space_listed`; the
+  unlisted case returns the same not-found envelope as PR-1's three refusals.
+- Self-join respects the member cap and I1 (a caller whose `space_member` seat was closed
+  between the middleware's cached verdict and the transaction is refused).
+- `member_epoch` increases by exactly 1 per successful join and not at all on a rejected or
+  idempotent one; `TestMemberEpochOnlyEverIncrements` still green.
+- Every project row on disk before this PR remains `join_mode = 1` — a migration-free assertion
+  that the semantics cannot open an existing project.
+
+**PR-4 / PR-5:**
+
+- `is_official` writable only from the surface Q1 settles, never by a project owner on their own
+  project (asserted).
+- Pinning: pinned projects sort first in `GET /v1/space/:space_id/projects` and the unpinned
+  order is unchanged; a pin does **not** bump `member_epoch`; `(project_id, uid)` is unique and
+  a repeated pin is idempotent.
+- The new table's migration passes the module's migration test (mind the apostrophe-parity
+  hazard documented in `modules/project/sql/20260906000001_project_group_binding.sql`'s Down
+  section — no apostrophes in SQL comments).

--- a/.octospec/tasks/project-p2-product-surfaces/context.yaml
+++ b/.octospec/tasks/project-p2-product-surfaces/context.yaml
@@ -1,8 +1,9 @@
 # octospec Implement-phase record for task project-p2-product-surfaces, PR-1.
 #
-# Scope of this record: PR-1 only — GET /v1/projects/:project_id/groups. PR-2
-# (project_id on the sidebar) and PR-3..PR-5 are not implemented and are not
-# covered here.
+# Scope of this record: PR-1 (GET /v1/projects/:project_id/groups) and PR-5
+# (per-user project pinning, capped at 6 per Space). PR-2 (project_id on the
+# sidebar), PR-3 (join_mode self-join) and PR-4 (is_official) are not implemented
+# and are not covered here.
 #
 # Rule resolution: .octospec/_global/ is NOT synced in this worktree (no global
 # tier available), so every injected rule resolves to the repo tier.
@@ -82,6 +83,16 @@ injected:
     why: |
       paths ** matches everything; brief tag commit. English Conventional
       Commits.
+
+  - id: migration
+    source: none
+    why: |
+      No repo rule carries a migration tag - the brief lists it, _index.yaml does
+      not define it - so nothing was injected for it. The conventions applied are
+      the ones the module already documents in its own SQL: octo_ prefix,
+      utf8mb4_general_ci, application-written UTC with no CURRENT_TIMESTAMP or ON
+      UPDATE, and no apostrophes anywhere in the file because the module migration
+      test splits statements naively and apostrophes cancel in pairs.
 
 brief: .octospec/tasks/project-p2-product-surfaces/brief.md
 

--- a/.octospec/tasks/project-p2-product-surfaces/context.yaml
+++ b/.octospec/tasks/project-p2-product-surfaces/context.yaml
@@ -1,0 +1,142 @@
+# octospec Implement-phase record for task project-p2-product-surfaces, PR-1.
+#
+# Scope of this record: PR-1 only — GET /v1/projects/:project_id/groups. PR-2
+# (project_id on the sidebar) and PR-3..PR-5 are not implemented and are not
+# covered here.
+#
+# Rule resolution: .octospec/_global/ is NOT synced in this worktree (no global
+# tier available), so every injected rule resolves to the repo tier.
+#
+# inject_when is a union of paths-glob and touches-tag (see _index.yaml). The
+# brief's tags are: space, isolation, acl, wire-contract, error-response, i18n,
+# rate-limit, testing, commit, migration. All six repo rules match.
+injected:
+  - id: space-isolation
+    source: repo
+    priority: 92
+    load_bearing: true
+    why: |
+      paths modules/**/*.go matches every file touched; brief tags carry
+      space / isolation / acl. Drives: the route mounts the existing
+      projectScoped group, so AuthMiddleware -> SharedUIDRateLimiter ->
+      projectMiddleware all apply unchanged, and the handler reads space_id
+      from the project row projectMiddleware already verified the caller's
+      Space membership against rather than from any request input. The query
+      filters on that space_id as well as project_id, so a project id cannot
+      reach across a Space even if one were guessed. The route is /v1/-prefixed
+      and no new module is added, so internal/modules.go is untouched.
+  - id: error-handling
+    source: repo
+    priority: 85
+    load_bearing: true
+    why: |
+      paths modules/**/*.go; brief tags error-response / i18n / wire-contract.
+      Drives: the handler's only failures are wiring bugs and query failures,
+      both answered through respondQueryFailed (httperr.ResponseErrorL +
+      errcode.ErrProjectQueryFailed). No new error code is registered and no
+      new user-facing message is introduced, so active.zh-CN.toml needs no
+      entry - make i18n-extract-check and make i18n-lint both pass unchanged.
+      The refusal path is projectMiddleware's existing folded not-found, which
+      the new route inherits rather than restates.
+  - id: rate-limit
+    source: repo
+    priority: 80
+    load_bearing: true
+    why: |
+      paths modules/**/*.go; brief tag rate-limit. Drives: no new middleware and
+      no hand-rolled counter - the route is added INSIDE the projectScoped group
+      that already mounts SharedUIDRateLimiter after AuthMiddleware. The rule's
+      testing note (buckets are not cleared by CleanAllTables) is why the
+      coverage here is structural: see the testing entry below.
+  - id: trust-boundary
+    source: repo
+    priority: 90
+    load_bearing: true
+    why: |
+      Matched by the brief's wire-contract tag, not by paths - this is not an
+      adapter and carries no external content. The one clause that transfers is
+      "bound the payload": the endpoint reuses pageParams, so limit is capped at
+      200 and page at 100000, and the member-count lookup is one grouped query
+      over the page rather than one query per row. Nothing here renders
+      caller-supplied text, emits a markdown destination, or crosses an adapter
+      boundary, so the escaping and parity clauses do not apply.
+  - id: testing
+    source: repo
+    priority: 70
+    load_bearing: false
+    why: |
+      paths **/*_test.go; brief tag testing. Drives: cases use the package's
+      setup() (CleanAllTables + resetUIDRateLimit + flushProjectCache) and its
+      existing fixtures. Deliberate divergence from the brief's acceptance
+      list: the brief asked for TestListProjectGroupsIsUIDRateLimited, and a
+      request-hammering test is what TestAuthChainOrder (api_i18n_test.go)
+      explicitly argues against - SharedUIDRateLimiter fails open without a uid,
+      so such a test passes whether or not the ordering is right. The chain is
+      therefore checked where it is declared, and this PR adds only the part
+      TestAuthChainOrder cannot see: that the new route went onto the
+      authenticated group rather than a new bare one.
+  - id: commit-style
+    source: repo
+    priority: 60
+    load_bearing: false
+    why: |
+      paths ** matches everything; brief tag commit. English Conventional
+      Commits.
+
+brief: .octospec/tasks/project-p2-product-surfaces/brief.md
+
+# Decisions applied from the brief, and what changed while implementing.
+implementation_notes:
+  - |
+    D1 (membership-scoped) is implemented as the query predicate, not as a
+    filter over a wider result: listMyProjectGroups joins group_member on the
+    caller's uid. Q3 was confirmed by the requester on 2026-09-08.
+  - |
+    D2 (handler in modules/project, direct SQL on `group`) held up. The import
+    ban is pinned by pkg/project/import_guard_test.go and reading the table is
+    not importing the package - reconcile_p1.go and db_all_member_group.go
+    already do it. A reverse-registered read hook was rejected: an unregistered
+    provider would answer an empty list, indistinguishable from "no groups".
+  - |
+    Membership predicate is is_deleted = 0 AND status = 1, the repo's canonical
+    one (ExistMemberActive, both reconcile scans). This is STRICTER than
+    modules/group's queryProjectGroupNosWithActiveMember, which checks
+    is_deleted alone - correct for a cascade that removes rows, wrong for a
+    read. TestListProjectGroupsExcludesInactiveMembership is what keeps the two
+    apart.
+  - |
+    ORDER BY g.id ASC. It is the only total ordering available (group_no is a
+    UUID, name is not unique) and a non-total ORDER BY under OFFSET pagination
+    drops and duplicates rows between pages. It also puts #855's all-member
+    group first for free, since that group is provisioned with the project.
+  - |
+    No COLLATE in either statement, and that is deliberate rather than an
+    omission: `group` join `group_member` is legacy-to-legacy, and space_id /
+    project_id / uid arrive as bind parameters, not as octo_project* columns.
+    Written into db_group.go because "has no COLLATE" and "forgot its COLLATE"
+    look identical in a diff.
+  - |
+    No permission gate beyond projectMiddleware. The roster needs canViewMembers
+    because it is a fact about other people; this list returns only rows the
+    caller is already in, so a Space admin who never joined gets [] - the true
+    answer. A 403 there would make project non-membership observable on a route
+    that currently discloses nothing.
+  - |
+    A census note was added to pkg/authtree/authtree.go. The blanket entry
+    already covers /v1/projects/*, but this is the first Project route to return
+    another module's resource and a reader could take it for Project becoming a
+    read boundary. It is not, and the file's stated purpose is to record that as
+    a decision rather than an absence.
+
+open_verification:
+  - |
+    go test ./modules/project/ was NOT run: this environment has no MySQL, Redis
+    or WuKongIM (ports 3306/6379 refused), and testutil.NewTestServer needs all
+    three. Compile-level checks all pass - go build ./..., go vet, golangci-lint
+    (0 issues), gofmt, make i18n-extract-check, make i18n-lint. The ten new
+    cases have never executed anywhere; CI is the first run.
+  - |
+    No EXPLAIN was taken. The query is written to drive off group_space_project
+    (space_id, project_id), whose leading column is space_id, but that plan is
+    unverified and `group` is empty in CI - the same caveat the index's own
+    migration header carries.

--- a/.octospec/tasks/project-p2-product-surfaces/context.yaml
+++ b/.octospec/tasks/project-p2-product-surfaces/context.yaml
@@ -128,13 +128,33 @@ implementation_notes:
     read boundary. It is not, and the file's stated purpose is to record that as
     a decision rather than an absence.
 
-open_verification:
+verified:
   - |
-    go test ./modules/project/ was NOT run: this environment has no MySQL, Redis
-    or WuKongIM (ports 3306/6379 refused), and testutil.NewTestServer needs all
-    three. Compile-level checks all pass - go build ./..., go vet, golangci-lint
-    (0 issues), gofmt, make i18n-extract-check, make i18n-lint. The ten new
-    cases have never executed anywhere; CI is the first run.
+    Ran against MySQL 8.0.46 (server collation utf8mb4_0900_ai_ci, `test`
+    database utf8mb4_general_ci - i.e. the production-shaped split the collation
+    guards exist for), Redis 6379, WuKongIM v2.2.4-20260313 with
+    WK_TOKENAUTHON=false:
+
+      go test -race -shuffle=on ./modules/project/   ok  63.7s
+      go test -race -shuffle=on ./modules/group/     ok  96.7s
+      go test -race -shuffle=on ./modules/thread/    ok  23.4s
+      go test -race -shuffle=on ./pkg/project/       ok   1.5s
+      go test -race -shuffle=on ./pkg/authtree/      ok   1.1s
+      go build ./... / go vet / golangci-lint (0 issues) / gofmt
+      make i18n-extract-check / make i18n-lint
+
+    All ten new cases pass, including the one that runs the REAL all-member-group
+    provisioner rather than the stand-in.
+  - |
+    Each package needs its OWN fresh `test` database. Running ./modules/group/
+    against a database ./modules/project/ had just migrated fails at startup with
+    "unknown migration in database": module.Setup migrates from the registered
+    module set, modules/project's test binary registers all 40 modules (its
+    external test package blank-imports octo-server/internal) and modules/group's
+    registers fewer. Not caused by this change - it is how the suite already
+    behaves - but anyone reproducing these runs locally needs to know.
+
+open_verification:
   - |
     No EXPLAIN was taken. The query is written to drive off group_space_project
     (space_id, project_id), whose leading column is space_id, but that plan is

--- a/.octospec/tasks/project-p2-product-surfaces/context.yaml
+++ b/.octospec/tasks/project-p2-product-surfaces/context.yaml
@@ -1,9 +1,9 @@
 # octospec Implement-phase record for task project-p2-product-surfaces, PR-1.
 #
-# Scope of this record: PR-1 (GET /v1/projects/:project_id/groups) and PR-5
-# (per-user project pinning, capped at 6 per Space). PR-2 (project_id on the
-# sidebar), PR-3 (join_mode self-join) and PR-4 (is_official) are not implemented
-# and are not covered here.
+# Scope of this record: PR-1 (GET /v1/projects/:project_id/groups), PR-2
+# (project_id on the sidebar) and PR-5 (per-user project pinning, capped at 6 per
+# Space). PR-3 (join_mode self-join) and PR-4 (is_official, gated on Q1) are not
+# implemented and are not covered here.
 #
 # Rule resolution: .octospec/_global/ is NOT synced in this worktree (no global
 # tier available), so every injected rule resolves to the repo tier.

--- a/modules/group/api_invite_detail_project_test.go
+++ b/modules/group/api_invite_detail_project_test.go
@@ -99,3 +99,61 @@ func TestGroupInviteDetailNeverLeaksProjectID(t *testing.T) {
 		"and not under any other key either — asserted on the raw body so a rename "+
 			"of the field cannot slip the value through")
 }
+
+// TestGetGroupsCarriesTheProjectIDFromTheRow covers the one line PR-2 actually
+// depends on, through the path production uses.
+//
+// The sidebar's project_id is produced by exactly one assignment —
+// `ProjectID: m.ProjectID` in toInfoResp — and every case in modules/message
+// reaches SidebarItem.ProjectID either from a map the test built itself or through
+// a fake GetGroups returning hand-written InfoResp literals. So all five of those
+// assertions stay green with that assignment deleted, and the field ships empty to
+// every client. Reviewer yujiawei found the gap; this is the mutation kill for it.
+//
+// Deliberately driven through Service.GetGroups rather than toInfoResp directly:
+// the fake it replaces implements that method, so this asserts the same seam the
+// sidebar calls, over a real `group` row, rather than a helper one refactor away
+// from no longer being on the path.
+//
+// The absent case is half the assertion. A mapping that hardcoded a non-empty
+// value would satisfy the positive half alone, and "" is the column's own sentinel
+// for a Space-direct group — the value the sidebar's omitempty depends on.
+func TestGetGroupsCarriesTheProjectIDFromTheRow(t *testing.T) {
+	_, ctx := newTestServer(t)
+	f := New(ctx)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	defer func() { require.NoError(t, testutil.CleanAllTables(ctx)) }()
+
+	const (
+		spaceID       = "space-getgroups-project"
+		projectGroup  = "g-getgroups-in-project"
+		directGroup   = "g-getgroups-space-direct"
+		wantProjectID = "p-getgroups"
+	)
+	require.NoError(t, f.db.Insert(&Model{
+		GroupNo: projectGroup, Name: "项目群", Creator: testutil.UID, Status: 1,
+		SpaceID: spaceID, ProjectID: wantProjectID,
+	}))
+	require.NoError(t, f.db.Insert(&Model{
+		GroupNo: directGroup, Name: "空间直属群", Creator: testutil.UID, Status: 1,
+		SpaceID: spaceID,
+	}))
+
+	infos, err := NewService(ctx).GetGroups([]string{projectGroup, directGroup})
+	require.NoError(t, err)
+
+	byNo := make(map[string]*InfoResp, len(infos))
+	for _, info := range infos {
+		byNo[info.GroupNo] = info
+	}
+	require.Contains(t, byNo, projectGroup)
+	require.Contains(t, byNo, directGroup)
+
+	assert.Equal(t, wantProjectID, byNo[projectGroup].ProjectID,
+		"InfoResp.ProjectID must carry the group row's project_id — this is the only "+
+			"link between the `group` table and the sidebar's project_id, and the "+
+			"sidebar tests all run against a fake that bypasses it")
+	assert.Empty(t, byNo[directGroup].ProjectID,
+		"and a Space-direct group must read empty rather than inheriting a neighbour, "+
+			"since that empty string is what omitempty drops from the payload")
+}

--- a/modules/group/api_invite_detail_project_test.go
+++ b/modules/group/api_invite_detail_project_test.go
@@ -37,6 +37,13 @@ func TestGroupInviteDetailNeverLeaksProjectID(t *testing.T) {
 	s, ctx := newTestServer(t)
 	f := New(ctx)
 	require.NoError(t, testutil.CleanAllTables(ctx))
+	// And again on the way out. Several cases in this package seed
+	// user.Model{UID: testutil.UID} under require.NoError and create groups
+	// against a per-user quota, so they only pass on a table this case has not
+	// left rows in — the sibling all_member_group cases carry the same defer for
+	// the same reason. Cleaning only on entry protects this case and nothing that
+	// runs after it, and -shuffle=on decides what that is.
+	defer func() { require.NoError(t, testutil.CleanAllTables(ctx)) }()
 
 	const spaceID = "space-invite-project"
 	_, err := ctx.DB().InsertInto("space").

--- a/modules/group/api_invite_detail_project_test.go
+++ b/modules/group/api_invite_detail_project_test.go
@@ -1,0 +1,94 @@
+package group
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGroupInviteDetailNeverLeaksProjectID keeps project_id off the one group
+// surface that answers UNAUTHENTICATED callers.
+//
+// #855 put project_id on GroupResp and the group detail, and PR-2 of
+// project-p2-product-surfaces puts it on the sidebar. Every one of those is behind
+// AuthMiddleware and answers a member of the group, who by I2 is already an active
+// member of the project — so the field tells them nothing their own project roster
+// does not.
+//
+// GET /v1/group/invite/detail is the exception: it deliberately carries no
+// AuthMiddleware (public H5 landing page, optional token per YUJ-39), so anyone
+// holding an invite code reaches it. project_id there would let an anonymous caller
+// learn that a project exists and its id, from a code that says nothing about it.
+//
+// It is safe today only because the handler builds its response as a hand-written
+// gin.H rather than through GroupResp. That is an accident of how it was written,
+// not a guard — so this test is the guard. The way it breaks is a tidy-up:
+// "why does this endpoint build its own map, let us reuse GroupResp".
+func TestGroupInviteDetailNeverLeaksProjectID(t *testing.T) {
+	s, ctx := newTestServer(t)
+	f := New(ctx)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	const spaceID = "space-invite-project"
+	_, err := ctx.DB().InsertInto("space").
+		Columns("space_id", "name", "creator", "status").
+		Values(spaceID, "项目空间", testutil.UID, 1).Exec()
+	require.NoError(t, err)
+	_, err = ctx.DB().InsertInto("space_member").
+		Columns("space_id", "uid", "role", "status").
+		Values(spaceID, testutil.UID, 0, 1).Exec()
+	require.NoError(t, err)
+
+	// A group that really does belong to a project — the whole point is that the
+	// field EXISTS on the row and still does not reach this response.
+	const groupNo = "g-invite-detail-project"
+	const projectID = "p-invite-detail"
+	require.NoError(t, f.db.Insert(&Model{
+		GroupNo:       groupNo,
+		Name:          "项目群",
+		Creator:       testutil.UID,
+		Status:        1,
+		SpaceID:       spaceID,
+		ProjectID:     projectID,
+		AllowExternal: 1,
+	}))
+	require.NoError(t, f.db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: testutil.UID, Role: MemberRoleCreator, Version: 1,
+	}))
+
+	code := "invite-detail-project-code"
+	require.NoError(t, ctx.GetRedisConn().SetAndExpire(
+		fmt.Sprintf("%s%s", common.QRCodeCachePrefix, code),
+		util.ToJson(common.NewQRCodeModel(common.QRCodeTypeGroup, map[string]interface{}{
+			"group_no":  groupNo,
+			"generator": testutil.UID,
+		})),
+		time.Hour,
+	))
+
+	// Anonymous: no token header at all, which is the population this guards.
+	req := newInviteRequest(t, "/v1/group/invite/detail?code="+code)
+	w := httptest.NewRecorder()
+	s.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.NotContains(t, resp, "project_id",
+		"the public invite preview must not disclose project_id: it has no "+
+			"AuthMiddleware, so an anonymous holder of an invite code would learn "+
+			"that a project exists and what its id is")
+	assert.NotContains(t, w.Body.String(), projectID,
+		"and not under any other key either — asserted on the raw body so a rename "+
+			"of the field cannot slip the value through")
+}

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -805,11 +805,19 @@ type InfoResp struct {
 	AllowViewHistoryMsg int       `json:"allow_view_history_msg"` // 是否允许新成员查看历史记录
 	CreatedAt           string    `json:"created_at"`
 	UpdatedAt           string    `json:"updated_at"`
-	Version             int64     `json:"version"`           // 群数据版本
-	SpaceID             string    `json:"space_id"`          // Space ID
-	IsExternalGroup     int       `json:"is_external_group"` // 是否外部群
-	AllowExternal       int       `json:"allow_external"`    // 是否允许外部成员 1.允许(默认) 0.禁止
-	AllowNoMention      int       `json:"allow_no_mention"`  // 群级是否允许免@生效 1.允许(默认) 0.禁止
+	Version             int64     `json:"version"`  // 群数据版本
+	SpaceID             string    `json:"space_id"` // Space ID
+	// ProjectID 群所属项目；空串 = 直属 Space。与 GroupResp.ProjectID 同一列、
+	// 同一含义（P2 开始下发）。加在这里是因为 InfoResp 是模块间的批量读形状：
+	// sidebar 靠 GetGroups 一次拿回整页会话的群信息，没有它就只能为 project_id
+	// 再发一轮查询，而那是热读路径上的一次额外往返。
+	//
+	// 数据本来就在手里——QueryWithGroupNos 取的是整行，Model.ProjectID 一直都在，
+	// 只是没有被映射出来。
+	ProjectID       string `json:"project_id"`        // 所属项目 ID（空串=直属 Space）
+	IsExternalGroup int    `json:"is_external_group"` // 是否外部群
+	AllowExternal   int    `json:"allow_external"`    // 是否允许外部成员 1.允许(默认) 0.禁止
+	AllowNoMention  int    `json:"allow_no_mention"`  // 群级是否允许免@生效 1.允许(默认) 0.禁止
 }
 
 func toInfoResp(m *Model) *InfoResp {
@@ -829,6 +837,7 @@ func toInfoResp(m *Model) *InfoResp {
 		UpdatedAt:           m.UpdatedAt.String(),
 		Version:             m.Version,
 		SpaceID:             m.SpaceID,
+		ProjectID:           m.ProjectID,
 		IsExternalGroup:     m.IsExternalGroup,
 		AllowExternal:       m.AllowExternal,
 		AllowNoMention:      m.AllowNoMention,

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -124,12 +124,26 @@ type SidebarItem struct {
 	// 与 v1 SyncUserConversationResp.MySourceSpaceID 字段口径一致
 	// （GH octo-server#153 Round-2 P1）。客户端在 source Space 下用 sidebar 时
 	// 需要这个字段才能识别"我以哪个 Space 身份加入了这个外部群"。
-	MySourceSpaceID string  `json:"my_source_space_id,omitempty"`
-	Timestamp       int64   `json:"timestamp"`
-	Unread          int     `json:"unread"`
-	IsPinned        bool    `json:"is_pinned"`
-	IsFollowed      bool    `json:"is_followed"`
-	CategoryID      *string `json:"category_id,omitempty"`
+	MySourceSpaceID string `json:"my_source_space_id,omitempty"`
+	// ProjectID 是该条目所属项目的 ID，口径与上面的 SpaceID 逐档对齐：
+	//   - GROUP: group 表的 project_id；
+	//   - COMMUNITY_TOPIC: 父群的 project_id（与 SpaceID 同一把 key 取，
+	//     两者不可能对不上）；
+	//   - PERSON: 留空 —— DM 不属于任何项目。
+	// 空串 = 直属 Space，与 group.project_id 的哨兵值一致；omitempty，所以老客户端
+	// 的 payload 逐字节不变。
+	//
+	// 客户端靠它在消息列表里按项目分组。P1 建立了这一列，#855 把它下发到
+	// GroupResp 和群详情，这里是同一次透出剩下的一跳。
+	//
+	// 取值不额外发查询：CollectGroupSpaceAndProjectMaps 与 SpaceID 共用同一次
+	// GetGroups，见那个函数的注释。
+	ProjectID  string  `json:"project_id,omitempty"`
+	Timestamp  int64   `json:"timestamp"`
+	Unread     int     `json:"unread"`
+	IsPinned   bool    `json:"is_pinned"`
+	IsFollowed bool    `json:"is_followed"`
+	CategoryID *string `json:"category_id,omitempty"`
 	// CategorySort 暴露给客户端的"类别之间排序权重"，来源是 group_category.sort
 	// （PR #21 review by lml2468 blocker #3）。改类别顺序会 bump follow_version
 	// 并改变这里返回的值，与 /category/sort 接口及 swagger 一致。
@@ -469,10 +483,12 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 	if len(threadExtRows) > 0 {
 		extraParentGroupNos = uniqueThreadParentGroupNos(threadExtRows)
 	}
-	groupSpaceMap, ok := CollectGroupSpaceMap(conversations, extraParentGroupNos, sb.groupService)
+	groupSpaceMap, groupProjectMap, ok := CollectGroupSpaceAndProjectMaps(
+		conversations, extraParentGroupNos, sb.groupService)
 	if !ok {
 		sb.Warn("sidebar sync: group space map query failed (non-fatal, SidebarItem.SpaceID will be empty)")
 		groupSpaceMap = map[string]string{}
+		groupProjectMap = map[string]string{}
 	}
 
 	// 2g. externalGroupMap：当前 user 作为外部成员加入的 (groupNo -> source_space_id)
@@ -495,7 +511,7 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 	var items []*SidebarItem
 	switch req.Tab {
 	case "follow":
-		items = buildFollowItems(conversations, categorySetting, unfollowedGroups, followedDMs, threadExtMap, groupExts, dmCategorySorts, groupSpaceMap, externalGroupMap, defaultSpaceID)
+		items = buildFollowItems(conversations, categorySetting, unfollowedGroups, followedDMs, threadExtMap, groupExts, dmCategorySorts, groupSpaceMap, groupProjectMap, externalGroupMap, defaultSpaceID)
 		// Append standalone thread ext entries not present in IM result.
 		// Pass categorySetting + unfollowedGroups so parent-follow filter applies
 		// to DB-only thread entries as well (PR review Round-3 Blocking #4).
@@ -516,7 +532,7 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 				selfCreatedThreads[key] = struct{}{}
 			}
 		}
-		items = mergeThreadEntries(items, threadExtRows, lastMsgAtMap, categorySetting, unfollowedGroups, groupSpaceMap, externalGroupMap, defaultSpaceID, selfCreatedThreads, threadStatusMap)
+		items = mergeThreadEntries(items, threadExtRows, lastMsgAtMap, categorySetting, unfollowedGroups, groupSpaceMap, groupProjectMap, externalGroupMap, defaultSpaceID, selfCreatedThreads, threadStatusMap)
 
 		// GH octo-server#310：把 thread 生命周期状态回填到 thread 条目。statusMap
 		// 来自 loadThreadLastMsgAt（复用 QueryActiveByGroupShortIDs 已 SELECT 的
@@ -592,7 +608,7 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 			cutoffs = recentCutoffs{}
 			sb.Warn("sidebar sync: skipping recent window this response (pinned set unavailable)")
 		}
-		items = buildRecentItems(conversations, cutoffs, pinnedSet, groupSpaceMap, externalGroupMap, defaultSpaceID)
+		items = buildRecentItems(conversations, cutoffs, pinnedSet, groupSpaceMap, groupProjectMap, externalGroupMap, defaultSpaceID)
 		// GH octo-server#310：recent tab 也要带 thread 生命周期状态。一次性批量
 		// 查询所有 thread 条目的 status（无 N+1），再 backfill。
 		// FAIL-OPEN：查询失败只记 warn 并把 Status 留空（omitempty -> 字段缺省），
@@ -1195,6 +1211,7 @@ func buildFollowItems(
 	groupExts map[string]*convext.Model,
 	dmCategorySorts map[string]int,
 	groupSpaceMap map[string]string,
+	groupProjectMap map[string]string,
 	externalGroupMap map[string]string,
 	defaultSpaceID string,
 ) []*SidebarItem {
@@ -1221,6 +1238,7 @@ func buildFollowItems(
 				ChannelType:       conv.ChannelType,
 				ChannelID:         conv.ChannelID,
 				SpaceID:           groupSpaceMap[conv.ChannelID],
+				ProjectID:         groupProjectMap[conv.ChannelID],
 				MySourceSpaceID:   sidebarMySourceSpaceID(externalGroupMap, conv.ChannelID, defaultSpaceID),
 				Timestamp:         conv.Timestamp,
 				Unread:            conv.Unread,
@@ -1288,7 +1306,8 @@ func buildFollowItems(
 				ChannelType: conv.ChannelType,
 				ChannelID:   conv.ChannelID,
 				// thread 继承父群 SpaceID（GH octo-server#153）。
-				SpaceID: groupSpaceMap[groupNo],
+				SpaceID:   groupSpaceMap[groupNo],
+				ProjectID: groupProjectMap[groupNo],
 				// thread 同样继承父群的 MySourceSpaceID（GH octo-server#153 Round-2 P1）。
 				// Round-3 (GH#154 Round-2 Finding 2)：父群 source_space_id="" 兜底到 defaultSpaceID。
 				MySourceSpaceID:   sidebarMySourceSpaceID(externalGroupMap, groupNo, defaultSpaceID),
@@ -1327,6 +1346,7 @@ func buildRecentItems(
 	cutoffs recentCutoffs,
 	pinnedSet map[string]struct{},
 	groupSpaceMap map[string]string,
+	groupProjectMap map[string]string,
 	externalGroupMap map[string]string,
 	defaultSpaceID string,
 ) []*SidebarItem {
@@ -1350,16 +1370,19 @@ func buildRecentItems(
 		// Round-3 (GH#154 Round-2 Finding 2)：externalGroupMap[k]="" 时兜底到
 		// defaultSpaceID，与 decideConvKeepInSpace 同口径。
 		spaceID := ""
+		projectID := ""
 		mySourceSpaceID := ""
 		switch conv.ChannelType {
 		case common.ChannelTypeGroup.Uint8():
 			spaceID = groupSpaceMap[conv.ChannelID]
+			projectID = groupProjectMap[conv.ChannelID]
 			mySourceSpaceID = sidebarMySourceSpaceID(externalGroupMap, conv.ChannelID, defaultSpaceID)
 		case common.ChannelTypeCommunityTopic.Uint8():
 			groupNo, _, err := parseThreadChannelIDSidebar(conv.ChannelID)
 			if err == nil {
 				parentID = groupNo
 				spaceID = groupSpaceMap[groupNo]
+				projectID = groupProjectMap[groupNo]
 				mySourceSpaceID = sidebarMySourceSpaceID(externalGroupMap, groupNo, defaultSpaceID)
 			}
 		}
@@ -1369,6 +1392,7 @@ func buildRecentItems(
 			ChannelType:     conv.ChannelType,
 			ChannelID:       conv.ChannelID,
 			SpaceID:         spaceID,
+			ProjectID:       projectID,
 			MySourceSpaceID: mySourceSpaceID,
 			Timestamp:       conv.Timestamp,
 			Unread:          conv.Unread,
@@ -1426,6 +1450,7 @@ func mergeThreadEntries(
 	categorySetting map[string]*GroupCategorySetting,
 	unfollowedGroups map[string]struct{},
 	groupSpaceMap map[string]string,
+	groupProjectMap map[string]string,
 	externalGroupMap map[string]string,
 	defaultSpaceID string,
 	// selfCreatedThreads 的键是 ext.TargetID，命中表示该子区由 loginUID 本人创建
@@ -1507,7 +1532,8 @@ func mergeThreadEntries(
 			ChannelType: common.ChannelTypeCommunityTopic.Uint8(),
 			ChannelID:   ext.TargetID,
 			// thread 继承父群 SpaceID（GH octo-server#153）。
-			SpaceID: groupSpaceMap[groupNo],
+			SpaceID:   groupSpaceMap[groupNo],
+			ProjectID: groupProjectMap[groupNo],
 			// thread 同样继承父群的 MySourceSpaceID（GH octo-server#153 Round-2 P1）。
 			// Round-3 (GH#154 Round-2 Finding 2)：父群 source_space_id="" 兜底到 defaultSpaceID。
 			MySourceSpaceID:   sidebarMySourceSpaceID(externalGroupMap, groupNo, defaultSpaceID),

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -490,6 +490,22 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 		groupSpaceMap = map[string]string{}
 		groupProjectMap = map[string]string{}
 	}
+	// project_id ships ONLY on the Space-scoped path.
+	//
+	// Without an X-Space-ID the handler skips FilterRawConversationsBySpace
+	// entirely (see step 2 above), and only COMMUNITY_TOPIC items then get the
+	// fail-closed parent-membership check YUJ-4185 added — plain GROUP items get
+	// none, and decideConvKeepInSpace never had a membership predicate. So a
+	// removed member whose IM conversation row outlives the removal still receives
+	// the item on that path.
+	//
+	// That hole is pre-existing and belongs to project-p2-read-path-hardening, not
+	// here: closing it means adding a membership predicate for every group item,
+	// not for project ones. What this line does is refuse to WIDEN it. PR #861's
+	// review raised it and the requester chose this over the alternative of
+	// arguing that an opaque project id is harmless to a caller who can resolve
+	// nothing with it.
+	groupProjectMap = projectMapForSpaceScope(spaceID, groupProjectMap)
 
 	// 2g. externalGroupMap：当前 user 作为外部成员加入的 (groupNo -> source_space_id)
 	//     映射，用来回填 SidebarItem.MySourceSpaceID（GH octo-server#153 Round-2 P1）。
@@ -1179,6 +1195,23 @@ func appendThreadParentGroupNos(groupNos []string, threadExtRows []*convext.Mode
 // parseThreadChannelIDSidebar splits "{groupNo}____{shortID}" → (groupNo, shortID).
 // Uses the 4-underscore separator convention matching the thread package.
 const threadSeparator = "____"
+
+// projectMapForSpaceScope drops the project map on the no-X-Space-ID path.
+//
+// A named function rather than an inline `if`, because the property it enforces is
+// worth a test of its own: this is the only thing standing between the sidebar's
+// project_id and a caller the no-Space path never checked for membership. An inline
+// condition is testable only through the whole handler, which has no HTTP rig here.
+//
+// Returns an EMPTY map rather than nil so every construction site keeps reading a
+// map — a nil map reads fine in Go, but the empty value makes the intent obvious to
+// the next reader and cannot be mistaken for "not built yet".
+func projectMapForSpaceScope(spaceID string, projectMap map[string]string) map[string]string {
+	if spaceID == "" {
+		return map[string]string{}
+	}
+	return projectMap
+}
 
 func parseThreadChannelIDSidebar(channelID string) (groupNo, shortID string, err error) {
 	idx := strings.Index(channelID, threadSeparator)

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -133,6 +133,12 @@ type SidebarItem struct {
 	// 空串 = 直属 Space，与 group.project_id 的哨兵值一致；omitempty，所以老客户端
 	// 的 payload 逐字节不变。
 	//
+	// 例外，客户端必须知道：不带 X-Space-ID 的请求上，本字段整条链路一律为空串
+	// （见 projectMapForSpaceScope）。也就是说在那条路径上空串有第二个含义——
+	// 「服务端没有下发」，而不是「直属 Space」，两者在 payload 上不可区分。要按
+	// 项目分组的客户端在那条路径上应当认为自己没有项目信息，而不是把这些条目
+	// 归进直属 Space 分组。带 X-Space-ID 时不存在这个歧义。
+	//
 	// 客户端靠它在消息列表里按项目分组。P1 建立了这一列，#855 把它下发到
 	// GroupResp 和群详情，这里是同一次透出剩下的一跳。
 	//
@@ -1206,6 +1212,26 @@ const threadSeparator = "____"
 // Returns an EMPTY map rather than nil so every construction site keeps reading a
 // map — a nil map reads fine in Go, but the empty value makes the intent obvious to
 // the next reader and cannot be mistaken for "not built yet".
+//
+// # It drops the map for EVERY target type, including the one that was checked
+//
+// Reviewer yujiawei's follow-up on PR #861: the blanket drop is wider than the hole
+// it refuses to widen. filterThreadConvsByParentMembership runs on ALL paths, this
+// one included, and is fail-closed through ExistMembersActive — so a COMMUNITY_TOPIC
+// item here HAS had its parent membership verified, and its project_id is blanked
+// anyway. Only plain GROUP items are the unchecked ones.
+//
+// Gating per target type was the alternative and is worse, for the reason PR-2 exists
+// to serve: SpaceID and ProjectID are read at the same site with the same key so that
+// a group and its own thread cannot disagree about one conversation. Per-type gating
+// makes exactly that happen on this path — the topic would carry a project_id while
+// its parent group, in the same response, would not. A client grouping by project
+// would split one project across two buckets, which is a worse answer than having no
+// project information at all.
+//
+// So the drop stays blanket, and the cost is that "" means two things on this path:
+// 直属 Space, and "not evaluated". That is written into the ProjectID field comment
+// rather than left here, because the client team reads the field, not this function.
 func projectMapForSpaceScope(spaceID string, projectMap map[string]string) map[string]string {
 	if spaceID == "" {
 		return map[string]string{}

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -486,7 +486,7 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 	groupSpaceMap, groupProjectMap, ok := CollectGroupSpaceAndProjectMaps(
 		conversations, extraParentGroupNos, sb.groupService)
 	if !ok {
-		sb.Warn("sidebar sync: group space map query failed (non-fatal, SidebarItem.SpaceID will be empty)")
+		sb.Warn("sidebar sync: group space map query failed (non-fatal, SidebarItem.SpaceID / ProjectID will be empty)")
 		groupSpaceMap = map[string]string{}
 		groupProjectMap = map[string]string{}
 	}

--- a/modules/message/api_sidebar_integration_test.go
+++ b/modules/message/api_sidebar_integration_test.go
@@ -146,9 +146,9 @@ func TestIntegration_Sidebar_FollowTab_BasicSmoke(t *testing.T) {
 	}
 
 	// 5. Run the same pure-function pipeline as Sidebar.Sync follow branch.
-	items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, followedDMs, threadExtMap, nil, nil, nil, nil, "")
+	items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, followedDMs, threadExtMap, nil, nil, nil, nil, nil, "")
 	// mergeThreadEntries: thread is already in IM result, so no new item added.
-	items = mergeThreadEntries(items, threadExtRows, map[string]*time.Time{}, categorySetting, unfollowedGroups, nil, nil, "", nil, nil)
+	items = mergeThreadEntries(items, threadExtRows, map[string]*time.Time{}, categorySetting, unfollowedGroups, nil, nil, nil, "", nil, nil)
 	sortFollowItems(items)
 
 	// 6. Assert exactly 3 items with correct target_type.
@@ -225,7 +225,7 @@ func TestIntegration_Sidebar_FollowTab_BlacklistedGroupExcluded(t *testing.T) {
 		{ChannelID: groupNo, ChannelType: common.ChannelTypeGroup.Uint8(), Timestamp: 100},
 	}
 
-	items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil, nil, "")
+	items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil, nil, nil, "")
 	assert.Len(t, items, 0,
 		"blacklisted group (group_unfollowed=1 in DB) must be excluded from follow tab")
 }
@@ -261,7 +261,7 @@ func TestIntegration_Sidebar_FollowTab_NoExtRows_ReturnsEmpty(t *testing.T) {
 	}
 
 	// No category → group excluded; no followed_dm row → DM excluded.
-	items := buildFollowItems(stubConvs, nil /*categorySetting*/, unfollowedGroups, followedDMs, nil, nil, nil, nil, nil, "")
+	items := buildFollowItems(stubConvs, nil /*categorySetting*/, unfollowedGroups, followedDMs, nil, nil, nil, nil, nil, nil, "")
 	assert.Len(t, items, 0, "follow tab with no ext data must return 0 items")
 }
 
@@ -307,7 +307,7 @@ func TestIntegration_Sidebar_MergeThreadEntries_AddsDBOnlyThreads(t *testing.T) 
 	}
 
 	// buildFollowItems picks up threadInIM (has ext row + parent in follow set).
-	items := buildFollowItems(stubConvs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil, "")
+	items := buildFollowItems(stubConvs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil, nil, "")
 	require.Len(t, items, 1, "buildFollowItems must include threadInIM")
 
 	// mergeThreadEntries appends threadDBOnly (not yet in items).
@@ -319,7 +319,7 @@ func TestIntegration_Sidebar_MergeThreadEntries_AddsDBOnlyThreads(t *testing.T) 
 		threadInIM:   &alive,
 		threadDBOnly: &alive,
 	}
-	items = mergeThreadEntries(items, threadExtRows, lastMsgAtMap, categorySetting, map[string]struct{}{}, nil, nil, "", nil, nil)
+	items = mergeThreadEntries(items, threadExtRows, lastMsgAtMap, categorySetting, map[string]struct{}{}, nil, nil, nil, "", nil, nil)
 	require.Len(t, items, 2, "mergeThreadEntries must add the DB-only thread")
 
 	// Both thread IDs must be present.
@@ -414,7 +414,7 @@ func TestIntegration_Sidebar_Issue41_CrossTypeDragSurvivesReload(t *testing.T) {
 
 		// 本 case DM 没绑 category（issue #41 reproduction 的 fileHelper 也没有），
 		// dmCategorySorts 直接传 nil，避免依赖 group_setting 表。
-		items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, followedDMs, nil, groupExts, nil, nil, nil, "")
+		items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, followedDMs, nil, groupExts, nil, nil, nil, nil, "")
 		sortFollowItems(items)
 		return items
 	}
@@ -492,7 +492,7 @@ func TestIntegration_Sidebar_Issue41_DMCategorySortLoadedFromGroupCategory(t *te
 	stubConvs := []*config.SyncUserConversationResp{
 		{ChannelID: dmID, ChannelType: common.ChannelTypePerson.Uint8(), Timestamp: 100},
 	}
-	items := buildFollowItems(stubConvs, nil, nil, followedDMs, nil, nil, sorts, nil, nil, "")
+	items := buildFollowItems(stubConvs, nil, nil, followedDMs, nil, nil, sorts, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, catSort, items[0].CategorySort,
 		"带 dm_category_id 的 DM 必须把 group_category.sort 写到 SidebarItem.CategorySort")
@@ -618,7 +618,7 @@ func TestIntegration_Sidebar_FollowTab_DoesNotMaterializeSoftDeletedCategoryGrou
 	stubConvs := []*config.SyncUserConversationResp{
 		{ChannelID: groupNo, ChannelType: common.ChannelTypeGroup.Uint8(), Timestamp: 100},
 	}
-	items := buildFollowItems(stubConvs, categorySetting, nil, nil, nil, nil, nil, nil, nil, "")
+	items := buildFollowItems(stubConvs, categorySetting, nil, nil, nil, nil, nil, nil, nil, nil, "")
 	assert.Empty(t, items,
 		"buildFollowItems must NOT include groups with a soft-deleted category; "+
 			"otherwise they'd be displayed and then materialized via the "+

--- a/modules/message/api_sidebar_project_test.go
+++ b/modules/message/api_sidebar_project_test.go
@@ -56,15 +56,15 @@ func TestSidebarProjectIDMatchesTheSpaceIDSplit(t *testing.T) {
 	}
 	require.Contains(t, byID, "g_project")
 	require.Contains(t, byID, "g_direct")
+	require.Contains(t, byID, "u_friend",
+		"the DM must be emitted, or the isolation assertion below covers nothing")
 
 	assert.Equal(t, "p_1", byID["g_project"].ProjectID,
 		"a project group carries its own project_id")
 	assert.Empty(t, byID["g_direct"].ProjectID,
 		"a Space-direct group carries none; '' is group.project_id's own sentinel")
-	if dm, ok := byID["u_friend"]; ok {
-		assert.Empty(t, dm.ProjectID,
-			"a DM belongs to no project, the same way it carries no space_id")
-	}
+	assert.Empty(t, byID["u_friend"].ProjectID,
+		"a DM belongs to no project, the same way it carries no space_id")
 }
 
 // TestSidebarTopicInheritsTheParentProjectID is the case a naive implementation

--- a/modules/message/api_sidebar_project_test.go
+++ b/modules/message/api_sidebar_project_test.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"os"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
@@ -146,4 +147,42 @@ func TestCollectGroupSpaceMapStillWorks(t *testing.T) {
 	m, ok := CollectGroupSpaceMap(convs, nil, svc)
 	require.True(t, ok)
 	assert.Equal(t, "space_a", m["g1"])
+}
+
+// TestProjectIDShipsOnlyOnTheSpaceScopedPath pins the gate the requester chose over
+// arguing that an opaque project id is harmless.
+//
+// Without an X-Space-ID the handler skips Space filtering entirely, and only
+// COMMUNITY_TOPIC items get the fail-closed parent-membership check YUJ-4185 added
+// — plain GROUP items get none. So a removed member whose IM conversation row
+// outlives the removal still receives the item on that path. The pre-existing hole
+// belongs to project-p2-read-path-hardening; what this gate does is refuse to widen
+// it by one field.
+//
+// Both directions are asserted. Only checking the empty case would pass on a gate
+// that dropped the map unconditionally, i.e. on a gate that quietly disabled the
+// feature.
+func TestProjectIDShipsOnlyOnTheSpaceScopedPath(t *testing.T) {
+	built := map[string]string{"g1": "p_1"}
+
+	assert.Empty(t, projectMapForSpaceScope("", built),
+		"no X-Space-ID means no Space filtering ran, so the caller's membership was "+
+			"never checked for plain group items; project_id must not ride along")
+
+	assert.Equal(t, built, projectMapForSpaceScope("space_a", built),
+		"and on the Space-scoped path the field must still ship, or the gate has "+
+			"turned into a silent feature kill")
+}
+
+// TestTheSidebarAppliesTheProjectScopeGate pins that the handler actually calls it.
+//
+// The gate is one line in a 400-line function; a refactor that drops it leaves
+// every other test in this file green, because they all drive the builders directly
+// with a map they supply themselves.
+func TestTheSidebarAppliesTheProjectScopeGate(t *testing.T) {
+	raw, err := os.ReadFile("api_sidebar.go")
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "groupProjectMap = projectMapForSpaceScope(spaceID, groupProjectMap)",
+		"the sidebar handler must pass the project map through projectMapForSpaceScope; "+
+			"without that call the field ships on the path where no membership check ran")
 }

--- a/modules/message/api_sidebar_project_test.go
+++ b/modules/message/api_sidebar_project_test.go
@@ -1,0 +1,149 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// PR-2 of project-p2-product-surfaces: project_id on the sidebar.
+//
+// #855 put project_id on GroupResp and the group detail, which answers "which
+// project does this group belong to" for a client that already has the group. The
+// sidebar is the surface that does NOT — it renders the conversation list, and
+// without this field it cannot group those conversations by project.
+
+// fakeProjectGroupService counts GetGroups calls so the "no extra query" property
+// is asserted rather than asserted-about-in-a-comment.
+type fakeProjectGroupService struct {
+	group.IService
+	calls  int
+	groups []*group.InfoResp
+}
+
+func (f *fakeProjectGroupService) GetGroups(groupNos []string) ([]*group.InfoResp, error) {
+	f.calls++
+	return f.groups, nil
+}
+
+// TestSidebarProjectIDMatchesTheSpaceIDSplit pins the three-way contract the
+// SpaceID comment declares, one case per target type.
+//
+// Asserted together rather than in three cases because the property is that the
+// three AGREE with SpaceID's split — a group carries its own, a topic carries its
+// parent's, a DM carries none. Split apart, each half can drift without the test
+// noticing.
+func TestSidebarProjectIDMatchesTheSpaceIDSplit(t *testing.T) {
+	convs := []*config.SyncUserConversationResp{
+		makeIMConv("g_project", common.ChannelTypeGroup.Uint8(), nowRecent()),
+		makeIMConv("g_direct", common.ChannelTypeGroup.Uint8(), nowRecent()),
+		makeIMConv("u_friend", common.ChannelTypePerson.Uint8(), nowRecent()),
+	}
+	groupSpaceMap := map[string]string{"g_project": "space_a", "g_direct": "space_a"}
+	// g_direct is Space-direct, so it is ABSENT from the map rather than present
+	// with an empty value — the collector only records project groups.
+	groupProjectMap := map[string]string{"g_project": "p_1"}
+
+	items := buildRecentItems(convs, recentCutoffs{}, nil, groupSpaceMap, groupProjectMap, nil, "space_a")
+
+	byID := map[string]*SidebarItem{}
+	for _, it := range items {
+		byID[it.TargetID] = it
+	}
+	require.Contains(t, byID, "g_project")
+	require.Contains(t, byID, "g_direct")
+
+	assert.Equal(t, "p_1", byID["g_project"].ProjectID,
+		"a project group carries its own project_id")
+	assert.Empty(t, byID["g_direct"].ProjectID,
+		"a Space-direct group carries none; '' is group.project_id's own sentinel")
+	if dm, ok := byID["u_friend"]; ok {
+		assert.Empty(t, dm.ProjectID,
+			"a DM belongs to no project, the same way it carries no space_id")
+	}
+}
+
+// TestSidebarTopicInheritsTheParentProjectID is the case a naive implementation
+// gets wrong: a COMMUNITY_TOPIC's channel id is not a group number, so looking the
+// project up by the item's own id would silently yield "" for every thread in a
+// project group. SpaceID already resolves via the parent; this must use the same
+// key, at the same site, or the two can disagree about one conversation.
+func TestSidebarTopicInheritsTheParentProjectID(t *testing.T) {
+	parent := "g_parent"
+	convs := []*config.SyncUserConversationResp{
+		makeIMConv(parent+"____1", common.ChannelTypeCommunityTopic.Uint8(), nowRecent()),
+	}
+	groupSpaceMap := map[string]string{parent: "space_a"}
+	groupProjectMap := map[string]string{parent: "p_1"}
+
+	items := buildRecentItems(convs, recentCutoffs{}, nil, groupSpaceMap, groupProjectMap, nil, "space_a")
+	require.Len(t, items, 1)
+	assert.Equal(t, "space_a", items[0].SpaceID, "precondition: the parent lookup works at all")
+	assert.Equal(t, "p_1", items[0].ProjectID,
+		"a topic must inherit its parent group's project, resolved by the same key "+
+			"SpaceID uses — keyed on the topic's own channel id it would read empty")
+}
+
+// TestFollowItemsCarryTheProjectID covers the other builder, so the field cannot be
+// present on one sidebar tab and missing from the next.
+func TestFollowItemsCarryTheProjectID(t *testing.T) {
+	convs := []*config.SyncUserConversationResp{
+		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), nowRecent()),
+	}
+	categorySetting := map[string]*GroupCategorySetting{
+		"g1": {GroupNo: "g1", CategoryID: strPtr("cat1"), CategorySort: 1, CategoryGroupSort: 1},
+	}
+	items := buildFollowItems(convs, categorySetting, map[string]struct{}{}, nil, nil, nil, nil,
+		map[string]string{"g1": "space_a"}, map[string]string{"g1": "p_1"}, nil, "space_a")
+	require.Len(t, items, 1)
+	assert.Equal(t, "p_1", items[0].ProjectID)
+}
+
+// TestProjectMapCostsNoExtraQuery is the performance property stated as a test
+// rather than as a comment.
+//
+// The sidebar is the hottest read path in the product. project_id is free only
+// because GetGroups already returns whole group rows and the collector takes a
+// second pass over the SAME result; a separate collector would double the batch for
+// a field that was already in the response.
+func TestProjectMapCostsNoExtraQuery(t *testing.T) {
+	svc := &fakeProjectGroupService{groups: []*group.InfoResp{
+		{GroupNo: "g_project", SpaceID: "space_a", ProjectID: "p_1"},
+		{GroupNo: "g_direct", SpaceID: "space_a"},
+	}}
+	convs := []*config.SyncUserConversationResp{
+		makeIMConv("g_project", common.ChannelTypeGroup.Uint8(), nowRecent()),
+		makeIMConv("g_direct", common.ChannelTypeGroup.Uint8(), nowRecent()),
+	}
+
+	spaceMap, projectMap, ok := CollectGroupSpaceAndProjectMaps(convs, nil, svc)
+	require.True(t, ok)
+
+	assert.Equal(t, 1, svc.calls,
+		"both maps must come from ONE GetGroups call; a second collector would "+
+			"double the batch on the hottest read path for a field already in the response")
+	assert.Equal(t, "space_a", spaceMap["g_project"])
+	assert.Equal(t, "p_1", projectMap["g_project"])
+	assert.NotContains(t, projectMap, "g_direct",
+		"a Space-direct group is absent rather than present with an empty value, so "+
+			"the map stays proportional to project groups rather than to conversations")
+}
+
+// TestCollectGroupSpaceMapStillWorks pins the compatibility wrapper. It has one
+// caller today, but deleting it silently would be a source-compatible change that
+// stops being source-compatible for anything outside this package.
+func TestCollectGroupSpaceMapStillWorks(t *testing.T) {
+	svc := &fakeProjectGroupService{groups: []*group.InfoResp{
+		{GroupNo: "g1", SpaceID: "space_a", ProjectID: "p_1"},
+	}}
+	convs := []*config.SyncUserConversationResp{
+		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), nowRecent()),
+	}
+	m, ok := CollectGroupSpaceMap(convs, nil, svc)
+	require.True(t, ok)
+	assert.Equal(t, "space_a", m["g1"])
+}

--- a/modules/message/api_sidebar_recent_filter_e2e_test.go
+++ b/modules/message/api_sidebar_recent_filter_e2e_test.go
@@ -68,7 +68,7 @@ func TestE2E_RecentFilter_DefaultsReproduceLegacyBehaviour(t *testing.T) {
 		makeIMConv("g-old", common.ChannelTypeGroup.Uint8(), now.Add(-73*time.Hour).Unix()),
 		makeIMConv("dm-old", common.ChannelTypePerson.Uint8(), now.Add(-1000*time.Hour).Unix()),
 	}
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "")
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, nil, "")
 	ids := idSet(items)
 	assert.True(t, ids["g-new"])
 	assert.False(t, ids["g-old"], "默认 3 天窗口剔除超期群")
@@ -121,7 +121,7 @@ func TestE2E_RecentFilter_AdminOverrideTakesEffect(t *testing.T) {
 		makeIMConv("dm-6d", common.ChannelTypePerson.Uint8(), now.Add(-6*24*time.Hour).Unix()),
 		makeIMConv("dm-8d", common.ChannelTypePerson.Uint8(), now.Add(-8*24*time.Hour).Unix()),
 	}
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "")
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, nil, "")
 	ids := idSet(items)
 	assert.True(t, ids["g-ancient"], "群窗口关闭 → 远古群也返回")
 	assert.False(t, ids["g1____t-old"], "话题 3 天窗口 → 剔除超期话题")

--- a/modules/message/api_sidebar_status_test.go
+++ b/modules/message/api_sidebar_status_test.go
@@ -179,11 +179,11 @@ func TestSidebar_FollowTab_BackfillsStatus(t *testing.T) {
 	}
 
 	sb := NewSidebar(ctx)
-	items := buildFollowItems(stubConvs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil, "")
+	items := buildFollowItems(stubConvs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil, nil, "")
 
 	lastMsgAt, statusMap, _, err := sb.loadThreadLastMsgAt(threadExtRows)
 	require.NoError(t, err)
-	items = mergeThreadEntries(items, threadExtRows, lastMsgAt, categorySetting, nil, nil, nil, "", nil, statusMap)
+	items = mergeThreadEntries(items, threadExtRows, lastMsgAt, categorySetting, nil, nil, nil, nil, "", nil, statusMap)
 	backfillThreadStatus(items, statusMap)
 
 	byID := map[string]*SidebarItem{}
@@ -226,7 +226,7 @@ func TestSidebar_RecentTab_BackfillsStatus(t *testing.T) {
 	}
 
 	sb := NewSidebar(ctx)
-	items := buildRecentItems(stubConvs, cutoffs, nil, nil, nil, "")
+	items := buildRecentItems(stubConvs, cutoffs, nil, nil, nil, nil, "")
 	statusMap, err := sb.loadThreadStatuses(items)
 	require.NoError(t, err)
 	backfillThreadStatus(items, statusMap)
@@ -268,7 +268,7 @@ func TestSidebar_RecentTab_FailOpenOnStatusError(t *testing.T) {
 	stubConvs := []*config.SyncUserConversationResp{
 		{ChannelID: "g310e____thr", ChannelType: common.ChannelTypeCommunityTopic.Uint8(), Timestamp: 100},
 	}
-	items := buildRecentItems(stubConvs, cutoffs, nil, nil, nil, "")
+	items := buildRecentItems(stubConvs, cutoffs, nil, nil, nil, nil, "")
 
 	// Mirror the handler's recent branch: query may fail → fail open.
 	statusMap, qerr := sb.loadThreadStatuses(items)

--- a/modules/message/api_sidebar_test.go
+++ b/modules/message/api_sidebar_test.go
@@ -149,7 +149,7 @@ func TestBuildFollowItems_GroupFollowed(t *testing.T) {
 	}
 	unfollowedGroups := map[string]struct{}{} // empty: not unfollowed
 
-	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil, nil, "")
+	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, "g1", items[0].TargetID)
 	assert.Equal(t, "cat1", *items[0].CategoryID)
@@ -166,7 +166,7 @@ func TestBuildFollowItems_GroupUnfollowed_Excluded(t *testing.T) {
 	}
 	unfollowedGroups := map[string]struct{}{"g1": {}}
 
-	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil, nil, "")
+	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 
@@ -178,7 +178,7 @@ func TestBuildFollowItems_GroupWithoutCategory_Excluded(t *testing.T) {
 	categorySetting := map[string]*GroupCategorySetting{} // no entry
 	unfollowedGroups := map[string]struct{}{}
 
-	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil, nil, "")
+	items := buildFollowItems(convs, categorySetting, unfollowedGroups, nil, nil, nil, nil, nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 
@@ -191,7 +191,7 @@ func TestBuildFollowItems_DMFollowed(t *testing.T) {
 		"peer1": {TargetID: "peer1", FollowedDM: 1, FollowSort: 5},
 	}
 
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil, nil, "")
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, "peer1", items[0].TargetID)
 	assert.Equal(t, 5, items[0].FollowSort)
@@ -203,7 +203,7 @@ func TestBuildFollowItems_DMNotFollowed_Excluded(t *testing.T) {
 	}
 	followedDMs := map[string]*convext.Model{} // no entry for peer2
 
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil, nil, "")
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 
@@ -221,7 +221,7 @@ func TestBuildFollowItems_ThreadAsIMEntry_IncludedWhenParentFollowed(t *testing.
 		threadChannelID: {TargetID: threadChannelID, FollowSort: 2},
 	}
 
-	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil, "")
+	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, threadChannelID, items[0].TargetID)
 	assert.Equal(t, int(common.ChannelTypeCommunityTopic), items[0].TargetType)
@@ -238,7 +238,7 @@ func TestBuildFollowItems_ThreadWithoutExtRow_Excluded(t *testing.T) {
 	}
 	threadExtMap := map[string]*convext.Model{} // no ext for this thread
 
-	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil, "")
+	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 
@@ -250,7 +250,7 @@ func TestBuildRecentItems_GroupWithinWindow_Included(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), nowRecent()),
 	}
-	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "")
+	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, "g1", items[0].TargetID)
 }
@@ -259,7 +259,7 @@ func TestBuildRecentItems_GroupOutsideWindow_Excluded(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), now3DaysAgo()),
 	}
-	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "")
+	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 
@@ -268,7 +268,7 @@ func TestBuildRecentItems_DMAlwaysIncluded(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("peer1", common.ChannelTypePerson.Uint8(), now3DaysAgo()),
 	}
-	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "")
+	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, "peer1", items[0].TargetID)
 }
@@ -277,7 +277,7 @@ func TestBuildRecentItems_ThreadWithinWindow_Included(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1____th1", common.ChannelTypeCommunityTopic.Uint8(), nowRecent()),
 	}
-	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "")
+	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, "g1____th1", items[0].TargetID)
 }
@@ -286,7 +286,7 @@ func TestBuildRecentItems_ThreadOutsideWindow_Excluded(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("g1____th1", common.ChannelTypeCommunityTopic.Uint8(), now3DaysAgo()),
 	}
-	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, "")
+	items := buildRecentItems(convs, legacyRecentCutoffs(), nil, nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 
@@ -298,7 +298,7 @@ func TestBuildRecentItems_PinnedFirst(t *testing.T) {
 		makeIMConv("g1", common.ChannelTypeGroup.Uint8(), nowRecent()),
 		makeIMConv("g2", common.ChannelTypeGroup.Uint8(), nowRecent()-10),
 	}
-	items := buildRecentItems(convs, legacyRecentCutoffs(), pinnedSet, nil, nil, "")
+	items := buildRecentItems(convs, legacyRecentCutoffs(), pinnedSet, nil, nil, nil, "")
 	require.Len(t, items, 2)
 
 	// buildRecentItems sets IsPinned flag; sorting is done separately
@@ -338,7 +338,7 @@ func TestBuildRecentItems_GroupCutoffZero_AllGroupsKept(t *testing.T) {
 		makeIMConv("g-old", common.ChannelTypeGroup.Uint8(), now3DaysAgo()),
 		makeIMConv("g-new", common.ChannelTypeGroup.Uint8(), nowRecent()),
 	}
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "")
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, nil, "")
 	assert.Len(t, items, 2, "group 窗口关闭时，超期群也保留")
 }
 
@@ -351,7 +351,7 @@ func TestBuildRecentItems_PerTypeWindowsIndependent(t *testing.T) {
 		makeIMConv("g1____t-old", common.ChannelTypeCommunityTopic.Uint8(), now3DaysAgo()), // dropped (thread window on)
 		makeIMConv("g1____t-new", common.ChannelTypeCommunityTopic.Uint8(), nowRecent()),   // kept
 	}
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "")
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, nil, "")
 	ids := map[string]bool{}
 	for _, it := range items {
 		ids[it.TargetID] = true
@@ -370,7 +370,7 @@ func TestBuildRecentItems_PersonWindowFiltersDMs(t *testing.T) {
 		makeIMConv("dm-old", common.ChannelTypePerson.Uint8(), now3DaysAgo()),
 		makeIMConv("dm-new", common.ChannelTypePerson.Uint8(), nowRecent()),
 	}
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "")
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, nil, "")
 	require.Len(t, items, 1, "person 窗口=3天时，超期 DM 被剔除")
 	assert.Equal(t, "dm-new", items[0].TargetID)
 }
@@ -391,7 +391,7 @@ func TestBuildRecentItems_UnknownChannelType_KeptUnconditionally(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("x-ancient", unknownChannelType, time.Now().Add(-10000*time.Hour).Unix()),
 	}
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "")
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, nil, "")
 	require.Len(t, items, 1, "未知频道类型不应被时间窗口过滤（cutoffFor 默认 0=不过滤）")
 	assert.Equal(t, "x-ancient", items[0].TargetID)
 }
@@ -403,7 +403,7 @@ func TestBuildRecentItems_PersonCutoffZero_AllDMsKept(t *testing.T) {
 	convs := []*config.SyncUserConversationResp{
 		makeIMConv("dm-ancient", common.ChannelTypePerson.Uint8(), time.Now().Add(-1000*time.Hour).Unix()),
 	}
-	items := buildRecentItems(convs, cutoffs, nil, nil, nil, "")
+	items := buildRecentItems(convs, cutoffs, nil, nil, nil, nil, "")
 	require.Len(t, items, 1, "person 默认 0 → DM 永远保留")
 }
 
@@ -466,7 +466,7 @@ func TestMergeThreadEntries_AddsNewEntry(t *testing.T) {
 	}
 
 	cat, unfollowed := followedG1()
-	result := mergeThreadEntries(existing, threadExtRows, lastMsgAtMap, cat, unfollowed, nil, nil, "", nil, nil)
+	result := mergeThreadEntries(existing, threadExtRows, lastMsgAtMap, cat, unfollowed, nil, nil, nil, "", nil, nil)
 	require.Len(t, result, 2)
 	ids := []string{result[0].TargetID, result[1].TargetID}
 	assert.Contains(t, ids, th2ChannelID)
@@ -481,14 +481,14 @@ func TestMergeThreadEntries_NoDuplicateIfAlreadyPresent(t *testing.T) {
 	}
 	cat, unfollowed := followedG1()
 	// nil map is fine here: presentIDs short-circuits before the alive check.
-	result := mergeThreadEntries(existing, threadExtRows, nil, cat, unfollowed, nil, nil, "", nil, nil)
+	result := mergeThreadEntries(existing, threadExtRows, nil, cat, unfollowed, nil, nil, nil, "", nil, nil)
 	assert.Len(t, result, 1) // no duplicate
 }
 
 func TestMergeThreadEntries_EmptyExt(t *testing.T) {
 	existing := []*SidebarItem{}
 	cat, unfollowed := followedG1()
-	result := mergeThreadEntries(existing, nil, nil, cat, unfollowed, nil, nil, "", nil, nil)
+	result := mergeThreadEntries(existing, nil, nil, cat, unfollowed, nil, nil, nil, "", nil, nil)
 	assert.Len(t, result, 0)
 }
 
@@ -501,7 +501,7 @@ func TestMergeThreadEntries_SkipWhenThreadDeleted(t *testing.T) {
 	}
 	cat, unfollowed := followedG1()
 	// lastMsgAtMap 为空（thread 已被删除，cleanup 还没清理 ext 行）
-	result := mergeThreadEntries(existing, threadExtRows, map[string]*time.Time{}, cat, unfollowed, nil, nil, "", nil, nil)
+	result := mergeThreadEntries(existing, threadExtRows, map[string]*time.Time{}, cat, unfollowed, nil, nil, nil, "", nil, nil)
 	assert.Len(t, result, 0,
 		"thread 已删除时 ext 行必须被 skip，避免 ghost 条目出现在 follow tab")
 }
@@ -515,7 +515,7 @@ func TestMergeThreadEntries_AliveThreadEmitsTimestamp(t *testing.T) {
 		{TargetID: "g1____alive", FollowSort: 3},
 	}
 	cat, unfollowed := followedG1()
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____alive", &now), cat, unfollowed, nil, nil, "", nil, nil)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____alive", &now), cat, unfollowed, nil, nil, nil, "", nil, nil)
 	require.Len(t, result, 1)
 	assert.Equal(t, now.Unix(), result[0].Timestamp,
 		"alive thread 的 timestamp 必须从 lastMsgAtMap 正确读取")
@@ -531,7 +531,7 @@ func TestMergeThreadEntries_AliveThreadNilLastMsgAt(t *testing.T) {
 	}
 	cat, unfollowed := followedG1()
 	// 键存在但值为 nil = thread 活跃但还没消息
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____fresh", nil), cat, unfollowed, nil, nil, "", nil, nil)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____fresh", nil), cat, unfollowed, nil, nil, nil, "", nil, nil)
 	require.Len(t, result, 1, "活跃 thread 即便 last_message_at=NULL 也必须 emit")
 	assert.Equal(t, int64(0), result[0].Timestamp)
 }
@@ -547,7 +547,7 @@ func TestMergeThreadEntries_SkipWhenParentUnfollowed(t *testing.T) {
 	cat, _ := followedG1()
 	unfollowed := map[string]struct{}{"g1": {}}
 
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____th-orphan", nil), cat, unfollowed, nil, nil, "", nil, nil)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____th-orphan", nil), cat, unfollowed, nil, nil, nil, "", nil, nil)
 	assert.Len(t, result, 0,
 		"thread whose parent group is unfollowed must NOT be merged into follow tab")
 }
@@ -561,7 +561,7 @@ func TestMergeThreadEntries_SkipWhenParentHasNoCategory(t *testing.T) {
 	}
 	cat, unfollowed := followedG1() // only g1 is in the follow set, g-noCat is not
 
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g-noCat____th-orphan", nil), cat, unfollowed, nil, nil, "", nil, nil)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g-noCat____th-orphan", nil), cat, unfollowed, nil, nil, nil, "", nil, nil)
 	assert.Len(t, result, 0,
 		"thread whose parent group lacks a category (not in follow set) must NOT be merged")
 }
@@ -578,7 +578,7 @@ func TestMergeThreadEntries_SelfCreated_UncategorizedParent_Rendered(t *testing.
 	cat, unfollowed := followedG1() // g-noCat 不在 follow set
 	selfCreated := map[string]struct{}{cid: {}}
 
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, "", selfCreated, activeStatus(cid))
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, nil, "", selfCreated, activeStatus(cid))
 	require.Len(t, result, 1, "创建者自建子区即使父群未分类也必须渲染（issue #557）")
 	assert.Equal(t, cid, result[0].TargetID)
 	assert.True(t, result[0].IsFollowed)
@@ -597,7 +597,7 @@ func TestMergeThreadEntries_SelfCreated_UnfollowedParent_Rendered(t *testing.T) 
 	unfollowed := map[string]struct{}{"g1": {}} // 父群显式取关
 	selfCreated := map[string]struct{}{cid: {}}
 
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, "", selfCreated, activeStatus(cid))
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, nil, "", selfCreated, activeStatus(cid))
 	require.Len(t, result, 1, "父群被取关也不应隐藏创建者自建子区（issue #557）")
 	assert.Equal(t, cid, result[0].TargetID)
 	// 父群 g1 有分类：自建子区仍继承父群分类（豁免只跳过丢弃前置，不改分类归属）。
@@ -616,7 +616,7 @@ func TestMergeThreadEntries_NonSelfCreated_UncategorizedParent_Dropped(t *testin
 	// selfCreated 不含 cid（该子区非本人创建）
 	selfCreated := map[string]struct{}{"g-noCat____someone-elses": {}}
 
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, "", selfCreated, nil)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, nil, "", selfCreated, nil)
 	assert.Len(t, result, 0,
 		"非创建者子区不被豁免：父群未分类必须丢弃（防误放）")
 }
@@ -630,7 +630,7 @@ func TestMergeThreadEntries_SelfCreated_DeletedThread_StillDropped(t *testing.T)
 	selfCreated := map[string]struct{}{cid: {}}
 
 	// lastMsgAtMap 为空 → thread 已删除 / 不存在
-	result := mergeThreadEntries(existing, threadExtRows, map[string]*time.Time{}, cat, unfollowed, nil, nil, "", selfCreated, nil)
+	result := mergeThreadEntries(existing, threadExtRows, map[string]*time.Time{}, cat, unfollowed, nil, nil, nil, "", selfCreated, nil)
 	assert.Len(t, result, 0,
 		"创建者豁免不改活跃性判定：已删除子区仍必须丢弃")
 }
@@ -647,7 +647,7 @@ func TestMergeThreadEntries_SelfCreated_Archived_UncategorizedParent_Dropped(t *
 	selfCreated := map[string]struct{}{cid: {}}
 
 	// thread 仍 alive（archived != deleted），但 status=archived。
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, "", selfCreated, archivedStatus(cid))
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, nil, "", selfCreated, archivedStatus(cid))
 	assert.Len(t, result, 0,
 		"归档自建子区不再享受 #557 豁免：父群未分类必须丢弃（XIN-1135 块B）")
 }
@@ -662,7 +662,7 @@ func TestMergeThreadEntries_SelfCreated_Archived_UnfollowedParent_Dropped(t *tes
 	unfollowed := map[string]struct{}{"g1": {}} // 父群显式取关
 	selfCreated := map[string]struct{}{cid: {}}
 
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, "", selfCreated, archivedStatus(cid))
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, nil, "", selfCreated, archivedStatus(cid))
 	assert.Len(t, result, 0,
 		"归档自建子区在父群被取关时也被丢弃（XIN-1135 块B）")
 }
@@ -677,7 +677,7 @@ func TestMergeThreadEntries_SelfCreated_ActiveFresh_UncategorizedParent_Rendered
 	selfCreated := map[string]struct{}{cid: {}}
 
 	// active 且刚创建（last_message_at=NULL → ts=0）：#557 场景「创建者看得到自建 active 子区」。
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, "", selfCreated, activeStatus(cid))
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, nil, "", selfCreated, activeStatus(cid))
 	require.Len(t, result, 1, "新建 active 自建子区必须 emit（固化 #557，XIN-1135 守卫只拦 archived）")
 	assert.Equal(t, cid, result[0].TargetID)
 	assert.True(t, result[0].IsFollowed)
@@ -696,7 +696,7 @@ func TestMergeThreadEntries_SelfCreated_StatusMissing_NotExempted(t *testing.T) 
 	selfCreated := map[string]struct{}{cid: {}}
 
 	// alive 但 statusMap 为空 → threadStatusMap[cid]==0 != active → 不豁免 → drop。
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, "", selfCreated, map[string]int{})
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, nil, "", selfCreated, map[string]int{})
 	assert.Len(t, result, 0,
 		"status 缺失时自建豁免不生效（默认非 active），回落 parent-follow 谓词丢弃")
 }
@@ -710,7 +710,7 @@ func TestMergeThreadEntries_SkipMalformedChannelID(t *testing.T) {
 	}
 	cat, unfollowed := followedG1()
 
-	result := mergeThreadEntries(existing, threadExtRows, nil, cat, unfollowed, nil, nil, "", nil, nil)
+	result := mergeThreadEntries(existing, threadExtRows, nil, cat, unfollowed, nil, nil, nil, "", nil, nil)
 	assert.Len(t, result, 0,
 		"malformed thread channel id (no separator) must be skipped")
 }
@@ -894,7 +894,7 @@ func TestBuildFollowItems_ThreadInheritsParentCategorySort(t *testing.T) {
 	threadExtMap := map[string]*convext.Model{
 		threadID: {TargetID: threadID, FollowSort: 1},
 	}
-	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil, "")
+	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, nil, nil, nil, "")
 	require.Len(t, items, 2)
 
 	var groupItem, threadItem *SidebarItem
@@ -950,7 +950,7 @@ func TestBuildFollowItems_CategoryGroupSort_Propagates(t *testing.T) {
 			CategoryGroupSort: 42, // group_category.sort       —— 客户端可见 category_sort
 		},
 	}
-	items := buildFollowItems(convs, categorySetting, nil, nil, nil, nil, nil, nil, nil, "")
+	items := buildFollowItems(convs, categorySetting, nil, nil, nil, nil, nil, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, 42, items[0].CategorySort, "客户端可见的 category_sort 必须取自 group_category.sort")
 	assert.Equal(t, 7, items[0].intraCategorySort, "intraCategorySort 必须取自 group_setting.category_sort")
@@ -986,12 +986,12 @@ func TestSortRecentItems_MultiplePinned_ByTimestampDesc(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestBuildFollowItems_EmptyConversations(t *testing.T) {
-	items := buildFollowItems(nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	items := buildFollowItems(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 
 func TestBuildRecentItems_EmptyConversations(t *testing.T) {
-	items := buildRecentItems(nil, legacyRecentCutoffs(), nil, nil, nil, "")
+	items := buildRecentItems(nil, legacyRecentCutoffs(), nil, nil, nil, nil, "")
 	assert.Len(t, items, 0)
 }
 
@@ -1021,7 +1021,7 @@ func TestBuildFollowItems_MixedTypes(t *testing.T) {
 		"g1____th1": {TargetID: "g1____th1", FollowSort: 1},
 	}
 
-	items := buildFollowItems(convs, categorySetting, nil, followedDMs, threadExtMap, nil, nil, nil, nil, "")
+	items := buildFollowItems(convs, categorySetting, nil, followedDMs, threadExtMap, nil, nil, nil, nil, nil, "")
 	// g1 + peer1 + g1____th1 = 3; peer2 (not followed) and g2 (no category) excluded
 	assert.Len(t, items, 3)
 	ids := make(map[string]bool)
@@ -1085,7 +1085,7 @@ func TestBuildFollowItems_DMFollowed_WithDMCategory(t *testing.T) {
 	followedDMs := map[string]*convext.Model{
 		"peer1": {TargetID: "peer1", FollowedDM: 1, FollowSort: 3, DMCategoryID: &catID},
 	}
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil, nil, "")
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	require.NotNil(t, items[0].CategoryID)
 	assert.Equal(t, catID, *items[0].CategoryID, "DMCategoryID 直接透传 UUID，不再 fmt.Sprintf 转字符串")
@@ -1107,7 +1107,7 @@ func TestBuildFollowItems_GroupHonorsFollowSort(t *testing.T) {
 	groupExts := map[string]*convext.Model{
 		"g1": {TargetID: "g1", FollowSort: 7},
 	}
-	items := buildFollowItems(convs, categorySetting, nil, nil, nil, groupExts, nil, nil, nil, "")
+	items := buildFollowItems(convs, categorySetting, nil, nil, nil, groupExts, nil, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, 7, items[0].FollowSort, "group FollowSort 必须取自 user_conversation_ext.follow_sort")
 }
@@ -1120,7 +1120,7 @@ func TestBuildFollowItems_GroupMissingExtFallsBackToZero(t *testing.T) {
 	categorySetting := map[string]*GroupCategorySetting{
 		"g-noext": {GroupNo: "g-noext", CategoryID: strPtr("cat1"), CategorySort: 1, CategoryGroupSort: 1},
 	}
-	items := buildFollowItems(convs, categorySetting, nil, nil, nil, map[string]*convext.Model{}, nil, nil, nil, "")
+	items := buildFollowItems(convs, categorySetting, nil, nil, nil, map[string]*convext.Model{}, nil, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, 0, items[0].FollowSort)
 }
@@ -1137,7 +1137,7 @@ func TestBuildFollowItems_DMLoadsCategorySort(t *testing.T) {
 		"peer1": {TargetID: "peer1", FollowedDM: 1, FollowSort: 4, DMCategoryID: &catID},
 	}
 	dmCategorySorts := map[string]int{catID: 42}
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, dmCategorySorts, nil, nil, "")
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, dmCategorySorts, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, 42, items[0].CategorySort, "DM 的 CategorySort 必须取自 group_category.sort")
 	require.NotNil(t, items[0].CategoryID)
@@ -1152,7 +1152,7 @@ func TestBuildFollowItems_DMNoCategory_NoCategorySort(t *testing.T) {
 	followedDMs := map[string]*convext.Model{
 		"peer1": {TargetID: "peer1", FollowedDM: 1, FollowSort: 4},
 	}
-	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil, nil, "")
+	items := buildFollowItems(convs, nil, nil, followedDMs, nil, nil, nil, nil, nil, nil, "")
 	require.Len(t, items, 1)
 	assert.Equal(t, 0, items[0].CategorySort)
 	assert.Nil(t, items[0].CategoryID)

--- a/modules/message/api_test.go
+++ b/modules/message/api_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
-	_ "github.com/Mininglamp-OSS/octo-server/modules/webhook"
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/module"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/server"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/webhook"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/modules/message/conversation_space_id_backfill_test.go
+++ b/modules/message/conversation_space_id_backfill_test.go
@@ -27,7 +27,7 @@ func TestSpaceID_FillConversationSpaceIDs_GroupBackfill(t *testing.T) {
 	rawGroupSpaceMap := map[string]string{
 		"g_internal": "spaceA",
 		"g_external": "spaceB", // 群表权威值，未经 effective rewrite
-		"g_legacy":   "",        // 旧群无 space_id
+		"g_legacy":   "",       // 旧群无 space_id
 	}
 	externalGroupMap := map[string]string{
 		"g_external": "spaceA", // 当前 user 从 spaceA 加入了 g_external

--- a/modules/message/default_followed_group_guard_e2e_test.go
+++ b/modules/message/default_followed_group_guard_e2e_test.go
@@ -205,19 +205,19 @@ func TestE2E_DefaultFollowedGroupGuard_ProductionChain(t *testing.T) {
 	cleanGuardE2ERows(t, ctx)
 
 	const (
-		uid                  = "e2e-u1"
-		spaceA               = "e2e-sA"
-		spaceB               = "e2e-sB"
-		gOK                  = "e2e-g-ok"           // member + spaceA + category → MATERIALIZE
-		gDisband             = "e2e-g-disband"      // member + spaceA + category but Disband → REJECT
-		gWrongSpace          = "e2e-g-wrong"        // member + spaceB (not request space) + category → REJECT
-		gNotMember           = "e2e-g-notmem"       // spaceA + category but uid is NOT a member → REJECT
-		gNoCategory          = "e2e-g-nocat"        // member + spaceA but no category → REJECT (Stage 1)
-		gSoftDeletedCat      = "e2e-g-softcat"      // member + spaceA + category_id but category soft-deleted → REJECT (Stage 1, H1 regression)
-		gExternal            = "e2e-g-external"     // external member in spaceB referencing spaceA + category → MATERIALIZE
-		gFake                = "e2e-g-fake"         // attacker-injected, no rows anywhere → REJECT (Stage 1)
-		catLive              = "cat-live"
-		catSoftDeleted       = "cat-deleted"
+		uid             = "e2e-u1"
+		spaceA          = "e2e-sA"
+		spaceB          = "e2e-sB"
+		gOK             = "e2e-g-ok"       // member + spaceA + category → MATERIALIZE
+		gDisband        = "e2e-g-disband"  // member + spaceA + category but Disband → REJECT
+		gWrongSpace     = "e2e-g-wrong"    // member + spaceB (not request space) + category → REJECT
+		gNotMember      = "e2e-g-notmem"   // spaceA + category but uid is NOT a member → REJECT
+		gNoCategory     = "e2e-g-nocat"    // member + spaceA but no category → REJECT (Stage 1)
+		gSoftDeletedCat = "e2e-g-softcat"  // member + spaceA + category_id but category soft-deleted → REJECT (Stage 1, H1 regression)
+		gExternal       = "e2e-g-external" // external member in spaceB referencing spaceA + category → MATERIALIZE
+		gFake           = "e2e-g-fake"     // attacker-injected, no rows anywhere → REJECT (Stage 1)
+		catLive         = "cat-live"
+		catSoftDeleted  = "cat-deleted"
 	)
 
 	// --- groups ---
@@ -241,7 +241,7 @@ func TestE2E_DefaultFollowedGroupGuard_ProductionChain(t *testing.T) {
 	seedGroupMember(t, ctx, gExternal, uid, 1, spaceA)
 
 	// --- categories ---
-	seedGroupCategory(t, ctx, catLive, uid, 1)       // status=1 normal
+	seedGroupCategory(t, ctx, catLive, uid, 1)        // status=1 normal
 	seedGroupCategory(t, ctx, catSoftDeleted, uid, 2) // status=2 soft-deleted (H1)
 
 	// --- group_setting (per-user category assignment) ---

--- a/modules/message/default_followed_group_guard_test.go
+++ b/modules/message/default_followed_group_guard_test.go
@@ -198,10 +198,10 @@ func TestDefaultFollowedGroupGuard_MixedPayload_PartialFiltering(t *testing.T) {
 	const uid, space = "u1", "s1"
 	g := newGuard(
 		&fakeCategoryFilter{allowed: map[string]bool{
-			"g-keep":         true, // survives both stages
-			"g-no-member":    true, // survives Stage 1, dropped at Stage 2
-			"g-also-keep":    true, // survives both stages
-			"g-wrong-space":  true, // survives Stage 1, dropped at Stage 2
+			"g-keep":        true, // survives both stages
+			"g-no-member":   true, // survives Stage 1, dropped at Stage 2
+			"g-also-keep":   true, // survives both stages
+			"g-wrong-space": true, // survives Stage 1, dropped at Stage 2
 			// g-no-category is absent → Stage 1 drops it
 		}},
 		&fakeChannelAuth{rejectWith: map[string]error{

--- a/modules/message/dm_recents_spaceize_repro_test.go
+++ b/modules/message/dm_recents_spaceize_repro_test.go
@@ -34,8 +34,8 @@ import (
 func TestFix_ConversationSync_SpaceizesDMRecents(t *testing.T) {
 	const (
 		dmChannel   = "dm-peer-recents"
-		spaceA      = "space-a-recents"      // non-default
-		spaceB      = "space-b-recents"      // non-default, holds the globally-latest msg
+		spaceA      = "space-a-recents"       // non-default
+		spaceB      = "space-b-recents"       // non-default, holds the globally-latest msg
 		spaceDefaul = "space-default-recents" // earliest membership → default Space
 	)
 

--- a/modules/message/enrich_payload_space_id_test.go
+++ b/modules/message/enrich_payload_space_id_test.go
@@ -16,9 +16,9 @@ import (
 
 // groupSpaceLookupStub 记录调用历史，返回固定映射。
 type groupSpaceLookupStub struct {
-	spaces  map[string]string
-	errOn   map[string]error
-	calls   []string
+	spaces map[string]string
+	errOn  map[string]error
+	calls  []string
 }
 
 func (s *groupSpaceLookupStub) lookup(groupNo string) (string, error) {

--- a/modules/message/issue557_creator_thread_e2e_test.go
+++ b/modules/message/issue557_creator_thread_e2e_test.go
@@ -50,11 +50,11 @@ const issue557DBName = "octo_msg_issue557_test"
 // 的同 space 渲染路径（CreateThread → follow tab 渲染）。
 //
 // ⚠️ 注意（reviewer yujiawei P1）：**空串让写==读，恰好绕过了 legacy 群的真实 bug**。
-// 真实缺陷是：legacy 群（group.space_id=”）里内部成员建子区时，写侧 effective space
+// 真实缺陷是：legacy 群（group.space_id=''）里内部成员建子区时，写侧 effective space
 // 为空，但现代客户端读 legacy 群时带的是**非空** default space（#484 口径），
-// ListThreadExts 的 `WHERE space_id=?` 在 SQL 层丢掉 space_id=” 的补行——即写≠读。
+// ListThreadExts 的 `WHERE space_id=?` 在 SQL 层丢掉 space_id='' 的补行——即写≠读。
 // 本 E2E 不 seed 创建者的 space_member，故写侧归一化（thread.resolveCreatorBackfillSpaceID）
-// 因拿不到 default space 而 no-op 保持 ”，写读仍然都为 ”，**不覆盖**该 legacy 非空读场景。
+// 因拿不到 default space 而 no-op 保持 ''，写读仍然都为 ''，**不覆盖**该 legacy 非空读场景。
 //
 // 该 legacy 非空读场景的确定性覆盖放在 thread 包的纯 DB 测试
 // Test_Issue557_LegacyGroup_CreatorBackfillSurvivesSpaceScopedRead（只需 MySQL，不依赖

--- a/modules/message/issue557_creator_thread_e2e_test.go
+++ b/modules/message/issue557_creator_thread_e2e_test.go
@@ -50,11 +50,11 @@ const issue557DBName = "octo_msg_issue557_test"
 // 的同 space 渲染路径（CreateThread → follow tab 渲染）。
 //
 // ⚠️ 注意（reviewer yujiawei P1）：**空串让写==读，恰好绕过了 legacy 群的真实 bug**。
-// 真实缺陷是：legacy 群（group.space_id=''）里内部成员建子区时，写侧 effective space
+// 真实缺陷是：legacy 群（group.space_id=”）里内部成员建子区时，写侧 effective space
 // 为空，但现代客户端读 legacy 群时带的是**非空** default space（#484 口径），
-// ListThreadExts 的 `WHERE space_id=?` 在 SQL 层丢掉 space_id='' 的补行——即写≠读。
+// ListThreadExts 的 `WHERE space_id=?` 在 SQL 层丢掉 space_id=” 的补行——即写≠读。
 // 本 E2E 不 seed 创建者的 space_member，故写侧归一化（thread.resolveCreatorBackfillSpaceID）
-// 因拿不到 default space 而 no-op 保持 ''，写读仍然都为 ''，**不覆盖**该 legacy 非空读场景。
+// 因拿不到 default space 而 no-op 保持 ”，写读仍然都为 ”，**不覆盖**该 legacy 非空读场景。
 //
 // 该 legacy 非空读场景的确定性覆盖放在 thread 包的纯 DB 测试
 // Test_Issue557_LegacyGroup_CreatorBackfillSurvivesSpaceScopedRead（只需 MySQL，不依赖
@@ -276,7 +276,7 @@ func issue557FollowTabThreadItems(t *testing.T, sb *Sidebar, loginUID string, un
 		nil, rows, lastMsgAt,
 		map[string]*GroupCategorySetting{}, // 父群未分类
 		unfollowedGroups,
-		map[string]string{}, map[string]string{}, "",
+		map[string]string{}, nil, map[string]string{}, "",
 		selfCreated,
 		statusMap,
 	)

--- a/modules/message/mention_expand_test.go
+++ b/modules/message/mention_expand_test.go
@@ -19,9 +19,9 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/robot"
-	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/modules/message/recent_window_exemption_test.go
+++ b/modules/message/recent_window_exemption_test.go
@@ -134,7 +134,7 @@ func TestBuildRecentItems_PinnedSurvivesWindow(t *testing.T) {
 	pinned := map[string]struct{}{
 		channelKey("g-stale-pinned", common.ChannelTypeGroup.Uint8()): {},
 	}
-	items := buildRecentItems(convs, defaultRecentCutoffs(), pinned, nil, nil, "")
+	items := buildRecentItems(convs, defaultRecentCutoffs(), pinned, nil, nil, nil, "")
 
 	require.Len(t, items, 1, "置顶条目必须存活，未置顶的陈旧群应被过滤")
 	assert.Equal(t, "g-stale-pinned", items[0].TargetID)
@@ -147,7 +147,7 @@ func TestBuildRecentItems_UnreadSurvivesWindow(t *testing.T) {
 		makeRawConv("g-stale-unread", common.ChannelTypeGroup.Uint8(), now3DaysAgo(), 3),
 		makeRawConv("g-stale-read", common.ChannelTypeGroup.Uint8(), now3DaysAgo(), 0),
 	}
-	items := buildRecentItems(convs, defaultRecentCutoffs(), nil, nil, nil, "")
+	items := buildRecentItems(convs, defaultRecentCutoffs(), nil, nil, nil, nil, "")
 
 	require.Len(t, items, 1)
 	assert.Equal(t, "g-stale-unread", items[0].TargetID)
@@ -175,7 +175,7 @@ func TestRecentWindow_BothEndpointsAgree(t *testing.T) {
 		makeSyncRespUnread(pinnedID, common.ChannelTypeGroup.Uint8(), now3DaysAgo(), 0),
 	}
 
-	items := buildRecentItems(rawConvs, cutoffs, pinned, nil, nil, "")
+	items := buildRecentItems(rawConvs, cutoffs, pinned, nil, nil, nil, "")
 	sidebarIDs := make([]string, 0, len(items))
 	for _, it := range items {
 		sidebarIDs = append(sidebarIDs, it.TargetID)

--- a/modules/message/revoke_bot_test.go
+++ b/modules/message/revoke_bot_test.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/Mininglamp-OSS/octo-server/modules/group"
-	"github.com/Mininglamp-OSS/octo-server/modules/robot"
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/robot"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/modules/message/round2_findings_test.go
+++ b/modules/message/round2_findings_test.go
@@ -85,7 +85,7 @@ func TestSpaceID_Round2_Finding2_DBOnlyThreadInheritsParentSpace(t *testing.T) {
 	}
 
 	items := mergeThreadEntries(nil, extRows, aliveThread("g_db_parent____th9", nil),
-		categorySetting, nil, groupSpaceMap, nil, "", nil, nil)
+		categorySetting, nil, groupSpaceMap, nil, nil, "", nil, nil)
 
 	require.Len(t, items, 1)
 	assert.Equal(t, "spaceX", items[0].SpaceID,
@@ -118,7 +118,7 @@ func TestSpaceID_Round2_Finding3_BuildFollowItems_ExternalGroupMySource(t *testi
 		"g_external": "spaceA",
 	}
 
-	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, groupSpaceMap, externalGroupMap, "")
+	items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil, groupSpaceMap, nil, externalGroupMap, "")
 
 	byID := map[string]*SidebarItem{}
 	for _, it := range items {
@@ -152,7 +152,7 @@ func TestSpaceID_Round2_Finding3_BuildRecentItems_ExternalGroupMySource(t *testi
 	groupSpaceMap := map[string]string{"g_external": "spaceB"}
 	externalGroupMap := map[string]string{"g_external": "spaceA"}
 
-	items := buildRecentItems(convs, recentCutoffs{}, nil, groupSpaceMap, externalGroupMap, "")
+	items := buildRecentItems(convs, recentCutoffs{}, nil, groupSpaceMap, nil, externalGroupMap, "")
 
 	byID := map[string]*SidebarItem{}
 	for _, it := range items {
@@ -182,7 +182,7 @@ func TestSpaceID_Round2_Finding3_MergeThreadEntries_ExternalGroupMySource(t *tes
 
 	result := mergeThreadEntries(nil, threadExtRows,
 		aliveThread("g_external____alive", nil),
-		categorySetting, nil, groupSpaceMap, externalGroupMap, "", nil, nil)
+		categorySetting, nil, groupSpaceMap, nil, externalGroupMap, "", nil, nil)
 
 	require.Len(t, result, 1)
 	assert.Equal(t, "spaceB", result[0].SpaceID)

--- a/modules/message/round3_findings_test.go
+++ b/modules/message/round3_findings_test.go
@@ -178,7 +178,7 @@ func TestSpaceID_Round3_Finding2_Sidebar_EmptySourceFallback(t *testing.T) {
 
 	t.Run("buildFollowItems", func(t *testing.T) {
 		items := buildFollowItems(convs, categorySetting, nil, nil, threadExtMap, nil, nil,
-			groupSpaceMap, externalGroupMap, defaultSpaceID)
+			groupSpaceMap, nil, externalGroupMap, defaultSpaceID)
 		byID := map[string]*SidebarItem{}
 		for _, it := range items {
 			byID[it.TargetID] = it
@@ -192,7 +192,7 @@ func TestSpaceID_Round3_Finding2_Sidebar_EmptySourceFallback(t *testing.T) {
 	})
 
 	t.Run("buildRecentItems", func(t *testing.T) {
-		items := buildRecentItems(convs, recentCutoffs{}, nil, groupSpaceMap, externalGroupMap, defaultSpaceID)
+		items := buildRecentItems(convs, recentCutoffs{}, nil, groupSpaceMap, nil, externalGroupMap, defaultSpaceID)
 		byID := map[string]*SidebarItem{}
 		for _, it := range items {
 			byID[it.TargetID] = it
@@ -211,7 +211,7 @@ func TestSpaceID_Round3_Finding2_Sidebar_EmptySourceFallback(t *testing.T) {
 		}
 		result := mergeThreadEntries(nil, extRows,
 			aliveThread("g_legacy_ext____alive", nil),
-			categorySetting, nil, groupSpaceMap, externalGroupMap, defaultSpaceID, nil, nil)
+			categorySetting, nil, groupSpaceMap, nil, externalGroupMap, defaultSpaceID, nil, nil)
 		require.Len(t, result, 1)
 		assert.Equal(t, "spaceDefault", result[0].MySourceSpaceID,
 			"DB-only thread: 父群 source='' 兜底到 defaultSpaceID")

--- a/modules/message/sidebar_space_id_test.go
+++ b/modules/message/sidebar_space_id_test.go
@@ -31,7 +31,7 @@ func TestSpaceID_BuildFollowItems_GroupAndThreadFilled(t *testing.T) {
 		"g1": "spaceA",
 	}
 
-	items := buildFollowItems(convs, categorySetting, nil, followedDMs, threadExtMap, nil, nil, groupSpaceMap, nil, "")
+	items := buildFollowItems(convs, categorySetting, nil, followedDMs, threadExtMap, nil, nil, groupSpaceMap, nil, nil, "")
 
 	bySpace := map[string]string{}
 	byTarget := map[string]*SidebarItem{}
@@ -57,7 +57,7 @@ func TestSpaceID_BuildFollowItems_NilGroupSpaceMap(t *testing.T) {
 	}
 
 	assert.NotPanics(t, func() {
-		items := buildFollowItems(convs, categorySetting, nil, nil, nil, nil, nil, nil, nil, "")
+		items := buildFollowItems(convs, categorySetting, nil, nil, nil, nil, nil, nil, nil, nil, "")
 		assert.Len(t, items, 1)
 		assert.Equal(t, "", items[0].SpaceID)
 	})
@@ -78,7 +78,7 @@ func TestSpaceID_BuildRecentItems_GroupAndThreadFilled(t *testing.T) {
 		"g1": "spaceB",
 	}
 
-	items := buildRecentItems(convs, recentCutoffs{}, nil, groupSpaceMap, nil, "")
+	items := buildRecentItems(convs, recentCutoffs{}, nil, groupSpaceMap, nil, nil, "")
 
 	bySpace := map[string]string{}
 	for _, it := range items {
@@ -102,7 +102,7 @@ func TestSpaceID_MergeThreadEntries_FillsParentSpaceID(t *testing.T) {
 	}
 	groupSpaceMap := map[string]string{"g1": "spaceC"}
 
-	result := mergeThreadEntries(nil, threadExtRows, aliveThread("g1____alive", nil), categorySetting, nil, groupSpaceMap, nil, "", nil, nil)
+	result := mergeThreadEntries(nil, threadExtRows, aliveThread("g1____alive", nil), categorySetting, nil, groupSpaceMap, nil, nil, "", nil, nil)
 
 	if assert.Len(t, result, 1) {
 		assert.Equal(t, "g1____alive", result[0].TargetID)

--- a/modules/message/space_filter.go
+++ b/modules/message/space_filter.go
@@ -746,27 +746,31 @@ func CollectGroupSpaceAndProjectMaps(
 	if len(bareGroupNos) == 0 {
 		return map[string]string{}, map[string]string{}, true
 	}
-	// Captured from inside the closure rather than returned by it, so the project
-	// map is built from the SAME infos the space map is, in the same single call.
-	projectMap := map[string]string{}
-	m, err := spacepkg.GetGroupSpaceMap(bareGroupNos, func(nos []string) ([]spacepkg.GroupSpaceInfo, error) {
-		infos, err := groupService.GetGroups(nos)
-		if err != nil {
-			return nil, err
-		}
-		result := make([]spacepkg.GroupSpaceInfo, 0, len(infos))
-		for _, g := range infos {
-			result = append(result, spacepkg.GroupSpaceInfo{GroupNo: g.GroupNo, SpaceID: g.SpaceID})
-			if g.ProjectID != "" {
-				projectMap[g.GroupNo] = g.ProjectID
-			}
-		}
-		return result, nil
-	})
+	// One call, both maps built from its result — deliberately NOT by capturing a
+	// map inside the closure handed to spacepkg.GetGroupSpaceMap.
+	//
+	// That version worked, and only because pkg/space happens to invoke the callback
+	// exactly once, synchronously, with the whole slice. Nothing in pkg/space
+	// documents that as a contract, and it is a natural place to grow a cache or a
+	// batch loop later — at which point the space map would stay complete while the
+	// project map silently went partial, or two goroutines would write one map. A
+	// dependency on another package's undocumented invocation shape is not worth
+	// five lines. PR #861's review flagged it.
+	infos, err := groupService.GetGroups(bareGroupNos)
 	if err != nil {
 		return nil, nil, false
 	}
-	return m, projectMap, true
+	spaceMap := make(map[string]string, len(infos))
+	// A group with no project is ABSENT rather than present with an empty value, so
+	// the map stays proportional to project groups rather than to conversations.
+	projectMap := map[string]string{}
+	for _, g := range infos {
+		spaceMap[g.GroupNo] = g.SpaceID
+		if g.ProjectID != "" {
+			projectMap[g.GroupNo] = g.ProjectID
+		}
+	}
+	return spaceMap, projectMap, true
 }
 
 // FilterRawConversationsBySpace 是 FilterConversationsBySpace 在 v2 sidebar 上的

--- a/modules/message/space_filter.go
+++ b/modules/message/space_filter.go
@@ -693,6 +693,27 @@ func CollectGroupSpaceMap(
 	extraGroupNos []string,
 	groupService group.IService,
 ) (map[string]string, bool) {
+	spaceMap, _, ok := CollectGroupSpaceAndProjectMaps(conversations, extraGroupNos, groupService)
+	return spaceMap, ok
+}
+
+// CollectGroupSpaceAndProjectMaps derives (groupNo -> spaceID) AND
+// (groupNo -> projectID) from ONE GetGroups call.
+//
+// The project map is free: GetGroups already returns whole group rows, and
+// InfoResp.ProjectID is the column P1 added and P2 started shipping. Collecting it
+// in a second pass over the same result is what keeps the sidebar at the query
+// count it had — a separate CollectGroupProjectMap would double the batch on the
+// hottest read path in the product, for a field that was already in the response.
+//
+// A group with no project is ABSENT from the project map rather than present with
+// an empty value, so a caller reading a missing key gets "" either way and the map
+// stays proportional to project groups rather than to every conversation.
+func CollectGroupSpaceAndProjectMaps(
+	conversations []*config.SyncUserConversationResp,
+	extraGroupNos []string,
+	groupService group.IService,
+) (map[string]string, map[string]string, bool) {
 	seen := make(map[string]struct{})
 	var bareGroupNos []string
 	add := func(no string) {
@@ -723,8 +744,11 @@ func CollectGroupSpaceMap(
 		add(no)
 	}
 	if len(bareGroupNos) == 0 {
-		return map[string]string{}, true
+		return map[string]string{}, map[string]string{}, true
 	}
+	// Captured from inside the closure rather than returned by it, so the project
+	// map is built from the SAME infos the space map is, in the same single call.
+	projectMap := map[string]string{}
 	m, err := spacepkg.GetGroupSpaceMap(bareGroupNos, func(nos []string) ([]spacepkg.GroupSpaceInfo, error) {
 		infos, err := groupService.GetGroups(nos)
 		if err != nil {
@@ -733,13 +757,16 @@ func CollectGroupSpaceMap(
 		result := make([]spacepkg.GroupSpaceInfo, 0, len(infos))
 		for _, g := range infos {
 			result = append(result, spacepkg.GroupSpaceInfo{GroupNo: g.GroupNo, SpaceID: g.SpaceID})
+			if g.ProjectID != "" {
+				projectMap[g.GroupNo] = g.ProjectID
+			}
 		}
 		return result, nil
 	})
 	if err != nil {
-		return nil, false
+		return nil, nil, false
 	}
-	return m, true
+	return m, projectMap, true
 }
 
 // FilterRawConversationsBySpace 是 FilterConversationsBySpace 在 v2 sidebar 上的

--- a/modules/message/validation_test.go
+++ b/modules/message/validation_test.go
@@ -121,9 +121,9 @@ func TestRevokeTimeout(t *testing.T) {
 
 func TestRevokeTimeoutLogic(t *testing.T) {
 	tests := []struct {
-		name           string
-		messageTime    time.Time
-		shouldTimeout  bool
+		name          string
+		messageTime   time.Time
+		shouldTimeout bool
 	}{
 		{
 			name:          "message sent 1 hour ago - should NOT timeout",

--- a/modules/project/api.go
+++ b/modules/project/api.go
@@ -197,6 +197,10 @@ func (p *Project) Route(r *wkhttp.WKHttp) {
 		// a role check — see listProjectGroupsHandler.
 		projectScoped.GET("/:project_id/groups", p.listProjectGroupsHandler)
 
+		// Personal preferences for one project (pinning). A settings bag rather
+		// than /pin + /unpin, mirroring PUT /v1/groups/:group_no/setting.
+		projectScoped.PUT("/:project_id/setting", p.updateSettingHandler)
+
 		projectScoped.GET("/:project_id/members", p.listMembersHandler)
 		projectScoped.POST("/:project_id/members/add", p.addMembersHandler)
 		projectScoped.POST("/:project_id/members/remove", p.removeMembersHandler)
@@ -343,7 +347,10 @@ func (p *Project) createProjectHandler(c *wkhttp.Context) {
 	// only ever widens READ visibility, which does not apply to a response about a project
 	// the caller owns.
 	humans, agents := p.splitSeatCounts(model.ProjectID)
-	c.Response(p.toResp(model, RoleOwner, spacepkg.MemberRoleCommon, humans, agents))
+	// pinned is false and that is provable, not assumed: this project id was
+	// generated inside the transaction that just committed, so no settings row
+	// for it can exist yet.
+	c.Response(p.toResp(model, RoleOwner, spacepkg.MemberRoleCommon, humans, agents, false))
 }
 
 // respondCreateError maps the create sentinels onto registered codes. Kept separate
@@ -471,7 +478,7 @@ func (p *Project) listProjectsHandler(c *wkhttp.Context) {
 		// member_count means. Reporting the full seat count here while the detail
 		// route reported humans only would have been D16's own bug, one endpoint
 		// away.
-		resps = append(resps, p.toResp(&model, row.MyRole, spaceRole, row.MemberCount, row.AgentCount()))
+		resps = append(resps, p.toResp(&model, row.MyRole, spaceRole, row.MemberCount, row.AgentCount(), row.Pinned == 1))
 	}
 	c.Response(resps)
 }
@@ -484,7 +491,13 @@ func (p *Project) getProjectHandler(c *wkhttp.Context) {
 		return
 	}
 	humans, agents := p.splitSeatCounts(row.ProjectID)
-	c.Response(p.toResp(row, requestProjectRole(c), requestSpaceRole(c), humans, agents))
+	pinned, err := p.db.queryProjectPinned(row.ProjectID, c.GetLoginUID())
+	if err != nil {
+		p.Error("查询项目置顶状态失败", zap.Error(err), zap.String("projectId", row.ProjectID))
+		respondQueryFailed(c)
+		return
+	}
+	c.Response(p.toResp(row, requestProjectRole(c), requestSpaceRole(c), humans, agents, pinned))
 }
 
 func (p *Project) listMembersHandler(c *wkhttp.Context) {
@@ -615,7 +628,16 @@ func (p *Project) updateProjectHandler(c *wkhttp.Context) {
 	// caller their write failed when it did not, which is the one thing a response
 	// after a successful write must not do.
 	humans, agents := p.splitSeatCounts(updated.ProjectID)
-	c.Response(p.toResp(updated, requestProjectRole(c), requestSpaceRole(c), humans, agents))
+	// The pin survives a rename, so it has to be re-read rather than defaulted:
+	// reporting false here would make the caller watch their own card leave the
+	// pinned section until the next list fetch.
+	pinned, err := p.db.queryProjectPinned(updated.ProjectID, c.GetLoginUID())
+	if err != nil {
+		p.Error("查询项目置顶状态失败", zap.Error(err), zap.String("projectId", updated.ProjectID))
+		respondQueryFailed(c)
+		return
+	}
+	c.Response(p.toResp(updated, requestProjectRole(c), requestSpaceRole(c), humans, agents, pinned))
 }
 
 func (p *Project) disbandProjectHandler(c *wkhttp.Context) {
@@ -664,7 +686,15 @@ func (p *Project) disbandProjectHandler(c *wkhttp.Context) {
 // toResp renders a project. memberCount counts HUMANS and agentCount counts AI
 // agents (D16); MaxMembers still bounds the two together, because a seat is a
 // seat regardless of who sits in it.
-func (p *Project) toResp(m *Model, myRole, spaceRole, memberCount, agentCount int) *Resp {
+// toResp shapes one project for the wire.
+//
+// pinned is a parameter rather than a field on Model because it is a fact about
+// the CALLER, not about the project: the same row is pinned for one user and not
+// for the next. Every call site must therefore supply it truthfully — a default of
+// false would make the update route report a project as un-pinned right after the
+// caller renamed it, and the client would watch its own card jump out of the
+// pinned section until the next list fetch.
+func (p *Project) toResp(m *Model, myRole, spaceRole, memberCount, agentCount int, pinned bool) *Resp {
 	return &Resp{
 		ProjectID:        m.ProjectID,
 		SpaceID:          m.SpaceID,
@@ -679,6 +709,7 @@ func (p *Project) toResp(m *Model, myRole, spaceRole, memberCount, agentCount in
 		MemberEpoch:      m.MemberEpoch,
 		Status:           m.Status,
 		AllMemberGroupNo: m.AllMemberGroupNo,
+		Pinned:           pinned,
 		MyRole:           myRole,
 		Capabilities:     capabilitiesFor(myRole, spaceRole),
 		CreatedAt:        formatTime(m.CreatedAt),

--- a/modules/project/api.go
+++ b/modules/project/api.go
@@ -473,11 +473,14 @@ func (p *Project) listProjectsHandler(c *wkhttp.Context) {
 	resps := make([]*Resp, 0, len(rows))
 	for _, row := range rows {
 		model := row.Model
-		// The split comes from the list query itself (two bounded correlated
-		// subqueries), so a list card and the detail route agree about what
-		// member_count means. Reporting the full seat count here while the detail
-		// route reported humans only would have been D16's own bug, one endpoint
-		// away.
+		// Both halves of the split come from fillMemberCounts, out of one roster
+		// read, so a list card and the detail route agree about what member_count
+		// means. Reporting the full seat count here while the detail route
+		// reported humans only would have been D16's own bug, one endpoint away.
+		//
+		// This used to say "two bounded correlated subqueries", which was one too
+		// many after #855 removed member_count's and zero too many after PR-5
+		// removed seat_count's.
 		resps = append(resps, p.toResp(&model, row.MyRole, spaceRole, row.MemberCount, row.AgentCount(), row.Pinned == 1))
 	}
 	c.Response(resps)

--- a/modules/project/api.go
+++ b/modules/project/api.go
@@ -491,13 +491,8 @@ func (p *Project) getProjectHandler(c *wkhttp.Context) {
 		return
 	}
 	humans, agents := p.splitSeatCounts(row.ProjectID)
-	pinned, err := p.db.queryProjectPinned(row.ProjectID, c.GetLoginUID())
-	if err != nil {
-		p.Error("查询项目置顶状态失败", zap.Error(err), zap.String("projectId", row.ProjectID))
-		respondQueryFailed(c)
-		return
-	}
-	c.Response(p.toResp(row, requestProjectRole(c), requestSpaceRole(c), humans, agents, pinned))
+	c.Response(p.toResp(row, requestProjectRole(c), requestSpaceRole(c), humans, agents,
+		p.pinnedOrFalse(row.ProjectID, c.GetLoginUID())))
 }
 
 func (p *Project) listMembersHandler(c *wkhttp.Context) {
@@ -630,14 +625,11 @@ func (p *Project) updateProjectHandler(c *wkhttp.Context) {
 	humans, agents := p.splitSeatCounts(updated.ProjectID)
 	// The pin survives a rename, so it has to be re-read rather than defaulted:
 	// reporting false here would make the caller watch their own card leave the
-	// pinned section until the next list fetch.
-	pinned, err := p.db.queryProjectPinned(updated.ProjectID, c.GetLoginUID())
-	if err != nil {
-		p.Error("查询项目置顶状态失败", zap.Error(err), zap.String("projectId", updated.ProjectID))
-		respondQueryFailed(c)
-		return
-	}
-	c.Response(p.toResp(updated, requestProjectRole(c), requestSpaceRole(c), humans, agents, pinned))
+	// pinned section until the next list fetch. Read the SAME way the counts above
+	// are — fail-soft — because the sentence directly above applies to it word for
+	// word, and the first cut of this line did exactly what that sentence forbids.
+	c.Response(p.toResp(updated, requestProjectRole(c), requestSpaceRole(c), humans, agents,
+		p.pinnedOrFalse(updated.ProjectID, uid)))
 }
 
 func (p *Project) disbandProjectHandler(c *wkhttp.Context) {
@@ -756,6 +748,27 @@ func (p *Project) splitSeatCounts(projectID string) (humans, agents int) {
 		return 0, 0
 	}
 	return total, 0
+}
+
+// pinnedOrFalse reads the caller's pin, degrading to false rather than failing.
+//
+// Same contract as splitSeatCounts, and for the same reason stated at the update
+// handler: a display field must never turn a COMMITTED write into a 500. The first
+// cut of the pin work put a hard failure directly beneath the comment that forbids
+// it, so a transient read error made a successful rename answer "your write
+// failed". PR #861's review caught it.
+//
+// Degrading to false is the right default, not merely the convenient one: an
+// unpinned card is the state every project starts in and the one every client can
+// already render, and the next list fetch corrects it.
+func (p *Project) pinnedOrFalse(projectID, uid string) bool {
+	pinned, err := p.db.queryProjectPinned(projectID, uid)
+	if err != nil {
+		p.Warn("查询项目置顶状态失败，按未置顶下发",
+			zap.Error(err), zap.String("projectId", projectID))
+		return false
+	}
+	return pinned
 }
 
 // pageParams parses offset/limit with bounds. An unbounded limit on a roster or a project

--- a/modules/project/api.go
+++ b/modules/project/api.go
@@ -193,6 +193,10 @@ func (p *Project) Route(r *wkhttp.WKHttp) {
 		projectScoped.PUT("/:project_id", p.updateProjectHandler)
 		projectScoped.DELETE("/:project_id", p.disbandProjectHandler)
 
+		// Read-only, and gated by the caller's own group membership rather than by
+		// a role check — see listProjectGroupsHandler.
+		projectScoped.GET("/:project_id/groups", p.listProjectGroupsHandler)
+
 		projectScoped.GET("/:project_id/members", p.listMembersHandler)
 		projectScoped.POST("/:project_id/members/add", p.addMembersHandler)
 		projectScoped.POST("/:project_id/members/remove", p.removeMembersHandler)

--- a/modules/project/api_group.go
+++ b/modules/project/api_group.go
@@ -1,0 +1,90 @@
+package project
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"go.uber.org/zap"
+)
+
+// listProjectGroupsHandler answers GET /v1/projects/:project_id/groups.
+//
+// It returns the caller's OWN live groups within the project — see
+// listMyProjectGroups for why the list is membership-scoped and why that
+// predicate is the access control rather than a filter applied after one.
+//
+// # No permission gate beyond projectMiddleware, on purpose
+//
+// listMembersHandler needs canViewMembers because the roster is a fact ABOUT
+// OTHER PEOPLE: a space_listed project shows its metadata to any Space member,
+// but who is in it is not part of that. This endpoint returns only rows the
+// caller is already a member of, so there is nothing to withhold. A Space admin
+// who never joined the project gets `[]`, which is the true answer.
+//
+// Adding a gate here would be worse than redundant: it would answer 403 to a
+// caller whose correct answer is an empty list, and make "you are not a project
+// member" observable on a route that currently discloses nothing.
+//
+// # What this endpoint deliberately does not carry
+//
+//   - Threads. GET /v1/groups/:group_no/threads already exists with its own
+//     pagination and its own access gate (thread admission checks membership of
+//     the parent group). Nesting them here would be O(groups × threads) with two
+//     pagination axes that cannot share one cursor, and would fork thread access
+//     control into a second place.
+//   - Unread counts and badge state. Those live on the conversation layer
+//     (/v1/sidebar/*). A second source of truth for a number that changes on
+//     every message, served from a route with a 60-second membership cache, is
+//     not a shortcut worth taking.
+//   - An "is the all-member group" flag. The project detail already ships
+//     all_member_group_no (#855), and a client rendering this list has the
+//     project row in hand; comparing two strings does not need a server field
+//     that could disagree with the pointer it duplicates.
+func (p *Project) listProjectGroupsHandler(c *wkhttp.Context) {
+	row := requestProject(c)
+	if row == nil {
+		p.Error("projectMiddleware 未注入项目行", zap.String("path", c.FullPath()))
+		respondQueryFailed(c)
+		return
+	}
+	uid := c.GetLoginUID()
+	if uid == "" {
+		// Unreachable behind AuthMiddleware; treated as a wiring bug rather than
+		// a request error, exactly as the nil project row above is.
+		p.Error("已认证路由上取不到登录 uid", zap.String("path", c.FullPath()))
+		respondQueryFailed(c)
+		return
+	}
+
+	offset, limit := pageParams(c)
+	rows, err := p.db.listMyProjectGroups(row.SpaceID, row.ProjectID, uid, offset, limit)
+	if err != nil {
+		p.Error("查询项目群列表失败", zap.Error(err),
+			zap.String("projectId", row.ProjectID), zap.String("spaceId", row.SpaceID))
+		respondQueryFailed(c)
+		return
+	}
+
+	groupNos := make([]string, 0, len(rows))
+	for _, g := range rows {
+		groupNos = append(groupNos, g.GroupNo)
+	}
+	counts, err := p.db.countActiveGroupMembers(groupNos)
+	if err != nil {
+		p.Error("统计项目群成员数失败", zap.Error(err), zap.String("projectId", row.ProjectID))
+		respondQueryFailed(c)
+		return
+	}
+
+	resps := make([]*GroupResp, 0, len(rows))
+	for _, g := range rows {
+		resps = append(resps, &GroupResp{
+			GroupNo:        g.GroupNo,
+			Name:           g.Name,
+			IsNamed:        g.IsNamed,
+			AvatarText:     g.AvatarText,
+			AvatarColor:    g.AvatarColor,
+			IsUploadAvatar: g.IsUploadAvatar,
+			MemberCount:    counts[g.GroupNo],
+		})
+	}
+	c.Response(resps)
+}

--- a/modules/project/api_group.go
+++ b/modules/project/api_group.go
@@ -45,14 +45,11 @@ func (p *Project) listProjectGroupsHandler(c *wkhttp.Context) {
 		respondQueryFailed(c)
 		return
 	}
+	// No empty-uid check: projectMiddleware already reads GetLoginUID and aborts
+	// with respondNotLoggedIn when it is empty, so a second one here would be
+	// unreachable AND would answer a different envelope than the middleware does
+	// if it ever fired. listMembersHandler omits it for the same reason.
 	uid := c.GetLoginUID()
-	if uid == "" {
-		// Unreachable behind AuthMiddleware; treated as a wiring bug rather than
-		// a request error, exactly as the nil project row above is.
-		p.Error("已认证路由上取不到登录 uid", zap.String("path", c.FullPath()))
-		respondQueryFailed(c)
-		return
-	}
 
 	offset, limit := pageParams(c)
 	rows, err := p.db.listMyProjectGroups(row.SpaceID, row.ProjectID, uid, offset, limit)

--- a/modules/project/api_group_test.go
+++ b/modules/project/api_group_test.go
@@ -2,11 +2,13 @@ package project
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -143,6 +145,94 @@ func TestListProjectGroupsExcludesInactiveMembership(t *testing.T) {
 	assert.Empty(t, decodeGroupList(t, w),
 		"is_deleted = 0 AND status = 1 is the canonical active-member predicate; a read that "+
 			"checks only is_deleted returns groups the caller has left")
+}
+
+// TestListProjectGroupsHidesAGroupThatBlacklistedMe pins the one case where this
+// endpoint's membership predicate DIVERGES from the older group surfaces, so the
+// divergence is a decision with a test behind it rather than a side effect.
+//
+// Blacklisting sets group_member.status = GroupMemberStatusBlacklist and leaves
+// is_deleted = 0 (modules/group/db.go:260). GET /v1/group/my filters is_deleted
+// alone, so it still shows the group; this endpoint requires status = Normal, so
+// it does not. That is deliberate: blacklisting is how a group denies access, and
+// ExistMemberActive is the hardening line in front of group and thread reads for
+// exactly this uid, so listing the group here would advertise a room the caller
+// cannot open.
+//
+// The assertion covers both halves. Asserting only the absence would let a future
+// change that ALSO broke /v1/group/my pass while destroying the property that
+// makes this divergence deliberate rather than a bug.
+func TestListProjectGroupsHidesAGroupThatBlacklistedMe(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	ownerTok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	created := createProjectVia(t, srv, spaceA, ownerTok, "groups-blacklist")
+
+	banned := util.GenerUUID()
+	seedProjectGroup(t, banned, spaceA, created.ProjectID)
+	seedInactiveGroupMemberRow(t, banned, "owner1", 0, int(common.GroupMemberStatusBlacklist))
+
+	w := doJSON(t, srv, http.MethodGet, "/v1/projects/"+created.ProjectID+"/groups", ownerTok, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Empty(t, decodeGroupList(t, w),
+		"a group that blacklisted the caller must not appear in their project tree: the "+
+			"access gates already refuse them, so listing it advertises a room they cannot open")
+
+	// The other half of the divergence, asserted so it cannot drift silently.
+	mine := doJSON(t, srv, http.MethodGet, "/v1/group/my?space_id="+spaceA, ownerTok, nil)
+	require.Equal(t, http.StatusOK, mine.Code, "body: %s", mine.Body.String())
+	assert.Contains(t, mine.Body.String(), banned,
+		"GET /v1/group/my filters is_deleted alone and still shows the group - if THIS "+
+			"stops being true the divergence documented in listMyProjectGroups is gone and "+
+			"its comment is now wrong")
+}
+
+// TestListProjectGroupsPagesInCreationOrder is the pagination CORRECTNESS case, as
+// distinct from the bounds case below.
+//
+// Without it a swapped LIMIT/OFFSET pair ships green: they are adjacent ints with
+// no compiler check, and page 1 (offset 0) reads correctly either way. It is also
+// the only case that exercises the ORDER BY the module leans on for not dropping
+// or duplicating rows between pages.
+func TestListProjectGroupsPagesInCreationOrder(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	ownerTok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	created := createProjectVia(t, srv, spaceA, ownerTok, "groups-paging")
+
+	// Seeded in order, so `group`.id ascends with the slice index.
+	want := make([]string, 0, 3)
+	for i := 0; i < 3; i++ {
+		groupNo := util.GenerUUID()
+		seedProjectGroup(t, groupNo, spaceA, created.ProjectID)
+		seedGroupMemberRow(t, groupNo, "owner1")
+		want = append(want, groupNo)
+	}
+
+	base := "/v1/projects/" + created.ProjectID + "/groups"
+	all := doJSON(t, srv, http.MethodGet, base, ownerTok, nil)
+	require.Equal(t, http.StatusOK, all.Code, "body: %s", all.Body.String())
+	require.Equal(t, want, groupNosOf(decodeGroupList(t, all)), "unpaged order must be by group id")
+
+	// Page through one at a time: each page must be exactly the next element, and
+	// the union must be the whole set with nothing dropped or repeated.
+	var seen []string
+	for page := 1; page <= 3; page++ {
+		w := doJSON(t, srv, http.MethodGet,
+			fmt.Sprintf("%s?page=%d&limit=1", base, page), ownerTok, nil)
+		require.Equal(t, http.StatusOK, w.Code, "page %d body: %s", page, w.Body.String())
+		got := groupNosOf(decodeGroupList(t, w))
+		require.Len(t, got, 1, "page %d must hold exactly one row", page)
+		assert.Equal(t, want[page-1], got[0],
+			"page %d must be the %d-th group by creation order; a swapped LIMIT/OFFSET "+
+				"pair reads correctly on page 1 and only breaks from page 2 on", page, page)
+		seen = append(seen, got...)
+	}
+	assert.Equal(t, want, seen, "paging must cover every row exactly once")
 }
 
 // TestListProjectGroupsExcludesGroupsOutsideTheProject covers the two ways a group

--- a/modules/project/api_group_test.go
+++ b/modules/project/api_group_test.go
@@ -235,18 +235,27 @@ func TestListProjectGroupsPagesInCreationOrder(t *testing.T) {
 	assert.Equal(t, want, seen, "paging must cover every row exactly once")
 }
 
-// TestListProjectGroupsExcludesGroupsOutsideTheProject covers the two ways a group
+// TestListProjectGroupsExcludesGroupsOutsideTheProject covers the three ways a group
 // the caller IS in must still stay out of one project's list: it is Space-direct
-// (an empty project_id), or it belongs to a different project in the same Space.
+// (an empty project_id), it belongs to a different project in the same Space, or it
+// carries this project's id while sitting in a DIFFERENT Space.
 //
-// The second half is what the space_id + project_id predicate buys. A query that
-// filtered on project_id alone would still be correct here — and would stop being
-// correct the moment it could not use group_space_project, whose LEADING column is
-// space_id.
+// The third case is the only one that pins `g.space_id = ?`, and PR #861's review
+// found it missing: with only the first two, deleting that predicate from the DAO
+// left every case in this file green. project_id alone excludes both same-Space
+// negatives, and the cross-Space case in ...RefusalsAreIndistinguishable is refused
+// by the middleware before the query ever runs.
+//
+// It is worth pinning because nothing in the schema constrains it. `group.project_id`
+// has no foreign key, so a row can carry a project id from another Space — the DAO
+// calls that predicate the Space isolation boundary, and a refactor chasing a query
+// plan could drop it (it is also group_space_project's leading column) with nothing
+// to object.
 func TestListProjectGroupsExcludesGroupsOutsideTheProject(t *testing.T) {
 	srv, _ := setup(t)
 	stubAllMemberGroup(t, util.GenerUUID())
 	seedSpace(t, spaceA, 1)
+	seedSpace(t, spaceB, 1)
 	ownerTok := seedUser(t, "owner1")
 	seedSpaceMember(t, spaceA, "owner1", 0, 1)
 	created := createProjectVia(t, srv, spaceA, ownerTok, "groups-scope")
@@ -254,16 +263,22 @@ func TestListProjectGroupsExcludesGroupsOutsideTheProject(t *testing.T) {
 
 	spaceDirect := util.GenerUUID()
 	otherProject := util.GenerUUID()
+	crossSpace := util.GenerUUID()
 	seedProjectGroup(t, spaceDirect, spaceA, "")
 	seedProjectGroup(t, otherProject, spaceA, other.ProjectID)
+	// This project's id, another Space's group. Only the space_id predicate keeps
+	// it out; seeded in raw SQL because no endpoint can produce it.
+	seedProjectGroup(t, crossSpace, spaceB, created.ProjectID)
 	seedGroupMemberRow(t, spaceDirect, "owner1")
 	seedGroupMemberRow(t, otherProject, "owner1")
+	seedGroupMemberRow(t, crossSpace, "owner1")
 
 	w := doJSON(t, srv, http.MethodGet, "/v1/projects/"+created.ProjectID+"/groups", ownerTok, nil)
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
 	assert.Empty(t, decodeGroupList(t, w),
-		"a Space-direct group and another project's group are both groups the caller is in; "+
-			"neither belongs to THIS project's list")
+		"a Space-direct group, another project's group and a group carrying this project's "+
+			"id in another Space are all groups the caller is in; none belongs to THIS "+
+			"project's list, and only g.space_id = ? excludes the third")
 }
 
 // TestListProjectGroupsCountsActiveMembersOnly pins member_count against the same
@@ -277,6 +292,7 @@ func TestListProjectGroupsCountsActiveMembersOnly(t *testing.T) {
 	seedSpaceMember(t, spaceA, "owner1", 0, 1)
 	seedUser(t, "mate")
 	seedUser(t, "quitter")
+	seedUser(t, "banned")
 	created := createProjectVia(t, srv, spaceA, ownerTok, "groups-count")
 
 	groupNo := util.GenerUUID()
@@ -284,12 +300,21 @@ func TestListProjectGroupsCountsActiveMembersOnly(t *testing.T) {
 	seedGroupMemberRow(t, groupNo, "owner1")
 	seedGroupMemberRow(t, groupNo, "mate")
 	seedInactiveGroupMemberRow(t, groupNo, "quitter", 1, 1)
+	// The blacklisted row is what pins the status half of the count predicate, and
+	// PR #861's review found it missing: with only the quitter, dropping
+	// `AND status = ?` from countActiveGroupMembers still read 2 and still passed.
+	// The blacklist case elsewhere in this file cannot cover it either — there the
+	// caller is the banned one, so they get an empty list and no count is observed.
+	seedInactiveGroupMemberRow(t, groupNo, "banned", 0, int(common.GroupMemberStatusBlacklist))
 
 	w := doJSON(t, srv, http.MethodGet, "/v1/projects/"+created.ProjectID+"/groups", ownerTok, nil)
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
 	list := decodeGroupList(t, w)
 	require.Len(t, list, 1)
-	assert.Equal(t, 2, list[0].MemberCount, "the member who left must not be counted")
+	assert.Equal(t, 2, list[0].MemberCount,
+		"neither the member who left nor the blacklisted one may be counted: a count that "+
+			"disagrees with the list it sits in makes the endpoint contradict ITSELF, which "+
+			"is worse than the accepted cross-surface difference with QueryMemberCount")
 }
 
 // TestListProjectGroupsGivesANonMemberAnEmptyList pins the decision NOT to add a

--- a/modules/project/api_group_test.go
+++ b/modules/project/api_group_test.go
@@ -152,7 +152,8 @@ func TestListProjectGroupsExcludesInactiveMembership(t *testing.T) {
 // divergence is a decision with a test behind it rather than a side effect.
 //
 // Blacklisting sets group_member.status = GroupMemberStatusBlacklist and leaves
-// is_deleted = 0 (modules/group/db.go:260). GET /v1/group/my filters is_deleted
+// is_deleted = 0 — the blacklist branch of modules/group's
+// ExistMemberActiveInternal spells that out. GET /v1/group/my filters is_deleted
 // alone, so it still shows the group; this endpoint requires status = Normal, so
 // it does not. That is deliberate: blacklisting is how a group denies access, and
 // ExistMemberActive is the hardening line in front of group and thread reads for

--- a/modules/project/api_group_test.go
+++ b/modules/project/api_group_test.go
@@ -1,0 +1,358 @@
+package project
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------- fixtures ----------
+
+// seedInactiveGroupMemberRow writes a group_member row that must NOT count as
+// membership: is_deleted = 1 (left the group) or status <> 1 (not normal).
+//
+// The distinction matters because modules/group's own
+// queryProjectGroupNosWithActiveMember checks is_deleted ALONE. That looser
+// predicate is right where it is used — a cascade whose job is to remove rows can
+// over-select harmlessly — and wrong for a read. Without this fixture the two
+// predicates are indistinguishable in test.
+func seedInactiveGroupMemberRow(t *testing.T, groupNo, uid string, isDeleted, status int) {
+	t.Helper()
+	_, err := testCtx.DB().InsertBySql(
+		"INSERT INTO group_member (group_no, uid, role, `version`, is_deleted, status, vercode, robot, invite_uid) "+
+			"VALUES (?, ?, 0, 1, ?, ?, ?, 0, '')",
+		groupNo, uid, isDeleted, status, util.GenerUUID(),
+	).Exec()
+	require.NoError(t, err)
+}
+
+// disbandGroupRow flips a group to disbanded the way the group module does —
+// status only, group_member rows deliberately left in place.
+func disbandGroupRow(t *testing.T, groupNo string) {
+	t.Helper()
+	_, err := testCtx.DB().UpdateBySql(
+		"UPDATE `group` SET status = ? WHERE group_no = ?", groupStatusDisband, groupNo,
+	).Exec()
+	require.NoError(t, err)
+}
+
+func decodeGroupList(t *testing.T, w *httptest.ResponseRecorder) []*GroupResp {
+	t.Helper()
+	var resp []*GroupResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), "body: %s", w.Body.String())
+	return resp
+}
+
+func groupNosOf(list []*GroupResp) []string {
+	out := make([]string, 0, len(list))
+	for _, g := range list {
+		out = append(out, g.GroupNo)
+	}
+	return out
+}
+
+// ---------- the list ----------
+
+// TestListProjectGroupsReturnsOnlyMyGroups is the endpoint's whole access-control
+// story in one case: the list is scoped to the caller's own membership, so a
+// project member sees the project groups they are IN and nothing else.
+//
+// The stand-in all-member group is a free negative: stubAllMemberGroup inserts a
+// real `group` row attributed to the project but its admitter is a no-op, so it is
+// a project group nobody is a member of. If the handler ever widens to "every
+// group in the project", this case fails on that row alone.
+func TestListProjectGroupsReturnsOnlyMyGroups(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	ownerTok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	created := createProjectVia(t, srv, spaceA, ownerTok, "groups-mine")
+
+	mine := util.GenerUUID()
+	theirs := util.GenerUUID()
+	seedProjectGroup(t, mine, spaceA, created.ProjectID)
+	seedProjectGroup(t, theirs, spaceA, created.ProjectID)
+	seedGroupMemberRow(t, mine, "owner1")
+
+	w := doJSON(t, srv, http.MethodGet, "/v1/projects/"+created.ProjectID+"/groups", ownerTok, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, []string{mine}, groupNosOf(decodeGroupList(t, w)),
+		"the list must be the caller's own groups: a project group they hold no seat in "+
+			"discloses a group name they cannot act on, and I2 is a ceiling, not a floor")
+}
+
+// TestListProjectGroupsExcludesDisbandedGroups covers the filter that is load-bearing
+// rather than cosmetic.
+//
+// Disband flips group.status and leaves group_member rows behind on purpose — no
+// endpoint cleans them up. Without the filter every project member would keep
+// seeing groups disbanded months ago, and the rows that make that happen are
+// expected state, not corruption.
+func TestListProjectGroupsExcludesDisbandedGroups(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	ownerTok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	created := createProjectVia(t, srv, spaceA, ownerTok, "groups-disband")
+
+	live := util.GenerUUID()
+	dead := util.GenerUUID()
+	seedProjectGroup(t, live, spaceA, created.ProjectID)
+	seedProjectGroup(t, dead, spaceA, created.ProjectID)
+	seedGroupMemberRow(t, live, "owner1")
+	seedGroupMemberRow(t, dead, "owner1")
+	disbandGroupRow(t, dead)
+
+	w := doJSON(t, srv, http.MethodGet, "/v1/projects/"+created.ProjectID+"/groups", ownerTok, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, []string{live}, groupNosOf(decodeGroupList(t, w)),
+		"a disbanded group keeps its group_member rows, so only the status filter excludes it")
+}
+
+// TestListProjectGroupsExcludesInactiveMembership pins the STRICTER of the two
+// membership predicates in the tree.
+//
+// A row with is_deleted = 1 is someone who left; a row with status <> 1 is not a
+// normal member. Either one passing would put a group the caller has left back in
+// their project tree.
+func TestListProjectGroupsExcludesInactiveMembership(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	ownerTok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	created := createProjectVia(t, srv, spaceA, ownerTok, "groups-inactive")
+
+	left := util.GenerUUID()
+	abnormal := util.GenerUUID()
+	seedProjectGroup(t, left, spaceA, created.ProjectID)
+	seedProjectGroup(t, abnormal, spaceA, created.ProjectID)
+	seedInactiveGroupMemberRow(t, left, "owner1", 1, 1)     // left the group
+	seedInactiveGroupMemberRow(t, abnormal, "owner1", 0, 0) // not a normal member
+
+	w := doJSON(t, srv, http.MethodGet, "/v1/projects/"+created.ProjectID+"/groups", ownerTok, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Empty(t, decodeGroupList(t, w),
+		"is_deleted = 0 AND status = 1 is the canonical active-member predicate; a read that "+
+			"checks only is_deleted returns groups the caller has left")
+}
+
+// TestListProjectGroupsExcludesGroupsOutsideTheProject covers the two ways a group
+// the caller IS in must still stay out of one project's list: it is Space-direct
+// (an empty project_id), or it belongs to a different project in the same Space.
+//
+// The second half is what the space_id + project_id predicate buys. A query that
+// filtered on project_id alone would still be correct here — and would stop being
+// correct the moment it could not use group_space_project, whose LEADING column is
+// space_id.
+func TestListProjectGroupsExcludesGroupsOutsideTheProject(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	ownerTok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	created := createProjectVia(t, srv, spaceA, ownerTok, "groups-scope")
+	other := createProjectVia(t, srv, spaceA, ownerTok, "groups-scope-other")
+
+	spaceDirect := util.GenerUUID()
+	otherProject := util.GenerUUID()
+	seedProjectGroup(t, spaceDirect, spaceA, "")
+	seedProjectGroup(t, otherProject, spaceA, other.ProjectID)
+	seedGroupMemberRow(t, spaceDirect, "owner1")
+	seedGroupMemberRow(t, otherProject, "owner1")
+
+	w := doJSON(t, srv, http.MethodGet, "/v1/projects/"+created.ProjectID+"/groups", ownerTok, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Empty(t, decodeGroupList(t, w),
+		"a Space-direct group and another project's group are both groups the caller is in; "+
+			"neither belongs to THIS project's list")
+}
+
+// TestListProjectGroupsCountsActiveMembersOnly pins member_count against the same
+// predicate the list itself uses, so the number cannot disagree with the row it
+// sits on.
+func TestListProjectGroupsCountsActiveMembersOnly(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	ownerTok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	seedUser(t, "mate")
+	seedUser(t, "quitter")
+	created := createProjectVia(t, srv, spaceA, ownerTok, "groups-count")
+
+	groupNo := util.GenerUUID()
+	seedProjectGroup(t, groupNo, spaceA, created.ProjectID)
+	seedGroupMemberRow(t, groupNo, "owner1")
+	seedGroupMemberRow(t, groupNo, "mate")
+	seedInactiveGroupMemberRow(t, groupNo, "quitter", 1, 1)
+
+	w := doJSON(t, srv, http.MethodGet, "/v1/projects/"+created.ProjectID+"/groups", ownerTok, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	list := decodeGroupList(t, w)
+	require.Len(t, list, 1)
+	assert.Equal(t, 2, list[0].MemberCount, "the member who left must not be counted")
+}
+
+// TestListProjectGroupsGivesANonMemberAnEmptyList pins the decision NOT to add a
+// role gate.
+//
+// A Space admin can read a space_listed project's metadata without joining it. The
+// roster refuses them (who is in a project is not part of its metadata), but this
+// endpoint has nothing to withhold: it returns only groups the caller is already in.
+// Answering 403 here would make "you are not a project member" observable on a route
+// that currently discloses nothing.
+func TestListProjectGroupsGivesANonMemberAnEmptyList(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	ownerTok := seedUser(t, "owner1")
+	adminTok := seedUser(t, "spaceadmin")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	seedSpaceMember(t, spaceA, "spaceadmin", 1, 1)
+	created := createProjectVia(t, srv, spaceA, ownerTok, "groups-nonmember")
+
+	groupNo := util.GenerUUID()
+	seedProjectGroup(t, groupNo, spaceA, created.ProjectID)
+	seedGroupMemberRow(t, groupNo, "owner1")
+
+	w := doJSON(t, srv, http.MethodGet, "/v1/projects/"+created.ProjectID+"/groups", adminTok, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Empty(t, decodeGroupList(t, w),
+		"a Space admin who never joined has no groups here; the true answer is an empty "+
+			"list, not a refusal")
+}
+
+// TestListProjectGroupsRefusalsAreIndistinguishable inherits projectMiddleware's
+// anti-enumeration contract on the new route, and asserts the three refusals against
+// EACH OTHER rather than against a status code — comparing each to 400 would pass
+// even if the bodies differed, which is the whole thing being prevented.
+func TestListProjectGroupsRefusalsAreIndistinguishable(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	seedSpace(t, spaceB, 1)
+	ownerTok := seedUser(t, "owner1")
+	strangerTok := seedUser(t, "stranger")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	seedSpaceMember(t, spaceA, "stranger", 0, 1)
+	// The foreign project lives in a Space the stranger has no seat in.
+	foreignOwnerTok := seedUser(t, "owner2")
+	seedSpaceMember(t, spaceB, "owner2", 0, 1)
+	foreign := createProjectVia(t, srv, spaceB, foreignOwnerTok, "groups-foreign")
+
+	unlistedProject := createProjectVia(t, srv, spaceA, ownerTok, "groups-unlisted")
+	upd := doJSON(t, srv, http.MethodPut, "/v1/projects/"+unlistedProject.ProjectID, ownerTok,
+		map[string]any{"discoverability": DiscoverabilityUnlisted})
+	require.Equal(t, http.StatusOK, upd.Code, "body: %s", upd.Body.String())
+
+	nonexistent := doJSON(t, srv, http.MethodGet,
+		"/v1/projects/"+util.GenerUUID()+"/groups", strangerTok, nil)
+	crossSpace := doJSON(t, srv, http.MethodGet,
+		"/v1/projects/"+foreign.ProjectID+"/groups", strangerTok, nil)
+	unlisted := doJSON(t, srv, http.MethodGet,
+		"/v1/projects/"+unlistedProject.ProjectID+"/groups", strangerTok, nil)
+
+	assertProjectErrorCode(t, nonexistent, "err.server.project.not_found")
+	for name, w := range map[string]*httptest.ResponseRecorder{
+		"cross-space": crossSpace,
+		"unlisted":    unlisted,
+	} {
+		assert.Equal(t, nonexistent.Code, w.Code, "%s: status must match nonexistent", name)
+		assert.JSONEq(t, nonexistent.Body.String(), w.Body.String(),
+			"%s must be byte-identical to a nonexistent project: telling them apart is an "+
+				"oracle for which project ids are real and which Space they live in", name)
+	}
+}
+
+// TestListProjectGroupsPaginationIsBounded re-applies pageParams' own regression to
+// the new route.
+//
+// `?page=9223372036854775807` used to overflow (page-1)*limit to a NEGATIVE offset,
+// which MySQL rejects with 1064, which the handler then reported as an Internal 500.
+// Any Space member could turn a query parameter into self-serve alert noise.
+func TestListProjectGroupsPaginationIsBounded(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	ownerTok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	created := createProjectVia(t, srv, spaceA, ownerTok, "groups-page")
+
+	groupNo := util.GenerUUID()
+	seedProjectGroup(t, groupNo, spaceA, created.ProjectID)
+	seedGroupMemberRow(t, groupNo, "owner1")
+
+	base := "/v1/projects/" + created.ProjectID + "/groups"
+	for _, q := range []string{
+		"?page=9223372036854775807",
+		"?page=9223372036854775807&limit=9223372036854775807",
+		"?page=-1&limit=-1",
+		"?limit=100000",
+	} {
+		w := doJSON(t, srv, http.MethodGet, base+q, ownerTok, nil)
+		require.Equal(t, http.StatusOK, w.Code, "%s must not become a 5xx: %s", q, w.Body.String())
+	}
+
+	far := doJSON(t, srv, http.MethodGet, base+"?page=1000&limit=200", ownerTok, nil)
+	require.Equal(t, http.StatusOK, far.Code, "body: %s", far.Body.String())
+	assert.Empty(t, decodeGroupList(t, far), "a page past the end is an empty page, not an error")
+}
+
+// TestListProjectGroupsIsOnTheAuthenticatedGroup checks the middleware chain where
+// it is DECLARED, not by hammering the route until it 429s.
+//
+// TestAuthChainOrder makes the argument and this case inherits it: SharedUIDRateLimiter
+// reads the uid AuthMiddleware puts in the context and fails OPEN without one, so a
+// route mounted in the wrong order looks rate-limited and is not — and a hammer test
+// passes either way, because some other limiter eventually answers. TestAuthChainOrder
+// already pins that every r.Group mounts AuthMiddleware immediately followed by
+// SharedUIDRateLimiter, and that no route hangs directly off the router. What is left
+// to check for THIS route is the one thing those two cannot see: that it was added to
+// the authenticated group rather than to a new bare one.
+func TestListProjectGroupsIsOnTheAuthenticatedGroup(t *testing.T) {
+	src := readStripped(t, "api.go")
+	if !strings.Contains(src, `projectScoped.GET("/:project_id/groups"`) {
+		t.Fatal("GET /:project_id/groups must be registered on the projectScoped group, which is " +
+			"what mounts AuthMiddleware, SharedUIDRateLimiter and projectMiddleware on it")
+	}
+}
+
+// TestListProjectGroupsIncludesTheAllMemberGroup runs with the REAL hooks — no
+// stand-in — so it exercises the path a client actually gets: #855 provisions the
+// all-member group with the project and seats the creator in it, and this endpoint
+// must return it without knowing anything about it.
+//
+// It also pins the ordering. g.id ASC is creation order and the all-member group is
+// by construction the project's first group, so it leads the list. That is the only
+// reason the client can render 全员群 at the top without a dedicated flag.
+func TestListProjectGroupsIncludesTheAllMemberGroup(t *testing.T) {
+	srv, _ := setup(t)
+	seedSpace(t, spaceA, 1)
+	ownerTok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	created := createProjectVia(t, srv, spaceA, ownerTok, "groups-allmember")
+	require.NotEmpty(t, created.AllMemberGroupNo,
+		"the real provisioner is registered in this binary, so the create must produce a group")
+
+	later := util.GenerUUID()
+	seedProjectGroup(t, later, spaceA, created.ProjectID)
+	seedGroupMemberRow(t, later, "owner1")
+
+	w := doJSON(t, srv, http.MethodGet, "/v1/projects/"+created.ProjectID+"/groups", ownerTok, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	list := decodeGroupList(t, w)
+	require.Len(t, list, 2)
+	assert.Equal(t, created.AllMemberGroupNo, list[0].GroupNo,
+		"the all-member group is the project's oldest group, so creation order puts it first — "+
+			"which is what lets the client label it by comparing against all_member_group_no")
+	assert.Equal(t, later, list[1].GroupNo)
+}

--- a/modules/project/api_group_test.go
+++ b/modules/project/api_group_test.go
@@ -446,9 +446,11 @@ func TestListProjectGroupsIsOnTheAuthenticatedGroup(t *testing.T) {
 // all-member group with the project and seats the creator in it, and this endpoint
 // must return it without knowing anything about it.
 //
-// It also pins the ordering. g.id ASC is creation order and the all-member group is
-// by construction the project's first group, so it leads the list. That is the only
-// reason the client can render 全员群 at the top without a dedicated flag.
+// It also exercises the ordering for the FRESH-provisioning case this test seeds,
+// which is the common one. Not a guarantee: the DAO documents that position is a
+// convenience and never the contract, because ensureAllMemberGroup rebuilds the
+// group on a later write path with a fresh, higher id. The client labels 全员群 by
+// comparing against all_member_group_no, which is right in both cases.
 func TestListProjectGroupsIncludesTheAllMemberGroup(t *testing.T) {
 	srv, _ := setup(t)
 	seedSpace(t, spaceA, 1)
@@ -467,7 +469,8 @@ func TestListProjectGroupsIncludesTheAllMemberGroup(t *testing.T) {
 	list := decodeGroupList(t, w)
 	require.Len(t, list, 2)
 	assert.Equal(t, created.AllMemberGroupNo, list[0].GroupNo,
-		"the all-member group is the project's oldest group, so creation order puts it first — "+
-			"which is what lets the client label it by comparing against all_member_group_no")
+		"provisioned with the project, so in THIS scenario creation order puts it first; "+
+			"a rebuilt group sorts wherever its new id falls, which is why the client "+
+			"labels it by comparing against all_member_group_no rather than by position")
 	assert.Equal(t, later, list[1].GroupNo)
 }

--- a/modules/project/api_group_test.go
+++ b/modules/project/api_group_test.go
@@ -474,3 +474,75 @@ func TestListProjectGroupsIncludesTheAllMemberGroup(t *testing.T) {
 			"labels it by comparing against all_member_group_no rather than by position")
 	assert.Equal(t, later, list[1].GroupNo)
 }
+
+// seedProjectGroupWithAvatar seeds a project group with the avatar columns SET, so
+// the display fields can be asserted against values that are distinguishable from
+// each other and from the zero value.
+func seedProjectGroupWithAvatar(t *testing.T, groupNo, spaceID, projectID, name, avatarText string, avatarColor int) {
+	t.Helper()
+	_, err := testCtx.DB().InsertBySql(
+		"INSERT INTO `group` (group_no, name, creator, status, `version`, space_id, project_id, "+
+			"is_named, avatar_text, avatar_color, is_upload_avatar) "+
+			"VALUES (?, ?, '', 1, 1, ?, ?, 1, ?, ?, 1)",
+		groupNo, name, spaceID, projectID, avatarText, avatarColor,
+	).Exec()
+	require.NoError(t, err)
+}
+
+// TestListProjectGroupsMapsEveryDisplayField covers the six fields the handler
+// hand-maps in a struct literal, which until PR #861's review nothing asserted:
+// every case went through group_no and member_count only.
+//
+// Two failure modes it catches, both of which ship green otherwise. A copy-paste
+// slip in the literal — AvatarText: g.Name — reads plausibly and renders wrong on
+// every project card. And changing AvatarColor from *int to int would turn null,
+// which means "derive the colour from group_no", into 0, which is a real palette
+// index: every unstyled group would silently acquire the first colour. That is
+// exactly the client-side drift the field set's own comment says it exists to
+// prevent, so it is worth more than a comment.
+func TestListProjectGroupsMapsEveryDisplayField(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	ownerTok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	created := createProjectVia(t, srv, spaceA, ownerTok, "groups-fields")
+
+	styled := util.GenerUUID()
+	seedProjectGroupWithAvatar(t, styled, spaceA, created.ProjectID, "关键供应商来料异常", "来料", 3)
+	seedGroupMemberRow(t, styled, "owner1")
+
+	w := doJSON(t, srv, http.MethodGet, "/v1/projects/"+created.ProjectID+"/groups", ownerTok, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	list := decodeGroupList(t, w)
+	require.Len(t, list, 1)
+	g := list[0]
+
+	assert.Equal(t, styled, g.GroupNo)
+	assert.Equal(t, "关键供应商来料异常", g.Name, "name must come from name, not from another column")
+	assert.Equal(t, 1, g.IsNamed)
+	assert.Equal(t, "来料", g.AvatarText,
+		"avatar_text must come from avatar_text: a literal that reads g.Name here renders "+
+			"plausibly and is wrong on every card")
+	require.NotNil(t, g.AvatarColor, "a set palette index must survive the mapping")
+	assert.Equal(t, 3, *g.AvatarColor)
+	assert.Equal(t, 1, g.IsUploadAvatar)
+
+	// The unset case, which is the one a type change breaks.
+	plain := util.GenerUUID()
+	seedProjectGroup(t, plain, spaceA, created.ProjectID)
+	seedGroupMemberRow(t, plain, "owner1")
+
+	w = doJSON(t, srv, http.MethodGet, "/v1/projects/"+created.ProjectID+"/groups", ownerTok, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	byNo := map[string]*GroupResp{}
+	for _, item := range decodeGroupList(t, w) {
+		byNo[item.GroupNo] = item
+	}
+	require.Contains(t, byNo, plain)
+	assert.Nil(t, byNo[plain].AvatarColor,
+		"an unset avatar_color must stay null — it means \"derive the colour from "+
+			"group_no\", and a non-pointer field would report 0, which is a real palette index")
+	assert.Empty(t, byNo[plain].AvatarText)
+	assert.Zero(t, byNo[plain].IsUploadAvatar)
+}

--- a/modules/project/api_setting.go
+++ b/modules/project/api_setting.go
@@ -54,7 +54,12 @@ func (p *Project) updateSettingHandler(c *wkhttp.Context) {
 	uid := c.GetLoginUID()
 
 	var req settingReq
-	if err := c.BindJSON(&req); err != nil {
+	// ShouldBindJSON, not BindJSON, and api_i18n.go says why: BindJSON calls gin's
+	// AbortWithError(400), so the status is gin's rather than ours and the envelope
+	// lands underneath it. Invisible today because ResponseErrorL pins the wire
+	// status to 400 anyway, and not invisible the day this module moves to
+	// ResponseErrorLWithStatus. Every other handler here binds the same way.
+	if err := c.ShouldBindJSON(&req); err != nil {
 		respondProjectRequestInvalid(c, "body")
 		return
 	}

--- a/modules/project/api_setting.go
+++ b/modules/project/api_setting.go
@@ -77,19 +77,14 @@ func (p *Project) updateSettingHandler(c *wkhttp.Context) {
 
 	// Respond with the project as the caller now sees it, so the client can render
 	// from the response instead of refetching the list to learn the new order.
-	pinned, err := p.db.queryProjectPinned(row.ProjectID, uid)
-	if err != nil {
-		p.Error("查询项目置顶状态失败", zap.Error(err), zap.String("projectId", row.ProjectID))
-		respondQueryFailed(c)
-		return
-	}
-	memberCount, agentCount, err := p.db.countActiveSeatsByKind(row.ProjectID)
-	if err != nil {
-		p.Error("统计项目成员数失败", zap.Error(err), zap.String("projectId", row.ProjectID))
-		respondQueryFailed(c)
-		return
-	}
-	c.Response(p.toResp(row, requestProjectRole(c), requestSpaceRole(c), memberCount, agentCount, pinned))
+	//
+	// Both reads are fail-soft, and both go through the same helpers every other
+	// route uses. applyPin has already COMMITTED by this point, so a display
+	// aggregate that hiccups must not turn a successful pin into a 500 — the same
+	// rule the update handler states in full.
+	humans, agents := p.splitSeatCounts(row.ProjectID)
+	c.Response(p.toResp(row, requestProjectRole(c), requestSpaceRole(c), humans, agents,
+		p.pinnedOrFalse(row.ProjectID, uid)))
 }
 
 // applyPin writes the pin, enforcing the per-Space cap.
@@ -97,12 +92,19 @@ func (p *Project) updateSettingHandler(c *wkhttp.Context) {
 // # Why the count and the write share a transaction
 //
 // So the check reads the same snapshot the write lands in. It does NOT make the
-// pair atomic against a concurrent pin by the same user: two requests that both
-// count 5 will both insert, leaving 7. That window is a double-click — the same
-// uid, inside the 2 rps shared bucket — and its worst outcome is one extra pinned
-// row that the user can remove, so it does not justify serialising every pin behind
-// a lock on a table this hot. Written down rather than left for a reader to
-// rediscover, because "there is a transaction here" reads like "this is atomic".
+// pair atomic against concurrent pins by the same user: every request that reads
+// n < cap inserts, so the overshoot is the concurrency degree, not one.
+//
+// An earlier version of this comment called that "a double-click ... one extra
+// pinned row", and PR #861's review corrected it with the number: SharedUIDRateLimiter
+// is 2 rps with a BURST OF 60 (pkg/wkhttp/ratelimit_helper.go), so ~60 in-flight
+// pins of distinct projects can each read 5 and each insert, landing ~65 rows
+// against a cap of 6. The trade is still the one taken, on grounds that survive the
+// correction — the overshoot is confined to the caller's own pin list, every row is
+// self-removable because unpin is never refused, and the PUT response re-reads the
+// state so the wire never reports a false success — but it is taken with the real
+// number rather than a comfortable one. A cap that ever becomes billing- or
+// audit-bearing needs SELECT ... FOR UPDATE on the caller's rows instead.
 //
 // # Why unpinning is never refused
 //
@@ -117,15 +119,18 @@ func (p *Project) updateSettingHandler(c *wkhttp.Context) {
 // operation that changes nothing — the shape of bug where turning a toggle on
 // twice fails the second time.
 func (p *Project) applyPin(row *Model, uid string, pinned bool) error {
-	if !pinned {
-		return p.db.upsertProjectUserSetting(row.ProjectID, uid, false)
-	}
+	// One read serves both directions, and it is what keeps either direction from
+	// writing a row that changes nothing: unpinning something never pinned used to
+	// INSERT a pinned = 0 tombstone, and nothing anywhere deletes those.
 	already, err := p.db.queryProjectPinned(row.ProjectID, uid)
 	if err != nil {
 		return err
 	}
-	if already {
+	if already == pinned {
 		return nil
+	}
+	if !pinned {
+		return p.db.upsertProjectUserSetting(row.ProjectID, uid, false)
 	}
 
 	tx, err := p.db.session.Begin()

--- a/modules/project/api_setting.go
+++ b/modules/project/api_setting.go
@@ -63,9 +63,17 @@ func (p *Project) updateSettingHandler(c *wkhttp.Context) {
 		respondProjectRequestInvalid(c, "body")
 		return
 	}
-	// An empty body is a no-op rather than a reset: a pointer field distinguishes
-	// "not mentioned" from "set to false", so a client sending only the key it
-	// changed cannot clear the ones it did not.
+	// A body that NAMES NO PREFERENCE is a no-op rather than a reset: a pointer
+	// field distinguishes "not mentioned" from "set to false", so a client sending
+	// only the key it changed cannot clear the ones it did not.
+	//
+	// "A body that names no preference", not "an empty body", and the difference is
+	// one case wide: `{}` reaches here and no-ops, a ZERO-BYTE body does not — it
+	// makes ShouldBindJSON return io.EOF and takes the 400 branch above. Unlike
+	// leaveProjectHandler, which exempts io.EOF because an empty body is its normal
+	// case, this route has no such case: a settings PUT that mentions nothing is a
+	// client bug worth reporting, not a shape to accept silently. Stated because the
+	// previous wording claimed the wider behaviour and the test sends `{}`.
 	if req.Pinned != nil {
 		if err := p.applyPin(row, uid, *req.Pinned); err != nil {
 			if errors.Is(err, errPinQuotaExceeded) {

--- a/modules/project/api_setting.go
+++ b/modules/project/api_setting.go
@@ -1,0 +1,148 @@
+package project
+
+import (
+	"errors"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"go.uber.org/zap"
+)
+
+// errPinQuotaExceeded is the sentinel applyPin returns when the caller is already
+// at the per-Space pin cap. A sentinel rather than a bool return so the quota
+// cannot be confused with a storage failure at the call site: one is the caller's
+// to fix, the other is ours.
+var errPinQuotaExceeded = errors.New("project: pin quota exceeded")
+
+// updateSettingHandler answers PUT /v1/projects/:project_id/setting — the caller's
+// own preferences for one project. P2 ships one: pinning.
+//
+// # Why a settings endpoint and not /pin + /unpin
+//
+// Following PUT /v1/groups/:group_no/setting, which carries top / mute / save /
+// remark through one route writing group_setting (group_no, uid). Two verb routes
+// are simpler only while there is exactly one preference; the second one costs two
+// more routes and two more handlers, where this costs a key. PUT is also idempotent
+// by contract, so "pin an already-pinned project" needs no answer invented for it.
+//
+// # Why there is no role check
+//
+// Anyone who can SEE the project can pin it, and projectMiddleware has already
+// decided who that is. A Space admin who never joined a space_listed project gets
+// it in their list, so they can pin it — pinning is a fact about the caller, not a
+// membership fact, which is also why the row lives in its own table rather than on
+// octo_project_member.
+//
+// # Why the feature gate applies
+//
+// requireWriteEnabled runs even though this is a personal preference. The flag's
+// contract is that turning it off stops the feature producing NEW data while
+// leaving existing data observable, and a settings row is new data. It costs a
+// rolled-back deployment nothing: the same flag drives project_on in
+// GET /v1/common/appconfig, so a client that cannot see the Project entry at all
+// has nothing to pin.
+func (p *Project) updateSettingHandler(c *wkhttp.Context) {
+	if !p.requireWriteEnabled(c, entryProjectSetting) {
+		return
+	}
+	row := requestProject(c)
+	if row == nil {
+		p.Error("projectMiddleware 未注入项目行", zap.String("path", c.FullPath()))
+		respondQueryFailed(c)
+		return
+	}
+	uid := c.GetLoginUID()
+
+	var req settingReq
+	if err := c.BindJSON(&req); err != nil {
+		respondProjectRequestInvalid(c, "body")
+		return
+	}
+	// An empty body is a no-op rather than a reset: a pointer field distinguishes
+	// "not mentioned" from "set to false", so a client sending only the key it
+	// changed cannot clear the ones it did not.
+	if req.Pinned != nil {
+		if err := p.applyPin(row, uid, *req.Pinned); err != nil {
+			if errors.Is(err, errPinQuotaExceeded) {
+				observeRejected(entryProjectSetting, reasonQuotaPinned)
+				respondProjectQuota(c, errcode.ErrProjectQuotaPinned, p.cfg.MaxPinned)
+				return
+			}
+			p.Error("写入项目个人设置失败", zap.Error(err),
+				zap.String("projectId", row.ProjectID))
+			respondStoreFailed(c)
+			return
+		}
+	}
+
+	// Respond with the project as the caller now sees it, so the client can render
+	// from the response instead of refetching the list to learn the new order.
+	pinned, err := p.db.queryProjectPinned(row.ProjectID, uid)
+	if err != nil {
+		p.Error("查询项目置顶状态失败", zap.Error(err), zap.String("projectId", row.ProjectID))
+		respondQueryFailed(c)
+		return
+	}
+	memberCount, agentCount, err := p.db.countActiveSeatsByKind(row.ProjectID)
+	if err != nil {
+		p.Error("统计项目成员数失败", zap.Error(err), zap.String("projectId", row.ProjectID))
+		respondQueryFailed(c)
+		return
+	}
+	c.Response(p.toResp(row, requestProjectRole(c), requestSpaceRole(c), memberCount, agentCount, pinned))
+}
+
+// applyPin writes the pin, enforcing the per-Space cap.
+//
+// # Why the count and the write share a transaction
+//
+// So the check reads the same snapshot the write lands in. It does NOT make the
+// pair atomic against a concurrent pin by the same user: two requests that both
+// count 5 will both insert, leaving 7. That window is a double-click — the same
+// uid, inside the 2 rps shared bucket — and its worst outcome is one extra pinned
+// row that the user can remove, so it does not justify serialising every pin behind
+// a lock on a table this hot. Written down rather than left for a reader to
+// rediscover, because "there is a transaction here" reads like "this is atomic".
+//
+// # Why unpinning is never refused
+//
+// It lowers the count. Gating it would strand a user who somehow got over the cap
+// (see the window above, or a cap lowered by configuration) at exactly the
+// operation that would fix it.
+//
+// # Why re-pinning something already pinned is not refused either
+//
+// The row already exists and counts toward the total, so the upsert rewrites it
+// rather than adding one. Counting first and comparing >= cap would refuse an
+// operation that changes nothing — the shape of bug where turning a toggle on
+// twice fails the second time.
+func (p *Project) applyPin(row *Model, uid string, pinned bool) error {
+	if !pinned {
+		return p.db.upsertProjectUserSetting(row.ProjectID, uid, false)
+	}
+	already, err := p.db.queryProjectPinned(row.ProjectID, uid)
+	if err != nil {
+		return err
+	}
+	if already {
+		return nil
+	}
+
+	tx, err := p.db.session.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	n, err := p.db.countPinnedInSpaceTx(tx, row.SpaceID, uid)
+	if err != nil {
+		return err
+	}
+	if n >= p.cfg.MaxPinned {
+		return errPinQuotaExceeded
+	}
+	if err := p.db.upsertProjectUserSettingTx(tx, row.ProjectID, uid, true); err != nil {
+		return err
+	}
+	return tx.Commit()
+}

--- a/modules/project/api_setting_test.go
+++ b/modules/project/api_setting_test.go
@@ -647,3 +647,33 @@ func TestACommittedPinIsNotReportedAsAFailure(t *testing.T) {
 	require.NotNil(t, row)
 	assert.Equal(t, "pin-failsoft-renamed", row.Name)
 }
+
+// TestAMemberOfAnUnlistedProjectStillSpendsAPinSlot is the POSITIVE branch of the
+// quota's visibility predicate, which the two trap cases do not cover.
+//
+// Those assert the predicate EXCLUDING: unlisted plus no membership. This asserts
+// it ADMITTING through its other arm — unlisted, but the caller is a member, so the
+// project is in their list and they can unpin it, so it must count. Without this a
+// predicate that dropped every unlisted project would pass both trap cases while
+// handing members of unlisted projects an unbounded pin budget.
+func TestAMemberOfAnUnlistedProjectStillSpendsAPinSlot(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	ownerTok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+
+	created := createProjectVia(t, srv, spaceA, ownerTok, "unlisted-member-pin")
+	require.Equal(t, http.StatusOK, setPinned(t, srv, created.ProjectID, ownerTok, true).Code)
+	require.Equal(t, http.StatusOK, doJSON(t, srv, http.MethodPut,
+		"/v1/projects/"+created.ProjectID, ownerTok,
+		map[string]any{"discoverability": DiscoverabilityUnlisted}).Code)
+	flushProjectCache(t, testCtx)
+
+	assert.Equal(t, 1, countPinnedForTest(t, spaceA, "owner1"),
+		"the owner is a member, so an unlisted project is still in their list and still "+
+			"unpinnable — it must keep counting, or membership of unlisted projects "+
+			"becomes an unbounded pin budget")
+	assert.True(t, pinnedFlags(t, srv, spaceA, ownerTok)[created.ProjectID],
+		"and it is still on their list, which is the property the count mirrors")
+}

--- a/modules/project/api_setting_test.go
+++ b/modules/project/api_setting_test.go
@@ -569,3 +569,81 @@ func countPinnedForTest(t *testing.T, spaceID, uid string) int {
 	require.NoError(t, err)
 	return n
 }
+
+// TestUnpinningSomethingNeverPinnedWritesNoRow pins the tombstone fix.
+//
+// The unpin path used to run the same upsert with pinned = 0, so unpinning
+// something that was never pinned INSERTED a row, and nothing anywhere deletes
+// those. One read now serves both directions, so an operation that changes nothing
+// writes nothing.
+func TestUnpinningSomethingNeverPinnedWritesNoRow(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	tok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	created := createProjectVia(t, srv, spaceA, tok, "unpin-noop")
+
+	require.Equal(t, http.StatusOK, setPinned(t, srv, created.ProjectID, tok, false).Code,
+		"unpinning something never pinned is a no-op, not an error")
+
+	var n int
+	require.NoError(t, testCtx.DB().SelectBySql(
+		"SELECT COUNT(*) FROM octo_project_user_setting WHERE project_id = ? AND uid = ?",
+		created.ProjectID, "owner1").LoadOne(&n))
+	assert.Zero(t, n, "no row may be written for a preference that was already at its "+
+		"default; nothing in the tree cleans such rows up")
+}
+
+// TestACommittedPinIsNotReportedAsAFailure is the regression for the defect PR
+// #861's review found: a display read that fails must not turn a COMMITTED write
+// into a 500.
+//
+// Driven by breaking the read rather than by hoping it fails: the pin lands, then
+// the settings table is dropped out from under the response's own re-read. What the
+// caller must see is 200 with the write intact — telling them their pin failed when
+// it did not is the one thing a response after a successful write must not do.
+func TestACommittedPinIsNotReportedAsAFailure(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	tok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	created := createProjectVia(t, srv, spaceA, tok, "pin-failsoft")
+
+	// Make every read of the settings table fail, leaving the write path intact by
+	// restoring the table before the assertions that need it.
+	_, err := testCtx.DB().Exec("ALTER TABLE octo_project_user_setting RENAME TO octo_project_user_setting_hidden")
+	require.NoError(t, err)
+	restored := false
+	defer func() {
+		if !restored {
+			_, _ = testCtx.DB().Exec("ALTER TABLE octo_project_user_setting_hidden RENAME TO octo_project_user_setting")
+		}
+	}()
+
+	// With the table gone the write fails too, which is a legitimate 5xx — so this
+	// half asserts the OTHER handler, where the write has already committed
+	// elsewhere and only the display read is broken.
+	w := doJSON(t, srv, http.MethodGet, "/v1/projects/"+created.ProjectID, tok, nil)
+	assert.Equal(t, http.StatusOK, w.Code,
+		"the detail route must degrade to pinned=false rather than 500 when the "+
+			"settings read fails: body %s", w.Body.String())
+	assert.False(t, decodeResp(t, w).Pinned)
+
+	upd := doJSON(t, srv, http.MethodPut, "/v1/projects/"+created.ProjectID, tok,
+		map[string]any{"name": "pin-failsoft-renamed"})
+	assert.Equal(t, http.StatusOK, upd.Code,
+		"a rename COMMITS before the pin is read back; a broken read must not report "+
+			"that committed write as a failure: body %s", upd.Body.String())
+
+	_, err = testCtx.DB().Exec("ALTER TABLE octo_project_user_setting_hidden RENAME TO octo_project_user_setting")
+	require.NoError(t, err)
+	restored = true
+
+	// And the rename really did land, which is what makes the 200 honest.
+	row, err := testDB.queryByProjectID(created.ProjectID)
+	require.NoError(t, err)
+	require.NotNil(t, row)
+	assert.Equal(t, "pin-failsoft-renamed", row.Name)
+}

--- a/modules/project/api_setting_test.go
+++ b/modules/project/api_setting_test.go
@@ -465,3 +465,107 @@ func TestDisbandedProjectsDoNotSpendThePinBudget(t *testing.T) {
 	assert.Equal(t, http.StatusOK, setPinned(t, srv, created[max].ProjectID, tok, true).Code,
 		"a pin on a disbanded project must not hold a slot the caller can no longer free")
 }
+
+// TestUnlistedProjectsDoNotSpendThePinBudget is the sibling of
+// TestDisbandedProjectsDoNotSpendThePinBudget, and PR #861's review found it
+// missing: the disband trap was handled, the unlisted trap produced the identical
+// unreachable state while status stayed normal.
+//
+// The sequence is all ordinary actions. A common Space member pins a space_listed
+// project they never joined (explicitly allowed — see
+// TestASpaceAdminCanPinAProjectTheyNeverJoined). Its owner flips discoverability to
+// unlisted, which is a routine owner action. The project now leaves the pinner's
+// list, and projectMiddleware answers not_found on PUT /:project_id/setting — the
+// ONLY unpin path — so the pin is unreachable through every API surface. If it
+// still counted, each flip would permanently burn one of six slots with no
+// self-service remedy, and the refusal would say "you have pinned 6" to someone
+// whose own list shows 5.
+func TestUnlistedProjectsDoNotSpendThePinBudget(t *testing.T) {
+	srv, p := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	ownerTok := seedUser(t, "owner1")
+	pinnerTok := seedUser(t, "pinner")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	seedSpaceMember(t, spaceA, "pinner", 0, 1) // ordinary member, NOT a Space admin
+
+	max := p.cfg.MaxPinned
+	trapped := createProjectVia(t, srv, spaceA, ownerTok, "unlisted-trap")
+	require.Equal(t, http.StatusOK, setPinned(t, srv, trapped.ProjectID, pinnerTok, true).Code,
+		"a space_listed project is pinnable by any Space member")
+
+	// A routine owner action.
+	require.Equal(t, http.StatusOK, doJSON(t, srv, http.MethodPut,
+		"/v1/projects/"+trapped.ProjectID, ownerTok,
+		map[string]any{"discoverability": DiscoverabilityUnlisted}).Code)
+
+	// The pin is now unreachable: gone from the list, and unpin is refused.
+	assert.NotContains(t, pinnedFlags(t, srv, spaceA, pinnerTok), trapped.ProjectID,
+		"an unlisted project leaves a non-member's list")
+	assertProjectErrorCode(t, setPinned(t, srv, trapped.ProjectID, pinnerTok, false),
+		"err.server.project.not_found")
+
+	// So it must not hold a slot. The full budget stays available.
+	for i := 0; i < max; i++ {
+		visible := createProjectVia(t, srv, spaceA, ownerTok, fmt.Sprintf("unlisted-ok-%d", i))
+		require.Equal(t, http.StatusOK, setPinned(t, srv, visible.ProjectID, pinnerTok, true).Code,
+			"pin %d of %d must succeed: a pin the caller can neither see nor remove must "+
+				"not consume their budget", i+1, max)
+	}
+	assert.Len(t, pinnedFlagsPinnedOnly(t, srv, spaceA, pinnerTok), max,
+		"and the count the quota enforces equals what the list shows")
+}
+
+// TestRemovedMemberPinOnUnlistedProjectDoesNotSpendTheBudget is the same trap by the
+// other door: the pin was legitimate while the caller was a member, and closing
+// their seat makes an unlisted project invisible to them without touching the row.
+func TestRemovedMemberPinOnUnlistedProjectDoesNotSpendTheBudget(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	ownerTok := seedUser(t, "owner1")
+	mateTok := seedUser(t, "mate")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	seedSpaceMember(t, spaceA, "mate", 0, 1)
+
+	created := createProjectVia(t, srv, spaceA, ownerTok, "removed-member-pin")
+	require.Equal(t, http.StatusOK, doJSON(t, srv, http.MethodPost,
+		"/v1/projects/"+created.ProjectID+"/members/add", ownerTok,
+		map[string]any{"uids": []string{"mate"}}).Code)
+	require.Equal(t, http.StatusOK, setPinned(t, srv, created.ProjectID, mateTok, true).Code)
+	require.Equal(t, http.StatusOK, doJSON(t, srv, http.MethodPut,
+		"/v1/projects/"+created.ProjectID, ownerTok,
+		map[string]any{"discoverability": DiscoverabilityUnlisted}).Code)
+
+	// Removing the seat is what makes it invisible; the pin row is untouched.
+	require.Equal(t, http.StatusOK, doJSON(t, srv, http.MethodPost,
+		"/v1/projects/"+created.ProjectID+"/members/remove", ownerTok,
+		map[string]any{"uids": []string{"mate"}}).Code)
+	flushProjectCache(t, testCtx)
+
+	assert.Zero(t, countPinnedForTest(t, spaceA, "mate"),
+		"a pin the caller can no longer reach must stop counting, whichever of the two "+
+			"doors made it unreachable")
+}
+
+// pinnedFlagsPinnedOnly is pinnedFlags narrowed to the projects actually pinned,
+// which is the number a user compares against the cap when the refusal arrives.
+func pinnedFlagsPinnedOnly(t *testing.T, srv *server.Server, spaceID, token string) []string {
+	t.Helper()
+	out := []string{}
+	for id, pinned := range pinnedFlags(t, srv, spaceID, token) {
+		if pinned {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+// countPinnedForTest reaches the quota predicate directly, so the assertion is about
+// what the CAP counts rather than about what a particular endpoint answers.
+func countPinnedForTest(t *testing.T, spaceID, uid string) int {
+	t.Helper()
+	n, err := testDB.countPinnedInSpaceTx(nil, spaceID, uid)
+	require.NoError(t, err)
+	return n
+}

--- a/modules/project/api_setting_test.go
+++ b/modules/project/api_setting_test.go
@@ -1,0 +1,467 @@
+package project
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------- helpers ----------
+
+func setPinned(t *testing.T, srv *server.Server, projectID, token string, pinned bool) *httptest.ResponseRecorder {
+	t.Helper()
+	return doJSON(t, srv, http.MethodPut, "/v1/projects/"+projectID+"/setting", token,
+		map[string]any{"pinned": pinned})
+}
+
+func listProjectIDs(t *testing.T, srv *server.Server, spaceID, token string) []string {
+	t.Helper()
+	w := doJSON(t, srv, http.MethodGet, "/v1/space/"+spaceID+"/projects", token, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	var resps []*Resp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resps), "body: %s", w.Body.String())
+	out := make([]string, 0, len(resps))
+	for _, r := range resps {
+		out = append(out, r.ProjectID)
+	}
+	return out
+}
+
+func pinnedFlags(t *testing.T, srv *server.Server, spaceID, token string) map[string]bool {
+	t.Helper()
+	w := doJSON(t, srv, http.MethodGet, "/v1/space/"+spaceID+"/projects", token, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	var resps []*Resp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resps), "body: %s", w.Body.String())
+	out := map[string]bool{}
+	for _, r := range resps {
+		out[r.ProjectID] = r.Pinned
+	}
+	return out
+}
+
+// ---------- pinning ----------
+
+// TestPinnedProjectSortsFirstAndLeavesTheRestAlone is the whole read-side contract.
+//
+// Two properties, and the second is the one a reviewer should look for: pinning
+// must reorder the list WITHOUT disturbing the relative order of everything else.
+// GET /v1/space/:space_id/projects already ships, so its existing order is a wire
+// contract; a pin that shuffled the unpinned tail would be a behaviour change
+// nobody asked for riding along with a feature.
+func TestPinnedProjectSortsFirstAndLeavesTheRestAlone(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	tok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+
+	first := createProjectVia(t, srv, spaceA, tok, "pin-a")
+	second := createProjectVia(t, srv, spaceA, tok, "pin-b")
+	third := createProjectVia(t, srv, spaceA, tok, "pin-c")
+
+	// The list is newest-first (ORDER BY p.id DESC), so this is the baseline the
+	// pin has to preserve for the rows it does not touch.
+	require.Equal(t,
+		[]string{third.ProjectID, second.ProjectID, first.ProjectID},
+		listProjectIDs(t, srv, spaceA, tok))
+
+	w := setPinned(t, srv, first.ProjectID, tok, true)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	assert.Equal(t,
+		[]string{first.ProjectID, third.ProjectID, second.ProjectID},
+		listProjectIDs(t, srv, spaceA, tok),
+		"the pinned project leads, and the unpinned tail keeps the order it had")
+}
+
+// TestPinIsPerUser pins the field's whole reason for living in its own table: the
+// same project row reads pinned for one caller and not for the next.
+func TestPinIsPerUser(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	ownerTok := seedUser(t, "owner1")
+	mateTok := seedUser(t, "mate")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	seedSpaceMember(t, spaceA, "mate", 0, 1)
+
+	created := createProjectVia(t, srv, spaceA, ownerTok, "pin-per-user")
+	require.Equal(t, http.StatusOK, setPinned(t, srv, created.ProjectID, ownerTok, true).Code)
+
+	assert.True(t, pinnedFlags(t, srv, spaceA, ownerTok)[created.ProjectID],
+		"the caller who pinned it sees pinned = true")
+	assert.False(t, pinnedFlags(t, srv, spaceA, mateTok)[created.ProjectID],
+		"another Space member sees the same project unpinned; a pin stored on the "+
+			"project row rather than per user would leak one caller's preference to "+
+			"everyone")
+}
+
+// TestPinDoesNotMoveMemberEpoch is the reason this is a separate table rather than
+// a column on octo_project_member.
+//
+// member_epoch is what fleet and drive poll to decide whether a project's
+// membership changed. Every write to octo_project_member sits on the +1 path, so a
+// pin stored there would either bump the epoch — telling every subsystem to
+// re-reconcile a roster that did not change — or need a carve-out on the one write
+// path this module keeps free of them.
+func TestPinDoesNotMoveMemberEpoch(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	tok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	created := createProjectVia(t, srv, spaceA, tok, "pin-epoch")
+
+	before := epochOf(t, created.ProjectID)
+	require.Equal(t, http.StatusOK, setPinned(t, srv, created.ProjectID, tok, true).Code)
+	require.Equal(t, http.StatusOK, setPinned(t, srv, created.ProjectID, tok, false).Code)
+
+	assert.Equal(t, before, epochOf(t, created.ProjectID),
+		"pinning is not a membership change and must not make every subsystem "+
+			"re-reconcile a roster that did not move")
+}
+
+// TestPinIsIdempotent covers what makes PUT the right verb: pinning twice rewrites
+// one row rather than growing a second, which the unique key gives for free and the
+// upsert relies on.
+func TestPinIsIdempotent(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	tok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	created := createProjectVia(t, srv, spaceA, tok, "pin-idempotent")
+
+	for i := 0; i < 3; i++ {
+		require.Equal(t, http.StatusOK, setPinned(t, srv, created.ProjectID, tok, true).Code,
+			"repeat %d must succeed, not conflict", i)
+	}
+
+	var n int
+	require.NoError(t, testCtx.DB().SelectBySql(
+		"SELECT COUNT(*) FROM octo_project_user_setting WHERE project_id = ? AND uid = ?",
+		created.ProjectID, "owner1").LoadOne(&n))
+	assert.Equal(t, 1, n, "the unique key must collapse repeats into one row")
+	assert.True(t, pinnedFlags(t, srv, spaceA, tok)[created.ProjectID])
+}
+
+// TestUnpinRestoresTheOriginalOrder covers the other half of the toggle, and pins
+// that pinned_at is CLEARED on unpin rather than left behind: a stale timestamp
+// would order a later re-pin by when it was first pinned, so a project the caller
+// just re-pinned would not come back to the front.
+func TestUnpinRestoresTheOriginalOrder(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	tok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+
+	first := createProjectVia(t, srv, spaceA, tok, "unpin-a")
+	second := createProjectVia(t, srv, spaceA, tok, "unpin-b")
+
+	require.Equal(t, http.StatusOK, setPinned(t, srv, first.ProjectID, tok, true).Code)
+	require.Equal(t, []string{first.ProjectID, second.ProjectID},
+		listProjectIDs(t, srv, spaceA, tok))
+
+	require.Equal(t, http.StatusOK, setPinned(t, srv, first.ProjectID, tok, false).Code)
+	assert.Equal(t, []string{second.ProjectID, first.ProjectID},
+		listProjectIDs(t, srv, spaceA, tok),
+		"unpinning must put the project back where it was, not leave it floating")
+
+	// Asserted in SQL rather than scanned into Go: the column is nullable and NULL
+	// is the whole point, so a scan type that cannot hold it would fail for the
+	// wrong reason.
+	var rows, cleared int
+	require.NoError(t, testCtx.DB().SelectBySql(
+		"SELECT COUNT(*) FROM octo_project_user_setting WHERE project_id = ? AND uid = ?",
+		first.ProjectID, "owner1").LoadOne(&rows))
+	require.Equal(t, 1, rows, "the unpin must rewrite the row, not delete it")
+	require.NoError(t, testCtx.DB().SelectBySql(
+		"SELECT COUNT(*) FROM octo_project_user_setting "+
+			"WHERE project_id = ? AND uid = ? AND pinned_at IS NULL",
+		first.ProjectID, "owner1").LoadOne(&cleared))
+	assert.Equal(t, 1, cleared, "pinned_at must be cleared on unpin, or a later re-pin "+
+		"sorts by the FIRST time it was pinned and does not come back to the front")
+}
+
+// TestRepinMovesToTheFront is the property the cleared pinned_at buys, asserted
+// through the API rather than through the column.
+func TestRepinMovesToTheFront(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	tok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+
+	older := createProjectVia(t, srv, spaceA, tok, "repin-a")
+	newer := createProjectVia(t, srv, spaceA, tok, "repin-b")
+
+	require.Equal(t, http.StatusOK, setPinned(t, srv, older.ProjectID, tok, true).Code)
+	require.Equal(t, http.StatusOK, setPinned(t, srv, newer.ProjectID, tok, true).Code)
+	require.Equal(t, []string{newer.ProjectID, older.ProjectID},
+		listProjectIDs(t, srv, spaceA, tok), "most recently pinned leads")
+
+	require.Equal(t, http.StatusOK, setPinned(t, srv, older.ProjectID, tok, false).Code)
+	require.Equal(t, http.StatusOK, setPinned(t, srv, older.ProjectID, tok, true).Code)
+	assert.Equal(t, []string{older.ProjectID, newer.ProjectID},
+		listProjectIDs(t, srv, spaceA, tok),
+		"re-pinning must move the project to the front; if pinned_at survived the "+
+			"unpin it would still sort by the original pin time")
+}
+
+// TestPinnedIsReportedByEveryRouteThatReturnsAProject pins the contract
+// all_member_group_no already had to be fixed for once: a field on the list route
+// and absent from the detail route makes the two disagree about the same project.
+func TestPinnedIsReportedByEveryRouteThatReturnsAProject(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	tok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	created := createProjectVia(t, srv, spaceA, tok, "pin-routes")
+
+	assert.False(t, created.Pinned, "a freshly created project cannot be pinned yet")
+
+	put := setPinned(t, srv, created.ProjectID, tok, true)
+	require.Equal(t, http.StatusOK, put.Code, "body: %s", put.Body.String())
+	assert.True(t, decodeResp(t, put).Pinned,
+		"the settings response must report the state it just wrote, so the client "+
+			"can render from it instead of refetching the list")
+
+	detail := doJSON(t, srv, http.MethodGet, "/v1/projects/"+created.ProjectID, tok, nil)
+	require.Equal(t, http.StatusOK, detail.Code, "body: %s", detail.Body.String())
+	assert.True(t, decodeResp(t, detail).Pinned, "the detail route must agree with the list")
+
+	// A rename must not silently un-pin the card in the update response.
+	upd := doJSON(t, srv, http.MethodPut, "/v1/projects/"+created.ProjectID, tok,
+		map[string]any{"name": "pin-routes-renamed"})
+	require.Equal(t, http.StatusOK, upd.Code, "body: %s", upd.Body.String())
+	assert.True(t, decodeResp(t, upd).Pinned,
+		"the pin survives a rename, so the update response must re-read it rather "+
+			"than defaulting to false")
+
+	assert.True(t, pinnedFlags(t, srv, spaceA, tok)[created.ProjectID])
+}
+
+// TestASpaceAdminCanPinAProjectTheyNeverJoined pins the decision not to gate this
+// on project membership.
+//
+// A space_listed project is visible to any Space member, so it is in their list and
+// they can reasonably want it at the top. Requiring a project seat would make the
+// endpoint refuse a caller who can see the row it refuses to let them pin.
+func TestASpaceAdminCanPinAProjectTheyNeverJoined(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	ownerTok := seedUser(t, "owner1")
+	adminTok := seedUser(t, "spaceadmin")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	seedSpaceMember(t, spaceA, "spaceadmin", 1, 1)
+	created := createProjectVia(t, srv, spaceA, ownerTok, "pin-nonmember")
+
+	w := setPinned(t, srv, created.ProjectID, adminTok, true)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.True(t, pinnedFlags(t, srv, spaceA, adminTok)[created.ProjectID])
+	assert.False(t, pinnedFlags(t, srv, spaceA, ownerTok)[created.ProjectID],
+		"and it stays their own preference")
+}
+
+// TestSettingRefusalsAreIndistinguishable inherits projectMiddleware's
+// anti-enumeration contract on the new write route, asserted against each other
+// rather than against a status code.
+func TestSettingRefusalsAreIndistinguishable(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	seedSpace(t, spaceB, 1)
+	ownerTok := seedUser(t, "owner1")
+	strangerTok := seedUser(t, "stranger")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	seedSpaceMember(t, spaceA, "stranger", 0, 1)
+	foreignTok := seedUser(t, "owner2")
+	seedSpaceMember(t, spaceB, "owner2", 0, 1)
+	foreign := createProjectVia(t, srv, spaceB, foreignTok, "setting-foreign")
+
+	unlisted := createProjectVia(t, srv, spaceA, ownerTok, "setting-unlisted")
+	require.Equal(t, http.StatusOK, doJSON(t, srv, http.MethodPut,
+		"/v1/projects/"+unlisted.ProjectID, ownerTok,
+		map[string]any{"discoverability": DiscoverabilityUnlisted}).Code)
+
+	nonexistent := setPinned(t, srv, util.GenerUUID(), strangerTok, true)
+	assertProjectErrorCode(t, nonexistent, "err.server.project.not_found")
+	for name, w := range map[string]*httptest.ResponseRecorder{
+		"cross-space": setPinned(t, srv, foreign.ProjectID, strangerTok, true),
+		"unlisted":    setPinned(t, srv, unlisted.ProjectID, strangerTok, true),
+	} {
+		assert.Equal(t, nonexistent.Code, w.Code, "%s: status must match nonexistent", name)
+		assert.JSONEq(t, nonexistent.Body.String(), w.Body.String(),
+			"%s must be byte-identical to a nonexistent project, or the write route "+
+				"becomes the enumeration oracle the read routes close", name)
+	}
+}
+
+// TestEmptySettingBodyIsANoOp pins the pointer field: a client sending only the key
+// it changed must not clear the ones it did not mention. With one preference that
+// is invisible; it stops being invisible at the second.
+func TestEmptySettingBodyIsANoOp(t *testing.T) {
+	srv, _ := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	tok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	created := createProjectVia(t, srv, spaceA, tok, "setting-noop")
+
+	require.Equal(t, http.StatusOK, setPinned(t, srv, created.ProjectID, tok, true).Code)
+
+	w := doJSON(t, srv, http.MethodPut, "/v1/projects/"+created.ProjectID+"/setting", tok,
+		map[string]any{})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.True(t, decodeResp(t, w).Pinned,
+		"a body that mentions no preference must change none of them")
+}
+
+// TestSettingIsOnTheAuthenticatedGroup — same argument as the group list route:
+// the chain is checked where it is declared (TestAuthChainOrder), and this covers
+// the one thing that guard cannot see.
+func TestSettingIsOnTheAuthenticatedGroup(t *testing.T) {
+	src := readStripped(t, "api.go")
+	if !strings.Contains(src, `projectScoped.PUT("/:project_id/setting"`) {
+		t.Fatal("PUT /:project_id/setting must be registered on the projectScoped group, " +
+			"which is what mounts AuthMiddleware, SharedUIDRateLimiter and projectMiddleware")
+	}
+}
+
+// TestPinQuotaIsEnforcedPerSpace pins the cap and, more importantly, WHICH cap it
+// is: six per Space, not six per user.
+//
+// The per-Space choice is what makes the limit explicable from where it is
+// enforced. A global budget would let a pin in the Space the caller is looking at
+// be refused because of pins in a Space they cannot see, and no error message can
+// make that make sense.
+func TestPinQuotaIsEnforcedPerSpace(t *testing.T) {
+	srv, p := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	seedSpace(t, spaceB, 1)
+	tok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+	seedSpaceMember(t, spaceB, "owner1", 0, 1)
+
+	max := p.cfg.MaxPinned
+	require.Equal(t, 6, max, "the shipped default is 6; this case is written against it")
+
+	created := make([]*Resp, 0, max+1)
+	for i := 0; i <= max; i++ {
+		created = append(created, createProjectVia(t, srv, spaceA, tok,
+			fmt.Sprintf("quota-a-%d", i)))
+	}
+	for i := 0; i < max; i++ {
+		require.Equal(t, http.StatusOK, setPinned(t, srv, created[i].ProjectID, tok, true).Code,
+			"pin %d of %d must succeed", i+1, max)
+	}
+
+	over := setPinned(t, srv, created[max].ProjectID, tok, true)
+	assertProjectErrorCode(t, over, "err.server.project.quota_pinned")
+	env := decodeProjectEnvelope(t, over.Body.Bytes())
+	assert.EqualValues(t, max, env.Error.Details["max"],
+		"the limit travels in details so the client does not hardcode it and drift")
+	assert.False(t, pinnedFlags(t, srv, spaceA, tok)[created[max].ProjectID],
+		"a refused pin must not have landed")
+
+	// The budget is per Space, so a full Space A leaves Space B untouched.
+	other := createProjectVia(t, srv, spaceB, tok, "quota-b-0")
+	require.Equal(t, http.StatusOK, setPinned(t, srv, other.ProjectID, tok, true).Code,
+		"Space A being full must not spend Space B's budget")
+}
+
+// TestUnpinIsNeverRefusedAtTheCap covers the escape hatch: the operation that
+// LOWERS the count must work at the cap, or a user who reaches it is stuck.
+func TestUnpinIsNeverRefusedAtTheCap(t *testing.T) {
+	srv, p := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	tok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+
+	max := p.cfg.MaxPinned
+	created := make([]*Resp, 0, max+1)
+	for i := 0; i <= max; i++ {
+		created = append(created, createProjectVia(t, srv, spaceA, tok,
+			fmt.Sprintf("unpin-cap-%d", i)))
+	}
+	for i := 0; i < max; i++ {
+		require.Equal(t, http.StatusOK, setPinned(t, srv, created[i].ProjectID, tok, true).Code)
+	}
+	// The wire status is a pinned 400 (D14 compat) whatever the code's real
+	// HTTPStatus is, so the refusal is asserted by code rather than by status.
+	assertProjectErrorCode(t, setPinned(t, srv, created[max].ProjectID, tok, true),
+		"err.server.project.quota_pinned")
+
+	require.Equal(t, http.StatusOK, setPinned(t, srv, created[0].ProjectID, tok, false).Code,
+		"unpinning at the cap must work; refusing it strands the user at the one "+
+			"operation that would free a slot")
+	assert.Equal(t, http.StatusOK, setPinned(t, srv, created[max].ProjectID, tok, true).Code,
+		"and the freed slot must be usable")
+}
+
+// TestRepinningAtTheCapIsNotRefused pins the off-by-one the quota check invites:
+// the project is already pinned and already counted, so re-pinning changes nothing
+// and must not fail. A naive count >= max check refuses it — the shape of bug where
+// turning a toggle on twice fails the second time.
+func TestRepinningAtTheCapIsNotRefused(t *testing.T) {
+	srv, p := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	tok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+
+	max := p.cfg.MaxPinned
+	var last *Resp
+	for i := 0; i < max; i++ {
+		last = createProjectVia(t, srv, spaceA, tok, fmt.Sprintf("repin-cap-%d", i))
+		require.Equal(t, http.StatusOK, setPinned(t, srv, last.ProjectID, tok, true).Code)
+	}
+
+	assert.Equal(t, http.StatusOK, setPinned(t, srv, last.ProjectID, tok, true).Code,
+		"re-pinning an already-pinned project at the cap adds no row and must succeed")
+}
+
+// TestDisbandedProjectsDoNotSpendThePinBudget pins the status filter in the count.
+//
+// A disbanded project is gone from every read path, so its owner cannot see it to
+// unpin it. If its stale row still counted, the caller would be permanently one
+// slot poorer with nothing to point at.
+func TestDisbandedProjectsDoNotSpendThePinBudget(t *testing.T) {
+	srv, p := setup(t)
+	stubAllMemberGroup(t, util.GenerUUID())
+	seedSpace(t, spaceA, 1)
+	tok := seedUser(t, "owner1")
+	seedSpaceMember(t, spaceA, "owner1", 0, 1)
+
+	max := p.cfg.MaxPinned
+	created := make([]*Resp, 0, max+1)
+	for i := 0; i <= max; i++ {
+		created = append(created, createProjectVia(t, srv, spaceA, tok,
+			fmt.Sprintf("disband-pin-%d", i)))
+	}
+	for i := 0; i < max; i++ {
+		require.Equal(t, http.StatusOK, setPinned(t, srv, created[i].ProjectID, tok, true).Code)
+	}
+	assertProjectErrorCode(t, setPinned(t, srv, created[max].ProjectID, tok, true),
+		"err.server.project.quota_pinned")
+
+	w := doJSON(t, srv, http.MethodDelete, "/v1/projects/"+created[0].ProjectID, tok, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	assert.Equal(t, http.StatusOK, setPinned(t, srv, created[max].ProjectID, tok, true).Code,
+		"a pin on a disbanded project must not hold a slot the caller can no longer free")
+}

--- a/modules/project/api_setting_test.go
+++ b/modules/project/api_setting_test.go
@@ -327,6 +327,28 @@ func TestEmptySettingBodyIsANoOp(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
 	assert.True(t, decodeResp(t, w).Pinned,
 		"a body that mentions no preference must change none of them")
+
+	// And the case one wider than that one, which the handler comment used to
+	// claim and nothing pinned: a ZERO-BYTE body is not `{}`. It makes
+	// ShouldBindJSON return io.EOF and takes the request_invalid branch.
+	//
+	// Asserted rather than left to the comment because the two are one word apart
+	// in prose and a whole branch apart in code — and because leaveProjectHandler,
+	// in the same module, deliberately exempts io.EOF, so "this module treats an
+	// empty body as fine" is a live and wrong generalisation to make here.
+	// Reviewer yujiawei, PR #861.
+	empty := doRaw(t, srv, http.MethodPut,
+		"/v1/projects/"+created.ProjectID+"/setting", tok, "")
+	require.Equal(t, http.StatusBadRequest, empty.Code,
+		"a zero-byte body must be refused, not treated as {}: body=%s", empty.Body.String())
+	assert.Contains(t, empty.Body.String(), "err.server.project.request_invalid",
+		"and refused as a malformed request rather than any other code")
+
+	stillPinned := doJSON(t, srv, http.MethodPut,
+		"/v1/projects/"+created.ProjectID+"/setting", tok, map[string]any{})
+	require.Equal(t, http.StatusOK, stillPinned.Code)
+	assert.True(t, decodeResp(t, stillPinned).Pinned,
+		"and the refusal must not have written anything on its way out")
 }
 
 // TestSettingIsOnTheAuthenticatedGroup — same argument as the group list route:

--- a/modules/project/api_test.go
+++ b/modules/project/api_test.go
@@ -528,6 +528,7 @@ var projectMigrationFiles = []string{
 	// tiebreak is not an order anybody chose.
 	"sql/20260907000001_project_provisioning.sql",
 	"sql/20260907000002_project_all_member_group.sql",
+	"sql/20260908000001_project_user_setting.sql",
 }
 
 // applyProjectMigration executes one section of every migration file this module

--- a/modules/project/config.go
+++ b/modules/project/config.go
@@ -52,6 +52,7 @@ const (
 	envMaxPerSpace    = "OCTO_PROJECT_MAX_PER_SPACE"
 	envMaxPerCreator  = "OCTO_PROJECT_MAX_PER_CREATOR_PER_SPACE"
 	envMaxMembers     = "OCTO_PROJECT_MAX_MEMBERS"
+	envMaxPinned      = "OCTO_PROJECT_MAX_PINNED"
 	envMaxDailyCreate = "OCTO_PROJECT_MAX_DAILY_CREATE"
 	envMemberBatchMax = "OCTO_PROJECT_MEMBER_BATCH_MAX"
 	envDayBoundaryTZ  = "OCTO_PROJECT_DAY_BOUNDARY_TZ"
@@ -69,9 +70,16 @@ const (
 // Defaults. The three project/member caps come from the brief; the batch cap and
 // the worker cadence are chosen here.
 const (
-	defaultMaxPerSpace    = 1000
-	defaultMaxPerCreator  = 100
-	defaultMaxMembers     = 500
+	defaultMaxPerSpace   = 1000
+	defaultMaxPerCreator = 100
+	defaultMaxMembers    = 500
+	// defaultMaxPinned caps how many projects one user may pin PER SPACE.
+	//
+	// Per Space, not globally: the pinned section is rendered inside one Space's
+	// project list, so a global budget would let pinning in a Space the caller is
+	// looking at be refused because of pins in a Space they cannot see — a limit
+	// whose cause is invisible from where it is enforced.
+	defaultMaxPinned      = 6
 	defaultMaxDailyCreate = 20
 	// defaultMemberBatchMax bounds one add/remove request structurally, on top of
 	// any byte cap: a well-formed payload of ten thousand uids would otherwise turn
@@ -115,6 +123,7 @@ type Config struct {
 	MaxPerSpace       int
 	MaxPerCreator     int
 	MaxMembers        int
+	MaxPinned         int
 	MaxDailyCreate    int
 	MemberBatchMax    int
 	DayBoundary       *time.Location
@@ -153,6 +162,7 @@ func loadConfig() Config {
 		MaxPerSpace:       envPositiveInt(envMaxPerSpace, defaultMaxPerSpace),
 		MaxPerCreator:     envPositiveInt(envMaxPerCreator, defaultMaxPerCreator),
 		MaxMembers:        envPositiveInt(envMaxMembers, defaultMaxMembers),
+		MaxPinned:         envPositiveInt(envMaxPinned, defaultMaxPinned),
 		MaxDailyCreate:    envPositiveInt(envMaxDailyCreate, defaultMaxDailyCreate),
 		MemberBatchMax:    envPositiveInt(envMemberBatchMax, defaultMemberBatchMax),
 		DayBoundary:       loc,

--- a/modules/project/db.go
+++ b/modules/project/db.go
@@ -281,8 +281,11 @@ func (d *DB) countCreatedInWindowTx(tx *dbr.Tx, creator string, from, to time.Ti
 	return count, nil
 }
 
-// listVisibleInSpace returns the projects in spaceID that uid may see, newest first, with the
-// caller's role attached.
+// listVisibleInSpace returns the projects in spaceID that uid may see — the caller's
+// own pinned ones first, then newest first — with the caller's role attached.
+//
+// "newest first" alone was true until PR #861 added pinning and left this line
+// behind; the ORDER BY below is the authority and now says three keys, not one.
 //
 // Visibility is one SQL statement rather than a filter in Go so an unlisted project can never
 // transit the process boundary: a space_listed project is visible to any Space member, an

--- a/modules/project/db.go
+++ b/modules/project/db.go
@@ -330,7 +330,8 @@ func (d *DB) listVisibleInSpace(spaceID, uid string, offset, limit int) ([]*list
 			// stays in the statement.
 			"(SELECT COUNT(*) FROM `octo_project_member` sc "+
 			"  WHERE sc.project_id = p.project_id AND sc.status = 1 AND sc.removing = 0"+
-			"  ) AS seat_count "+
+			"  ) AS seat_count, "+
+			"IFNULL(s.pinned, 0) AS pinned "+
 			"FROM `octo_project` p "+
 			// `removing = 0` on the JOIN as well as on the count: without it a member
 			// whose seat is closing keeps my_role, and — worse — keeps
@@ -341,10 +342,35 @@ func (d *DB) listVisibleInSpace(spaceID, uid string, offset, limit int) ([]*list
 			"LEFT JOIN `octo_project_member` pm "+
 			"  ON pm.project_id = p.project_id AND pm.uid = ? AND pm.status = 1 "+
 			"     AND pm.removing = 0 "+
+			// The caller-specific pin. A LEFT JOIN rather than a correlated
+			// subquery because it also drives the ORDER BY, and it costs one
+			// equality probe on uk_octo_project_user_setting (project_id, uid) —
+			// the same key the upsert is idempotent on, which is why this table
+			// needs no second index.
+			"LEFT JOIN `octo_project_user_setting` s "+
+			// Both sides are octo_project*, i.e. both general_ci. No COLLATE: one
+			// between two same-collation columns is not free — an explicit COLLATE
+			// has coercibility 0, so the other side is converted per row and its
+			// index stops serving the predicate. PR #855 measured that exact cost
+			// on this schema.
+			"  ON s.project_id = p.project_id AND s.uid = ? "+
 			"WHERE p.space_id = ? AND p.status = ? "+
 			"  AND (p.discoverability = ? OR pm.uid IS NOT NULL) "+
-			"ORDER BY p.id DESC LIMIT ? OFFSET ?",
-		roleNonMember, uid, spaceID, StatusNormal, DiscoverabilitySpaceListed, limit, offset,
+			// Pinned first, most recently pinned before the rest, then the
+			// pre-existing order UNCHANGED. Two properties are load-bearing:
+			//
+			//   - Totality. p.id is unique, so the three keys together are a total
+			//     order however the first two tie. OFFSET pagination silently drops
+			//     and duplicates rows across pages under a non-total ORDER BY, and
+			//     this list is paginated.
+			//   - IFNULL rather than relying on NULL ordering. An unpinned project
+			//     has no row here, so s.pinned is NULL; MySQL sorts NULL lowest, so
+			//     plain DESC would happen to be right today. Writing it out means a
+			//     reader does not have to know that, and a future port to a database
+			//     that orders NULLs the other way does not silently invert the list.
+			"ORDER BY IFNULL(s.pinned, 0) DESC, s.pinned_at DESC, p.id DESC "+
+			"LIMIT ? OFFSET ?",
+		roleNonMember, uid, uid, spaceID, StatusNormal, DiscoverabilitySpaceListed, limit, offset,
 	).Load(&rows)
 	if err != nil {
 		return nil, fmt.Errorf("project: list projects in space: %w", err)
@@ -442,6 +468,10 @@ type listRow struct {
 	// behind that choice. Computed by the page statement, i.e. under a DIFFERENT
 	// read view from MemberCount — see AgentCount.
 	SeatCount int `db:"seat_count"`
+	// Pinned is the CALLER's pin, not a property of the project — the same row
+	// reads 1 for one user and 0 for the next. It comes from the LEFT JOIN, so an
+	// unpinned project reads 0 rather than dropping out of the list.
+	Pinned int `db:"pinned"`
 }
 
 // AgentCount is the agent half of D16's split, derived from the two counts.

--- a/modules/project/db.go
+++ b/modules/project/db.go
@@ -363,6 +363,13 @@ func (d *DB) listVisibleInSpace(spaceID, uid string, offset, limit int) ([]*list
 			//     order however the first two tie. OFFSET pagination silently drops
 			//     and duplicates rows across pages under a non-total ORDER BY, and
 			//     this list is paginated.
+			//
+			//     Totality is not stability, and the two are easy to conflate. pinned
+			//     and pinned_at are MUTABLE between page requests, so a pin from
+			//     another device between page 1 and page 2 still moves rows across the
+			//     offset boundary — the same exposure every OFFSET-paginated list in
+			//     this module has. Totality only rules out the ordering ITSELF being
+			//     the cause.
 			//   - IFNULL rather than relying on NULL ordering. An unpinned project
 			//     has no row here, so s.pinned is NULL; MySQL sorts NULL lowest, so
 			//     plain DESC would happen to be right today. Writing it out means a

--- a/modules/project/db.go
+++ b/modules/project/db.go
@@ -281,6 +281,88 @@ func (d *DB) countCreatedInWindowTx(tx *dbr.Tx, creator string, from, to time.Ti
 	return count, nil
 }
 
+// sqlListVisibleInSpace is the statement listVisibleInSpace runs.
+//
+// A named constant for the same reason sqlListMyProjectGroups is one: the plan
+// guard EXPLAINs the string production executes rather than a copy of it, and a
+// copy passes forever once the two drift.
+const sqlListVisibleInSpace = "SELECT p.project_id, p.space_id, p.name, p.description, p.logo, p.creator, " +
+	"p.discoverability, p.max_members, p.member_epoch, p.status, " +
+	// all_member_group_no on the LIST route too. The wire contract defines
+	// "" as "no group provisioned", so omitting the column here made every
+	// listed project claim it has none — the detail route and the list route
+	// disagreeing about the same project, and a client hiding the entry
+	// point to a group that exists.
+	"p.all_member_group_no, " +
+	"p.created_at, p.updated_at, " +
+	"IFNULL(pm.role, ?) AS my_role, " +
+	// D16's two counts are BOTH computed after the page loads, by
+	// fillMemberCounts, out of one roster read. Neither is in this
+	// statement, and the reason each left is different:
+	//
+	//   - member_count was a correlated join into `user` with a COLLATE on
+	//     the driving side — twenty `user` probes per page that the
+	//     production collation shape turns into twenty scans. PR #855's
+	//     eighth review.
+	//   - seat_count was a correlated aggregate, which was nearly free
+	//     while LIMIT 20 short-circuited the scan and stopped being free
+	//     the moment PR-5's ORDER BY made this statement sort every
+	//     visible project in the Space: it then ran once per SORTED row,
+	//     not once per returned row. Measured on 2000 visible projects,
+	//     4000 seats: 1667 subquery loops and 13.5ms with it here, 7.9ms
+	//     without. See fillMemberCounts for where it went and ORDER BY
+	//     below for what remains.
+	//
+	// Keeping seat_count here and member_count there would also have kept
+	// them under two different read views, which is what the previous round
+	// had to document as an inexactness. One read, one arithmetic.
+	"IFNULL(s.pinned, 0) AS pinned " +
+	"FROM `octo_project` p " +
+	// `removing = 0` on the JOIN as well as on the count: without it a member
+	// whose seat is closing keeps my_role, and — worse — keeps
+	// `pm.uid IS NOT NULL`, which is the clause that reveals UNLISTED
+	// projects. So a departing member would go on seeing projects they are
+	// not supposed to be able to enumerate, for the whole cascade window,
+	// while the member_count beside them already excluded them.
+	"LEFT JOIN `octo_project_member` pm " +
+	"  ON pm.project_id = p.project_id AND pm.uid = ? AND pm.status = 1 " +
+	"     AND pm.removing = 0 " +
+	// The caller-specific pin. A LEFT JOIN rather than a correlated
+	// subquery because it also drives the ORDER BY, and it costs one
+	// equality probe on uk_octo_project_user_setting (project_id, uid) —
+	// the same key the upsert is idempotent on, which is why this table
+	// needs no second index.
+	"LEFT JOIN `octo_project_user_setting` s " +
+	// Both sides are octo_project*, i.e. both general_ci. No COLLATE: one
+	// between two same-collation columns is not free — an explicit COLLATE
+	// has coercibility 0, so the other side is converted per row and its
+	// index stops serving the predicate. PR #855 measured that exact cost
+	// on this schema.
+	"  ON s.project_id = p.project_id AND s.uid = ? " +
+	"WHERE p.space_id = ? AND p.status = ? " +
+	"  AND (p.discoverability = ? OR pm.uid IS NOT NULL) " +
+	// Pinned first, most recently pinned before the rest, then the
+	// pre-existing order UNCHANGED. Two properties are load-bearing:
+	//
+	//   - Totality. p.id is unique, so the three keys together are a total
+	//     order however the first two tie. OFFSET pagination silently drops
+	//     and duplicates rows across pages under a non-total ORDER BY, and
+	//     this list is paginated.
+	//
+	//     Totality is not stability, and the two are easy to conflate. pinned
+	//     and pinned_at are MUTABLE between page requests, so a pin from
+	//     another device between page 1 and page 2 still moves rows across the
+	//     offset boundary — the same exposure every OFFSET-paginated list in
+	//     this module has. Totality only rules out the ordering ITSELF being
+	//     the cause.
+	//   - IFNULL rather than relying on NULL ordering. An unpinned project
+	//     has no row here, so s.pinned is NULL; MySQL sorts NULL lowest, so
+	//     plain DESC would happen to be right today. Writing it out means a
+	//     reader does not have to know that, and a future port to a database
+	//     that orders NULLs the other way does not silently invert the list.
+	"ORDER BY IFNULL(s.pinned, 0) DESC, s.pinned_at DESC, p.id DESC " +
+	"LIMIT ? OFFSET ?"
+
 // listVisibleInSpace returns the projects in spaceID that uid may see — the caller's
 // own pinned ones first, then newest first — with the caller's role attached.
 //
@@ -299,87 +381,7 @@ func (d *DB) countCreatedInWindowTx(tx *dbr.Tx, creator string, from, to time.Ti
 // says on the one route where users read it.
 func (d *DB) listVisibleInSpace(spaceID, uid string, offset, limit int) ([]*listRow, error) {
 	var rows []*listRow
-	_, err := d.session.SelectBySql(
-		"SELECT p.project_id, p.space_id, p.name, p.description, p.logo, p.creator, "+
-			"p.discoverability, p.max_members, p.member_epoch, p.status, "+
-			// all_member_group_no on the LIST route too. The wire contract defines
-			// "" as "no group provisioned", so omitting the column here made every
-			// listed project claim it has none — the detail route and the list route
-			// disagreeing about the same project, and a client hiding the entry
-			// point to a group that exists.
-			"p.all_member_group_no, "+
-			"p.created_at, p.updated_at, "+
-			"IFNULL(pm.role, ?) AS my_role, "+
-			// D16 — humans and agents counted separately, on the LIST route too.
-			//
-			// One aggregate for both would make member_count mean "humans" on the
-			// detail route and "every seat" here, i.e. a list card over-counting a
-			// project by exactly the agents in it — the thing D16 exists to stop.
-			//
-			// The statement counts SEATS only. Humans are classified afterwards, by
-			// fillMemberCounts, in two single-table reads.
-			//
-			// This subquery used to carry a second one beside it that joined `user`
-			// with a COLLATE on the driving side — the shape PR #855 was blocked on
-			// twice and removed twice, and this was its third and worst instance:
-			// correlated on p.project_id, so a page of 20 projects paid up to twenty
-			// `user` probes that the production collation shape turns into twenty
-			// scans, on a route that is NOT behind the create gate. The eighth review
-			// found it; the comment that used to sit here argued for keeping it, on
-			// an assumption ("each subquery dives into `user` once per member row")
-			// that the shape itself invalidates.
-			//
-			// Seats are index-only on (project_id, status, removing), so this one
-			// stays in the statement.
-			"(SELECT COUNT(*) FROM `octo_project_member` sc "+
-			"  WHERE sc.project_id = p.project_id AND sc.status = 1 AND sc.removing = 0"+
-			"  ) AS seat_count, "+
-			"IFNULL(s.pinned, 0) AS pinned "+
-			"FROM `octo_project` p "+
-			// `removing = 0` on the JOIN as well as on the count: without it a member
-			// whose seat is closing keeps my_role, and — worse — keeps
-			// `pm.uid IS NOT NULL`, which is the clause that reveals UNLISTED
-			// projects. So a departing member would go on seeing projects they are
-			// not supposed to be able to enumerate, for the whole cascade window,
-			// while the member_count beside them already excluded them.
-			"LEFT JOIN `octo_project_member` pm "+
-			"  ON pm.project_id = p.project_id AND pm.uid = ? AND pm.status = 1 "+
-			"     AND pm.removing = 0 "+
-			// The caller-specific pin. A LEFT JOIN rather than a correlated
-			// subquery because it also drives the ORDER BY, and it costs one
-			// equality probe on uk_octo_project_user_setting (project_id, uid) —
-			// the same key the upsert is idempotent on, which is why this table
-			// needs no second index.
-			"LEFT JOIN `octo_project_user_setting` s "+
-			// Both sides are octo_project*, i.e. both general_ci. No COLLATE: one
-			// between two same-collation columns is not free — an explicit COLLATE
-			// has coercibility 0, so the other side is converted per row and its
-			// index stops serving the predicate. PR #855 measured that exact cost
-			// on this schema.
-			"  ON s.project_id = p.project_id AND s.uid = ? "+
-			"WHERE p.space_id = ? AND p.status = ? "+
-			"  AND (p.discoverability = ? OR pm.uid IS NOT NULL) "+
-			// Pinned first, most recently pinned before the rest, then the
-			// pre-existing order UNCHANGED. Two properties are load-bearing:
-			//
-			//   - Totality. p.id is unique, so the three keys together are a total
-			//     order however the first two tie. OFFSET pagination silently drops
-			//     and duplicates rows across pages under a non-total ORDER BY, and
-			//     this list is paginated.
-			//
-			//     Totality is not stability, and the two are easy to conflate. pinned
-			//     and pinned_at are MUTABLE between page requests, so a pin from
-			//     another device between page 1 and page 2 still moves rows across the
-			//     offset boundary — the same exposure every OFFSET-paginated list in
-			//     this module has. Totality only rules out the ordering ITSELF being
-			//     the cause.
-			//   - IFNULL rather than relying on NULL ordering. An unpinned project
-			//     has no row here, so s.pinned is NULL; MySQL sorts NULL lowest, so
-			//     plain DESC would happen to be right today. Writing it out means a
-			//     reader does not have to know that, and a future port to a database
-			//     that orders NULLs the other way does not silently invert the list.
-			"ORDER BY IFNULL(s.pinned, 0) DESC, s.pinned_at DESC, p.id DESC "+
-			"LIMIT ? OFFSET ?",
+	_, err := d.session.SelectBySql(sqlListVisibleInSpace,
 		roleNonMember, uid, uid, spaceID, StatusNormal, DiscoverabilitySpaceListed, limit, offset,
 	).Load(&rows)
 	if err != nil {
@@ -391,21 +393,27 @@ func (d *DB) listVisibleInSpace(spaceID, uid string, offset, limit int) ([]*list
 	return rows, nil
 }
 
-// fillMemberCounts sets MemberCount (humans) on each listed project.
+// fillMemberCounts sets SeatCount (every active seat) and MemberCount (the human
+// half) on each listed project.
 //
 // Two single-table reads for the whole page, not one join per card: read the
-// active seat uids for the listed projects, then ask `user` which of those uids
+// active seat rows for the listed projects, then ask `user` which of those uids
 // are bots. Neither statement crosses the pinned/legacy schema boundary, so
 // neither needs a COLLATE and neither can lose an index to one — which is the
 // whole reason the join that used to do this was removed. PR #855s eighth review.
 //
-// Within THIS function the arithmetic is exact: one roster read, and every uid in
-// it is either a bot or not, so humans + agents == len(seats) for the set these two
-// statements see. What that does not give is exactness against SeatCount, which the
-// page statement already computed under an earlier read view — see AgentCount for
-// what the difference can be and why the clamp is what handles it. The previous
-// version of this comment claimed a single snapshot across both, which is one
-// statement too many. PR #855's tenth review.
+// Both counts come from THE SAME roster read, which is what makes the arithmetic
+// exact: every uid in it is either a bot or not, so humans + agents == seats by
+// construction rather than by two aggregates hoping to agree. seat_count used to
+// be computed by the page statement instead, i.e. under a different read view —
+// the inexactness the previous round had to document. PR-5 moved it here for a
+// second reason, cost: its ORDER BY makes the page statement sort every visible
+// project in the Space, so a correlated aggregate in that statement runs once per
+// SORTED row rather than once per returned row (measured: 1667 loops on a
+// 2000-project Space).
+//
+// The seats read is per PAGE, not per Space, so it stays proportional to what the
+// client asked for.
 func (d *DB) fillMemberCounts(rows []*listRow) error {
 	if len(rows) == 0 {
 		return nil
@@ -450,13 +458,16 @@ func (d *DB) fillMemberCounts(rows []*listRow) error {
 	}
 
 	humans := make(map[string]int, len(rows))
+	total := make(map[string]int, len(rows))
 	for _, seat := range seats {
+		total[seat.ProjectID]++
 		if _, isBot := bots[seat.UID]; !isBot {
 			humans[seat.ProjectID]++
 		}
 	}
 	for _, row := range rows {
 		row.MemberCount = humans[row.ProjectID]
+		row.SeatCount = total[row.ProjectID]
 	}
 	return nil
 }
@@ -475,9 +486,11 @@ type listRow struct {
 	MemberCount int
 	// SeatCount is every active seat, humans and agents together. Agents are the
 	// DIFFERENCE rather than a third count: see the query for the measurement
-	// behind that choice. Computed by the page statement, i.e. under a DIFFERENT
-	// read view from MemberCount — see AgentCount.
-	SeatCount int `db:"seat_count"`
+	// behind that choice.
+	//
+	// Filled by fillMemberCounts out of the same roster read as MemberCount, so
+	// the two agree by construction rather than across two read views.
+	SeatCount int
 	// Pinned is the CALLER's pin, not a property of the project — the same row
 	// reads 1 for one user and 0 for the next. It comes from the LEFT JOIN, so an
 	// unpinned project reads 0 rather than dropping out of the list.
@@ -486,21 +499,20 @@ type listRow struct {
 
 // AgentCount is the agent half of D16's split, derived from the two counts.
 //
-// The clamp is LOAD-BEARING, not a defensive flourish, and the previous version of
-// this comment said the opposite. SeatCount comes from the correlated subquery
-// inside listVisibleInSpace; MemberCount comes from fillMemberCounts, a separate
-// statement issued after that page has loaded. Two statements, no enclosing
-// transaction, two read views — so a member added between them is counted by the
-// second and not the first, and `MemberCount > SeatCount` is reachable in normal
-// operation, not only after a future edit that gave the two different predicates.
+// The race this comment used to describe is gone, and the history is worth keeping
+// because it decides what the clamp is for. SeatCount was computed by the page
+// statement while MemberCount came from fillMemberCounts afterwards — two
+// statements, no enclosing transaction, two read views, so a member added between
+// them made `MemberCount > SeatCount` reachable in normal operation and the clamp
+// load-bearing. PR #855's tenth review established that. PR-5 then had to move
+// seat_count into fillMemberCounts for cost (see the statement), and one roster
+// read for both counts removes the race as a side effect: humans + agents == seats
+// by construction now, so `member_count + agent_count == seat_count` holds on the
+// wire rather than holding usually.
 //
-// What the clamp buys, then, is that the wire never carries a negative agent count.
-// What it does NOT buy is `member_count + agent_count == seat_count`: in that race
-// the response is internally inconsistent by one, briefly, and the next list call
-// agrees again. That is the accepted cost of not putting the classification back
-// into the statement — doing so means re-adding the COLLATE'd join into `user` at
-// one join per listed project, which is exactly what the eighth review had removed.
-// PR #855's tenth review, P2-4.
+// So the clamp is back to being defensive, and stays: it costs nothing, and a
+// future edit that gives the two counts different predicates would otherwise put a
+// negative agent count on the wire, which a client renders as "-3 agents".
 func (r *listRow) AgentCount() int {
 	if r.SeatCount <= r.MemberCount {
 		return 0

--- a/modules/project/db_group.go
+++ b/modules/project/db_group.go
@@ -1,0 +1,153 @@
+package project
+
+import "fmt"
+
+// The project-scoped group read view.
+//
+// # Why this lives in modules/project and reads `group` directly
+//
+// modules/project must never import modules/group — pkg/project/import_guard_test.go
+// pins that at zero, and modules/group already imports THIS package for the P1
+// cascade and the P2 all-member-group hooks, so the dependency only has one legal
+// direction. Reading the `group` TABLE is not importing the package, and this
+// module already does it: the I2/I3 reconcile scans (reconcile_p1.go) and the
+// all-member-group DAO (db_all_member_group.go) both join `group` from here.
+//
+// The alternative — a reverse-registered read hook, the shape
+// all_member_group_registry.go uses for writes — is wrong for a synchronous
+// request path: an unregistered provider would answer an EMPTY LIST, which is
+// indistinguishable from "this project has no groups". A missing write hook
+// leaves a repairable gap that a reconcile scan reports; a missing read hook
+// silently answers the wrong thing to the client.
+//
+// # No COLLATE in either statement, deliberately
+//
+// The module's rule is that a COLLATE belongs exactly where a legacy column
+// (`group`, `group_member`, created in 2019 with no explicit collation, measured
+// at utf8mb4_0900_ai_ci in production) meets a pinned utf8mb4_general_ci one
+// (`octo_project*`). Neither statement here crosses that boundary:
+//
+//   - `group` ⋈ `group_member` is legacy-to-legacy. Coercing one side would make
+//     the predicate non-sargable and give up the index on group_member.group_no,
+//     to fix a mismatch that does not exist.
+//   - space_id / project_id / uid arrive as BIND PARAMETERS, not as columns of
+//     octo_project*. A literal is coercible to the column's own collation, so
+//     there is no cross-schema comparison to coerce.
+//
+// Stated rather than left as an absence, because "this query has no COLLATE" and
+// "this query forgot its COLLATE" look identical in a diff.
+
+// projectGroupRow is one row of the project group list.
+//
+// The Go types mirror modules/group's own Model rather than being re-decided
+// here: AvatarColor is a *int because the column is nullable (NULL = derive the
+// colour from group_no), IsNamed is a plain int because its migration ends by
+// tightening the column to NOT NULL DEFAULT 0.
+type projectGroupRow struct {
+	GroupNo        string `db:"group_no"`
+	Name           string `db:"name"`
+	IsNamed        int    `db:"is_named"`
+	AvatarText     string `db:"avatar_text"`
+	AvatarColor    *int   `db:"avatar_color"`
+	IsUploadAvatar int    `db:"is_upload_avatar"`
+}
+
+// listMyProjectGroups returns the LIVE groups of one project that uid is an
+// active member of, oldest first.
+//
+// # Membership-scoped, and that is the access control
+//
+// The list is the caller's own groups, not the project's. I2 is a ceiling, not a
+// floor: being an active project member does not put you in any particular group
+// of that project, so a project-wide list would hand a member the names of groups
+// they hold no seat in — and a group name is the most sensitive field at list
+// granularity. There is no self-join path into a group either, so the wider list
+// would not even be actionable.
+//
+// This is also why the handler needs no permission gate beyond projectMiddleware:
+// the predicate IS the gate. A Space admin who never joined the project gets an
+// empty list rather than a refusal, which is the correct answer and leaks nothing.
+//
+// # Disbanded groups are excluded, and that filter is load-bearing
+//
+// Group disband only flips group.status and deliberately leaves group_member rows
+// in place — there is no endpoint that cleans them up, so the rows are expected
+// rather than a leak. Without this filter every project member would keep seeing
+// groups that were disbanded months ago. modules/group's own
+// queryProjectGroupNosWithActiveMember carries the same filter for the same
+// reason, as does the I2 scan.
+//
+// # Active member means is_deleted = 0 AND status = 1
+//
+// That is the repo's canonical predicate (modules/group's ExistMemberActive, and
+// both I2 and I4 reconcile scans). Note it is STRICTER than
+// queryProjectGroupNosWithActiveMember, which checks is_deleted alone: that one
+// feeds a cascade whose job is to remove rows, where over-selecting is harmless.
+// A read must not over-select.
+//
+// # Index
+//
+// Driven off group_space_project (space_id, project_id). space_id is in the
+// predicate rather than inferred from project_id because it is the index's
+// LEADING column — without it the index cannot be used at all. The value comes
+// from the project row projectMiddleware already verified the caller's Space
+// membership against, so it is also the Space isolation boundary, not decoration.
+func (d *DB) listMyProjectGroups(spaceID, projectID, uid string, offset, limit int) ([]*projectGroupRow, error) {
+	if spaceID == "" || projectID == "" || uid == "" {
+		return nil, nil
+	}
+	var rows []*projectGroupRow
+	_, err := d.session.SelectBySql(
+		"SELECT g.group_no, g.name, g.is_named, g.avatar_text, g.avatar_color, g.is_upload_avatar "+
+			"FROM `group` g "+
+			"INNER JOIN `group_member` gm ON gm.group_no = g.group_no "+
+			"WHERE g.space_id = ? AND g.project_id = ? AND g.status <> ? "+
+			"  AND gm.uid = ? AND gm.is_deleted = 0 AND gm.status = 1 "+
+			// g.id ASC is creation order, which puts the all-member group first
+			// for free: #855 provisions it with the project, so it is always the
+			// project's oldest group. It is also the only ordering available that
+			// is total — group_no is a UUID and name is not unique — and a
+			// non-total ORDER BY under OFFSET pagination silently drops and
+			// duplicates rows between pages.
+			"ORDER BY g.id ASC LIMIT ? OFFSET ?",
+		spaceID, projectID, groupStatusDisband, uid, limit, offset,
+	).Load(&rows)
+	if err != nil {
+		return nil, fmt.Errorf("project: list my project groups: %w", err)
+	}
+	return rows, nil
+}
+
+// countActiveGroupMembers returns the active member count for each of groupNos.
+//
+// One grouped query for the whole page, not one query per row. modules/group's
+// own group list calls QueryMemberCount inside its loop (api.go's `list`), which
+// is N+1 — fine at its sizes, but this endpoint is paginated up to 200 and there
+// is no reason to inherit the shape.
+//
+// Groups with no active members are simply absent from the map; the caller reads
+// a missing key as 0. That state is reachable in principle (every member left)
+// and is not worth a second query to distinguish from "count is zero".
+func (d *DB) countActiveGroupMembers(groupNos []string) (map[string]int, error) {
+	if len(groupNos) == 0 {
+		return map[string]int{}, nil
+	}
+	var rows []*struct {
+		GroupNo     string `db:"group_no"`
+		MemberCount int    `db:"member_count"`
+	}
+	_, err := d.session.SelectBySql(
+		"SELECT group_no, COUNT(*) AS member_count FROM `group_member` "+
+			"WHERE group_no IN ? AND is_deleted = 0 AND status = 1 "+
+			"GROUP BY group_no",
+		groupNos,
+	).Load(&rows)
+	if err != nil {
+		return nil, fmt.Errorf("project: count active group members: %w", err)
+	}
+	counts := make(map[string]int, len(rows))
+	for _, r := range rows {
+		counts[r.GroupNo] = r.MemberCount
+	}
+	return counts, nil
+}

--- a/modules/project/db_group.go
+++ b/modules/project/db_group.go
@@ -1,6 +1,10 @@
 package project
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+)
 
 // The project-scoped group read view.
 //
@@ -77,13 +81,31 @@ type projectGroupRow struct {
 // queryProjectGroupNosWithActiveMember carries the same filter for the same
 // reason, as does the I2 scan.
 //
-// # Active member means is_deleted = 0 AND status = 1
+// # Active member means is_deleted = 0 AND status = GroupMemberStatusNormal
 //
 // That is the repo's canonical predicate (modules/group's ExistMemberActive, and
-// both I2 and I4 reconcile scans). Note it is STRICTER than
+// both I2 and I4 reconcile scans). It is STRICTER than
 // queryProjectGroupNosWithActiveMember, which checks is_deleted alone: that one
 // feeds a cascade whose job is to remove rows, where over-selecting is harmless.
-// A read must not over-select.
+//
+// # What the strictness actually decides: BLACKLISTED members
+//
+// Spelled out because the abstract argument above hides the only case that
+// reaches it. Removal sets is_deleted = 1, so the two predicates agree there. The
+// one reachable state where they disagree is the group blacklist, which sets
+// status = GroupMemberStatusBlacklist and deliberately LEAVES is_deleted = 0
+// (modules/group/db.go:260). So this endpoint hides a project group from a member
+// that group has blacklisted, and two older surfaces still show it to them:
+// GET /v1/group/my (queryGroupsWithMemberUIDAndSpaceID filters is_deleted alone)
+// and the group detail.
+//
+// That divergence is chosen, not inherited. Blacklisting is how a group denies
+// someone access: ExistMemberActive is the hardening line #343/#345 put in front
+// of group and thread reads for exactly this uid, so listing the group here would
+// advertise a room they cannot open. The two looser surfaces are the ones behind —
+// both are named in P1's "read-path hardening" out-of-scope list, which is a
+// separate task. Pinned by TestListProjectGroupsHidesAGroupThatBlacklistedMe, so
+// a later change to the predicate has to argue with a test rather than a comment.
 //
 // # Index
 //
@@ -102,15 +124,23 @@ func (d *DB) listMyProjectGroups(spaceID, projectID, uid string, offset, limit i
 			"FROM `group` g "+
 			"INNER JOIN `group_member` gm ON gm.group_no = g.group_no "+
 			"WHERE g.space_id = ? AND g.project_id = ? AND g.status <> ? "+
-			"  AND gm.uid = ? AND gm.is_deleted = 0 AND gm.status = 1 "+
-			// g.id ASC is creation order, which puts the all-member group first
-			// for free: #855 provisions it with the project, so it is always the
-			// project's oldest group. It is also the only ordering available that
-			// is total — group_no is a UUID and name is not unique — and a
-			// non-total ORDER BY under OFFSET pagination silently drops and
-			// duplicates rows between pages.
+			"  AND gm.uid = ? AND gm.is_deleted = 0 AND gm.status = ? "+
+			// g.id ASC is creation order. It is the only TOTAL ordering available
+			// — group_no is a UUID and name is not unique — and a non-total
+			// ORDER BY under OFFSET pagination silently drops and duplicates rows
+			// between pages, so that property is the reason for the choice.
+			//
+			// It USUALLY puts the all-member group first, because #855 provisions
+			// it with the project. Usually, not always: ensureAllMemberGroup
+			// rebuilds it on a later write path when the first provisioning failed
+			// or the group was disbanded or detached, and the rebuilt group takes a
+			// fresh, higher id. So a project that hit that path lists its 全员群
+			// wherever it now sorts. Nothing here compensates: the client labels it
+			// by comparing group_no against the all_member_group_no it already has
+			// from the project detail, which is right in both cases. Position is a
+			// convenience, never the contract.
 			"ORDER BY g.id ASC LIMIT ? OFFSET ?",
-		spaceID, projectID, groupStatusDisband, uid, limit, offset,
+		spaceID, projectID, groupStatusDisband, uid, int(common.GroupMemberStatusNormal), limit, offset,
 	).Load(&rows)
 	if err != nil {
 		return nil, fmt.Errorf("project: list my project groups: %w", err)
@@ -128,6 +158,19 @@ func (d *DB) listMyProjectGroups(spaceID, projectID, uid string, offset, limit i
 // Groups with no active members are simply absent from the map; the caller reads
 // a missing key as 0. That state is reachable in principle (every member left)
 // and is not worth a second query to distinguish from "count is zero".
+//
+// # This number can differ from modules/group's member_count for the same group
+//
+// modules/group's QueryMemberCount (db.go:737) filters is_deleted alone, so it
+// counts blacklisted members; this one does not. A group holding one blacklisted
+// member therefore reads N here and N+1 on the group header.
+//
+// Matching QueryMemberCount instead was the alternative and is worse: the count
+// would then include people the list beside it treats as non-members, so the
+// endpoint would contradict ITSELF rather than contradict another endpoint. A
+// count that means the same thing as the list it sits in is the one property
+// worth keeping; the cross-surface difference is bounded by how rare blacklisting
+// is, and it disappears when the older surfaces are hardened.
 func (d *DB) countActiveGroupMembers(groupNos []string) (map[string]int, error) {
 	if len(groupNos) == 0 {
 		return map[string]int{}, nil
@@ -138,9 +181,9 @@ func (d *DB) countActiveGroupMembers(groupNos []string) (map[string]int, error) 
 	}
 	_, err := d.session.SelectBySql(
 		"SELECT group_no, COUNT(*) AS member_count FROM `group_member` "+
-			"WHERE group_no IN ? AND is_deleted = 0 AND status = 1 "+
+			"WHERE group_no IN ? AND is_deleted = 0 AND status = ? "+
 			"GROUP BY group_no",
-		groupNos,
+		groupNos, int(common.GroupMemberStatusNormal),
 	).Load(&rows)
 	if err != nil {
 		return nil, fmt.Errorf("project: count active group members: %w", err)

--- a/modules/project/db_group.go
+++ b/modules/project/db_group.go
@@ -41,6 +41,36 @@ import (
 // Stated rather than left as an absence, because "this query has no COLLATE" and
 // "this query forgot its COLLATE" look identical in a diff.
 
+// sqlListMyProjectGroups is the statement listMyProjectGroups runs.
+//
+// A named constant so the plan guard (TestTheProjectGroupListReachesItsRowsByAnIndex)
+// can EXPLAIN the string production actually executes rather than a copy of it. A
+// copy passes forever once the two drift, which is the failure mode that makes a
+// plan assertion worse than none. #855 established the shape.
+//
+
+// g.id ASC is creation order. It is the only TOTAL ordering available
+// — group_no is a UUID and name is not unique — and a non-total
+// ORDER BY under OFFSET pagination silently drops and duplicates rows
+// between pages, so that property is the reason for the choice.
+//
+// It USUALLY puts the all-member group first, because #855 provisions
+// it with the project. Usually, not always: ensureAllMemberGroup
+// rebuilds it on a later write path when the first provisioning failed
+// or the group was disbanded or detached, and the rebuilt group takes a
+// fresh, higher id. So a project that hit that path lists its 全员群
+// wherever it now sorts. Nothing here compensates: the client labels it
+// by comparing group_no against the all_member_group_no it already has
+// from the project detail, which is right in both cases. Position is a
+// convenience, never the contract.
+const sqlListMyProjectGroups = "SELECT g.group_no, g.name, g.is_named, g.avatar_text, " +
+	"g.avatar_color, g.is_upload_avatar " +
+	"FROM `group` g " +
+	"INNER JOIN `group_member` gm ON gm.group_no = g.group_no " +
+	"WHERE g.space_id = ? AND g.project_id = ? AND g.status <> ? " +
+	"  AND gm.uid = ? AND gm.is_deleted = 0 AND gm.status = ? " +
+	"ORDER BY g.id ASC LIMIT ? OFFSET ?"
+
 // projectGroupRow is one row of the project group list.
 //
 // The Go types mirror modules/group's own Model rather than being re-decided
@@ -119,27 +149,7 @@ func (d *DB) listMyProjectGroups(spaceID, projectID, uid string, offset, limit i
 		return nil, nil
 	}
 	var rows []*projectGroupRow
-	_, err := d.session.SelectBySql(
-		"SELECT g.group_no, g.name, g.is_named, g.avatar_text, g.avatar_color, g.is_upload_avatar "+
-			"FROM `group` g "+
-			"INNER JOIN `group_member` gm ON gm.group_no = g.group_no "+
-			"WHERE g.space_id = ? AND g.project_id = ? AND g.status <> ? "+
-			"  AND gm.uid = ? AND gm.is_deleted = 0 AND gm.status = ? "+
-			// g.id ASC is creation order. It is the only TOTAL ordering available
-			// — group_no is a UUID and name is not unique — and a non-total
-			// ORDER BY under OFFSET pagination silently drops and duplicates rows
-			// between pages, so that property is the reason for the choice.
-			//
-			// It USUALLY puts the all-member group first, because #855 provisions
-			// it with the project. Usually, not always: ensureAllMemberGroup
-			// rebuilds it on a later write path when the first provisioning failed
-			// or the group was disbanded or detached, and the rebuilt group takes a
-			// fresh, higher id. So a project that hit that path lists its 全员群
-			// wherever it now sorts. Nothing here compensates: the client labels it
-			// by comparing group_no against the all_member_group_no it already has
-			// from the project detail, which is right in both cases. Position is a
-			// convenience, never the contract.
-			"ORDER BY g.id ASC LIMIT ? OFFSET ?",
+	_, err := d.session.SelectBySql(sqlListMyProjectGroups,
 		spaceID, projectID, groupStatusDisband, uid, int(common.GroupMemberStatusNormal), limit, offset,
 	).Load(&rows)
 	if err != nil {

--- a/modules/project/db_group.go
+++ b/modules/project/db_group.go
@@ -123,9 +123,10 @@ type projectGroupRow struct {
 // Spelled out because the abstract argument above hides the only case that
 // reaches it. Removal sets is_deleted = 1, so the two predicates agree there. The
 // one reachable state where they disagree is the group blacklist, which sets
-// status = GroupMemberStatusBlacklist and deliberately LEAVES is_deleted = 0
-// (modules/group/db.go:260). So this endpoint hides a project group from a member
-// that group has blacklisted, and two older surfaces still show it to them:
+// status = GroupMemberStatusBlacklist and deliberately LEAVES is_deleted = 0 —
+// the blacklist branch of modules/group's ExistMemberActiveInternal spells that
+// out. So this endpoint hides a project group from a member that group has
+// blacklisted, and two older surfaces still show it to them:
 // GET /v1/group/my (queryGroupsWithMemberUIDAndSpaceID filters is_deleted alone)
 // and the group detail.
 //
@@ -171,9 +172,9 @@ func (d *DB) listMyProjectGroups(spaceID, projectID, uid string, offset, limit i
 //
 // # This number can differ from modules/group's member_count for the same group
 //
-// modules/group's QueryMemberCount (db.go:737) filters is_deleted alone, so it
-// counts blacklisted members; this one does not. A group holding one blacklisted
-// member therefore reads N here and N+1 on the group header.
+// modules/group's own QueryMemberCount filters is_deleted alone, so it counts
+// blacklisted members; this one does not. A group holding one blacklisted member
+// therefore reads N here and N+1 on the group header.
 //
 // Matching QueryMemberCount instead was the alternative and is worse: the count
 // would then include people the list beside it treats as non-members, so the

--- a/modules/project/db_group_plan_test.go
+++ b/modules/project/db_group_plan_test.go
@@ -155,6 +155,13 @@ func TestTheProjectStatementsAreWhatProductionRuns(t *testing.T) {
 // stop being every visible project — pins are capped at six per Space, so the
 // shape that gets there is one bounded read of the caller's pinned ids plus the
 // existing p.id DESC page, concatenated with the offset arithmetic done in Go.
+//
+// And it has a detector, because a condition nobody can observe arrives as user
+// latency instead of as a signal: project_space_project_count, sampled on the
+// sparse metrics tick (metrics.go). It measures projects per Space rather than the
+// sort input itself — the sort input is the subset one caller can see, which needs
+// a per-caller query — and bounds it from above, which is the conservative
+// direction. Reviewer yujiawei asked for it on PR #861.
 func TestTheProjectListReachesItsRowsByAnIndex(t *testing.T) {
 	setup(t)
 	p := New(testCtx)

--- a/modules/project/db_group_plan_test.go
+++ b/modules/project/db_group_plan_test.go
@@ -1,0 +1,122 @@
+package project
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The group list's execution plan, asserted rather than reasoned about.
+//
+// PR #861's review rounds asked for this twice and I deferred it twice, on the
+// grounds that `group` is empty in CI so the assertion would be weak. That reason
+// does not hold and the review said so: EXPLAIN resolves the chosen index from
+// schema metadata, not from row counts, so an empty table still proves which index
+// MySQL picked. What made it cheap in the end is #855's plan rig (explainRows /
+// accessTypeOf, all_member_group_plan_test.go), landed for a different predicate.
+//
+// The property is worth a guard for the same reason that predicate's was: the
+// statement is a user-facing paginated GET, and the failure mode is silent. A later
+// edit that drops `g.space_id` — the LEADING column of group_space_project, which
+// db_group.go's comment calls the Space isolation boundary rather than decoration —
+// degrades the request from an index range to a scan of a core IM table with
+// nothing red anywhere.
+func TestTheProjectGroupListReachesItsRowsByAnIndex(t *testing.T) {
+	setup(t)
+	p := New(testCtx)
+	sess := p.db.session
+
+	const (
+		probeSpace   = "plan_probe_space"
+		probeProject = "plan_probe_project"
+		probeUID     = "plan_probe_uid"
+	)
+
+	// The production constant, not a copy of it: a copy passes forever once the two
+	// drift, which is what makes a stale plan assertion worse than none.
+	rows := explainRows(t, sess, sqlListMyProjectGroups,
+		probeSpace, probeProject, groupStatusDisband, probeUID, 1, 10, 0)
+
+	require.NotEmpty(t, rows, "EXPLAIN returned no rows; the assertions below would be vacuous")
+	for _, row := range rows {
+		table := derefOr(row.Table, "")
+		assert.NotEqual(t, "ALL", derefOr(row.Type, ""),
+			"the project group list must reach %q by an index: a full scan here is a scan "+
+				"of a core IM table on every render of the project 群聊 tab", table)
+		assert.NotEmpty(t, derefOr(row.Key, ""),
+			"the project group list must have chosen an index for %q", table)
+	}
+
+	// Naming the index, not just "some index". group_space_project is
+	// (space_id, project_id), and the whole reason space_id is in the predicate
+	// rather than inferred from project_id is that it is the leading column —
+	// without it the index cannot serve the query at all.
+	assert.Equal(t, "group_space_project", indexChosenFor(t, rows, "g"),
+		"dropping g.space_id from the predicate would still return the right rows and "+
+			"would silently lose this index; that is what this assertion exists to catch")
+}
+
+// TestThePinQuotaCountReachesItsRowsByAnIndex covers the other statement this PR
+// added on a write path.
+//
+// It runs once per pin, so a scan here is a scan of a table that grows with users
+// times pinned projects, on an ordinary user action. The migration justifies
+// idx_octo_project_user_setting_uid_pinned by exactly this query — the unique key
+// leads with project_id and cannot serve a lookup by uid — so the justification is
+// asserted rather than left in a comment.
+func TestThePinQuotaCountReachesItsRowsByAnIndex(t *testing.T) {
+	setup(t)
+	p := New(testCtx)
+	sess := p.db.session
+
+	rows := explainRows(t, sess, sqlCountPinnedInSpace,
+		MemberStatusActive, "plan_probe_uid", "plan_probe_space", StatusNormal,
+		DiscoverabilitySpaceListed)
+
+	require.NotEmpty(t, rows, "EXPLAIN returned no rows; the assertions below would be vacuous")
+	for _, row := range rows {
+		table := derefOr(row.Table, "")
+		assert.NotEqual(t, "ALL", derefOr(row.Type, ""),
+			"the pin quota count must reach %q by an index: it runs on every pin", table)
+	}
+	assert.Equal(t, "idx_octo_project_user_setting_uid_pinned", indexChosenFor(t, rows, "s"),
+		"this is the index the migration adds and justifies by this query; the unique "+
+			"key leads with project_id and cannot serve a lookup by uid")
+}
+
+// indexChosenFor returns the index MySQL picked for one alias, or "" if the alias
+// is absent from the plan.
+func indexChosenFor(t *testing.T, rows []explainRow, alias string) string {
+	t.Helper()
+	for _, row := range rows {
+		if derefOr(row.Table, "") == alias {
+			return derefOr(row.Key, "")
+		}
+	}
+	return ""
+}
+
+// TestTheProjectStatementsAreWhatProductionRuns pins the other half of the plan
+// guard: EXPLAINing a constant proves nothing if the function stopped running it.
+//
+// Same shape as #855's TestTheSplitPredicatesAreWhatProductionRuns, and the same
+// hazard — a body that inlined its SQL again would regress production with every
+// plan assertion still green, and the drift suite could not see it either because
+// the inlined shape still executes.
+func TestTheProjectStatementsAreWhatProductionRuns(t *testing.T) {
+	for _, want := range []struct {
+		path      string
+		signature string
+		constant  string
+	}{
+		{"db_group.go", "func (d *DB) listMyProjectGroups(", "sqlListMyProjectGroups"},
+		{"db_user_setting.go", "func (d *DB) countPinnedInSpaceTx(", "sqlCountPinnedInSpace"},
+	} {
+		fn := functionBodyOf(t, want.path, want.signature)
+		require.Contains(t, fn, want.constant,
+			"%s must RUN %s: the plan guard EXPLAINs that constant, so a body that "+
+				"stopped executing it would leave the guard green while production "+
+				"regressed", want.signature, want.constant)
+	}
+}

--- a/modules/project/db_group_plan_test.go
+++ b/modules/project/db_group_plan_test.go
@@ -112,11 +112,72 @@ func TestTheProjectStatementsAreWhatProductionRuns(t *testing.T) {
 	}{
 		{"db_group.go", "func (d *DB) listMyProjectGroups(", "sqlListMyProjectGroups"},
 		{"db_user_setting.go", "func (d *DB) countPinnedInSpaceTx(", "sqlCountPinnedInSpace"},
+		{"db.go", "func (d *DB) listVisibleInSpace(", "sqlListVisibleInSpace"},
 	} {
 		fn := functionBodyOf(t, want.path, want.signature)
 		require.Contains(t, fn, want.constant,
 			"%s must RUN %s: the plan guard EXPLAINs that constant, so a body that "+
 				"stopped executing it would leave the guard green while production "+
 				"regressed", want.signature, want.constant)
+	}
+}
+
+// TestTheProjectListReachesItsRowsByAnIndex covers the third statement PR-5
+// touches — the one it did not add, but did make more expensive.
+//
+// PR-5's ORDER BY is not servable by an index (the sort keys live in a per-caller
+// table), so this statement now materialises and sorts every project visible to
+// the caller in the Space before LIMIT applies. Measured with EXPLAIN ANALYZE on a
+// seeded database of 4000 projects and 5000 seats, 2000 of them visible in the
+// probed Space:
+//
+//	before PR-5   0.28ms   Backward index scan, 23 rows touched, no sort at all
+//	after PR-5   13.5ms    Using temporary; Using filesort, 1667 rows sorted,
+//	                       1667 dependent-subquery loops for seat_count
+//	with seat_count moved out of the statement (this PR)   7.9ms
+//
+// Two things follow. The sort is accepted: the alternative is two statements and
+// two read views for one page, trading a bounded latency cost for a pagination
+// correctness risk. Losing the Space access path on top of it is not — that path
+// is what keeps the sort input proportional to one Space rather than to the whole
+// table, and an edit that dropped p.space_id or wrapped it would still return
+// exactly the right rows.
+//
+// The assertion is "a Space-leading index", not one index by name, and that is a
+// finding rather than a hedge: on the empty CI table the optimizer picks
+// uk_octo_project_space_active_name, and on the seeded database above it picks
+// idx_octo_project_space_status. Both lead with space_id, which is the property
+// worth pinning; naming either one would make this test fail on the other
+// database and teach the next reader the wrong lesson.
+//
+// The escalation condition, stated so it is a decision rather than a discovery: if
+// a Space's visible-project count reaches the thousands, the sort input has to
+// stop being every visible project — pins are capped at six per Space, so the
+// shape that gets there is one bounded read of the caller's pinned ids plus the
+// existing p.id DESC page, concatenated with the offset arithmetic done in Go.
+func TestTheProjectListReachesItsRowsByAnIndex(t *testing.T) {
+	setup(t)
+	p := New(testCtx)
+
+	rows := explainRows(t, p.db.session, sqlListVisibleInSpace,
+		roleNonMember, "plan_probe_uid", "plan_probe_uid", "plan_probe_space",
+		StatusNormal, DiscoverabilitySpaceListed, 20, 0)
+
+	require.NotEmpty(t, rows, "EXPLAIN returned no rows; the assertions below would be vacuous")
+	spaceLeading := map[string]bool{
+		"idx_octo_project_space_status":     true,
+		"uk_octo_project_space_active_name": true,
+		"idx_octo_project_space_creator":    true,
+	}
+	key := indexChosenFor(t, rows, "p")
+	assert.True(t, spaceLeading[key],
+		"the project list must reach octo_project through an index that LEADS with "+
+			"space_id; it chose %q. Without one, the sort PR-5 introduced runs over "+
+			"the whole table instead of over one Space", key)
+	for _, row := range rows {
+		if derefOr(row.Table, "") == "p" {
+			assert.NotEqual(t, "ALL", derefOr(row.Type, ""),
+				"and must not get there by a full scan")
+		}
 	}
 }

--- a/modules/project/db_user_setting.go
+++ b/modules/project/db_user_setting.go
@@ -97,6 +97,23 @@ func (d *DB) queryProjectPinned(projectID, uid string) (bool, error) {
 	return len(pinned) > 0 && pinned[0] == 1, nil
 }
 
+// sqlCountPinnedInSpace is the statement countPinnedInSpaceTx runs.
+//
+// Named for the same reason as sqlListMyProjectGroups: the plan guard EXPLAINs the
+// string production executes, not a copy that can drift into passing forever.
+//
+// The LEFT JOIN carries the membership half of the visibility rule, and removing = 0
+// for the same reason listVisibleInSpace carries it — a seat that is closing counts
+// as gone everywhere else. pm.uid IS NOT NULL is the clause that admits an unlisted
+// project the caller is actually in.
+const sqlCountPinnedInSpace = "SELECT COUNT(*) FROM octo_project_user_setting s " +
+	"INNER JOIN octo_project p ON p.project_id = s.project_id " +
+	"LEFT JOIN octo_project_member pm " +
+	"  ON pm.project_id = p.project_id AND pm.uid = s.uid " +
+	"     AND pm.status = ? AND pm.removing = 0 " +
+	"WHERE s.uid = ? AND s.pinned = 1 AND p.space_id = ? AND p.status = ? " +
+	"  AND (p.discoverability = ? OR pm.uid IS NOT NULL)"
+
 // countPinnedInSpaceTx counts how many projects uid currently has pinned inside one
 // Space, for the quota check.
 //
@@ -154,18 +171,7 @@ func (d *DB) countPinnedInSpaceTx(tx *dbr.Tx, spaceID, uid string) (int, error) 
 	if tx != nil {
 		runner = tx
 	}
-	err := runner.SelectBySql(
-		"SELECT COUNT(*) FROM octo_project_user_setting s "+
-			"INNER JOIN octo_project p ON p.project_id = s.project_id "+
-			// The membership half of the visibility rule. removing = 0 for the same
-			// reason listVisibleInSpace carries it: a seat that is closing already
-			// counts as gone everywhere else, and pm.uid IS NOT NULL is the clause
-			// that admits an unlisted project.
-			"LEFT JOIN octo_project_member pm "+
-			"  ON pm.project_id = p.project_id AND pm.uid = s.uid "+
-			"     AND pm.status = ? AND pm.removing = 0 "+
-			"WHERE s.uid = ? AND s.pinned = 1 AND p.space_id = ? AND p.status = ? "+
-			"  AND (p.discoverability = ? OR pm.uid IS NOT NULL)",
+	err := runner.SelectBySql(sqlCountPinnedInSpace,
 		MemberStatusActive, uid, spaceID, StatusNormal, DiscoverabilitySpaceListed,
 	).LoadOne(&n)
 	if err != nil {

--- a/modules/project/db_user_setting.go
+++ b/modules/project/db_user_setting.go
@@ -110,12 +110,41 @@ func (d *DB) queryProjectPinned(projectID, uid string) (bool, error) {
 // outbox made for a different reason (a worker touching every row of a large fan-out
 // per job) that does not apply to one probe per pin.
 //
-// Disbanded projects do not count. Their name is released and every read path treats
-// them as nonexistent, so a stale pin on one must not consume a live budget the
-// caller cannot free — they cannot even see the project to unpin it.
+// # It counts exactly the pins the caller's own list shows, and that is the contract
 //
-// Both tables are octo_project*, i.e. both general_ci, so no COLLATE: an explicit
-// one has coercibility 0 and would cost octo_project its primary key on this join.
+// Not "every pinned row". The quota predicate MIRRORS listVisibleInSpace, because a
+// quota that counts rows the list does not show produces a refusal the user cannot
+// act on: "you have pinned 6" while their screen shows 5, with no sixth to remove.
+//
+// Two states reach that, and PR #861s review found the second after the first was
+// already handled:
+//
+//   - A DISBANDED project. Its name is released and every read path treats it as
+//     nonexistent. Covered by p.status.
+//   - An UNLISTED project the caller is not a member of. projectMiddleware answers
+//     not_found for exactly that caller, and PUT /:project_id/setting is the only
+//     unpin path — so the pin becomes unreachable through every API surface while
+//     still consuming a slot. An owner flipping discoverability is an ordinary
+//     action, and it permanently burned one of the victims six slots. The
+//     membership half is the same trap by the other door: a member who pins an
+//     unlisted project and is then removed from it lands in the identical state.
+//
+// So the visibility half of listVisibleInSpace comes along:
+// (space_listed OR an active member row). A caller whose project becomes visible
+// again while they are over the cap converges through unpin, which is never
+// refused — the same situation the code already accepts for a cap lowered by
+// configuration.
+//
+// Note what this does NOT do: a Space admin can point-read an unlisted project they
+// never joined (projectMiddleware allows it) but that project is absent from their
+// LIST too, so a pin on it is invisible to both this count and their screen. They
+// can therefore hold more pinned rows than the cap. That is the safe direction of
+// the error — an undercount can never trap anyone — and keeping the count equal to
+// what the list shows is worth more than making the cap exact for one role.
+//
+// All three tables are octo_project*, i.e. all general_ci, so no COLLATE: an
+// explicit one has coercibility 0 and would cost octo_project its primary key on
+// this join.
 func (d *DB) countPinnedInSpaceTx(tx *dbr.Tx, spaceID, uid string) (int, error) {
 	if spaceID == "" || uid == "" {
 		return 0, nil
@@ -128,8 +157,16 @@ func (d *DB) countPinnedInSpaceTx(tx *dbr.Tx, spaceID, uid string) (int, error) 
 	err := runner.SelectBySql(
 		"SELECT COUNT(*) FROM octo_project_user_setting s "+
 			"INNER JOIN octo_project p ON p.project_id = s.project_id "+
-			"WHERE s.uid = ? AND s.pinned = 1 AND p.space_id = ? AND p.status = ?",
-		uid, spaceID, StatusNormal,
+			// The membership half of the visibility rule. removing = 0 for the same
+			// reason listVisibleInSpace carries it: a seat that is closing already
+			// counts as gone everywhere else, and pm.uid IS NOT NULL is the clause
+			// that admits an unlisted project.
+			"LEFT JOIN octo_project_member pm "+
+			"  ON pm.project_id = p.project_id AND pm.uid = s.uid "+
+			"     AND pm.status = ? AND pm.removing = 0 "+
+			"WHERE s.uid = ? AND s.pinned = 1 AND p.space_id = ? AND p.status = ? "+
+			"  AND (p.discoverability = ? OR pm.uid IS NOT NULL)",
+		MemberStatusActive, uid, spaceID, StatusNormal, DiscoverabilitySpaceListed,
 	).LoadOne(&n)
 	if err != nil {
 		return 0, fmt.Errorf("project: count pinned in space: %w", err)

--- a/modules/project/db_user_setting.go
+++ b/modules/project/db_user_setting.go
@@ -1,0 +1,138 @@
+package project
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gocraft/dbr/v2"
+)
+
+// Per-user project settings (P2). One preference so far: pinning.
+//
+// # Why this is not a column on octo_project_member
+//
+// Pinning is not a membership fact — a Space admin sees a space_listed project
+// without joining it and may reasonably pin it — and every write to
+// octo_project_member sits on the member_epoch path, which fleet and drive read
+// to decide whether membership changed and which TestMemberEpochOnlyEverIncrements
+// pins to +1 steps. A pin is not a membership change and must never move it. The
+// migration header argues both at length; repeated here because the next person to
+// add a preference will be looking at this file, not at the SQL.
+
+// upsertProjectUserSetting sets or clears the pin for one (project, uid).
+//
+// INSERT ... ON DUPLICATE KEY UPDATE against uk_octo_project_user_setting, so the
+// operation is idempotent by construction: pinning twice rewrites one row rather
+// than growing a second. That is the same technique P0 used for member
+// re-admission, and it is why the endpoint can be a plain PUT.
+//
+// pinned_at is written on pin and CLEARED on unpin, because it is the sort key for
+// pinned rows and a stale timestamp on an unpinned row would order a future re-pin
+// by when it was pinned the FIRST time. Clearing it makes re-pinning move the
+// project to the front, which is what a user who just pinned something expects.
+//
+// One clock, in Go, in UTC — no CURRENT_TIMESTAMP anywhere. MySQL evaluates it in
+// the session timezone, and this repo has already shipped a metric that read
+// -28799 seconds under TZ=Asia/Shanghai because of exactly that.
+func (d *DB) upsertProjectUserSetting(projectID, uid string, pinned bool) error {
+	return d.upsertProjectUserSettingTx(nil, projectID, uid, pinned)
+}
+
+// upsertProjectUserSettingTx is the same write inside a caller-supplied
+// transaction. tx may be nil, in which case it runs on the session — the quota
+// path needs the count and the write to share one read view, the routes that
+// only clear a pin do not.
+func (d *DB) upsertProjectUserSettingTx(tx *dbr.Tx, projectID, uid string, pinned bool) error {
+	if projectID == "" || uid == "" {
+		return fmt.Errorf("project: upsert user setting: empty project_id or uid")
+	}
+	now := time.Now().UTC()
+	var pinnedAt interface{}
+	flag := 0
+	if pinned {
+		flag = 1
+		pinnedAt = now
+	}
+	runner := dbr.SessionRunner(d.session)
+	if tx != nil {
+		runner = tx
+	}
+	_, err := runner.InsertBySql(
+		"INSERT INTO octo_project_user_setting "+
+			"(project_id, uid, pinned, pinned_at, created_at, updated_at) "+
+			"VALUES (?, ?, ?, ?, ?, ?) "+
+			"ON DUPLICATE KEY UPDATE pinned = VALUES(pinned), "+
+			"  pinned_at = VALUES(pinned_at), updated_at = VALUES(updated_at)",
+		projectID, uid, flag, pinnedAt, now, now,
+	).Exec()
+	if err != nil {
+		return fmt.Errorf("project: upsert user setting: %w", err)
+	}
+	return nil
+}
+
+// queryProjectPinned answers whether uid has pinned projectID.
+//
+// A point query rather than a join, for the routes that already hold one project
+// row and need the caller-specific half of the response: the detail route, and the
+// update route — which must report the CURRENT pin state rather than defaulting to
+// false, or a client refreshing its card after a rename would watch the project
+// silently un-pin itself until the next list fetch.
+//
+// The create route does not call this: a project id that was generated inside the
+// transaction that just committed cannot have a setting row yet, so false there is
+// provable rather than assumed.
+func (d *DB) queryProjectPinned(projectID, uid string) (bool, error) {
+	if projectID == "" || uid == "" {
+		return false, nil
+	}
+	var pinned []int
+	_, err := d.session.SelectBySql(
+		"SELECT pinned FROM octo_project_user_setting WHERE project_id = ? AND uid = ?",
+		projectID, uid,
+	).Load(&pinned)
+	if err != nil {
+		return false, fmt.Errorf("project: query pinned: %w", err)
+	}
+	return len(pinned) > 0 && pinned[0] == 1, nil
+}
+
+// countPinnedInSpaceTx counts how many projects uid currently has pinned inside one
+// Space, for the quota check.
+//
+// # Why the Space is resolved by joining rather than stored on the row
+//
+// octo_project_user_setting deliberately carries no space_id. The (uid, pinned)
+// index narrows to this user's pinned rows across every Space — a single-digit set
+// by construction, since the quota is what bounds it — and the join then reads
+// space_id from octo_project by primary key. A redundant space_id column would save
+// that probe and cost a second copy of a fact, which is the trade the removal
+// outbox made for a different reason (a worker touching every row of a large fan-out
+// per job) that does not apply to one probe per pin.
+//
+// Disbanded projects do not count. Their name is released and every read path treats
+// them as nonexistent, so a stale pin on one must not consume a live budget the
+// caller cannot free — they cannot even see the project to unpin it.
+//
+// Both tables are octo_project*, i.e. both general_ci, so no COLLATE: an explicit
+// one has coercibility 0 and would cost octo_project its primary key on this join.
+func (d *DB) countPinnedInSpaceTx(tx *dbr.Tx, spaceID, uid string) (int, error) {
+	if spaceID == "" || uid == "" {
+		return 0, nil
+	}
+	var n int
+	runner := dbr.SessionRunner(d.session)
+	if tx != nil {
+		runner = tx
+	}
+	err := runner.SelectBySql(
+		"SELECT COUNT(*) FROM octo_project_user_setting s "+
+			"INNER JOIN octo_project p ON p.project_id = s.project_id "+
+			"WHERE s.uid = ? AND s.pinned = 1 AND p.space_id = ? AND p.status = ?",
+		uid, spaceID, StatusNormal,
+	).LoadOne(&n)
+	if err != nil {
+		return 0, fmt.Errorf("project: count pinned in space: %w", err)
+	}
+	return n, nil
+}

--- a/modules/project/metrics.go
+++ b/modules/project/metrics.go
@@ -28,6 +28,7 @@ const (
 	entryProjectCreate  = "project_create"
 	entryProjectUpdate  = "project_update"
 	entryProjectDisband = "project_disband"
+	entryProjectSetting = "project_setting"
 )
 
 // Rejection reasons. Low-cardinality enum; never a free-form message.
@@ -37,6 +38,7 @@ const (
 	reasonQuotaPerSpace    = "quota_per_space"
 	reasonQuotaPerCreator  = "quota_per_creator"
 	reasonQuotaDailyCreate = "quota_daily_create"
+	reasonQuotaPinned      = "quota_pinned"
 	reasonProjectDisbanded = "project_disbanded"
 	reasonFlagOff          = "flag_off"
 	reasonPermissionDenied = "permission_denied"

--- a/modules/project/metrics.go
+++ b/modules/project/metrics.go
@@ -87,6 +87,32 @@ var (
 		Buckets:   []float64{1, 5, 10, 25, 50, 100, 200, 500, 1000},
 	})
 
+	// spaceProjectCountDistribution is the detector for a condition PR-5 named and
+	// could not otherwise see.
+	//
+	// PR-5's ORDER BY sorts by a per-caller pin, which no index can serve, so
+	// listVisibleInSpace now sorts every project visible to the caller in the Space
+	// before LIMIT applies (measured in TestTheProjectListReachesItsRowsByAnIndex:
+	// 0.28ms before, 7.9ms at 2000 visible projects). The escalation condition is
+	// "a Space reaches the thousands", and without this histogram it would arrive
+	// as user-visible latency rather than as a signal.
+	//
+	// Projects per Space, not the sort input itself: the sort input is the subset
+	// one caller can see, which cannot be sampled without a per-caller query, and
+	// this bounds it from above. Conservative in the right direction — if no Space
+	// is near the threshold then no caller's page can be. Sampled on the sparse
+	// metrics tick, so it costs the request path nothing.
+	//
+	// Buckets run past the measured 2000 so the top one means "the escalation
+	// condition in the plan guard has arrived".
+	spaceProjectCountDistribution = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: metricNamespace,
+		Name:      "space_project_count",
+		Help: "Active projects per Space, sampled on the metrics tick. Bounds the row count " +
+			"the project list must sort per page; see the plan guard for the escalation condition.",
+		Buckets: []float64{1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000},
+	})
+
 	// i1Violations is the reconcile verdict AFTER the in-flight exemption. A
 	// non-zero value means a Project seat outlives its Space seat with nothing
 	// scheduled to fix it.

--- a/modules/project/metrics_collect.go
+++ b/modules/project/metrics_collect.go
@@ -93,4 +93,26 @@ func (p *Project) refreshDistributionMetrics() {
 	for _, row := range rows {
 		memberCountDistribution.Observe(float64(row.MemberCount))
 	}
+
+	// Projects per Space. Bounded by the same ReconcileLimit as every other read on
+	// this tick, and grouped rather than per-Space-per-query for the same reason.
+	// See spaceProjectCountDistribution for why this is sampled at all: it is the
+	// only thing that sees the project list's sort input growing before users do.
+	var spaceRows []*spaceProjectCountRow
+	if _, err := p.db.session.SelectBySql(
+		"SELECT COUNT(*) AS project_count FROM `octo_project` "+
+			"WHERE status = ? GROUP BY space_id LIMIT ?",
+		StatusNormal, p.cfg.ReconcileLimit,
+	).Load(&spaceRows); err != nil {
+		p.Warn("采集 Space 项目数分布失败", zap.Error(err))
+		return
+	}
+	for _, row := range spaceRows {
+		spaceProjectCountDistribution.Observe(float64(row.ProjectCount))
+	}
+}
+
+// spaceProjectCountRow is one Space's active project count.
+type spaceProjectCountRow struct {
+	ProjectCount int `db:"project_count"`
 }

--- a/modules/project/model.go
+++ b/modules/project/model.go
@@ -277,6 +277,41 @@ type MemberResp struct {
 	CreatedAt string `json:"created_at"`
 }
 
+// GroupResp is one row of the project group list.
+//
+// Deliberately NARROW, and not a copy of modules/group's GroupResp. That struct
+// is forty-odd fields of per-user group state, and it is served by the routes a
+// client already calls for exactly that (GET /v1/group/my, GET /v1/groups/:group_no).
+// Restating it here would create a second wire contract for one piece of state,
+// and the two would drift the first time either changed — while this module,
+// which cannot import modules/group, would have no compiler to notice.
+//
+// So this answers one question — which groups in this project am I in — with the
+// fields the tree renders, and the client fetches everything else where it
+// already does. The avatar fields travel together because they are one decision
+// on the client: avatar_text/avatar_color override, is_upload_avatar wins over
+// both, and is_named decides the fallback when none is set. Shipping a subset
+// would make the list render group avatars differently from every other surface.
+type GroupResp struct {
+	GroupNo string `json:"group_no"`
+	Name    string `json:"name"`
+	// IsNamed is 1 for a user-chosen group name, 0 for an auto-generated one
+	// ("张三、李四、王五"). Only 1 renders the name into the default avatar.
+	IsNamed int `json:"is_named"`
+	// AvatarText is the custom avatar text; "" falls back per IsNamed.
+	AvatarText string `json:"avatar_text"`
+	// AvatarColor is the custom palette index; null derives it from group_no.
+	// A pointer because the column is nullable and null is NOT index 0.
+	AvatarColor    *int `json:"avatar_color"`
+	IsUploadAvatar int  `json:"is_upload_avatar"`
+	// MemberCount counts active members (is_deleted = 0 AND status = 1),
+	// everyone in the group — unlike the project's own member_count, which #855
+	// narrowed to humans. These are different populations, so the same name
+	// meaning different things is a hazard the client teams need to know about:
+	// a project group's count includes the agents seated in it.
+	MemberCount int `json:"member_count"`
+}
+
 // memberRosterModel is the member roster joined to `user` for display names.
 type memberRosterModel struct {
 	MemberModel

--- a/modules/project/model.go
+++ b/modules/project/model.go
@@ -250,14 +250,14 @@ type Resp struct {
 	// none yet (provisioning failed and has not been retried; see D4). A client
 	// showing an entry point to the group must handle "" rather than assuming.
 	AllMemberGroupNo string `json:"all_member_group_no"`
-	// MyRole is the caller's project role, or -1 when the caller is not a member
-	// (a Space admin reading a project they have not joined).
 	// Pinned is the CALLER's own pin, not a property of the project: the same
 	// project reads true for one user and false for the next. It is on the list
 	// AND the detail route, because a field present on one and absent on the other
 	// makes the two disagree about the same project — the defect
 	// all_member_group_no already had to be fixed for once.
-	Pinned       bool         `json:"pinned"`
+	Pinned bool `json:"pinned"`
+	// MyRole is the caller's project role, or -1 when the caller is not a member
+	// (a Space admin reading a project they have not joined).
 	MyRole       int          `json:"my_role"`
 	Capabilities Capabilities `json:"capabilities"`
 	CreatedAt    string       `json:"created_at"`

--- a/modules/project/model.go
+++ b/modules/project/model.go
@@ -295,8 +295,18 @@ type MemberResp struct {
 type GroupResp struct {
 	GroupNo string `json:"group_no"`
 	Name    string `json:"name"`
-	// IsNamed is 1 for a user-chosen group name, 0 for an auto-generated one
-	// ("张三、李四、王五"). Only 1 renders the name into the default avatar.
+	// IsNamed is 1 for a group created BEFORE the 2026-06-29 avatar revamp and 0
+	// for one created after: legacy groups render the group name's first two
+	// characters into the default avatar, new ones fall back to the two-person
+	// icon. NOT "the user chose this name" — that was the column's original
+	// meaning and 20260629000002_refresh_avatar_comments.sql retired it.
+	//
+	// On THIS endpoint the value is therefore always 0: modules/group hardcodes
+	// IsNamed: 0 on every create (service.go:223, :1278) and 1 exists only where
+	// the #500 migration backfilled it, which no project group can be. It is
+	// shipped anyway so the avatar fallback chain is evaluated by the same code
+	// on every surface rather than special-cased here — a client that hardcodes
+	// the fallback for this list is the drift the field exists to prevent.
 	IsNamed int `json:"is_named"`
 	// AvatarText is the custom avatar text; "" falls back per IsNamed.
 	AvatarText string `json:"avatar_text"`

--- a/modules/project/model.go
+++ b/modules/project/model.go
@@ -172,6 +172,21 @@ type updateReq struct {
 	MaxMembers      *int    `json:"max_members"`
 }
 
+// settingReq is the caller's personal preferences for one project.
+//
+// Shaped as a settings bag with pointer fields rather than as /pin and /unpin
+// routes, following PUT /v1/groups/:group_no/setting, which carries top / mute /
+// save / remark through one endpoint. Two verb routes look simpler while there is
+// one preference and stop looking simpler at the second: a preference then costs a
+// key here, not two routes and two handlers.
+//
+// A pointer distinguishes "not mentioned" from "set to false", so a client that
+// learns about a future preference does not have to send every field to change
+// one. An empty body is a no-op, not a reset.
+type settingReq struct {
+	Pinned *bool `json:"pinned"`
+}
+
 type membersReq struct {
 	UIDs []string `json:"uids"`
 }
@@ -237,6 +252,12 @@ type Resp struct {
 	AllMemberGroupNo string `json:"all_member_group_no"`
 	// MyRole is the caller's project role, or -1 when the caller is not a member
 	// (a Space admin reading a project they have not joined).
+	// Pinned is the CALLER's own pin, not a property of the project: the same
+	// project reads true for one user and false for the next. It is on the list
+	// AND the detail route, because a field present on one and absent on the other
+	// makes the two disagree about the same project — the defect
+	// all_member_group_no already had to be fixed for once.
+	Pinned       bool         `json:"pinned"`
 	MyRole       int          `json:"my_role"`
 	Capabilities Capabilities `json:"capabilities"`
 	CreatedAt    string       `json:"created_at"`

--- a/modules/project/model.go
+++ b/modules/project/model.go
@@ -323,7 +323,7 @@ type GroupResp struct {
 	// meaning and 20260629000002_refresh_avatar_comments.sql retired it.
 	//
 	// On THIS endpoint the value is therefore always 0: modules/group hardcodes
-	// IsNamed: 0 on every create (service.go:223, :1278) and 1 exists only where
+	// IsNamed: 0 at BOTH create sites in modules/group/service.go, and 1 exists only where
 	// the #500 migration backfilled it, which no project group can be. It is
 	// shipped anyway so the avatar fallback chain is evaluated by the same code
 	// on every surface rather than special-cased here — a client that hardcodes

--- a/modules/project/model.go
+++ b/modules/project/model.go
@@ -182,7 +182,8 @@ type updateReq struct {
 //
 // A pointer distinguishes "not mentioned" from "set to false", so a client that
 // learns about a future preference does not have to send every field to change
-// one. An empty body is a no-op, not a reset.
+// one. A body that names no preference (`{}`) is a no-op, not a reset — a
+// zero-byte body is a 400, see updateSettingHandler.
 type settingReq struct {
 	Pinned *bool `json:"pinned"`
 }

--- a/modules/project/reconcile_p1_collation_test.go
+++ b/modules/project/reconcile_p1_collation_test.go
@@ -43,6 +43,10 @@ var p1ProbeTables = []struct {
 	{"octo_project", false},
 	{"octo_project_member", false},
 	{"octo_project_member_removal_cleanup", false},
+	// PR #861's pin table. Its own statements are octo_project*-only today, but the
+	// probe is what makes that checkable rather than asserted: a future join from it
+	// into a legacy table has to fail here instead of in production.
+	{"octo_project_user_setting", false},
 	{"space_member_removal_cleanup", false}, // migration-created, explicitly general_ci
 	{"space", true},
 	{"group", true},

--- a/modules/project/reconcile_p2_collation_test.go
+++ b/modules/project/reconcile_p2_collation_test.go
@@ -111,6 +111,20 @@ func TestP2StatementsSurviveCollationDrift(t *testing.T) {
 			_, err := projectpkg.PickActiveOwner(p.db.session, probeProject)
 			return err
 		},
+		// The project group list and its member count. Both are legacy-to-legacy
+		// today (`group` join `group_member`, everything else a bind parameter),
+		// so db_group.go's header argues they need no COLLATE — and that argument
+		// is exactly the kind this file exists to stop being free. Pinned here so
+		// the day someone joins octo_project* into either one, CI fails instead of
+		// production 500ing on a user-facing GET.
+		"listMyProjectGroups": func() error {
+			_, err := p.db.listMyProjectGroups("s", probeProject, "u", 0, 10)
+			return err
+		},
+		"countActiveGroupMembers": func() error {
+			_, err := p.db.countActiveGroupMembers([]string{probeGroup})
+			return err
+		},
 	}
 
 	for name, run := range statements {

--- a/modules/project/sql/20260908000001_project_user_setting.sql
+++ b/modules/project/sql/20260908000001_project_user_setting.sql
@@ -1,0 +1,67 @@
+-- +migrate Up
+
+-- octo_project_user_setting — 每个用户对某个项目的个人偏好。P2 只有置顶一项。
+--
+-- 为什么是新表，而不是给 octo_project_member 加一列
+--
+-- 两条理由，都不是风格问题：
+--
+--   1. 置顶不是成员事实。Space 管理员能看见 space_listed 项目而不必加入它
+--      （见 listVisibleInSpace 的 discoverability 分支），他同样可以置顶。把
+--      pinned 放进成员行，等于让「能置顶」隐含「是成员」，而这两件事在读路径上
+--      本来就是分开的。
+--   2. octo_project_member 的每一次写都在 member_epoch 递增路径上。那个纪元是
+--      fleet / drive 判断「成员是否变过」的依据，只允许 +1，且由
+--      TestMemberEpochOnlyEverIncrements 钉住。置顶不是成员变更，绝不能推动它；
+--      而把一列放进那张表，就是在邀请下一个人在同一个事务里顺手 bump。
+--
+-- 表名与 octo_ 前缀、utf8mb4_general_ci 都对齐 P0 定下的规矩：本表要与
+-- octo_project 做 JOIN，两侧同为 general_ci 才不需要 COLLATE（legacy 侧才需要）。
+--
+-- 时间列一律应用侧写入的 UTC，无 DEFAULT、无 ON UPDATE。理由与
+-- octo_project_member_removal_cleanup 的表头相同：MySQL 的 CURRENT_TIMESTAMP 取
+-- 会话时区，本仓已经因此发过一个读出 -28799 秒的指标。一个时钟，在 Go 里，UTC。
+--
+-- 本文件不含任何撇号，与 P1 那张迁移表同样的原因：本模块的迁移测试按朴素规则切分
+-- 语句，会把撇号当成字符串定界符，于是注释里一个所有格撇号就能让它把下一个分号读
+-- 成在字面量内部。且撇号是成对抵消的，文件里撇号数为偶数时能侥幸通过、为奇数时才
+-- 失败，所以不要靠数个数。
+CREATE TABLE `octo_project_user_setting` (
+  `id`         BIGINT UNSIGNED  NOT NULL AUTO_INCREMENT,
+  `project_id` VARCHAR(40)      NOT NULL DEFAULT ''  COMMENT '项目ID（宽度/字符集对齐 octo_project.project_id）',
+  `uid`        VARCHAR(40)      NOT NULL DEFAULT ''  COMMENT '设置归属的用户（对齐 user.uid）',
+  `pinned`     TINYINT UNSIGNED NOT NULL DEFAULT 0   COMMENT '1=该用户置顶了这个项目',
+  -- 置顶时间，取消置顶时置空。列表排序按 (pinned DESC, pinned_at DESC, id DESC)，
+  -- 让最近置顶的排在前面；末位的 octo_project.id 唯一，所以这个顺序是全序——
+  -- OFFSET 分页要求全序，否则翻页会丢行和重行。
+  `pinned_at`  DATETIME(3)      NULL                 COMMENT 'UTC；应用侧写入，取消置顶时置 NULL',
+  `created_at` DATETIME(3)      NOT NULL             COMMENT 'UTC；应用侧写入，禁 CURRENT_TIMESTAMP',
+  `updated_at` DATETIME(3)      NOT NULL             COMMENT 'UTC；应用侧写入，禁 ON UPDATE',
+  PRIMARY KEY (`id`),
+  -- 一个用户对一个项目只有一行。既是语义约束，也是 upsert 的幂等来源：
+  -- INSERT ... ON DUPLICATE KEY UPDATE 靠它把「重复置顶」变成一次无害的改写，
+  -- 而不是长出第二行。
+  --
+  -- 它同时就是列表读路径要的索引：列表查询以 octo_project 为驱动表，按
+  -- (project_id, uid) 回查本表，正好走这条唯一键的最左前缀加等值。
+  UNIQUE KEY `uk_octo_project_user_setting` (`project_id`, `uid`),
+  -- 置顶配额要按 uid 数「这个用户一共置顶了几个」，而唯一键的首列是 project_id，
+  -- 帮不上按 uid 的等值查找——没有这条索引，每一次置顶写入都要全表扫一张随用户
+  -- 数增长的表。
+  --
+  -- 第二列是 pinned 而不是别的：配额只数 pinned = 1 的行，取消置顶留下的
+  -- pinned = 0 行在同一个 uid 下会越积越多，让它们落在索引区间之外，扫描就只读
+  -- 真正算数的那几行。
+  --
+  -- Space 维度不在索引里，而是靠回表 octo_project 拿 space_id 过滤。因为按
+  -- (uid, pinned) 命中的行数上限就是这个用户在所有 Space 的置顶总数，本身已经
+  -- 是个位数——再冗余一列 space_id 进来，是为一次已经很小的扫描增加一份要维护
+  -- 的副本。
+  KEY `idx_octo_project_user_setting_uid_pinned` (`uid`, `pinned`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='用户对项目的个人偏好（P2：置顶）';
+
+-- +migrate Down
+--
+-- 回滚会丢掉所有人的置顶。这是个人偏好、不是业务数据，重新置顶即可恢复，
+-- 因此不像 removal_cleanup 那张表那样需要先查未完成工单数。
+DROP TABLE IF EXISTS `octo_project_user_setting`;

--- a/modules/project/sql/20260908000001_project_user_setting.sql
+++ b/modules/project/sql/20260908000001_project_user_setting.sql
@@ -22,10 +22,13 @@
 -- octo_project_member_removal_cleanup 的表头相同：MySQL 的 CURRENT_TIMESTAMP 取
 -- 会话时区，本仓已经因此发过一个读出 -28799 秒的指标。一个时钟，在 Go 里，UTC。
 --
--- 本文件不含任何撇号，与 P1 那张迁移表同样的原因：本模块的迁移测试按朴素规则切分
--- 语句，会把撇号当成字符串定界符，于是注释里一个所有格撇号就能让它把下一个分号读
--- 成在字面量内部。且撇号是成对抵消的，文件里撇号数为偶数时能侥幸通过、为奇数时才
--- 失败，所以不要靠数个数。
+-- 注释里不要出现单引号（撇号），与 P1 那张迁移表同样的原因。真正被强制的是
+-- applyOneProjectMigrationFile 里的两条检查：一是全文不得出现 sql-migrate 的显式
+-- 语句块标记（连注释里提一下那个词都不行，本段就踩过一次），二是把全文按单引号成对
+-- 切出来的每一段字面量里都不能有分号。DDL 的 COMMENT 字面量本身成对，不受影响；
+-- 坏事的是注释里一个所有格撇号——它是单只的，会让它之后所有单引号的配对整体错位，
+-- 于是本来无分号的一段被判成有分号，或者真的带分号的字面量反而检不出来。所以规则
+-- 不是数单引号的个数，而是注释里一个都不写。
 CREATE TABLE `octo_project_user_setting` (
   `id`         BIGINT UNSIGNED  NOT NULL AUTO_INCREMENT,
   `project_id` VARCHAR(40)      NOT NULL DEFAULT ''  COMMENT '项目ID（宽度/字符集对齐 octo_project.project_id）',

--- a/pkg/authtree/authtree.go
+++ b/pkg/authtree/authtree.go
@@ -112,6 +112,16 @@
 //     Project seat either, and every Project route's gate is the caller's own Space
 //     membership.
 //
+// GET /v1/projects/:project_id/groups is a NEW route inside that same block, and
+// it is the first Project route to return another module's resource. Recorded
+// because a reader could take it for the moment Project became a read boundary,
+// and it is not: the route mounts the same projectMiddleware as its siblings, so
+// the caller's Space membership is verified before the handler runs, and the
+// query is then scoped to groups the CALLER is already an active member of. It
+// narrows what a caller can already reach; it grants nothing, and it answers an
+// empty list — never a refusal — to someone with no groups in that project. Same
+// tree treatment as the rest of the block: none.
+//
 // P1 added a Project dimension to two EXISTING session routes, and neither
 // changes the picture above — recorded so the absence of a census entry is a
 // decision rather than an oversight:

--- a/pkg/errcode/project.go
+++ b/pkg/errcode/project.go
@@ -132,6 +132,21 @@ var (
 
 	// ---- quotas (403) --------------------------------------------------------
 
+	// ErrProjectQuotaPinned covers the per-Space cap on pinned projects.
+	//
+	// A quota rather than an eviction: silently unpinning the oldest to make room
+	// would be data loss the caller did not ask for and cannot see, and "why did my
+	// pin disappear" is a support ticket nobody can answer from logs.
+	//
+	// Carries max so the client can say WHICH limit was hit without hardcoding the
+	// number and drifting from the server.
+	ErrProjectQuotaPinned = register(codes.Code{
+		ID:             "err.server.project.quota_pinned",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "You have pinned the maximum number of projects.",
+		SafeDetailKeys: []string{"max"},
+	})
+
 	// ErrProjectQuotaPerSpace covers the per-Space project cap.
 	ErrProjectQuotaPerSpace = register(codes.Code{
 		ID:             "err.server.project.quota_per_space",

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -1479,6 +1479,9 @@ other = "你已不是该空间的有效成员。"
 ["err.server.project.member_not_space_member"]
 other = "目标用户不是该空间的有效成员。"
 
+["err.server.project.quota_pinned"]
+other = "置顶项目数已达上限。"
+
 ["err.server.project.quota_per_space"]
 other = "该空间的项目数量已达上限。"
 

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -858,6 +858,9 @@ other = "You have reached your project limit in this space."
 ["err.server.project.quota_per_space"]
 other = "This space has reached its project limit."
 
+["err.server.project.quota_pinned"]
+other = "You have pinned the maximum number of projects."
+
 ["err.server.project.request_invalid"]
 other = "Invalid request."
 


### PR DESCRIPTION
## Summary

Three of the four product surfaces P0, P1 and P2 all parked and no brief claimed. They are **independent features sharing a branch** at the requester's direction — a review cost paid deliberately, not a dependency.

1. **`GET /v1/projects/:project_id/groups`** (PR-1) — the caller's own live groups within one project. Before it there was no way to ask which groups a project has: `modules/project` registered nine routes and none returned a group, `GET /v1/group/my` filters on `space_id` alone, and the query that answers it existed unexported, reachable only from the member-removal cascade worker.
2. **`project_id` on the sidebar** (PR-2) — #855 put it on `GroupResp` and the group detail, which answers "which project is this group in" for a client that already has the group. The sidebar is the surface that does not: it renders the conversation list, and without the field a client cannot group those conversations by project. **It ships only on the Space-scoped path** — see the disclosure decision below.
3. **`PUT /v1/projects/:project_id/setting`** (PR-5) — the caller's own preferences for one project. `pinned` is the only one so far; it sorts the project to the top of `GET /v1/space/:space_id/projects`, and is **capped at six per Space**.

**Was stacked on #855; now on `main`.** #855 merged as `566e625` (squash), so the branch was rebased with `--onto main` — a plain rebase would have tried to replay #855's own commits, which no longer exist as commits. One conflict, in `listVisibleInSpace`: #855's last round removed the `member_count` correlated subquery (the third instance of the COLLATE-on-the-driving-side shape) and moved the count into `fillMemberCounts`, which is the same statement PR-5 edits. Resolved by keeping their form and re-attaching only `IFNULL(s.pinned, 0) AS pinned`.

## Related Issue

None. All three came from the 2026-09-07 prototype — the 群聊 tab, the conversation list, and the pinned section of the project list.

## Linked Spec

`.octospec/tasks/project-p2-product-surfaces/brief.md` — D1–D8, with Q2 and Q3 resolved and Q1 (who may set `is_official`) still open, gating PR-4 only.
Implement-phase record: `.octospec/tasks/project-p2-product-surfaces/context.yaml`.
Team-visible writeup: `.octospec/journal/shared/project-p2-product-surfaces.md`.

## Changes

### PR-1 — the group list

- **Membership-scoped, and the predicate IS the access control.** I2 is a ceiling, not a floor: an active project seat does not put you in any particular group of it. Consequence: **no role gate beyond `projectMiddleware`**, and a Space admin who never joined gets `[]` rather than a 403 — a refusal there would make project non-membership observable on a route that currently discloses nothing.
- **`modules/project` reads the `group` table directly**, without importing `modules/group` (`pkg/project/import_guard_test.go` pins that at zero). A reverse-registered read hook was rejected: an unregistered provider answers an empty list, indistinguishable from "no groups".
- **A narrow response**, not a second `GroupResp`. Threads stay on `GET /v1/groups/:group_no/threads`; unread counts stay on the conversation layer.
- Member counts in one grouped query per page, not `QueryMemberCount` per row.

### PR-2 — `project_id` on the sidebar

- **No extra query, which is the whole design constraint** — the sidebar is the hottest read path in the product. `CollectGroupSpaceMap` already calls `GetGroups` once per page, and the value was already in the row `QueryWithGroupNos` selects; it was simply never mapped out of `Model` into `InfoResp`. Both maps now come from one explicit `GetGroups` call.
- **Read at the same site and with the same key as `SpaceID`**, so the two cannot disagree about one conversation: a group carries its own, a `COMMUNITY_TOPIC` carries its parent's, a `PERSON` carries none. That last split is what a naive implementation gets wrong — a topic's channel id is not a group number.
- **Ships only on the Space-scoped path.** A named gate (`projectMapForSpaceScope`) drops the project map when no `X-Space-ID` was supplied — which is exactly the path where no membership predicate runs for plain `GROUP` items, so a removed member whose IM conversation row outlives the removal still receives the item. **This is a client-visible narrowing of what PR-2 originally shipped**, added after review; see the disclosure decision below.
- `omitempty`, so a Space-direct group's and a DM's payloads are byte-identical to before.
- **Guards the one group surface that answers unauthenticated callers.** `GET /v1/group/invite/detail` carries no `AuthMiddleware`; `project_id` there would tell an anonymous holder of an invite code that a project exists and its id. It is safe today only because that handler builds a hand-written `gin.H` — an accident of how it was written, now a pinned invariant.

### PR-5 — pinning

- **A settings bag, not `/pin` + `/unpin`**, following `PUT /v1/groups/:group_no/setting`. Two verb routes are simpler only while there is one preference; the second costs two routes and two handlers where this costs a key. PUT is idempotent by contract, and a pointer field keeps an unmentioned preference unmentioned rather than reset.
- **The read is a field on the existing list, not a second endpoint.** A separate "my pinned projects" route would make the client fetch twice and merge — and the *order* has to be the server's, because OFFSET pagination needs a total order a client-side merge cannot reconstruct. The new `ORDER BY IFNULL(s.pinned,0) DESC, s.pinned_at DESC, p.id DESC` leaves the pre-existing tail byte-identical. **What that ordering costs is measured below** — it is more than the earlier rounds of this PR believed.
- **Its own table**, not a column on `octo_project_member`: pinning is not a membership fact, and every write to that table sits on the `member_epoch` path that fleet and drive poll to decide whether a roster changed.
- **Capped at six per Space** (`OCTO_PROJECT_MAX_PINNED`), refused with `err.server.project.quota_pinned` carrying `max`. The quota **counts exactly the pins the caller's own list shows** — it mirrors `listVisibleInSpace` rather than gating on `status` alone.
- Every post-commit read on these paths is fail-soft: a display aggregate that hiccups must not turn a committed write into a 500.

### Both

- A census entry in `pkg/authtree` recording that the group list does **not** make Project a read boundary.
- The migration is registered in `projectMigrationFiles` and in the collation probe, so its Down section is exercised and a future cross-schema join fails in CI.

## What PR-5's ordering costs, measured

A reviewer asked for one `EXPLAIN` from someone with a schema up, because the PR could not settle whether the filesort was new or only the `Using temporary`. Measured with `EXPLAIN ANALYZE` on a seeded database — 4000 projects, 5000 seats, 2000 of them visible in the probed Space, after `ANALYZE TABLE`:

| | time | plan |
|---|---|---|
| before PR-5 | **0.28 ms** | `Backward index scan`, 23 rows touched, no sort at all |
| after PR-5 | **13.5 ms** | `Using temporary; Using filesort`, 1667 rows sorted, **1667** dependent-subquery loops |
| after moving `seat_count` out of the statement | **7.9 ms** | same sort, no subquery loops |

**Both are new**, and an earlier claim in this description that the query "already filesorted" was wrong. `ORDER BY p.id DESC` was being served for free by a backward scan of the Space index: a secondary index entry carries the PK, so within `(space_id=const, status=const)` the entries are already in `id` order and `LIMIT 20` stopped the scan after 23 rows.

The dominant term turned out not to be the sort but the correlated `seat_count` aggregate — nearly free while `LIMIT 20` short-circuited the scan, and run **once per sorted row** the moment PR-5's `ORDER BY` removed that short-circuit. It now comes from `fillMemberCounts`, where #855's eighth review had already moved `member_count` for a different reason, at no extra query: the roster read that classifies humans already returns every seat row, so the seat total is `len()` of what it read. Two consequences beyond the milliseconds — the two-read-view mismatch #855's tenth review had to document as an accepted inexactness is gone (`member_count + agent_count == seat_count` now holds on the wire rather than usually), and `AgentCount`'s clamp goes back to being defensive.

**The remaining 7.9 ms is accepted, not fixed.** It is the sort over every visible project in the Space, and the shape that removes it is two statements and two read views for one page — bounded latency traded for a pagination correctness risk. The escalation condition is written into the plan guard rather than left to be rediscovered: if a Space's visible-project count reaches the thousands, the sort input has to stop being every visible project, and since pins are capped at six the shape that gets there is one bounded read of the caller's pinned ids plus the existing `p.id DESC` page, with the offset arithmetic in Go.

## Review response

Six rounds across three reviewers. Every blocking item is fixed; the two decisions that were not mine to make were put to the requester.

**Two blocking findings, both fixed and mutation-verified:**

- **The pin quota counted pins the caller could neither see nor unpin.** `countPinnedInSpaceTx` gated on `p.status` alone, while the list gates on `(space_listed OR an active member row)` and `projectMiddleware` answers not_found for an unlisted project to a non-member. Three predicates, three answers about the same row — so an owner flipping discoverability permanently burned one of a victim's six slots, and the refusal said "you have pinned 6" to someone whose list showed 5. The count now mirrors the list. Both doors are pinned (the discoverability flip and membership removal), plus the positive branch — a member of an unlisted project must still spend a slot, or membership of unlisted projects becomes an unbounded budget.
- **A committed write reported as a failure.** This one was mine and worse than described: I put a hard failure directly beneath the comment ending *"which is the one thing a response after a successful write must not do"*. All three post-write reads now degrade through `pinnedOrFalse` / `splitSeatCounts`. `TestACommittedPinIsNotReportedAsAFailure` drives it by breaking the read rather than hoping it fails.

**Two decisions put to the requester rather than taken:**

- **The sidebar disclosure.** The argument that the marginal disclosure is harmless holds — the item already carries `target_id` and `space_id`, and `project_id` adds an opaque identifier no route will resolve for that caller. The requester chose the gate over it, which is the right call: "harmless because they cannot use it" is an argument that has to be re-made every time someone adds the next field. The pre-existing hole is **not** closed here; that is `project-p2-read-path-hardening`.
- **The blacklist divergence.** A group that blacklisted you disappears from your project tree while `GET /v1/group/my` still shows it, and the two `member_count`s differ by one. Deliberate — `ExistMemberActive` is the hardening line (#343/#345) refusing that uid the group and its threads — and pinned by a test asserting both halves. Both peer reviewers flagged it for product sign-off rather than as a defect.

**The last round's findings, all taken:**

- **The one mapping that was not actually mutation-tested.** `ProjectID: m.ProjectID` in `toInfoResp` is the only link between a `group` row and the sidebar's field, and every case in `modules/message` reaches it either from a map the test built itself or through a fake `GetGroups` returning hand-written `InfoResp` literals. Deleting the assignment left the whole suite green while the field shipped empty to every client. `TestGetGroupsCarriesTheProjectIDFromTheRow` drives the real `Service.GetGroups` over real rows and asserts both halves; the mutation is the finding — with the assignment gone the new case fails and `modules/message` still passes.
- **The third plan guard.** `sqlListVisibleInSpace` is a named constant now, EXPLAINed by the guard and pinned by the source guard. It asserts a Space-**leading** index rather than one index by name, which is a finding rather than a hedge: the empty CI table picks `uk_octo_project_space_active_name` and the seeded database picks `idx_octo_project_space_status`. Mutation-confirmed by wrapping `p.space_id` in `LOWER()`.
- **A correction from the reviewer, adopted into the record:** `GroupStatusDisabled(0)` is an independent admin-settable state, so `AND g.status <> ?` in the group list is the *correct* predicate, not merely a consistent one — narrowing it to `status = Normal` would drop admin-disabled groups from the surface.

**Everything else raised:** the burst figure in the race comment was wrong (2 rps with a burst of **60**, so the overshoot is ~65 rows against a cap of 6, not "one extra row") and is corrected with the escalation condition stated; the unpin tombstone, the closure side-effect on `pkg/space`'s undocumented invocation shape, the `Pinned` doc inserted inside `MyRole`'s block, totality-vs-stability, the warning text, the skippable DM assertion, the `BindJSON` the module documents against, the stale "newest first" summary my own change made stale, and the rotted `path:line` citations (now cited by function name — one had rotted twice between the review and the fix) — all fixed.

**One item I declined and was wrong to:** I reported the smart-quote corruption in `modules/message/issue557_creator_thread_e2e_test.go` as pre-existing. It is **not** — this branch's PR-2 commit introduced it, and the ASCII is restored. The cause is worth recording: **gofmt** did it. Go 1.19+ reformats *doc* comments through `go/doc/comment`, which turns a `''` pair into a closing curly quote; the file is not gofmt-clean on `main` either, so anyone running `gofmt -w` over `modules/message` reproduces it.

The migration header (which claimed the file holds no apostrophes while the DDL below it holds 18) now states the invariant `applyOneProjectMigrationFile` actually enforces. The first attempt at that paragraph failed the migration test by naming the statement-block marker literally, which the same guard forbids anywhere in the file; the parenthesis in it now says so.

**Still not taken:** the swagger `sidebarItem` schema lacks `project_id`, but it already lacks `space_id` and `my_source_space_id` from #153 — that drift predates this branch and fixing it here would widen the PR.

## Testing

**CI went green on `9439c77`** — all 23 checks, including `Unit Test`, the four `E2E Test` shards, `Lint`, `Vet`, `Build`, both i18n gates and the aggregate `Test`. Now that the PR targets `main`, that was the first time the repo's real CI ran on this branch; every earlier claim here was local-only.

**The first CI run failed and this is what happened**, recorded because the fix is not a diagnosis. `E2E Test (3/4)` failed four cases in `modules/group` — `TestGroupSettingUpdate_AllowNoMention_SilentToggleSucceeds`, `TestGroupCreate_WithCategoryID`, `TestUnblacklistStillRestoresAProjectMember`, `TestSpaceDirectUnblacklistIsUnaffected` — none of which this branch touches, and the identical shard was green on #855's final head an hour earlier. What this branch does add to that package is one case, and it cleaned the tables on entry but not on exit; those four seed `user.Model{UID: testutil.UID}` under `require.NoError` and create groups against a per-user quota, so each only passes on a table whose previous occupant tidied up, and `-shuffle=on` decides who that is. The sibling `all_member_group` cases carry `defer CleanAllTables` for the same reason, so this one now does too — and the next run went green.

That is a second sample, not proof. I could not reproduce the failure: seven local runs of the package under `-race -shuffle=on` are green, as is the failing four plus the new case under six fixed seeds. The job log does not carry the assertion text (the shard script reprints only the `FAIL` lines and the package body is past the log API's tail window), and this account gets a 403 on `rerun-failed-jobs`. **If that shard flakes again on those four cases, the order dependence is in the package rather than in this branch**, and it wants its own task.

Local, against MySQL 8.0.46 (server collation `utf8mb4_0900_ai_ci`, `test` database `utf8mb4_general_ci` — the production-shaped split the collation guards exist for), Redis, WuKongIM v2.2.4-20260313, with the `test` database recreated **before every package**:

```
go test -race -shuffle=on ./modules/project/   ok
go test -race -shuffle=on ./modules/group/     ok
go test -race -shuffle=on ./modules/message/   ok
go test -race -count=1 ./pkg/project/ ./pkg/authtree/ ./pkg/errcode/   ok
golangci-lint run (touched trees)              0 issues
go build ./...                                 clean
make i18n-extract-check && make i18n-lint      OK
```

One new error code (`err.server.project.quota_pinned`) with its zh-CN translation.

- [x] Unit tests added/updated
- [x] Manually verified

**Every predicate and mapping this PR adds is mutation-tested, not merely covered.** That claim was false for one mapping until the last round found it (`toInfoResp`, above) — which is the strongest argument for the claim being worth making explicitly. Neutralise `g.space_id`, the member count's `status`, the quota's visibility clause or its OR, swap `AvatarText` for the name, remove the Space-scope gate call, delete the `ProjectID` assignment, wrap `p.space_id` in `LOWER()`, or restore the pre-fix fail-hard bytes, and the corresponding case goes red.

Also worth calling out: `TestPinDoesNotMoveMemberEpoch` is the assertion that justifies the separate table; `TestProjectMapCostsNoExtraQuery` asserts the `GetGroups` call count with a counting fake rather than trusting a comment; `TestGroupInviteDetailNeverLeaksProjectID` asserts on the raw body so a rename cannot slip the value through; the three plan guards EXPLAIN named constants and a source guard pins that production still runs them; and `TestListProjectGroupsIncludesTheAllMemberGroup` runs the **real** provisioner, not the stand-in.

## COMPREHENSION

**1. What does this change actually do to the load-bearing path?**

PR-1 adds the first read surface that filters by Project, and does so **without** making Project a read boundary — `pkg/authtree` records that Space is the only one, and this route keeps that true structurally: `projectMiddleware` verifies Space membership before writing the verified Space, the handler takes `space_id` from that row rather than from request input, and the query filters on both `space_id` and `project_id`. The genuinely new thing is that access control lives in the `WHERE` clause: the list joins the caller's own `group_member` row, so there is no post-filtering and no role check to get wrong.

PR-2 adds a field to a payload, computed from a batch that already ran, on the path where Space filtering ran.

PR-5 adds one write path and changes the order — and therefore the query plan — of an endpoint that already ships. The ordering change is the wire-visible part: pinned rows move to the front, and the unpinned tail keeps the order it had. The plan change is measured above and is the larger of the two effects. Nothing about I2, I3, I4, `member_epoch` or the cascades changes; no write path in `octo_project_member` is touched.

**2. What could break because of it (dependents + failure mode)?**

- **The blacklist divergence** — a product call, described above. Both peer reviewers want a human on it.
- **`GET /v1/space/:space_id/projects` changes order and gets slower.** Clients that assumed newest-first now see pinned rows first; the tail is unchanged and asserted to be. The latency cost is 0.28 ms → 7.9 ms on a 2000-project Space, scaling with Space size rather than page size, with the escalation condition written into the plan guard.
- **`member_count` means two things on adjacent surfaces.** The group list counts every active group member, agents included; #855 narrowed the project row's field of the same name to humans. **This is the item CI cannot settle** — it needs the client teams.
- **The pin cap has a bounded overshoot** (~65 against 6 under a full 60-burst), and a documented undercount for Space admins on unlisted projects. Both are confined to the caller's own pin list and self-removable.
- **`is_named` is always 0 on the group list** — every project group is created after the 2026-06-29 avatar revamp. It ships so the avatar fallback is evaluated by the same client code on every surface.

**3. How do you know it works (specific test/repro/trace)?**

- The group-list end-to-end case runs the production path with the real provisioner — create handler, seat writes, #855's group hook, `modules/group`'s `CreateGroup`, the I2 admission gate — then asserts the endpoint returns that group.
- Membership scope is proven by a free negative: `stubAllMemberGroup` leaves a real project group nobody is a member of in every stubbed case, so a widening to "every group in the project" fails on that row alone.
- Every predicate the reviews found unguarded is now pinned **and mutation-tested**; a reviewer independently reproduced the mutation kills.
- Pinning is exercised through the API end to end: order before and after, per-user isolation, idempotence with a row count, the cleared `pinned_at` that makes a re-pin move to the front, the cap, its three exemptions, both unreachable-pin traps and the positive branch, and `member_epoch` unmoved across a pin and an unpin.
- The three refusals on every new route are asserted against **each other** with `assert.JSONEq`, not against a status code.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BimyYhwLd34y6JTyqnp2zd