### PR TITLE
feat: synchronize AI team groups

### DIFF
--- a/.octospec/journal/shared/ai-team-all-bots-group.md
+++ b/.octospec/journal/shared/ai-team-all-bots-group.md
@@ -1,0 +1,57 @@
+---
+type: Journal
+title: "Journal: ai-team-all-bots-group"
+description: Projects each user's active AI Team Agent roster into protected two-member containers and one visible owner-plus-all-agents group, including automatic Bot creation hooks and reconciliation.
+tags: ["ai-team", "group", "space", "isolation", "acl", "bot", "testing"]
+timestamp: 2026-09-08T19:20:00+08:00
+# --- octospec extension fields ---
+task: ai-team-all-bots-group
+upstream: "User request; design informed by server PR #855"
+source: user
+---
+
+# Journal: ai-team-all-bots-group
+
+## Result
+
+Added one durable `ai_team_group` registration per `(space_id, user_uid)` and a
+visible `purpose=ai_team_group` group named “我的AI团队”. Its exact live roster
+is the owner plus every eligible `ai_team_agent.is_added=1` Bot whose private
+two-member container is ready. Removing an Agent keeps its private container and
+session history but removes it from the team group; reactivation reuses both
+group identities.
+
+AI Team listing now acts as the legacy-data convergence point: it creates Agent
+rows only for owned Bots that never had one, repairs all active pair containers,
+and then projects the complete team group. BotFather conversation creation,
+`POST /v1/user/bots`, and `MintBotOBO` call the same idempotent provisioner after
+the Bot's Space membership is durable. Temporary MySQL 1213/1205 conflicts retry
+the whole idempotent add/remove/list reconciliation up to three times.
+
+Ordinary web, manager, service, Bot API, scan/invite, org-directory, ownership,
+and disband paths cannot mutate either managed group. The visible team group is
+included in normal human and Bot group lists and allows personal settings, while
+the existing pair container and its threads remain hidden. Lifecycle cleanup can
+still remove deleted or departed identities from both managed group types.
+
+## Structural learnings / gotchas
+
+- The Agent table must remain the only roster authority. Accepting a Bot directly
+  into the team group would create a second source of truth and make repair
+  direction ambiguous.
+- The safe convergence order is pair containers first, then one exact team-roster
+  projection. Projecting only the newly added Bot misses inactive, invalid, or
+  stale rows and cannot repair old data.
+- Unique keys prevent duplicate durable identities but do not prevent InnoDB
+  from choosing a transaction as a deadlock victim. The entire orchestration is
+  idempotent, so bounded whole-operation retries are a safe backstop.
+- The repository's test packages share a hard-coded MySQL database. Running
+  `go test ./...` in package-parallel mode lets schema-owning fixture tests race
+  migrations and table cleanup; target integration tests must be rerun serially
+  after rebuilding that disposable database.
+
+## Verification
+
+See `.octospec/tasks/ai-team-all-bots-group/verification.md` for passing focused,
+race, vet, i18n, and whitespace checks plus the documented shared-database limits
+on full-suite execution.

--- a/.octospec/learnings/pending/ai-team-all-bots-group.md
+++ b/.octospec/learnings/pending/ai-team-all-bots-group.md
@@ -1,0 +1,32 @@
+---
+type: Learning
+title: "Retry the complete idempotent projection after transactional lock conflicts"
+description: A unique key guarantees one durable projection identity but concurrent multi-transaction reconciliation can still deadlock; retry the complete idempotent orchestration on MySQL 1213/1205 only.
+tags: ["database", "mysql", "concurrency", "idempotency", "testing"]
+timestamp: 2026-09-08T19:20:00+08:00
+# --- octospec extension fields ---
+source: self
+origin_task: ai-team-all-bots-group
+status: pending
+candidate_rule: testing
+---
+
+# Retry the complete idempotent projection after transactional lock conflicts
+
+## Context
+
+Concurrent first activation of one Agent correctly converged to one Agent row,
+one private group, and one team group through unique constraints and row locks,
+but one caller could still receive MySQL 1213 while transactions crossed the
+Agent, group, and member tables.
+
+## Rule of thumb
+
+When an operation is composed of multiple independently committed, idempotent
+reconciliation steps, retry the complete orchestration from its first authority
+check after MySQL 1213 or 1205. Do not retry arbitrary errors, do not retry only
+the statement that lost its transaction, and keep the attempt budget small.
+
+Pair this with a real-MySQL concurrent test that asserts both caller success and
+the cardinality of every durable identity. A unique-row assertion alone can pass
+while several callers still fail.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,19 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-09-08 — ai-team-all-bots-group
+
+- **Added** — One visible “我的AI团队” group per Space/user, projected exactly
+  from active `ai_team_agent` rows after all private two-member containers are
+  ready. Existing owned Bots are lazily backfilled; all three production User
+  Bot creation paths trigger the same idempotent activation orchestration.
+- **Protected** — Ordinary human, manager, Bot API, invite/scan, org-directory,
+  transfer, exit, and disband paths cannot change either AI-managed group type;
+  personal settings remain available on the visible team group.
+- **Hardened** — Add/remove/list convergence retries complete idempotent
+  operations for MySQL 1213/1205, with concurrent real-MySQL and race coverage.
+  See [journal](journal/shared/ai-team-all-bots-group.md).
+
 ## 2026-09-06 — project-p0-foundation (PR #841 第一轮 review：TDD 修复 blocker 与 Q 项)
 
 - **Fixed (blocking)** — remove 批次中途解散丢弃已提交部分（errProjectGone 镜像 add 的

--- a/.octospec/tasks/ai-team-all-bots-group/brief.md
+++ b/.octospec/tasks/ai-team-all-bots-group/brief.md
@@ -1,0 +1,101 @@
+---
+type: Task
+title: "Task: ai-team-all-bots-group"
+description: 以 AI Team Agent 为权威名册，同步维护每个 Agent 的二人群和本人加全部 Agent 的“我的AI团队”群。
+tags: ["space", "isolation", "auth", "acl", "bot-api", "wire-contract", "error-response", "i18n", "test", "commit"]
+timestamp: 2026-09-08T16:49:23+08:00
+slug: ai-team-all-bots-group
+upstream: user-request
+source: user
+---
+
+# Task: ai-team-all-bots-group
+
+## Goal
+
+在 `main` 已有“每个 AI Team Agent 一个本人 + Bot 的受保护二人父群”之外，为每个
+`(space_id, user_uid)` 自动维护一个可见的“我的AI团队”群。`ai_team_agent` 是两类群的
+唯一权威名册：每个有效 Agent 必须同时拥有就绪的二人群，并且出现在该用户的 AI 全员群；
+全员群中也不得出现没有有效 Agent 记录的 Bot。新建 Bot 完成 Space 绑定后自动注册为
+Agent、创建二人群并加入全员群；移除或失效时两边同步收敛，普通入口不能拉入其他人。
+
+## Background
+
+- 当前 `modules/ai_team` 用 `ai_team_agent` 维护每个 User Bot 的二人容器，并把这些
+  `purpose=ai_session_container` 群从普通群聊/会话界面隐藏；它没有用户级的 AI 总群。
+- “全部 AI”定义为该 `(space_id,user_uid)` 下 `ai_team_agent.is_added=1` 且仍通过当前
+  AI Team 权限校验的 Agent：`robot.status=1`、`robot.creator_uid=user_uid`，Bot 用户有效，
+  并且本人和 Bot 都是目标 Space 的有效成员。App Bot、他人 Bot、跨 Space Bot 和系统
+  Bot 不属于该集合，也不能只进入群而不写 Agent 记录。
+- Server PR #855（远端分支 `origin/claude/project-p2-all-member-group-85vjhr`）是设计参考：
+  权威名册投影、唯一群指针、并发建群租约、内部准入、普通成员变更保护，以及失败后的
+  补建/对账。该 PR 尚未合入 `main`，本任务不能依赖其代码已存在，也不能把项目成员
+  语义直接套到 AI 所有权语义上。
+
+## Load-bearing list
+
+- `space` / `isolation` / `auth` / `acl`：总群严格按 Space 和 Bot 所有权隔离；群主只能
+  是该 `(space_id,user_uid)` 的有效本人，不能因客户端传参或旧快照混入跨 Space 成员。
+- 每个 `(space_id,user_uid)` 最多一个有效 AI 总群；并发首次访问、并发建 Bot 和重试
+  必须收敛到同一个 `group_no`，不能产生两个“我的AI团队”群或悬空指针。
+- 总群与现有二人 session container 使用不同的持久化身份/`purpose`。总群应出现在正常
+  群聊和会话列表中；现有二人群及 thread 仍保持隐藏和二成员不变量。
+- `ai_team_agent` 是二人群和总群的共同权威状态。Agent 激活必须同时确保二人群及总群
+  成员就绪；Agent 移除/失效必须同步撤销总群成员资格，同时按既有历史保留语义保护已建
+  二人群和 session，不允许出现“只在总群”或“有效 Agent 没有二人群”的正常态。
+- 总群成员集合是权威 Agent 名册的投影。仅服务端内部 reconcile/admission 路径可改变它；
+  邀请、扫码、确认邀请、Bot API、管理员 API、加/删成员、退群、转让、解散等普通入口
+  都不得破坏“本人 + 全部有效自有 Bot”的精确集合。
+- Bot 创建的所有生产入口（BotFather 对话创建、`/v1/user/bots`、`MintBotOBO`）都必须在
+  Bot 核心记录和 Space 绑定成功后调用同一个幂等 Agent 激活编排：upsert Agent、确保
+  二人群、确保全员群并入群。`POST /v1/ai-team/agents/:bot_id` 复用同一编排而不是另一套
+  写法；Bot 删除、禁用、Agent 移除、Space 成员移除和用户离开 Space 必须同步或最终
+  收敛两类群状态。
+- 建群和成员写入必须复用 group 的统一写入、版本、通知和 WuKongIM 订阅语义；DB 已提交
+  而 IM 调用失败时必须有可重试状态，不能把未就绪群返回成可聊天成功，也不能回滚已成功
+  的 Bot 创建。
+- 现有 `GET /v1/ai-team/agents` 作为旧数据的惰性补建/双向校准触发点：为符合权限但尚无
+  Agent 行的既有自有 Bot 补 Agent，为每个有效 Agent 补二人群，并校准全员群；响应以
+  向后兼容字段暴露总群 `group_no`/就绪状态。路由继续使用 Auth ->
+  SharedUIDRateLimiter -> SpaceMiddleware，用户可见失败继续使用 i18n error envelope。
+- 总群采用现有普通群消息规则；`@某 AI`、`@所有 AI` 和免 @ 开关沿用当前 group/robot
+  实现，不为该群增加隐式全 Bot fan-out。
+
+## Out of scope
+
+- 不替换或合并每个 Bot 的二人父群，不改变 AI session/thread、runtime session key、
+  历史消息和会话控制语义。
+- 不纳入 App Bot、共享 Bot、他人 Bot、跨 Space Bot或普通人类成员，也不创建跨 Space
+  的全局 AI 群。
+- 不实现前端界面，不改变普通群的 @、免 @、Bot 回复或消息扇出协议。
+- 不合入或重做 PR #855 的项目全员群功能；只复用经验证的并发、保护和收敛思路。
+- 不允许通过本任务新增的内部能力任意维护其他受保护群。
+
+## Acceptance
+
+- 一个拥有 N 个符合条件 User Bot 的用户首次进入 AI Team 时，系统为它们补齐 N 条有效
+  Agent 记录和 N 个各含“本人 + 对应 Bot”的二人群，并且最终只有一个名为“我的AI团队”
+  的可见群，其活跃成员恰好是本人 + 这 N 个 Agent；N=0 时不创建空壳群。
+- 已有 Bot 用户无需重建 Bot：调用 AI Team 列表即可幂等补建/修复 Agent、二人群和总群，
+  并返回稳定的总群 `group_no`；重复和并发调用不创建重复群、不重复成员、不重复产生
+  可见副作用。
+- 三条生产建 Bot 路径在 Space 绑定成功后自动创建有效 Agent、确保对应二人群，并把 Bot
+  加入已有总群；若它是首个 Agent，则创建总群。`POST /v1/ai-team/agents/:bot_id` 对已有
+  Bot 得到相同结果。任一步 DB/IM 临时失败都不得把“二人群已就绪、总群未就绪”暴露成
+  完整成功，失败有日志/指标，并能由后续列表或生命周期触发重试后双向收敛。
+- `DELETE /v1/ai-team/agents/:bot_id`、删除/禁用 Bot 或撤销其目标 Space 席位后，该 Bot
+  不再是总群活跃成员/IM subscriber；Agent 行转为非激活。其二人群和 session 按现有
+  可逆移除/历史保留语义继续受保护，再次激活时复用原二人群并重新加入总群。
+  删除最后一个 Bot 后保留还是解散总群必须采用一个确定且有测试覆盖的策略，默认保留
+  本人单成员群以保留聊天历史，后续新 Bot 复用原 `group_no`。
+- 任意普通入口尝试邀请另一名人类/他人 Bot、移除有效自有 Bot、让本人退群、转让或解散
+  总群时均被拒绝，且 DB 成员、群主和 IM 订阅不变；服务端生命周期清理仍可执行。
+- 总群显示在正常群详情、群列表和会话列表中；现有 `ai_session_container` 父群及其 thread
+  仍被过滤。用户级免打扰、置顶和清空本人聊天记录继续可用。
+- 测试显式断言双向一致性：每个有效 Agent 都有唯一就绪二人群且是总群成员；总群里的
+  每个 Bot 都有同 Space 的有效 Agent 和对应二人群。并发建 Bot、建群写回落空、DB/IM
+  部分失败、跨 Space/他人 Bot 注入、软删除成员恢复、混合 collation，以及旧数据惰性
+  补建均有回归测试。
+- 运行聚焦的 `modules/ai_team`、`modules/group`、`modules/botfather` 测试，再运行
+  `go test ./...`；若改动错误码或本地化行为，同时运行 `make i18n-extract-check` 和
+  `make i18n-lint`。需要真实 MySQL、Redis、WuKongIM 的场景记录到 `verification.md`。

--- a/.octospec/tasks/ai-team-all-bots-group/context.yaml
+++ b/.octospec/tasks/ai-team-all-bots-group/context.yaml
@@ -1,0 +1,14 @@
+injected:
+  - id: space-isolation
+    source: repo
+  - id: trust-boundary
+    source: repo
+  - id: error-handling
+    source: repo
+  - id: rate-limit
+    source: repo
+  - id: testing
+    source: repo
+  - id: commit-style
+    source: repo
+brief: .octospec/tasks/ai-team-all-bots-group/brief.md

--- a/.octospec/tasks/ai-team-all-bots-group/verification.md
+++ b/.octospec/tasks/ai-team-all-bots-group/verification.md
@@ -1,0 +1,38 @@
+# Verification
+
+Verified on 2026-09-08 in worktree
+`/Users/kense/Projects/octo/octo-server-ai-team-all-bots-group`.
+
+## Passing checks
+
+- `go test -p 1 ./modules/ai_team -count=1`
+- `go test -race ./modules/ai_team -run 'TestRetryAITeamMutation|TestAITeamConcurrentAgentActivationCreatesOnePairAndOneTeamGroup|TestAITeamGroupAndAgentContainersConvergeTogether' -count=1`
+- `go test ./modules/group -run '^TestNoGroupMemberWritesOutsideTheAdmissionFunnel$' -count=1`
+- `go test ./modules/botfather -run '^TestAITeamProvisioner|^TestEveryUserBotCreationPathTriggersAITeamProvisioning$' -count=1`
+- `go test ./pkg/aiteam -count=1`
+- `go test ./modules/bot_api -run '^$' -count=1`
+- `go vet ./...`
+- `make i18n-extract-check`
+- `make i18n-lint`
+- `git diff --check`
+
+The AI Team integration suite used the local MySQL, Redis, and WuKongIM test
+services. It covers eager pair-group creation, exact team-group projection,
+removal/reactivation, stale member repair, mixed collations, IM failure recovery,
+and concurrent first activation. The concurrent projection tests also pass with
+the Go race detector.
+
+## Environment-limited checks
+
+- `go test ./... -count=1` is not a reliable supported mode for this checkout:
+  package tests run in parallel against the same hard-coded MySQL database named
+  `test`. Several packages replace shared tables with test-local schemas while
+  others run migrations or clean all tables. The run failed across unrelated
+  packages with `unknown migration in database`, missing-column errors, and
+  cross-package data deletion. The local disposable `test` database was rebuilt
+  afterward and the target AI Team suite passed serially.
+- `go test -p 1 ./modules/group -count=1` and the full BotFather suite encounter
+  the repository's legacy migration-ledger mismatch (`event_legacy01.sql` or
+  `report_legacy01.sql`). Their focused source guard and AI Team hook tests pass.
+- `golangci-lint` is not installed in this environment; `go vet ./...` and the
+  repository's Go-based lint targets above pass.

--- a/modules/ai_team/1module.go
+++ b/modules/ai_team/1module.go
@@ -5,12 +5,14 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
+	"github.com/Mininglamp-OSS/octo-server/modules/botfather"
 )
 
 //go:embed sql
 var sqlFS embed.FS
 
 func init() {
+	botfather.RegisterAITeamProvisioner(ProvisionOwnedBot)
 	register.AddModule(func(ctx interface{}) register.Module {
 		return register.Module{
 			Name: "ai_team",

--- a/modules/ai_team/api_test.go
+++ b/modules/ai_team/api_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	_ "github.com/Mininglamp-OSS/octo-server/internal"
 	aiteammod "github.com/Mininglamp-OSS/octo-server/modules/ai_team"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	aiteampkg "github.com/Mininglamp-OSS/octo-server/pkg/aiteam"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/gin-gonic/gin"
@@ -137,11 +138,14 @@ func TestAITeamAgentLifecycleAndSessionIdempotency(t *testing.T) {
 	assert.Equal(t, aiteammod.AgentGroupTypeCloudClone, emptyPage.Groups[0].Type)
 	assert.Equal(t, aiteammod.AgentGroupTypePersonalAssistant, emptyPage.Groups[1].Type)
 	assert.Equal(t, aiteammod.AgentGroupTypeDigitalEmployee, emptyPage.Groups[2].Type)
-	for _, group := range emptyPage.Groups {
-		assert.Zero(t, group.Count)
-		assert.NotNil(t, group.Items)
-		assert.Empty(t, group.Items)
-	}
+	assert.Zero(t, emptyPage.Groups[0].Count)
+	assert.EqualValues(t, 1, emptyPage.Groups[1].Count)
+	assert.Equal(t, []string{f.botID}, agentBotIDs(emptyPage.Groups[1].Items))
+	assert.Zero(t, emptyPage.Groups[2].Count)
+	require.NotNil(t, emptyPage.TeamGroup)
+	require.NotEmpty(t, emptyPage.TeamGroup.GroupNo)
+	assert.Equal(t, aiteampkg.TeamGroupName, emptyPage.TeamGroup.Name)
+	assert.Equal(t, 2, emptyPage.TeamGroup.State)
 
 	w = request(t, f, http.MethodPost, "/v1/ai-team/agents/"+f.botID, "", nil)
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
@@ -151,7 +155,14 @@ func TestAITeamAgentLifecycleAndSessionIdempotency(t *testing.T) {
 	}
 	decodeJSON(t, w, &first)
 	assert.Equal(t, f.botID, first.BotID)
-	assert.Empty(t, first.GroupNo, "adding an AI must not eagerly create a group")
+	assert.NotEmpty(t, first.GroupNo, "activating an Agent must eagerly create its two-member group")
+
+	var teamMembers []string
+	_, err := testContext.DB().Select("uid").From("group_member").
+		Where("group_no=? AND status=1 AND is_deleted=0", emptyPage.TeamGroup.GroupNo).
+		OrderBy("uid").Load(&teamMembers)
+	require.NoError(t, err)
+	assert.Equal(t, []string{f.botID, f.uid}, teamMembers)
 
 	w = request(t, f, http.MethodPost, "/v1/ai-team/agents/"+f.botID, "", nil)
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
@@ -226,6 +237,12 @@ func TestAITeamAgentLifecycleAndSessionIdempotency(t *testing.T) {
 
 	w = request(t, f, http.MethodDelete, "/v1/ai-team/agents/"+f.botID, "", nil)
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	teamMembers = nil
+	_, err = testContext.DB().Select("uid").From("group_member").
+		Where("group_no=? AND status=1 AND is_deleted=0", emptyPage.TeamGroup.GroupNo).
+		OrderBy("uid").Load(&teamMembers)
+	require.NoError(t, err)
+	assert.Equal(t, []string{f.uid}, teamMembers)
 	w = request(t, f, http.MethodPost, "/v1/ai-team/agents/"+f.botID, "", nil)
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 	var restored struct {
@@ -233,6 +250,12 @@ func TestAITeamAgentLifecycleAndSessionIdempotency(t *testing.T) {
 	}
 	decodeJSON(t, w, &restored)
 	assert.Equal(t, session1.GroupNo, restored.GroupNo)
+	teamMembers = nil
+	_, err = testContext.DB().Select("uid").From("group_member").
+		Where("group_no=? AND status=1 AND is_deleted=0", emptyPage.TeamGroup.GroupNo).
+		OrderBy("uid").Load(&teamMembers)
+	require.NoError(t, err)
+	assert.Equal(t, []string{f.botID, f.uid}, teamMembers)
 
 	// Model the authoritative Space-removal aftermath: the owner and their Bot
 	// have been soft-removed from the parent while the durable agent/session rows
@@ -284,6 +307,116 @@ func TestAITeamAgentLifecycleAndSessionIdempotency(t *testing.T) {
 	mu.Unlock()
 	assert.ElementsMatch(t, []string{f.uid, f.botID}, channels[session1.GroupNo])
 	assert.ElementsMatch(t, []string{f.uid, f.botID}, channels[session1.ChannelID])
+}
+
+func TestAITeamGroupAndAgentContainersConvergeTogether(t *testing.T) {
+	f := seedFixture(t)
+	w := request(t, f, http.MethodGet, "/v1/ai-team/agents", "", nil)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var page aiteammod.AgentPage
+	decodeJSON(t, w, &page)
+	require.NotNil(t, page.TeamGroup)
+
+	secondBot := "ai_bot_" + util.GenerUUID()[:8]
+	_, err := testContext.DB().InsertBySql(
+		"INSERT INTO `user` (uid,name,short_no,status,is_destroy) VALUES (?,?,?,1,0)",
+		secondBot, "Second assistant", secondBot).Exec()
+	require.NoError(t, err)
+	_, err = testContext.DB().InsertBySql(
+		"INSERT INTO robot (robot_id,creator_uid,status) VALUES (?,?,1)", secondBot, f.uid).Exec()
+	require.NoError(t, err)
+	_, err = testContext.DB().InsertBySql(
+		"INSERT INTO space_member (space_id,uid,status) VALUES (?,?,1)", f.spaceID, secondBot).Exec()
+	require.NoError(t, err)
+
+	w = request(t, f, http.MethodPost, "/v1/ai-team/agents/"+secondBot, "", nil)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var second aiteammod.Agent
+	decodeJSON(t, w, &second)
+	require.NotEmpty(t, second.GroupNo)
+
+	assertMembers := func(groupNo string, want []string) {
+		t.Helper()
+		var got []string
+		_, queryErr := testContext.DB().Select("uid").From("group_member").
+			Where("group_no=? AND status=1 AND is_deleted=0", groupNo).OrderBy("uid").Load(&got)
+		require.NoError(t, queryErr)
+		assert.ElementsMatch(t, want, got)
+	}
+	assertMembers(second.GroupNo, []string{f.uid, secondBot})
+	assertMembers(page.TeamGroup.GroupNo, []string{f.botID, secondBot, f.uid})
+
+	outsider := "outsider_" + util.GenerUUID()[:8]
+	_, err = testContext.DB().InsertBySql(
+		"INSERT INTO `user` (uid,name,short_no,status,is_destroy) VALUES (?,?,?,1,0)",
+		outsider, "Outsider", outsider).Exec()
+	require.NoError(t, err)
+	_, err = testContext.DB().InsertBySql(
+		"INSERT INTO space_member (space_id,uid,status) VALUES (?,?,1)", f.spaceID, outsider).Exec()
+	require.NoError(t, err)
+	_, err = group.NewService(testContext).AddGroupMembers(&group.AddGroupMembersServiceReq{
+		GroupNo: page.TeamGroup.GroupNo, Members: []string{outsider}, OperatorUID: f.uid,
+	})
+	require.ErrorIs(t, err, aiteampkg.ErrContainerProtected)
+	assertMembers(page.TeamGroup.GroupNo, []string{f.botID, secondBot, f.uid})
+
+	w = request(t, f, http.MethodPut, "/v1/groups/"+page.TeamGroup.GroupNo+"/setting", "", map[string]any{"mute": 1})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	w = request(t, f, http.MethodPut, "/v1/groups/"+page.TeamGroup.GroupNo+"/setting", "", map[string]any{"allow_no_mention": 0})
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "err.server.ai_team.container_protected")
+
+	// A bypassed/stale row and a missing desired member are both repaired by the
+	// same exact-roster projection on the next AI-team list call.
+	groupDB := group.NewDB(testContext)
+	require.NoError(t, groupDB.InsertMember(&group.MemberModel{
+		GroupNo: page.TeamGroup.GroupNo, UID: outsider, Role: group.MemberRoleCommon,
+		Status: 1, Version: 1, Vercode: outsider + "@1",
+	}))
+	_, err = testContext.DB().Update("group_member").Set("is_deleted", 1).
+		Where("group_no=? AND uid=?", page.TeamGroup.GroupNo, f.botID).Exec()
+	require.NoError(t, err)
+	w = request(t, f, http.MethodGet, "/v1/ai-team/agents", "", nil)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assertMembers(page.TeamGroup.GroupNo, []string{f.botID, secondBot, f.uid})
+
+	w = request(t, f, http.MethodDelete, "/v1/ai-team/agents/"+secondBot, "", nil)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assertMembers(page.TeamGroup.GroupNo, []string{f.botID, f.uid})
+	assertMembers(second.GroupNo, []string{f.uid, secondBot})
+}
+
+func TestAITeamConcurrentAgentActivationCreatesOnePairAndOneTeamGroup(t *testing.T) {
+	f := seedFixture(t)
+	svc := aiteammod.NewService(testContext)
+
+	const workers = 6
+	errCh := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := svc.AddAgent(f.spaceID, f.uid, f.botID)
+			errCh <- err
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+
+	var agentCount, pairGroupCount, teamGroupCount int
+	require.NoError(t, testContext.DB().Select("COUNT(*)").From("ai_team_agent").
+		Where("space_id=? AND user_uid=? AND bot_id=?", f.spaceID, f.uid, f.botID).LoadOne(&agentCount))
+	require.NoError(t, testContext.DB().Select("COUNT(*)").From("`group`").
+		Where("creator=? AND space_id=? AND purpose=?", f.uid, f.spaceID, aiteampkg.GroupPurpose).LoadOne(&pairGroupCount))
+	require.NoError(t, testContext.DB().Select("COUNT(*)").From("`group`").
+		Where("creator=? AND space_id=? AND purpose=?", f.uid, f.spaceID, aiteampkg.TeamGroupPurpose).LoadOne(&teamGroupCount))
+	assert.Equal(t, 1, agentCount)
+	assert.Equal(t, 1, pairGroupCount)
+	assert.Equal(t, 1, teamGroupCount)
 }
 
 func TestAITeamListAgentsGroupsByHostingAndKeepsCursorTotals(t *testing.T) {
@@ -659,7 +792,7 @@ func TestAITeamQueriesSurviveProductionCollationShape(t *testing.T) {
 		`CREATE TABLE user (uid VARCHAR(40) PRIMARY KEY, name VARCHAR(100), status TINYINT, is_destroy TINYINT) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci`,
 		`CREATE TABLE space (space_id VARCHAR(40) PRIMARY KEY, status TINYINT) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci`,
 		`CREATE TABLE space_member (space_id VARCHAR(40), uid VARCHAR(40), status TINYINT, UNIQUE KEY uk_space_member(space_id,uid)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci`,
-		"CREATE TABLE `group` (group_no VARCHAR(40) PRIMARY KEY, creator VARCHAR(40), space_id VARCHAR(40), project_id VARCHAR(40) NOT NULL DEFAULT '', purpose VARCHAR(32), status TINYINT, KEY idx_group_purpose(purpose)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"CREATE TABLE `group` (group_no VARCHAR(40) PRIMARY KEY, name VARCHAR(50) NOT NULL DEFAULT '', creator VARCHAR(40), space_id VARCHAR(40), project_id VARCHAR(40) NOT NULL DEFAULT '', purpose VARCHAR(32), status TINYINT, version BIGINT NOT NULL DEFAULT 0, allow_view_history_msg TINYINT NOT NULL DEFAULT 1, allow_external TINYINT NOT NULL DEFAULT 0, allow_no_mention TINYINT NOT NULL DEFAULT 1, KEY idx_group_purpose(purpose)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
 		`CREATE TABLE group_member (group_no VARCHAR(40), uid VARCHAR(40), remark VARCHAR(100) NOT NULL DEFAULT '', role TINYINT, version BIGINT, status TINYINT, vercode VARCHAR(80), is_deleted TINYINT NOT NULL DEFAULT 0, invite_uid VARCHAR(40), robot TINYINT, bot_admin TINYINT NOT NULL DEFAULT 0, forbidden_expir_time BIGINT NOT NULL DEFAULT 0, is_external TINYINT NOT NULL DEFAULT 0, source_space_id VARCHAR(40) NOT NULL DEFAULT '', created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, UNIQUE KEY uk_group_member(group_no,uid)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci`,
 		`CREATE TABLE thread (id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY, short_id VARCHAR(32), group_no VARCHAR(40), name VARCHAR(100), status TINYINT, message_count BIGINT DEFAULT 0, last_message_content TEXT, last_message_at TIMESTAMP NULL, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, UNIQUE KEY uk_thread_short(short_id), KEY idx_thread_group(group_no)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci`,
 		`CREATE TABLE thread_setting (group_no VARCHAR(40), short_id VARCHAR(32), uid VARCHAR(40), mute TINYINT NOT NULL DEFAULT 0, UNIQUE KEY uk_thread_setting(group_no,short_id,uid)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci`,
@@ -675,10 +808,11 @@ func TestAITeamQueriesSurviveProductionCollationShape(t *testing.T) {
 		INSERT INTO robot(robot_id,creator_uid,status) VALUES ('bot','human',1);
 		INSERT INTO space(space_id,status) VALUES ('space',1);
 		INSERT INTO space_member(space_id,uid,status) VALUES ('space','human',1),('space','bot',1);
-		INSERT INTO ` + "`group`" + `(group_no,creator,space_id,purpose,status) VALUES ('parent','human','space','ai_session_container',1);
-		INSERT INTO group_member(group_no,uid,role,version,status,vercode,invite_uid,robot) VALUES ('parent','human',1,1,1,'human@1','human',0),('parent','bot',0,2,1,'bot@1','human',1);
+		INSERT INTO ` + "`group`" + `(group_no,name,creator,space_id,purpose,status) VALUES ('parent','Bot AI','human','space','ai_session_container',1),('team','我的AI团队','human','space','ai_team_group',1);
+		INSERT INTO group_member(group_no,uid,role,version,status,vercode,invite_uid,robot) VALUES ('parent','human',1,1,1,'human@1','human',0),('parent','bot',0,2,1,'bot@1','human',1),('team','human',1,3,1,'human@2','human',0),('team','bot',0,4,1,'bot@2','human',1);
 		INSERT INTO thread(short_id,group_no,name,status,last_message_content) VALUES ('session','parent','Session',1,'');
 		INSERT INTO ai_team_agent(space_id,user_uid,bot_id,group_no,is_added,container_state) VALUES ('space','human','bot','parent',1,2);
+		INSERT INTO ai_team_group(space_id,user_uid,group_no,state) VALUES ('space','human','team',2);
 		INSERT INTO ai_team_session(agent_id,short_id,idempotency_key,request_hash,state) SELECT id,'session','key','hash',2 FROM ai_team_agent;`)
 	require.NoError(t, err)
 

--- a/modules/ai_team/model.go
+++ b/modules/ai_team/model.go
@@ -76,7 +76,14 @@ type AgentGroup struct {
 	Items []*Agent       `json:"items"`
 }
 
+type TeamGroup struct {
+	GroupNo string `db:"group_no" json:"group_no"`
+	Name    string `db:"name" json:"name"`
+	State   int    `db:"state" json:"state"`
+}
+
 type AgentPage struct {
 	Groups     []*AgentGroup `json:"groups"`
+	TeamGroup  *TeamGroup    `json:"team_group,omitempty"`
 	NextCursor string        `json:"next_cursor,omitempty"`
 }

--- a/modules/ai_team/service.go
+++ b/modules/ai_team/service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -14,9 +15,12 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	aiteampkg "github.com/Mininglamp-OSS/octo-server/pkg/aiteam"
+	"github.com/go-sql-driver/mysql"
 	"github.com/gocraft/dbr/v2"
 	"go.uber.org/zap"
 )
+
+const aiTeamMutationRetryAttempts = 3
 
 type Service struct {
 	ctx           *config.Context
@@ -74,7 +78,58 @@ func validateAuthorityTx(tx *dbr.Tx, spaceID, userUID, botID string) error {
 }
 
 func (s *Service) AddAgent(spaceID, userUID, botID string) (*Agent, error) {
-	if _, err := s.validateAuthority(spaceID, userUID, botID); err != nil {
+	var agent *Agent
+	err := retryAITeamMutation(func() error {
+		var attemptErr error
+		agent, attemptErr = s.addAgentOnce(spaceID, userUID, botID)
+		return attemptErr
+	})
+	return agent, err
+}
+
+// addAgentOnce performs one idempotent activation attempt. Keeping the entire
+// orchestration behind the retry boundary matters: a lock conflict can occur in
+// the private-container transaction or while projecting the team-group roster.
+func (s *Service) addAgentOnce(spaceID, userUID, botID string) (*Agent, error) {
+	if _, err := s.ensureAgentContainer(spaceID, userUID, botID); err != nil {
+		return nil, err
+	}
+	if err := s.reconcileActiveAgentContainers(spaceID, userUID); err != nil {
+		return nil, err
+	}
+	if _, err := s.ensureTeamGroup(spaceID, userUID); err != nil {
+		return nil, err
+	}
+	return s.getAgent(spaceID, userUID, botID, false)
+}
+
+func retryAITeamMutation(fn func() error) error {
+	var lastErr error
+	for attempt := 0; attempt < aiTeamMutationRetryAttempts; attempt++ {
+		err := fn()
+		if err == nil || !isRetryableAITeamMutationError(err) {
+			return err
+		}
+		lastErr = err
+		if attempt+1 < aiTeamMutationRetryAttempts {
+			time.Sleep(time.Duration(attempt+1) * 3 * time.Millisecond)
+		}
+	}
+	return fmt.Errorf("ai team: mutation retries exhausted: %w", lastErr)
+}
+
+func isRetryableAITeamMutationError(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	return errors.As(err, &mysqlErr) && (mysqlErr.Number == 1213 || mysqlErr.Number == 1205)
+}
+
+// ensureAgentContainer is the idempotent half of Agent activation that owns the
+// private two-member group. It deliberately does not recurse into team-group
+// reconciliation, allowing a caller to repair every Agent first and project the
+// complete roster exactly once afterwards.
+func (s *Service) ensureAgentContainer(spaceID, userUID, botID string) (*Agent, error) {
+	botName, err := s.validateAuthority(spaceID, userUID, botID)
+	if err != nil {
 		return nil, err
 	}
 	tx, err := s.ctx.DB().Begin()
@@ -102,17 +157,37 @@ func (s *Service) AddAgent(spaceID, userUID, botID string) (*Agent, error) {
 		return nil, errNotFound
 	}
 
-	containerNeedsReconcile := false
-	if agent.GroupNo != "" {
-		repaired, repairErr := s.admitContainerMembersTx(tx, agent.GroupNo, spaceID, userUID, botID)
-		if repairErr != nil {
-			return nil, repairErr
+	if agent.GroupNo == "" {
+		agent.GroupNo = util.GenerUUID()
+		groupName := strings.TrimSpace(botName)
+		if groupName == "" {
+			groupName = botID
 		}
-		containerNeedsReconcile = repaired || agent.ContainerState != containerReady
-		if containerNeedsReconcile {
-			if _, err = tx.Update("ai_team_agent").Set("container_state", containerProvisioning).Where("id=?", agent.ID).Exec(); err != nil {
-				return nil, err
-			}
+		groupName += " · AI"
+		if r := []rune(groupName); len(r) > group.MaxGroupNameLen {
+			groupName = string(r[:group.MaxGroupNameLen])
+		}
+		version, genErr := s.ctx.GenSeq(common.GroupSeqKey)
+		if genErr != nil {
+			return nil, genErr
+		}
+		if _, err = tx.InsertBySql("INSERT INTO `group` (group_no,name,creator,status,version,allow_view_history_msg,space_id,allow_external,allow_no_mention,purpose) VALUES (?,?,?,?,?,?,?,?,?,?)",
+			agent.GroupNo, groupName, userUID, group.GroupStatusNormal, version, 1, spaceID, 0, 1, aiteampkg.GroupPurpose).Exec(); err != nil {
+			return nil, err
+		}
+		if _, err = tx.Update("ai_team_agent").Set("group_no", agent.GroupNo).Set("container_state", containerProvisioning).Where("id=?", agent.ID).Exec(); err != nil {
+			return nil, err
+		}
+		agent.ContainerState = containerProvisioning
+	}
+	repaired, repairErr := s.admitContainerMembersTx(tx, agent.GroupNo, spaceID, userUID, botID)
+	if repairErr != nil {
+		return nil, repairErr
+	}
+	containerNeedsReconcile := repaired || agent.ContainerState != containerReady
+	if containerNeedsReconcile {
+		if _, err = tx.Update("ai_team_agent").Set("container_state", containerProvisioning).Where("id=?", agent.ID).Exec(); err != nil {
+			return nil, err
 		}
 	}
 	if err = tx.Commit(); err != nil {
@@ -143,6 +218,12 @@ func (s *Service) AddAgent(spaceID, userUID, botID string) (*Agent, error) {
 }
 
 func (s *Service) RemoveAgent(spaceID, userUID, botID string) error {
+	return retryAITeamMutation(func() error {
+		return s.removeAgentOnce(spaceID, userUID, botID)
+	})
+}
+
+func (s *Service) removeAgentOnce(spaceID, userUID, botID string) error {
 	if _, err := s.validateAuthority(spaceID, userUID, botID); err != nil {
 		return err
 	}
@@ -154,7 +235,8 @@ func (s *Service) RemoveAgent(spaceID, userUID, botID string) error {
 	if err != nil {
 		return err
 	}
-	return nil
+	_, err = s.ensureTeamGroup(spaceID, userUID)
+	return err
 }
 
 func (s *Service) getAgent(spaceID, userUID, botID string, requireAdded bool) (*Agent, error) {
@@ -195,6 +277,15 @@ func (s *Service) eligibleAgentsQuery(spaceID, userUID string, columns ...string
 }
 
 func (s *Service) ListAgents(spaceID, userUID string, beforeID int64, limit int) (*AgentPage, error) {
+	var teamGroup *TeamGroup
+	err := retryAITeamMutation(func() error {
+		var attemptErr error
+		teamGroup, attemptErr = s.reconcileTeam(spaceID, userUID)
+		return attemptErr
+	})
+	if err != nil {
+		return nil, err
+	}
 	if limit <= 0 || limit > maxPageSize {
 		limit = defaultPageSize
 	}
@@ -208,7 +299,7 @@ func (s *Service) ListAgents(spaceID, userUID string, beforeID int64, limit int)
 		q = q.Where("a.id<?", beforeID)
 	}
 	rows := make([]*Agent, 0)
-	_, err := q.Load(&rows)
+	_, err = q.Load(&rows)
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +321,7 @@ func (s *Service) ListAgents(spaceID, userUID string, beforeID int64, limit int)
 	for _, groupCount := range groupCounts {
 		counts[groupCount.Type] = groupCount.Count
 	}
-	page := &AgentPage{Groups: []*AgentGroup{
+	page := &AgentPage{TeamGroup: teamGroup, Groups: []*AgentGroup{
 		{Type: AgentGroupTypeCloudClone, Count: counts[AgentGroupTypeCloudClone], Items: make([]*Agent, 0)},
 		{Type: AgentGroupTypePersonalAssistant, Count: counts[AgentGroupTypePersonalAssistant], Items: make([]*Agent, 0)},
 		{Type: AgentGroupTypeDigitalEmployee, Count: 0, Items: make([]*Agent, 0)},

--- a/modules/ai_team/service_retry_test.go
+++ b/modules/ai_team/service_retry_test.go
@@ -1,0 +1,53 @@
+package ai_team
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryAITeamMutation(t *testing.T) {
+	deadlock := &mysql.MySQLError{Number: 1213, Message: "Deadlock found"}
+	lockTimeout := &mysql.MySQLError{Number: 1205, Message: "Lock wait timeout exceeded"}
+
+	t.Run("retries transient lock conflicts", func(t *testing.T) {
+		attempts := 0
+		err := retryAITeamMutation(func() error {
+			attempts++
+			if attempts == 1 {
+				return fmt.Errorf("activate agent: %w", deadlock)
+			}
+			if attempts == 2 {
+				return lockTimeout
+			}
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 3, attempts)
+	})
+
+	t.Run("returns non-lock errors immediately", func(t *testing.T) {
+		want := errors.New("forbidden")
+		attempts := 0
+		err := retryAITeamMutation(func() error {
+			attempts++
+			return want
+		})
+		assert.ErrorIs(t, err, want)
+		assert.Equal(t, 1, attempts)
+	})
+
+	t.Run("preserves the final lock error", func(t *testing.T) {
+		attempts := 0
+		err := retryAITeamMutation(func() error {
+			attempts++
+			return deadlock
+		})
+		assert.ErrorIs(t, err, deadlock)
+		assert.Equal(t, aiTeamMutationRetryAttempts, attempts)
+	})
+}

--- a/modules/ai_team/sql/20260908000001_ai_team_group.sql
+++ b/modules/ai_team/sql/20260908000001_ai_team_group.sql
@@ -1,0 +1,17 @@
+-- +migrate Up
+
+CREATE TABLE `ai_team_group` (
+  `space_id` VARCHAR(40) NOT NULL,
+  `user_uid` VARCHAR(40) NOT NULL,
+  `group_no` VARCHAR(40) NULL,
+  `state` TINYINT NOT NULL DEFAULT 0 COMMENT '0=未分配 1=配置中 2=就绪 3=失败',
+  `last_error` VARCHAR(255) NOT NULL DEFAULT '',
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`space_id`, `user_uid`),
+  UNIQUE KEY `uk_ai_team_group_no` (`group_no`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- +migrate Down
+
+DROP TABLE IF EXISTS `ai_team_group`;

--- a/modules/ai_team/team_group.go
+++ b/modules/ai_team/team_group.go
@@ -1,0 +1,213 @@
+package ai_team
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	aiteampkg "github.com/Mininglamp-OSS/octo-server/pkg/aiteam"
+	"github.com/gocraft/dbr/v2"
+	"go.uber.org/zap"
+)
+
+// ProvisionOwnedBot is the lifecycle entry used after a User Bot has been
+// durably bound to a Space. It activates the Agent and converges both managed
+// groups before returning.
+func ProvisionOwnedBot(ctx *config.Context, spaceID, userUID, botID string) error {
+	if !aiteampkg.Enabled() {
+		return nil
+	}
+	_, err := NewService(ctx).AddAgent(spaceID, userUID, botID)
+	return err
+}
+
+// reconcileTeam backfills only Bot identities that have never had an Agent
+// row. An explicit DELETE leaves is_added=0 behind, so ordinary list calls do
+// not silently undo a user's removal.
+func (s *Service) reconcileTeam(spaceID, userUID string) (*TeamGroup, error) {
+	missing, err := s.missingOwnedBotIDs(spaceID, userUID)
+	if err != nil {
+		return nil, err
+	}
+	for _, botID := range missing {
+		if _, err = s.ensureAgentContainer(spaceID, userUID, botID); err != nil {
+			return nil, err
+		}
+	}
+	if err = s.reconcileActiveAgentContainers(spaceID, userUID); err != nil {
+		return nil, err
+	}
+	return s.ensureTeamGroup(spaceID, userUID)
+}
+
+func (s *Service) missingOwnedBotIDs(spaceID, userUID string) ([]string, error) {
+	botIDs := make([]string, 0)
+	_, err := s.ctx.DB().SelectBySql(`
+		SELECT r.robot_id
+		FROM robot r
+		JOIN user u ON u.uid=r.robot_id AND u.status=1 AND u.is_destroy<>2
+		JOIN space sp ON sp.space_id=? AND sp.status=1
+		JOIN space_member human_sm ON human_sm.space_id=sp.space_id AND human_sm.uid=? AND human_sm.status=1
+		JOIN space_member bot_sm ON bot_sm.space_id=sp.space_id AND bot_sm.uid=r.robot_id AND bot_sm.status=1
+		LEFT JOIN ai_team_agent a ON a.space_id=sp.space_id COLLATE utf8mb4_general_ci
+			AND a.user_uid=r.creator_uid COLLATE utf8mb4_general_ci
+			AND a.bot_id=r.robot_id COLLATE utf8mb4_general_ci
+		WHERE r.creator_uid=? AND r.status=1 AND a.id IS NULL
+		ORDER BY r.robot_id`, spaceID, userUID, userUID).Load(&botIDs)
+	return botIDs, err
+}
+
+func (s *Service) reconcileActiveAgentContainers(spaceID, userUID string) error {
+	botIDs := make([]string, 0)
+	_, err := s.eligibleAgentsQuery(spaceID, userUID, "a.bot_id").OrderAsc("a.bot_id").Load(&botIDs)
+	if err != nil {
+		return err
+	}
+	for _, botID := range botIDs {
+		if _, err = s.ensureAgentContainer(spaceID, userUID, botID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Service) desiredTeamBotIDs(spaceID, userUID string) ([]string, error) {
+	botIDs := make([]string, 0)
+	_, err := s.eligibleAgentsQuery(spaceID, userUID, "a.bot_id").
+		Where("a.group_no IS NOT NULL AND a.group_no<>'' AND a.container_state=?", containerReady).
+		OrderAsc("a.bot_id").Load(&botIDs)
+	return botIDs, err
+}
+
+func desiredTeamBotIDsTx(tx *dbr.Tx, spaceID, userUID string) ([]string, error) {
+	botIDs := make([]string, 0)
+	_, err := tx.SelectBySql(`SELECT a.bot_id
+		FROM ai_team_agent a
+		JOIN robot r ON r.robot_id=a.bot_id COLLATE utf8mb4_0900_ai_ci
+			AND r.status=1 AND r.creator_uid=a.user_uid COLLATE utf8mb4_0900_ai_ci
+		JOIN user u ON u.uid=a.bot_id COLLATE utf8mb4_0900_ai_ci AND u.status=1 AND u.is_destroy<>2
+		JOIN space sp ON sp.space_id=a.space_id COLLATE utf8mb4_0900_ai_ci AND sp.status=1
+		JOIN space_member human_sm ON human_sm.space_id=a.space_id COLLATE utf8mb4_0900_ai_ci
+			AND human_sm.uid=a.user_uid COLLATE utf8mb4_0900_ai_ci AND human_sm.status=1
+		JOIN space_member bot_sm ON bot_sm.space_id=a.space_id COLLATE utf8mb4_0900_ai_ci
+			AND bot_sm.uid=a.bot_id COLLATE utf8mb4_0900_ai_ci AND bot_sm.status=1
+		WHERE a.space_id=? AND a.user_uid=? AND a.is_added=1
+			AND a.group_no IS NOT NULL AND a.group_no<>'' AND a.container_state=?
+		ORDER BY a.bot_id FOR UPDATE`, spaceID, userUID, containerReady).Load(&botIDs)
+	return botIDs, err
+}
+
+func (s *Service) ensureTeamGroup(spaceID, userUID string) (*TeamGroup, error) {
+	botIDs, err := s.desiredTeamBotIDs(spaceID, userUID)
+	if err != nil {
+		return nil, err
+	}
+
+	var existing int
+	if err = s.ctx.DB().Select("COUNT(*)").From("ai_team_group").
+		Where("space_id=? AND user_uid=?", spaceID, userUID).LoadOne(&existing); err != nil {
+		return nil, err
+	}
+	if len(botIDs) == 0 && existing == 0 {
+		return nil, nil
+	}
+
+	tx, err := s.ctx.DB().Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	if len(botIDs) > 0 {
+		if _, err = tx.InsertBySql(`INSERT IGNORE INTO ai_team_group
+			(space_id,user_uid,state) VALUES (?,?,?)`, spaceID, userUID, containerUnassigned).Exec(); err != nil {
+			return nil, err
+		}
+	}
+	var row struct {
+		GroupNo string `db:"group_no"`
+		State   int    `db:"state"`
+	}
+	count, err := tx.SelectBySql(`SELECT IFNULL(group_no,'') AS group_no,state
+		FROM ai_team_group WHERE space_id=? AND user_uid=? FOR UPDATE`, spaceID, userUID).Load(&row)
+	if err != nil {
+		return nil, err
+	}
+	if count == 0 {
+		return nil, nil
+	}
+	// Re-read and lock the authoritative Agent rows after taking the owner-group
+	// row lock. This prevents an older roster snapshot from running after a newer
+	// AddAgent/RemoveAgent reconciliation and removing its result.
+	botIDs, err = desiredTeamBotIDsTx(tx, spaceID, userUID)
+	if err != nil {
+		return nil, err
+	}
+
+	created := false
+	if row.GroupNo == "" {
+		row.GroupNo = util.GenerUUID()
+		version, genErr := s.ctx.GenSeq(common.GroupSeqKey)
+		if genErr != nil {
+			return nil, genErr
+		}
+		if _, err = tx.InsertBySql(`INSERT INTO `+"`group`"+`
+			(group_no,name,creator,status,version,allow_view_history_msg,space_id,allow_external,allow_no_mention,purpose)
+			VALUES (?,?,?,?,?,?,?,?,?,?)`, row.GroupNo, aiteampkg.TeamGroupName, userUID,
+			group.GroupStatusNormal, version, 1, spaceID, 0, 1, aiteampkg.TeamGroupPurpose).Exec(); err != nil {
+			return nil, err
+		}
+		if _, err = tx.Update("ai_team_group").Set("group_no", row.GroupNo).
+			Set("state", containerProvisioning).Set("last_error", "").
+			Where("space_id=? AND user_uid=?", spaceID, userUID).Exec(); err != nil {
+			return nil, err
+		}
+		row.State = containerProvisioning
+		created = true
+	}
+
+	changed, err := group.SyncAITeamGroupMembersTx(s.ctx, tx, row.GroupNo, spaceID, userUID, botIDs)
+	if err != nil {
+		return nil, err
+	}
+	needsIM := created || changed || row.State != containerReady
+	if needsIM && row.State == containerReady {
+		if _, err = tx.Update("ai_team_group").Set("state", containerProvisioning).
+			Where("space_id=? AND user_uid=?", spaceID, userUID).Exec(); err != nil {
+			return nil, err
+		}
+	}
+	if err = tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	if needsIM {
+		subscribers := append([]string{userUID}, botIDs...)
+		if err = s.ctx.IMCreateOrUpdateChannel(&config.ChannelCreateReq{
+			ChannelID: row.GroupNo, ChannelType: common.ChannelTypeGroup.Uint8(), Subscribers: subscribers,
+		}); err != nil {
+			s.markTeamGroupFailure(spaceID, userUID, err)
+			return nil, fmt.Errorf("%w: provision AI-team group channel: %v", errIMUnavailable, err)
+		}
+		if _, err = s.ctx.DB().Update("ai_team_group").Set("state", containerReady).Set("last_error", "").
+			Where("space_id=? AND user_uid=? AND group_no=?", spaceID, userUID, row.GroupNo).Exec(); err != nil {
+			return nil, err
+		}
+		row.State = containerReady
+	}
+	return &TeamGroup{GroupNo: row.GroupNo, Name: aiteampkg.TeamGroupName, State: row.State}, nil
+}
+
+func (s *Service) markTeamGroupFailure(spaceID, userUID string, cause error) {
+	reason := strings.TrimSpace(cause.Error())
+	if runes := []rune(reason); len(runes) > 255 {
+		reason = string(runes[:255])
+	}
+	if _, err := s.ctx.DB().Update("ai_team_group").Set("state", containerFailed).Set("last_error", reason).
+		Where("space_id=? AND user_uid=?", spaceID, userUID).Exec(); err != nil {
+		s.Error("mark AI-team group provisioning failure", zap.Error(err), zap.String("space_id", spaceID), zap.String("uid", userUID))
+	}
+}

--- a/modules/bot_api/groups.go
+++ b/modules/bot_api/groups.go
@@ -49,13 +49,13 @@ func (ba *BotAPI) getGroups(c *wkhttp.Context) {
 	var err error
 	if spaceID != "" {
 		_, err = ba.ctx.DB().SelectBySql(
-			"SELECT gm.group_no, g.name, g.space_id FROM group_member gm INNER JOIN `group` g ON gm.group_no = g.group_no WHERE gm.uid = ? AND gm.is_deleted = 0 AND g.space_id = ? AND g.purpose = ''",
-			robotID, spaceID,
+			"SELECT gm.group_no, g.name, g.space_id FROM group_member gm INNER JOIN `group` g ON gm.group_no = g.group_no WHERE gm.uid = ? AND gm.is_deleted = 0 AND g.space_id = ? AND g.purpose IN ('', ?)",
+			robotID, spaceID, aiteampkg.TeamGroupPurpose,
 		).Load(&groups)
 	} else {
 		_, err = ba.ctx.DB().SelectBySql(
-			"SELECT gm.group_no, g.name, g.space_id FROM group_member gm INNER JOIN `group` g ON gm.group_no = g.group_no WHERE gm.uid = ? AND gm.is_deleted = 0 AND g.purpose = ''",
-			robotID,
+			"SELECT gm.group_no, g.name, g.space_id FROM group_member gm INNER JOIN `group` g ON gm.group_no = g.group_no WHERE gm.uid = ? AND gm.is_deleted = 0 AND g.purpose IN ('', ?)",
+			robotID, aiteampkg.TeamGroupPurpose,
 		).Load(&groups)
 	}
 	if err != nil {

--- a/modules/botfather/ai_team_hook.go
+++ b/modules/botfather/ai_team_hook.go
@@ -1,0 +1,33 @@
+package botfather
+
+import (
+	"sync"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+)
+
+// AITeamProvisioner is invoked only after a User Bot and its Space membership
+// are durable. The reverse registration keeps botfather independent from the
+// AI-team module while giving every production creation path one hook.
+type AITeamProvisioner func(ctx *config.Context, spaceID, ownerUID, botID string) error
+
+var (
+	aiTeamProvisionerMu sync.RWMutex
+	aiTeamProvisioner   AITeamProvisioner
+)
+
+func RegisterAITeamProvisioner(fn AITeamProvisioner) {
+	aiTeamProvisionerMu.Lock()
+	defer aiTeamProvisionerMu.Unlock()
+	aiTeamProvisioner = fn
+}
+
+func provisionAITeam(ctx *config.Context, spaceID, ownerUID, botID string) error {
+	aiTeamProvisionerMu.RLock()
+	fn := aiTeamProvisioner
+	aiTeamProvisionerMu.RUnlock()
+	if fn == nil || spaceID == "" || ownerUID == "" || botID == "" {
+		return nil
+	}
+	return fn(ctx, spaceID, ownerUID, botID)
+}

--- a/modules/botfather/ai_team_hook_test.go
+++ b/modules/botfather/ai_team_hook_test.go
@@ -1,0 +1,55 @@
+package botfather
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAITeamProvisionerReceivesAuthoritativeCreationIdentity(t *testing.T) {
+	aiTeamProvisionerMu.Lock()
+	previous := aiTeamProvisioner
+	aiTeamProvisionerMu.Unlock()
+	t.Cleanup(func() { RegisterAITeamProvisioner(previous) })
+
+	wantErr := errors.New("projection failed")
+	var gotSpace, gotOwner, gotBot string
+	RegisterAITeamProvisioner(func(_ *config.Context, spaceID, ownerUID, botID string) error {
+		gotSpace, gotOwner, gotBot = spaceID, ownerUID, botID
+		return wantErr
+	})
+
+	err := provisionAITeam(&config.Context{}, "space", "owner", "bot")
+	require.ErrorIs(t, err, wantErr)
+	require.Equal(t, "space", gotSpace)
+	require.Equal(t, "owner", gotOwner)
+	require.Equal(t, "bot", gotBot)
+}
+
+func TestAITeamProvisionerSkipsIncompleteIdentity(t *testing.T) {
+	aiTeamProvisionerMu.Lock()
+	previous := aiTeamProvisioner
+	aiTeamProvisionerMu.Unlock()
+	t.Cleanup(func() { RegisterAITeamProvisioner(previous) })
+
+	called := false
+	RegisterAITeamProvisioner(func(_ *config.Context, _, _, _ string) error {
+		called = true
+		return nil
+	})
+	require.NoError(t, provisionAITeam(&config.Context{}, "", "owner", "bot"))
+	require.False(t, called)
+}
+
+func TestEveryUserBotCreationPathTriggersAITeamProvisioning(t *testing.T) {
+	for _, filename := range []string{"command.go", "api_user.go", "mint_obo.go"} {
+		body, err := os.ReadFile(filename)
+		require.NoError(t, err)
+		require.Contains(t, strings.ReplaceAll(string(body), " ", ""), "provisionAITeam(",
+			"%s must converge the Agent, pair group, and AI-team group after Space binding", filename)
+	}
+}

--- a/modules/botfather/api_user.go
+++ b/modules/botfather/api_user.go
@@ -214,6 +214,7 @@ func (bf *BotFather) createUserBot(c *wkhttp.Context) {
 
 	// Add bot to Space (best-effort, non-critical)
 	// Verify caller belongs to the Space before adding bot (prevent cross-Space injection)
+	botBoundToSpace := false
 	if spaceID != "" {
 		var memberCount int
 		_, countErr := bf.db.session.SelectBySql(
@@ -229,9 +230,17 @@ func (bf *BotFather) createUserBot(c *wkhttp.Context) {
 			).Exec()
 			if spErr != nil {
 				bf.Error("Bot加入Space失败", zap.String("spaceID", spaceID), zap.Error(spErr))
+			} else {
+				botBoundToSpace = true
 			}
 		} else {
 			bf.Warn("用户不属于指定Space，跳过", zap.String("uid", uid), zap.String("spaceID", spaceID))
+		}
+	}
+	if botBoundToSpace {
+		if provisionErr := provisionAITeam(bf.ctx, spaceID, uid, robotID); provisionErr != nil {
+			bf.Warn("Bot已创建但AI团队群同步失败，将由后续AI团队请求重试",
+				zap.String("robotID", robotID), zap.String("spaceID", spaceID), zap.Error(provisionErr))
 		}
 	}
 

--- a/modules/botfather/command.go
+++ b/modules/botfather/command.go
@@ -866,6 +866,10 @@ func (h *commandHandler) createBot(creatorUID, fromUID, name, username, botToken
 		}
 		return errCreateBotSpaceBindingFailed
 	}
+	if provisionErr := provisionAITeam(h.ctx, targetSpaceID, creatorUID, robotID); provisionErr != nil {
+		h.Warn("Bot已创建但AI团队群同步失败，将由后续AI团队请求重试",
+			zap.String("robotID", robotID), zap.String("spaceID", targetSpaceID), zap.Error(provisionErr))
+	}
 
 	// 兼容：仍添加好友关系（过渡期）
 	err = h.userService.AddFriend(creatorUID, &user.FriendReq{

--- a/modules/botfather/mint_obo.go
+++ b/modules/botfather/mint_obo.go
@@ -60,6 +60,10 @@ func MintBotOBO(ctx *config.Context, ownerUID, spaceID, displayName, botToken st
 			zap.Error(err), zap.String("bot_uid", robotID), zap.String("space_id", spaceID))
 		return nil, fmt.Errorf("MintBotOBO: add bot to space: %w", err)
 	}
+	if provisionErr := provisionAITeam(ctx, spaceID, ownerUID, robotID); provisionErr != nil {
+		h.Warn("MintBotOBO: Bot已创建但AI团队群同步失败，将由后续AI团队请求重试",
+			zap.Error(provisionErr), zap.String("bot_uid", robotID), zap.String("space_id", spaceID))
+	}
 
 	if err := h.userService.AddFriend(ownerUID, &user.FriendReq{UID: ownerUID, ToUID: robotID}); err != nil {
 		h.Warn("MintBotOBO: 好友 owner->bot 失败", zap.Error(err))

--- a/modules/group/admission.go
+++ b/modules/group/admission.go
@@ -3,6 +3,7 @@ package group
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
@@ -93,6 +94,9 @@ const (
 	// channel and to the group's threads, and touches NEITHER InsertMemberTx nor
 	// recoverMemberTx. It is an admission path because that is what it does.
 	AdmissionEntryUnblacklist = "a11_unblacklist"
+	// AdmissionEntryAITeamGroup is the internal exact-roster projection for the
+	// visible "我的AI团队" group. It is never reachable from an HTTP handler.
+	AdmissionEntryAITeamGroup = "a12_ai_team_group"
 )
 
 // Rejection reasons. Low-cardinality enum; never a free-form message.
@@ -277,8 +281,11 @@ type MemberAdmission struct {
 }
 
 type aiTeamActiveMember struct {
-	UID    string `db:"uid"`
-	Status int    `db:"status"`
+	UID       string `db:"uid"`
+	Role      int    `db:"role"`
+	Status    int    `db:"status"`
+	Robot     int    `db:"robot"`
+	IsDeleted int    `db:"is_deleted"`
 }
 
 // AdmitAITeamContainerMembersTx is the narrow admission bridge used while an
@@ -387,6 +394,161 @@ func hasExactAITeamMembers(members []*aiTeamActiveMember, ownerUID, botUID strin
 		}
 	}
 	return foundOwner && foundBot
+}
+
+// SyncAITeamGroupMembersTx projects the authoritative AI-agent roster into the
+// visible "我的AI团队" group. Unlike ordinary admission, this bridge owns the
+// complete set: it restores missing desired members and soft-deletes every
+// extra member while the parent row and all member rows are locked.
+func SyncAITeamGroupMembersTx(
+	ctx *config.Context,
+	tx *dbr.Tx,
+	groupNo, spaceID, ownerUID string,
+	botUIDs []string,
+) (bool, error) {
+	if groupNo == "" || spaceID == "" || ownerUID == "" {
+		return false, errors.New("group: invalid AI-team group projection")
+	}
+
+	var parent struct {
+		SpaceID   string `db:"space_id"`
+		Creator   string `db:"creator"`
+		Purpose   string `db:"purpose"`
+		ProjectID string `db:"project_id"`
+		Status    int    `db:"status"`
+	}
+	count, err := tx.SelectBySql(
+		"SELECT space_id,creator,purpose,project_id,status FROM `group` WHERE group_no=? FOR UPDATE",
+		groupNo,
+	).Load(&parent)
+	if err != nil {
+		return false, fmt.Errorf("group: query AI-team group for projection: %w", err)
+	}
+	if count != 1 || parent.SpaceID != spaceID || parent.Creator != ownerUID ||
+		parent.Purpose != aiteampkg.TeamGroupPurpose || parent.ProjectID != "" ||
+		parent.Status == GroupStatusDisband {
+		return false, errors.New("group: AI-team group projection target mismatch")
+	}
+
+	var ownerCount int
+	if err = tx.SelectBySql(`SELECT COUNT(*) FROM user u
+		JOIN space sp ON sp.space_id=? AND sp.status=1
+		JOIN space_member sm ON sm.space_id=sp.space_id AND sm.uid=u.uid AND sm.status=1
+		WHERE u.uid=? AND u.status=1 AND u.is_destroy<>2`, spaceID, ownerUID).LoadOne(&ownerCount); err != nil {
+		return false, fmt.Errorf("group: validate AI-team group owner: %w", err)
+	}
+	if ownerCount != 1 {
+		return false, errors.New("group: AI-team group owner is not active in space")
+	}
+
+	uniqueBots := make([]string, 0, len(botUIDs))
+	seen := make(map[string]struct{}, len(botUIDs))
+	for _, uid := range botUIDs {
+		if uid == "" || uid == ownerUID {
+			return false, errors.New("group: invalid AI-team group bot roster")
+		}
+		if _, ok := seen[uid]; ok {
+			continue
+		}
+		seen[uid] = struct{}{}
+		uniqueBots = append(uniqueBots, uid)
+	}
+	sort.Strings(uniqueBots)
+	if len(uniqueBots) > 0 {
+		var authorized []string
+		_, err = tx.SelectBySql(`SELECT r.robot_id FROM robot r
+			JOIN user u ON u.uid=r.robot_id AND u.status=1 AND u.is_destroy<>2
+			JOIN space_member sm ON sm.space_id=? AND sm.uid=r.robot_id AND sm.status=1
+			WHERE r.creator_uid=? AND r.status=1 AND r.robot_id IN ?
+			ORDER BY r.robot_id FOR UPDATE`, spaceID, ownerUID, uniqueBots).Load(&authorized)
+		if err != nil {
+			return false, fmt.Errorf("group: validate AI-team group bots: %w", err)
+		}
+		if len(authorized) != len(uniqueBots) {
+			return false, errors.New("group: AI-team group roster contains unauthorized bot")
+		}
+		for i := range authorized {
+			if authorized[i] != uniqueBots[i] {
+				return false, errors.New("group: AI-team group roster authorization mismatch")
+			}
+		}
+	}
+
+	var current []*aiTeamActiveMember
+	if _, err = tx.SelectBySql(
+		"SELECT uid,role,status,robot,is_deleted FROM group_member WHERE group_no=? FOR UPDATE",
+		groupNo,
+	).Load(&current); err != nil {
+		return false, fmt.Errorf("group: lock AI-team group members: %w", err)
+	}
+	desired := make(map[string]MemberAdmission, len(uniqueBots)+1)
+	desired[ownerUID] = MemberAdmission{UID: ownerUID, Role: MemberRoleCreator, InviteUID: ownerUID}
+	for _, uid := range uniqueBots {
+		desired[uid] = MemberAdmission{UID: uid, Role: MemberRoleCommon, InviteUID: ownerUID, Robot: 1}
+	}
+	currentByUID := make(map[string]*aiTeamActiveMember, len(current))
+	changed := false
+	db := NewDB(ctx)
+	for _, member := range current {
+		currentByUID[member.UID] = member
+		if member.IsDeleted == 0 {
+			if _, ok := desired[member.UID]; !ok {
+				version, versionErr := ctx.GenSeq(common.GroupMemberSeqKey)
+				if versionErr != nil {
+					return false, versionErr
+				}
+				if err = db.DeleteMemberTx(groupNo, member.UID, version, tx); err != nil {
+					return false, fmt.Errorf("group: remove extra AI-team group member: %w", err)
+				}
+				changed = true
+			}
+		}
+	}
+
+	admissions := make([]MemberAdmission, 0, len(desired))
+	for uid, want := range desired {
+		row := currentByUID[uid]
+		if row != nil && row.IsDeleted == 0 && row.Status == int(common.GroupMemberStatusNormal) &&
+			row.Role == want.Role && row.Robot == want.Robot {
+			continue
+		}
+		version, versionErr := ctx.GenSeq(common.GroupMemberSeqKey)
+		if versionErr != nil {
+			return false, versionErr
+		}
+		want.Version = version
+		admissions = append(admissions, want)
+	}
+	if len(admissions) > 0 {
+		if err = db.admitOrRestoreMembersTx(tx, groupNo, spaceID, "", admissions, AdmissionEntryAITeamGroup); err != nil {
+			return false, err
+		}
+		for _, admission := range admissions {
+			if err = db.normalizeManagedMemberTx(groupNo, admission.UID, admission.Role, admission.Robot, admission.Version, tx); err != nil {
+				return false, fmt.Errorf("group: normalize AI-team group member: %w", err)
+			}
+		}
+		changed = true
+	}
+
+	var active []*aiTeamActiveMember
+	if _, err = tx.SelectBySql(
+		"SELECT uid,role,status,robot,is_deleted FROM group_member WHERE group_no=? AND is_deleted=0 FOR UPDATE",
+		groupNo,
+	).Load(&active); err != nil {
+		return false, fmt.Errorf("group: verify AI-team group projection: %w", err)
+	}
+	if len(active) != len(desired) {
+		return false, errors.New("group: AI-team group member projection is incomplete")
+	}
+	for _, member := range active {
+		want, ok := desired[member.UID]
+		if !ok || member.Status != int(common.GroupMemberStatusNormal) ||
+			member.Role != want.Role || member.Robot != want.Robot {
+			return false, errors.New("group: AI-team group member projection mismatch")
+		}
+	}
+	return changed, nil
 }
 
 // admitOrRestoreMembersTx is the single admission entry. Every path that adds a

--- a/modules/group/admission_i2_test.go
+++ b/modules/group/admission_i2_test.go
@@ -117,6 +117,7 @@ func TestProjectGroupRefusesANonProjectMember(t *testing.T) {
 		AdmissionEntryOrgEmployeeUpdate,
 		AdmissionEntryPresetGroups,
 		AdmissionEntryUnblacklist,
+		AdmissionEntryAITeamGroup,
 	}
 	for _, entry := range entries {
 		t.Run(entry, func(t *testing.T) {

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -112,7 +112,7 @@ func (g *Group) Route(r *wkhttp.WKHttp) {
 		groups.POST("/:group_no/members_delete", memberRemoveRateLimiter, protectAIContainer, g.memberRemove) // 移除群成员
 		groups.GET("/:group_no/membersync", g.syncMembers)                                                    // 同步群成员
 		groups.GET("/:group_no", g.groupGet)                                                                  // 获取群信息
-		groups.PUT("/:group_no/setting", protectAIContainer, g.groupSettingUpdate)                            // 修改群设置
+		groups.PUT("/:group_no/setting", g.protectAISessionContainerMutation, g.groupSettingUpdate)           // 修改群设置
 		groups.PUT("/:group_no", protectAIContainer, g.groupUpdate)                                           // 修改群信息
 		groups.PUT("/:group_no/members/:uid", protectAIContainer, g.memberUpdate)                             // 修改群的群成员信息
 		groups.POST("/:group_no/exit", protectAIContainer, g.groupExit)                                       // 退出群聊
@@ -208,6 +208,25 @@ func (g *Group) protectAIContainerMutation(c *wkhttp.Context) {
 		return
 	}
 	if protected {
+		httperr.ResponseErrorL(c, errcode.ErrAITeamContainerProtected, nil, nil)
+		c.Abort()
+		return
+	}
+	c.Next()
+}
+
+// protectAISessionContainerMutation lets the visible AI-team group use normal
+// per-user preferences. groupSettingUpdate separately rejects group-level keys
+// for that group, while the hidden two-member container remains fully sealed.
+func (g *Group) protectAISessionContainerMutation(c *wkhttp.Context) {
+	purpose, err := aiteampkg.Purpose(g.ctx.DB(), c.Param("group_no"))
+	if err != nil {
+		g.Error("query AI group purpose failed", zap.Error(err), zap.String("group_no", c.Param("group_no")))
+		httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
+		c.Abort()
+		return
+	}
+	if purpose == aiteampkg.GroupPurpose {
 		httperr.ResponseErrorL(c, errcode.ErrAITeamContainerProtected, nil, nil)
 		c.Abort()
 		return
@@ -1757,7 +1776,7 @@ func (g *Group) addMembersTxWithSpace(members []string, groupNo string, operator
 	if err := tx.Select("purpose").From("`group`").Where("group_no=?", groupNo).LoadOne(&purpose); err != nil {
 		return nil, err
 	}
-	if purpose == aiteampkg.GroupPurpose {
+	if aiteampkg.IsProtectedPurpose(purpose) {
 		return nil, aiteampkg.ErrContainerProtected
 	}
 
@@ -3412,6 +3431,18 @@ func (g *Group) groupSettingUpdate(c *wkhttp.Context) {
 		if groupUpdateActionMap[key] != nil {
 			containsGroupUpdate = true
 			break
+		}
+	}
+	if containsGroupUpdate {
+		purpose, err := aiteampkg.Purpose(g.ctx.DB(), groupNo)
+		if err != nil {
+			g.Error("查询 AI 团队群用途失败", zap.Error(err), zap.String("group_no", groupNo))
+			httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
+			return
+		}
+		if purpose == aiteampkg.TeamGroupPurpose {
+			httperr.ResponseErrorL(c, errcode.ErrAITeamContainerProtected, nil, nil)
+			return
 		}
 	}
 	if containsGroupUpdate {

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -94,6 +94,23 @@ func (d *DB) DeleteMemberTx(groupNo string, uid string, version int64, tx *dbr.T
 	return err
 }
 
+// normalizeManagedMemberTx repairs the role/status flags of a member whose
+// membership is owned by a server-managed group projection. Callers must first
+// pass the member through admitOrRestoreMembersTx; keeping this primitive in DB
+// preserves the single group_member write boundary enforced by source guards.
+func (d *DB) normalizeManagedMemberTx(groupNo, uid string, role, robot int, version int64, tx *dbr.Tx) error {
+	_, err := tx.Update("group_member").
+		Set("role", role).
+		Set("status", int(common.GroupMemberStatusNormal)).
+		Set("robot", robot).
+		Set("bot_admin", 0).
+		Set("is_deleted", 0).
+		Set("forbidden_expir_time", 0).
+		Set("version", version).
+		Where("group_no=? AND uid=?", groupNo, uid).Exec()
+	return err
+}
+
 // DeleteMember 删除群成员
 func (d *DB) DeleteMember(groupNo string, uid string, version int64) error {
 	_, err := d.session.Update("group_member").Set("is_deleted", 1).Set("version", version).Where("group_no=? and uid=?", groupNo, uid).Exec()
@@ -746,14 +763,14 @@ func (d *DB) queryCreatedCountWithDate(date string) (int64, error) {
 // querySavedGroups 查询我保存的群
 func (d *DB) querySavedGroups(uid string) ([]*DetailModel, error) {
 	var detailModels []*DetailModel
-	_, err := d.session.Select("`group`.*,IFNULL(group_setting.version,0) + `group`.version  version,IFNULL(group_setting.chat_pwd_on,0) chat_pwd_on,IFNULL(group_setting.mute,0) mute,IFNULL(group_setting.top,0) top,IFNULL(group_setting.show_nick,0) show_nick,IFNULL(group_setting.save,0) save,IFNULL(group_setting.remark,'') remark").From("`group`").LeftJoin(`group_setting`, "`group`.group_no=group_setting.group_no").Where("`group_setting`.save=1 and `group_setting`.uid=? and `group`.purpose=''", uid).Load(&detailModels)
+	_, err := d.session.Select("`group`.*,IFNULL(group_setting.version,0) + `group`.version  version,IFNULL(group_setting.chat_pwd_on,0) chat_pwd_on,IFNULL(group_setting.mute,0) mute,IFNULL(group_setting.top,0) top,IFNULL(group_setting.show_nick,0) show_nick,IFNULL(group_setting.save,0) save,IFNULL(group_setting.remark,'') remark").From("`group`").LeftJoin(`group_setting`, "`group`.group_no=group_setting.group_no").Where("`group_setting`.save=1 and `group_setting`.uid=? and `group`.purpose IN ?", uid, []string{"", aiteampkg.TeamGroupPurpose}).Load(&detailModels)
 	return detailModels, err
 }
 
 // queryGroupsWithMemberUIDAndSpaceID 查询某用户在某 Space 下加入的所有群
 func (d *DB) queryGroupsWithMemberUIDAndSpaceID(memberUID string, spaceID string) ([]*Model, error) {
 	var models []*Model
-	_, err := d.session.Select("distinct `group`.*").From("`group`").LeftJoin("group_member", "`group`.group_no=group_member.group_no").Where("group_member.uid=? and group_member.is_deleted=0 and `group`.space_id=? and `group`.purpose=''", memberUID, spaceID).Load(&models)
+	_, err := d.session.Select("distinct `group`.*").From("`group`").LeftJoin("group_member", "`group`.group_no=group_member.group_no").Where("group_member.uid=? and group_member.is_deleted=0 and `group`.space_id=? and `group`.purpose IN ?", memberUID, spaceID, []string{"", aiteampkg.TeamGroupPurpose}).Load(&models)
 	return models, err
 }
 
@@ -784,7 +801,7 @@ func (d *DB) queryAllGroupsWithMemberUID(memberUID string) ([]*Model, error) {
 // 查询某个用户参与的所有群
 func (d *DB) queryGroupsWithMemberUID(memberUID string) ([]*Model, error) {
 	var models []*Model
-	_, err := d.session.Select("distinct `group`.*").From("`group`").LeftJoin("group_member", "`group`.group_no=group_member.group_no").Where("group_member.uid=? and group_member.is_deleted=0 and `group`.purpose=''", memberUID).Load(&models)
+	_, err := d.session.Select("distinct `group`.*").From("`group`").LeftJoin("group_member", "`group`.group_no=group_member.group_no").Where("group_member.uid=? and group_member.is_deleted=0 and `group`.purpose IN ?", memberUID, []string{"", aiteampkg.TeamGroupPurpose}).Load(&models)
 	return models, err
 }
 

--- a/modules/group/event.go
+++ b/modules/group/event.go
@@ -447,7 +447,7 @@ func (g *Group) handleOrgOrDeptEmployeeUpdate(data []byte, commit config.EventCo
 		isAdd := false
 		for _, groupModel := range groups {
 			if m.GroupNo == groupModel.GroupNo {
-				if groupModel.Purpose == aiteampkg.GroupPurpose {
+				if aiteampkg.IsProtectedPurpose(groupModel.Purpose) {
 					g.Warn("组织成员同步不能修改 AI 会话容器",
 						zap.String("group_no", m.GroupNo), zap.String("uid", m.EmployeeUid), zap.String("action", m.Action))
 					break
@@ -806,7 +806,7 @@ func (g *Group) handleOrgEmployeeExit(data []byte, commit config.EventCommit) {
 				// containers may only change through explicit lifecycle cleanup;
 				// otherwise an HR event can remove the owner or Bot and break the
 				// two-member confidentiality boundary.
-				if group.Purpose == aiteampkg.GroupPurpose {
+				if aiteampkg.IsProtectedPurpose(group.Purpose) {
 					break
 				}
 				realGroups = append(realGroups, groupNo)

--- a/modules/group/lifecycle_group_lookup_test.go
+++ b/modules/group/lifecycle_group_lookup_test.go
@@ -15,6 +15,7 @@ func TestGetGroupsWithMemberUIDForLifecycleCleanupIncludesAITeamContainers(t *te
 	for _, model := range []*Model{
 		{GroupNo: "ordinary_lifecycle_lookup", Name: "ordinary", Creator: "owner", Status: GroupStatusNormal},
 		{GroupNo: "ai_lifecycle_lookup", Name: "ai", Creator: "owner", Status: GroupStatusNormal, Purpose: aiteam.GroupPurpose},
+		{GroupNo: "ai_team_lifecycle_lookup", Name: "ai team", Creator: "owner", Status: GroupStatusNormal, Purpose: aiteam.TeamGroupPurpose},
 	} {
 		require.NoError(t, NewDB(ctx).Insert(model))
 		require.NoError(t, NewDB(ctx).InsertMember(&MemberModel{
@@ -24,15 +25,18 @@ func TestGetGroupsWithMemberUIDForLifecycleCleanupIncludesAITeamContainers(t *te
 
 	productGroups, err := svc.GetGroupsWithMemberUID(botUID)
 	require.NoError(t, err)
-	require.Len(t, productGroups, 1)
-	require.Equal(t, "ordinary_lifecycle_lookup", productGroups[0].GroupNo)
+	require.Len(t, productGroups, 2)
+	require.ElementsMatch(t,
+		[]string{"ordinary_lifecycle_lookup", "ai_team_lifecycle_lookup"},
+		[]string{productGroups[0].GroupNo, productGroups[1].GroupNo},
+	)
 
 	lifecycleGroups, err := svc.GetGroupsWithMemberUIDForLifecycleCleanup(botUID)
 	require.NoError(t, err)
-	require.Len(t, lifecycleGroups, 2)
+	require.Len(t, lifecycleGroups, 3)
 	require.ElementsMatch(t,
-		[]string{"ordinary_lifecycle_lookup", "ai_lifecycle_lookup"},
-		[]string{lifecycleGroups[0].GroupNo, lifecycleGroups[1].GroupNo},
+		[]string{"ordinary_lifecycle_lookup", "ai_lifecycle_lookup", "ai_team_lifecycle_lookup"},
+		[]string{lifecycleGroups[0].GroupNo, lifecycleGroups[1].GroupNo, lifecycleGroups[2].GroupNo},
 	)
 }
 

--- a/modules/group/project_cascade_guard_test.go
+++ b/modules/group/project_cascade_guard_test.go
@@ -100,6 +100,7 @@ func TestEveryAdmissionEntryLabelIsEmitted(t *testing.T) {
 		AdmissionEntryOrgEmployeeUpdate,
 		AdmissionEntryPresetGroups,
 		AdmissionEntryUnblacklist,
+		AdmissionEntryAITeamGroup,
 	}
 
 	for _, entry := range entries {

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -275,7 +275,7 @@ func (s *Service) RemoveUserFromGroupsForLifecycleCleanup(uid string) error {
 			Members:              []string{uid},
 			OperatorUID:          uid,
 			SuppressRemoveNotice: true,
-			AllowProtected:       group.Purpose == aiteampkg.GroupPurpose,
+			AllowProtected:       aiteampkg.IsProtectedPurpose(group.Purpose),
 		})
 		if removeErr != nil {
 			cleanupErrs = append(cleanupErrs, fmt.Errorf("remove %s from group %s: %w", uid, group.GroupNo, removeErr))

--- a/pkg/aiteam/aiteam.go
+++ b/pkg/aiteam/aiteam.go
@@ -12,6 +12,8 @@ import (
 
 const (
 	GroupPurpose       = "ai_session_container"
+	TeamGroupPurpose   = "ai_team_group"
+	TeamGroupName      = "我的AI团队"
 	DefaultSessionName = "新对话"
 )
 
@@ -39,10 +41,28 @@ func IsProtectedGroup(session *dbr.Session, groupNo string) (bool, error) {
 	if session == nil || strings.TrimSpace(groupNo) == "" {
 		return false, nil
 	}
-	var count int
-	err := session.Select("COUNT(*)").From("`group`").
-		Where("group_no=? AND purpose=?", groupNo, GroupPurpose).LoadOne(&count)
-	return count > 0, err
+	purpose, err := Purpose(session, groupNo)
+	return IsProtectedPurpose(purpose), err
+}
+
+// IsProtectedPurpose reports whether membership and ownership of a group are
+// server-managed by AI Team rather than by ordinary group APIs.
+func IsProtectedPurpose(purpose string) bool {
+	return purpose == GroupPurpose || purpose == TeamGroupPurpose
+}
+
+// Purpose returns the persisted server-managed purpose, or an empty string for
+// an ordinary or unknown group.
+func Purpose(session *dbr.Session, groupNo string) (string, error) {
+	if session == nil || strings.TrimSpace(groupNo) == "" {
+		return "", nil
+	}
+	var purposes []string
+	_, err := session.Select("purpose").From("`group`").Where("group_no=?", groupNo).Limit(1).Load(&purposes)
+	if err != nil || len(purposes) == 0 {
+		return "", err
+	}
+	return purposes[0], nil
 }
 
 // LookupReadySessionTarget resolves automatic Bot delivery exclusively from

--- a/pkg/aiteam/aiteam_test.go
+++ b/pkg/aiteam/aiteam_test.go
@@ -22,6 +22,13 @@ func TestEnabled(t *testing.T) {
 	}
 }
 
+func TestProtectedPurposes(t *testing.T) {
+	assert.True(t, IsProtectedPurpose(GroupPurpose))
+	assert.True(t, IsProtectedPurpose(TeamGroupPurpose))
+	assert.False(t, IsProtectedPurpose(""))
+	assert.False(t, IsProtectedPurpose("ordinary"))
+}
+
 func TestExcludeProtectedItemsSkipsNonGroupChannelsBeforeDB(t *testing.T) {
 	protected, err := ExcludeProtectedItems(nil, [][2]string{
 		{"person-a", "1"},


### PR DESCRIPTION
## Summary

Maintain one visible "我的AI团队" group for every Space/user AI Team and keep it synchronized with the existing private two-member Agent containers.

## Related Issue

User-requested change; no linked issue.

## Linked Spec

[`.octospec/tasks/ai-team-all-bots-group/brief.md`](https://github.com/kense-lab/octo-server/blob/feat/ai-team-all-bots-group/.octospec/tasks/ai-team-all-bots-group/brief.md)

## Changes

- Add a unique `(space_id, user_uid)` team-group registry and exact owner-plus-active-Agent roster projection.
- Eagerly provision every active Agent private pair group and reconcile legacy owned Bots from the AI Team list endpoint.
- Automatically provision Agent state from all three User Bot creation paths.
- Protect both AI-managed group types from ordinary human, manager, Bot API, invite, directory, ownership, and disband mutations while keeping personal settings available on the visible team group.
- Retry complete idempotent Agent add/remove/list reconciliation on transient MySQL 1213/1205 conflicts.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified
- `go test -p 1 ./modules/ai_team -count=1`
- `go test -race ./modules/ai_team -run 'TestRetryAITeamMutation|TestAITeamConcurrentAgentActivationCreatesOnePairAndOneTeamGroup|TestAITeamGroupAndAgentContainersConvergeTogether' -count=1`
- Focused group admission guard, BotFather provisioning hook, `pkg/aiteam`, and Bot API compilation checks
- `go vet ./...`
- `make i18n-extract-check`
- `make i18n-lint`
- `git diff --check`

`go test ./...` was also attempted. This repository shares one hard-coded MySQL `test` database across concurrently executed packages, so unrelated schema fixtures and migration ledgers collided. The disposable database was rebuilt and the target suite passed serially. Details are recorded in the linked verification file.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**

   `ai_team_agent` remains the sole roster authority. Add, remove, Bot creation, and list-time repair first converge each active Agent private group, then project the complete validated roster into one Space-scoped team group. A unique registry row and transactional row locks prevent duplicate team groups, while ordinary mutation paths reject both managed purposes.

2. **What could break because of it (dependents + failure mode)?**

   The affected dependents are AI Team listing and activation, User Bot creation, group membership/admin APIs, Bot group discovery, lifecycle cleanup, and WuKongIM subscriptions. A DB or IM failure can temporarily leave a provisioning state, but no ready success is returned; later idempotent reconciliation repairs it. Incorrect purpose filtering could hide the visible team group or expose private containers, so the two purposes are deliberately handled separately.

3. **How do you know it works (specific test/repro/trace)?**

   Real-MySQL integration tests assert one pair group and one team group under six concurrent activations, exact bidirectional membership, removal/reactivation, stale and unauthorized member repair, Space and ownership rejection, visibility, and personal-setting behavior. The concurrent path also passes under `-race`, and source guards cover the centralized group-member admission boundary and all three Bot creation hooks.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
