### PR TITLE
feat: eagerly provision AI agent groups

### DIFF
--- a/.octospec/journal/shared/eva-assistant-eager-ai-group.md
+++ b/.octospec/journal/shared/eva-assistant-eager-ai-group.md
@@ -1,0 +1,50 @@
+---
+type: Journal
+title: "Journal: eva-assistant-eager-ai-group"
+description: Eagerly provisions each AI Team Agent's private owner-and-Bot group and wires EVA assistant creation to the authenticated Agent endpoint.
+tags: [ai-team, space, auth, group, idempotency, eva]
+timestamp: 2026-09-08T00:00:00+08:00
+# --- octospec extension fields ---
+task: eva-assistant-eager-ai-group
+upstream: chat-request
+source: user
+---
+
+# Journal: eva-assistant-eager-ai-group
+
+## Result
+
+`POST /v1/ai-team/agents/{bot_id}` now creates or repairs the protected
+`ai_session_container` group before returning. The existing Agent row lock
+serializes group allocation, the group admission bridge enforces exactly the
+owner and Bot as active members, and the WuKongIM parent channel is provisioned
+without creating a thread or `ai_team_session` row. `CreateSession` shares the
+same transactional helper, retaining recovery for legacy Agent rows whose
+`group_no` is empty.
+
+The companion EVA change calls the Agent endpoint after User Bot creation with
+the existing Octo Session Token in `token` and the selected Space in
+`X-Space-ID`. It completes registration before persisting/enabling the local
+Bot, and retries Agent reconciliation for existing BotStore records that still
+have their Bot and Space identifiers. The `uk_` credential remains confined to
+User Bot creation.
+
+## Structural learnings and gotchas
+
+- User Bot ownership and AI Team membership are different boundaries: Bot
+  creation uses the user API key, while AI Team registration remains an
+  authenticated, Space-scoped user action.
+- A local `container_state=ready` value cannot prove that the external
+  WuKongIM channel still exists. Explicit Agent registration therefore replays
+  the idempotent parent/topic upserts even for a ready row.
+- IM failure happens after the group transaction commits. The durable Agent and
+  group remain retryable, but EVA must not mark the local binding successful
+  until the Agent request succeeds.
+
+## Verification
+
+- `go test ./modules/ai_team/... -count=1`
+- `npm test -- --run src/main/libs/octoAutoConnect.test.ts`
+- Changed-file ESLint with zero warnings.
+- `tsc --project electron-tsconfig.json --noEmit`
+

--- a/.octospec/learnings/pending/external-readiness-needs-reconciliation.md
+++ b/.octospec/learnings/pending/external-readiness-needs-reconciliation.md
@@ -1,0 +1,35 @@
+---
+type: Learning
+title: "External readiness needs an idempotent reconciliation path"
+description: A local ready bit records a completed attempt, not the continued existence of externally managed state; an explicit retry endpoint must replay idempotent external upserts.
+tags: [idempotency, reconciliation, distributed-state, recovery]
+timestamp: 2026-09-08T00:00:00+08:00
+# --- octospec extension fields ---
+source: self
+origin_task: eva-assistant-eager-ai-group
+status: pending
+candidate_rule: testing
+---
+
+# External readiness needs an idempotent reconciliation path
+
+## Context
+
+AI Team stores `container_state=ready` after creating its WuKongIM parent and
+topic channels. That state proves the last provisioning attempt succeeded, but
+cannot prove that the external channels still exist later. A retry that skips
+external work solely because the database says `ready` cannot repair external
+state loss.
+
+## Learning
+
+When an API is explicitly documented as create-or-repair across a database and
+an external system, a local ready bit may optimize background work but must not
+short-circuit the explicit repair operation. Replay the external system's
+idempotent upsert, return its failure to the caller, and preserve enough durable
+local identity for the next request to retry the same object rather than create
+a duplicate.
+
+Tests should cover both halves: stable local identity across retries, and an
+observed external upsert even when the local row was already present.
+

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,20 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-09-08 — eva-assistant-eager-ai-group
+
+- **Changed** — `POST /v1/ai-team/agents/{bot_id}` now creates or repairs the
+  protected owner+Bot group and its WuKongIM parent channel before returning,
+  while creating no thread/session. `CreateSession` reuses the shared container
+  helper and keeps legacy empty-`group_no` recovery.
+- **Integrated** — EVA assistant auto-connect now registers the new Bot through
+  the authenticated, Space-scoped Agent endpoint before persisting/enabling the
+  local Bot; existing Bot records with Bot/Space identifiers are reconciled too.
+- **Learned** — a database `ready` bit cannot prove external IM state still
+  exists, so explicit idempotent registration must replay external upserts. See
+  [journal](journal/shared/eva-assistant-eager-ai-group.md) and
+  [learning](learnings/pending/external-readiness-needs-reconciliation.md).
+
 ## 2026-09-06 — project-p0-foundation (PR #841 第一轮 review：TDD 修复 blocker 与 Q 项)
 
 - **Fixed (blocking)** — remove 批次中途解散丢弃已提交部分（errProjectGone 镜像 add 的

--- a/.octospec/tasks/eva-assistant-eager-ai-group/brief.md
+++ b/.octospec/tasks/eva-assistant-eager-ai-group/brief.md
@@ -1,0 +1,91 @@
+---
+type: Task
+title: "Task: eva-assistant-eager-ai-group"
+description: Automatically register newly created EVA assistant Bots as AI Team agents and eagerly provision their private two-member group.
+tags: [space, isolation, auth, acl, thread, wire-contract, error-response, i18n, test]
+timestamp: 2026-09-08T00:00:00+08:00
+# --- octospec extension fields ---
+slug: eva-assistant-eager-ai-group
+upstream: chat-request
+source: self
+---
+
+# Task: eva-assistant-eager-ai-group
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+## Goal
+
+Make “create assistant” converge to the complete Octo state expected by EVA:
+after EVA creates the assistant's User Bot, EVA registers that Bot through
+`POST /v1/ai-team/agents/{bot_id}`, and octo-server returns only after the
+protected owner+Bot AI group has been created or reconciled. This removes the
+current mismatch where an Octo Bot exists but its private AI group is deferred
+until the first session is created.
+
+## Background
+
+- EVA currently selects an Octo Space, exchanges its XRUI token for a `uk_`
+  User API Key, and calls `POST /v1/user/bots`.
+- EVA already maintains a separate Octo login Session Token through
+  `OctoAuthManager`; AI Team endpoints use that token plus `X-Space-ID`.
+- octo-server's `AddAgent` currently creates the `ai_team_agent` row but creates
+  the `ai_session_container` group lazily in `CreateSession`.
+- A User Bot is user-owned, but AI Team registration and its group are scoped by
+  `(space_id, user_uid, bot_id)`. Generic User Bot creation must remain usable
+  without automatically registering every Bot as an AI Team agent.
+
+## Load-bearing list
+
+- `space`, `isolation`, `auth`, `acl`: the request must use the selected Bot
+  Space, require the authenticated owner, and admit only that owner and Bot.
+- `thread`: eager Agent registration creates the parent AI group only; it must
+  not create an `ai_team_session`, thread, or topic channel.
+- `wire-contract`, `error-response`, `i18n`: preserve the existing
+  `POST /v1/ai-team/agents/{bot_id}` request/response contract and localized
+  error envelope while surfacing group/IM provisioning failure.
+- `test`, `testing`: update lifecycle expectations and add focused EVA request
+  coverage for token and Space header propagation.
+- Idempotency and recovery: repeated Agent registration must reuse the same
+  group, repair owner/Bot DB membership and WuKongIM parent-channel state, and
+  preserve the legacy `CreateSession` recovery path for Agent rows with no
+  group.
+- Cross-repository integration: octo-server and EVA client must agree on Bot ID,
+  selected Space ID, and Octo Session Token usage.
+
+## Out of scope
+
+- Do not make `POST /v1/user/bots` implicitly register every User Bot as an AI
+  Team agent.
+- Do not add `uk_` authentication support to AI Team endpoints or weaken their
+  existing authenticated-user and Space middleware.
+- Do not expose the private AI group to other Space members or change group
+  mutation protections.
+- Do not create an initial AI Team session/thread during assistant creation.
+- Do not change Space selection policy, Bot deletion semantics, or unrelated
+  EVA/OpenClaw flows.
+
+## Acceptance
+
+- On a valid first `POST /v1/ai-team/agents/{bot_id}`, the response contains a
+  non-empty stable `group_no`; exactly one active protected
+  `ai_session_container` group exists with exactly the owner and Bot as active
+  members; its WuKongIM parent channel is provisioned; and no AI Team session or
+  thread is created.
+- Repeating the Agent request returns the same `group_no` without duplicate DB
+  rows and repairs missing/deleted owner/Bot membership and parent-channel state.
+- An unauthorized owner, inactive/foreign Space membership, or invalid Bot is
+  still rejected through the existing localized error contract.
+- Creating a session after eager registration reuses the same parent group;
+  legacy Agent rows with an empty `group_no` still converge successfully.
+- EVA's local assistant auto-connect flow calls the Agent endpoint after Bot
+  creation with `token: <Octo Session Token>` and `X-Space-ID: <selected space>`.
+  The Bot ID is URL-encoded and no token is logged.
+- If EVA cannot obtain Octo Session credentials or Agent registration fails,
+  assistant auto-connect reports failure and does not persist/enable the local
+  Bot as successfully bound.
+- The cloud BotFather-style flow remains unchanged unless it is also part of
+  “create assistant”; generic Bot creation alone does not create the AI group.
+- Focused Go tests, EVA Vitest coverage, changed-file ESLint, and Electron
+  TypeScript compilation pass.

--- a/.octospec/tasks/eva-assistant-eager-ai-group/context.yaml
+++ b/.octospec/tasks/eva-assistant-eager-ai-group/context.yaml
@@ -1,0 +1,14 @@
+injected:
+  - id: space-isolation
+    source: repo
+  - id: trust-boundary
+    source: repo
+  - id: error-handling
+    source: repo
+  - id: rate-limit
+    source: repo
+  - id: testing
+    source: repo
+  - id: commit-style
+    source: repo
+brief: .octospec/tasks/eva-assistant-eager-ai-group/brief.md

--- a/modules/ai_team/api_test.go
+++ b/modules/ai_team/api_test.go
@@ -146,15 +146,40 @@ func TestAITeamAgentLifecycleAndSessionIdempotency(t *testing.T) {
 	w = request(t, f, http.MethodPost, "/v1/ai-team/agents/"+f.botID, "", nil)
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 	var first struct {
-		BotID   string `json:"bot_id"`
-		GroupNo string `json:"group_no"`
+		BotID          string `json:"bot_id"`
+		GroupNo        string `json:"group_no"`
+		ContainerState int    `json:"container_state"`
 	}
 	decodeJSON(t, w, &first)
 	assert.Equal(t, f.botID, first.BotID)
-	assert.Empty(t, first.GroupNo, "adding an AI must not eagerly create a group")
+	require.NotEmpty(t, first.GroupNo, "adding an AI must eagerly create its private group")
+	assert.Equal(t, 2, first.ContainerState)
+
+	var eagerGroupCount, eagerMemberCount, eagerSessionCount, eagerThreadCount int
+	var eagerMemberUIDs []string
+	require.NoError(t, testContext.DB().Select("COUNT(*)").From("`group`").
+		Where("group_no=? AND space_id=? AND creator=? AND purpose=?", first.GroupNo, f.spaceID, f.uid, "ai_session_container").
+		LoadOne(&eagerGroupCount))
+	require.NoError(t, testContext.DB().Select("COUNT(*)").From("group_member").
+		Where("group_no=? AND status=1 AND is_deleted=0", first.GroupNo).LoadOne(&eagerMemberCount))
+	_, err := testContext.DB().Select("uid").From("group_member").
+		Where("group_no=? AND status=1 AND is_deleted=0", first.GroupNo).OrderBy("uid").Load(&eagerMemberUIDs)
+	require.NoError(t, err)
+	require.NoError(t, testContext.DB().Select("COUNT(*)").From("ai_team_session").LoadOne(&eagerSessionCount))
+	require.NoError(t, testContext.DB().Select("COUNT(*)").From("thread").Where("group_no=?", first.GroupNo).LoadOne(&eagerThreadCount))
+	assert.Equal(t, 1, eagerGroupCount)
+	assert.Equal(t, 2, eagerMemberCount)
+	assert.Equal(t, []string{f.botID, f.uid}, eagerMemberUIDs)
+	assert.Zero(t, eagerSessionCount)
+	assert.Zero(t, eagerThreadCount)
 
 	w = request(t, f, http.MethodPost, "/v1/ai-team/agents/"+f.botID, "", nil)
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var repeated struct {
+		GroupNo string `json:"group_no"`
+	}
+	decodeJSON(t, w, &repeated)
+	assert.Equal(t, first.GroupNo, repeated.GroupNo)
 	w = request(t, f, http.MethodGet, "/v1/ai-team/agents/"+f.botID+"/sessions", "", nil)
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 	assert.Contains(t, w.Body.String(), `"items":[]`)
@@ -169,6 +194,7 @@ func TestAITeamAgentLifecycleAndSessionIdempotency(t *testing.T) {
 	decodeJSON(t, w, &session1)
 	require.NotEmpty(t, session1.SessionID)
 	require.NotEmpty(t, session1.GroupNo)
+	assert.Equal(t, first.GroupNo, session1.GroupNo)
 	assert.Equal(t, session1.GroupNo+"____"+session1.SessionID, session1.ChannelID)
 
 	target, err := aiteampkg.LookupReadySessionTarget(testContext.DB(), session1.ChannelID, f.uid)
@@ -539,6 +565,59 @@ func TestAITeamSessionProvisionFailureDoesNotPoisonReadyContainer(t *testing.T) 
 		Where("space_id=? AND user_uid=? AND bot_id=?", f.spaceID, f.uid, f.botID).
 		LoadOne(&containerState))
 	assert.Equal(t, 2, containerState, "one failed thread must not downgrade a ready parent")
+}
+
+func TestAITeamAddAgentProvisionFailureIsRetryable(t *testing.T) {
+	f := seedFixture(t)
+	failingIM := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "forced IM failure", http.StatusInternalServerError)
+	}))
+	defer failingIM.Close()
+	cfg := testContext.GetConfig()
+	previousURL := cfg.WuKongIM.APIURL
+	cfg.WuKongIM.APIURL = failingIM.URL
+	defer func() { cfg.WuKongIM.APIURL = previousURL }()
+
+	w := request(t, f, http.MethodPost, "/v1/ai-team/agents/"+f.botID, "", nil)
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "err.server.ai_team.im_unavailable")
+
+	var persisted struct {
+		GroupNo        string `db:"group_no"`
+		ContainerState int    `db:"container_state"`
+	}
+	var sessionCount, threadCount int
+	require.NoError(t, testContext.DB().Select("group_no", "container_state").From("ai_team_agent").
+		Where("space_id=? AND user_uid=? AND bot_id=?", f.spaceID, f.uid, f.botID).
+		LoadOne(&persisted))
+	require.NotEmpty(t, persisted.GroupNo)
+	assert.Equal(t, 3, persisted.ContainerState)
+	require.NoError(t, testContext.DB().Select("COUNT(*)").From("ai_team_session").LoadOne(&sessionCount))
+	require.NoError(t, testContext.DB().Select("COUNT(*)").From("thread").Where("group_no=?", persisted.GroupNo).LoadOne(&threadCount))
+	assert.Zero(t, sessionCount)
+	assert.Zero(t, threadCount)
+
+	var provisioned config.ChannelCreateReq
+	successIM := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/channel" {
+			_ = json.NewDecoder(r.Body).Decode(&provisioned)
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer successIM.Close()
+	cfg.WuKongIM.APIURL = successIM.URL
+	w = request(t, f, http.MethodPost, "/v1/ai-team/agents/"+f.botID, "", nil)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var retried struct {
+		GroupNo        string `json:"group_no"`
+		ContainerState int    `json:"container_state"`
+	}
+	decodeJSON(t, w, &retried)
+	assert.Equal(t, persisted.GroupNo, retried.GroupNo)
+	assert.Equal(t, 2, retried.ContainerState)
+	assert.Equal(t, persisted.GroupNo, provisioned.ChannelID)
+	assert.Equal(t, common.ChannelTypeGroup.Uint8(), provisioned.ChannelType)
+	assert.ElementsMatch(t, []string{f.uid, f.botID}, provisioned.Subscribers)
 }
 
 func TestAITeamRejectsMissingSpaceForeignBotAndOrdinaryMutation(t *testing.T) {

--- a/modules/ai_team/service.go
+++ b/modules/ai_team/service.go
@@ -74,7 +74,8 @@ func validateAuthorityTx(tx *dbr.Tx, spaceID, userUID, botID string) error {
 }
 
 func (s *Service) AddAgent(spaceID, userUID, botID string) (*Agent, error) {
-	if _, err := s.validateAuthority(spaceID, userUID, botID); err != nil {
+	botName, err := s.validateAuthority(spaceID, userUID, botID)
+	if err != nil {
 		return nil, err
 	}
 	tx, err := s.ctx.DB().Begin()
@@ -102,42 +103,34 @@ func (s *Service) AddAgent(spaceID, userUID, botID string) (*Agent, error) {
 		return nil, errNotFound
 	}
 
-	containerNeedsReconcile := false
-	if agent.GroupNo != "" {
-		repaired, repairErr := s.admitContainerMembersTx(tx, agent.GroupNo, spaceID, userUID, botID)
-		if repairErr != nil {
-			return nil, repairErr
-		}
-		containerNeedsReconcile = repaired || agent.ContainerState != containerReady
-		if containerNeedsReconcile {
-			if _, err = tx.Update("ai_team_agent").Set("container_state", containerProvisioning).Where("id=?", agent.ID).Exec(); err != nil {
-				return nil, err
-			}
-		}
+	groupNo, _, err := s.ensureContainerTx(tx, agent, botName, spaceID, userUID, botID)
+	if err != nil {
+		return nil, err
 	}
 	if err = tx.Commit(); err != nil {
 		return nil, err
 	}
-	if containerNeedsReconcile {
-		if err = s.ensureContainerIMReady(agent.ID, agent.GroupNo, userUID, botID); err != nil {
-			s.markContainerFailure(agent.ID, err)
-			return nil, fmt.Errorf("%w: reconcile IM channels: %v", errIMUnavailable, err)
-		}
-		readyTx, beginErr := s.ctx.DB().Begin()
-		if beginErr != nil {
-			return nil, beginErr
-		}
-		defer readyTx.RollbackUnlessCommitted()
-		if err = validateAuthorityTx(readyTx, spaceID, userUID, botID); err != nil {
-			s.markContainerFailure(agent.ID, err)
-			return nil, err
-		}
-		if _, err = readyTx.Update("ai_team_agent").Set("container_state", containerReady).Where("id=?", agent.ID).Exec(); err != nil {
-			return nil, err
-		}
-		if err = readyTx.Commit(); err != nil {
-			return nil, err
-		}
+	// Re-run the idempotent IM upserts even for an already-ready Agent. The DB
+	// cannot tell whether WuKongIM lost a channel, so every explicit AddAgent is
+	// also the repair operation for the parent and any existing topics.
+	if err = s.ensureContainerIMReady(agent.ID, groupNo, userUID, botID); err != nil {
+		s.markContainerFailure(agent.ID, err)
+		return nil, fmt.Errorf("%w: reconcile IM channels: %v", errIMUnavailable, err)
+	}
+	readyTx, beginErr := s.ctx.DB().Begin()
+	if beginErr != nil {
+		return nil, beginErr
+	}
+	defer readyTx.RollbackUnlessCommitted()
+	if err = validateAuthorityTx(readyTx, spaceID, userUID, botID); err != nil {
+		s.markContainerFailure(agent.ID, err)
+		return nil, err
+	}
+	if _, err = readyTx.Update("ai_team_agent").Set("container_state", containerReady).Where("id=?", agent.ID).Exec(); err != nil {
+		return nil, err
+	}
+	if err = readyTx.Commit(); err != nil {
+		return nil, err
 	}
 	return s.getAgent(spaceID, userUID, botID, false)
 }
@@ -258,6 +251,55 @@ func (s *Service) admitContainerMembersTx(tx *dbr.Tx, groupNo, spaceID, userUID,
 	return group.AdmitAITeamContainerMembersTx(s.ctx, tx, groupNo, spaceID, userUID, botID)
 }
 
+// ensureContainerTx creates or repairs the private parent group while the
+// caller holds the ai_team_agent row lock. It deliberately provisions no
+// thread: adding an Agent makes the owner+Bot group ready, while sessions stay
+// an explicit follow-up action.
+func (s *Service) ensureContainerTx(
+	tx *dbr.Tx,
+	agent *lockedAgent,
+	botName, spaceID, userUID, botID string,
+) (string, bool, error) {
+	groupNo := agent.GroupNo
+	if groupNo == "" {
+		groupNo = util.GenerUUID()
+		groupName := strings.TrimSpace(botName)
+		if groupName == "" {
+			groupName = botID
+		}
+		groupName += " · AI"
+		if r := []rune(groupName); len(r) > group.MaxGroupNameLen {
+			groupName = string(r[:group.MaxGroupNameLen])
+		}
+		version, err := s.ctx.GenSeq(common.GroupSeqKey)
+		if err != nil {
+			return "", false, err
+		}
+		if _, err = tx.InsertBySql("INSERT INTO `group` (group_no,name,creator,status,version,allow_view_history_msg,space_id,allow_external,allow_no_mention,purpose) VALUES (?,?,?,?,?,?,?,?,?,?)",
+			groupNo, groupName, userUID, group.GroupStatusNormal, version, 1, spaceID, 0, 1, aiteampkg.GroupPurpose).Exec(); err != nil {
+			return "", false, err
+		}
+		if _, err = tx.Update("ai_team_agent").Set("group_no", groupNo).Set("container_state", containerProvisioning).Where("id=?", agent.ID).Exec(); err != nil {
+			return "", false, err
+		}
+		agent.GroupNo = groupNo
+		agent.ContainerState = containerProvisioning
+	}
+
+	membershipRepaired, err := s.admitContainerMembersTx(tx, groupNo, spaceID, userUID, botID)
+	if err != nil {
+		return "", false, err
+	}
+	containerNeedsReconcile := agent.ContainerState != containerReady || membershipRepaired
+	if containerNeedsReconcile && agent.ContainerState != containerProvisioning {
+		if _, err = tx.Update("ai_team_agent").Set("container_state", containerProvisioning).Where("id=?", agent.ID).Exec(); err != nil {
+			return "", false, err
+		}
+		agent.ContainerState = containerProvisioning
+	}
+	return groupNo, containerNeedsReconcile, nil
+}
+
 func (s *Service) CreateSession(spaceID, userUID, botID, idempotencyKey, name string) (*Session, error) {
 	botName, err := s.validateAuthority(spaceID, userUID, botID)
 	if err != nil {
@@ -288,42 +330,9 @@ func (s *Service) CreateSession(spaceID, userUID, botID, idempotencyKey, name st
 		return nil, errNotFound
 	}
 
-	groupNo := agent.GroupNo
-	if groupNo == "" {
-		groupNo = util.GenerUUID()
-		groupName := strings.TrimSpace(botName)
-		if groupName == "" {
-			groupName = botID
-		}
-		groupName += " · AI"
-		if r := []rune(groupName); len(r) > group.MaxGroupNameLen {
-			groupName = string(r[:group.MaxGroupNameLen])
-		}
-		version, genErr := s.ctx.GenSeq(common.GroupSeqKey)
-		if genErr != nil {
-			return nil, genErr
-		}
-		_, err = tx.InsertBySql("INSERT INTO `group` (group_no,name,creator,status,version,allow_view_history_msg,space_id,allow_external,allow_no_mention,purpose) VALUES (?,?,?,?,?,?,?,?,?,?)",
-			groupNo, groupName, userUID, group.GroupStatusNormal, version, 1, spaceID, 0, 1, aiteampkg.GroupPurpose).Exec()
-		if err != nil {
-			return nil, err
-		}
-		_, err = tx.Update("ai_team_agent").Set("group_no", groupNo).Set("container_state", containerProvisioning).Where("id=?", agent.ID).Exec()
-		if err != nil {
-			return nil, err
-		}
-		agent.ContainerState = containerProvisioning
-	}
-
-	membershipRepaired, err := s.admitContainerMembersTx(tx, groupNo, spaceID, userUID, botID)
+	groupNo, containerNeedsReconcile, err := s.ensureContainerTx(tx, agent, botName, spaceID, userUID, botID)
 	if err != nil {
 		return nil, err
-	}
-	containerNeedsReconcile := agent.ContainerState != containerReady || membershipRepaired
-	if membershipRepaired && agent.ContainerState == containerReady {
-		if _, err = tx.Update("ai_team_agent").Set("container_state", containerProvisioning).Where("id=?", agent.ID).Exec(); err != nil {
-			return nil, err
-		}
 	}
 
 	var existing *Session


### PR DESCRIPTION
## Summary

Eagerly create and reconcile the private owner-and-Bot group when an AI Team Agent is registered. This lets EVA assistant creation produce the expected two-member AI group immediately, without creating a session or thread.

## Related Issue

N/A — requested through the EVA integration workflow.

## Linked Spec

[`.octospec/tasks/eva-assistant-eager-ai-group/brief.md`](.octospec/tasks/eva-assistant-eager-ai-group/brief.md)

## Changes

- Create the protected `ai_session_container` group and admit exactly the owner and Bot during `POST /v1/ai-team/agents/{bot_id}`.
- Re-run idempotent WuKongIM channel upserts on Agent registration so retries repair external channel state.
- Share container allocation with `CreateSession`, preserving legacy empty-`group_no` recovery without creating a session during Agent registration.
- Cover eager creation, stable group identity, exact membership, no-thread behavior, and IM failure recovery.

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified
- `go test ./modules/ai_team/... -count=1`

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**

   Agent registration now allocates the group under the existing Agent-row lock, writes the protected Space-scoped parent and exact owner/Bot membership transactionally, then provisions WuKongIM before returning. Session creation still owns thread creation and reuses the same helper for legacy rows.

2. **What could break because of it (dependents + failure mode)?**

   Agent registration now depends synchronously on WuKongIM and may return the existing localized 503 when channel provisioning fails. The durable Agent/group state is retained with a retryable container state, and repeated registration reuses the same group rather than duplicating it. Existing clients now receive a non-empty `group_no` immediately.

3. **How do you know it works (specific test/repro/trace)?**

   The AI Team package tests assert one stable protected group, exactly two active members, zero sessions/threads after registration, reuse by subsequent session creation, authorization isolation, and recovery from a forced WuKongIM failure. The full `modules/ai_team` suite passes after rebasing onto `origin/main`.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)