### PR TITLE
feat(ppt): route presentation comment mentions to bots

### DIFF
--- a/.octospec/tasks/doc-comment-bot-mention-mvp/brief.md
+++ b/.octospec/tasks/doc-comment-bot-mention-mvp/brief.md
@@ -111,11 +111,21 @@ docs-backend 在评论写入和实际编辑/回复时判定，`from_uid` 等上�
   直接入队。
 - 灰度配置采用环境变量，启动时读取：
   - `OCTO_DOCS_BOT_MENTION_ENABLED`，默认 `false`；
+  - `OCTO_DOCS_BOT_MENTION_PPT_ENABLED`，默认 `false`，仅控制新的 PPT 评论任务；
   - `OCTO_DOCS_BOT_MENTION_SPACE_ALLOWLIST`；
   - `OCTO_DOCS_BOT_MENTION_DOC_ALLOWLIST`。
   开关为 true 后，doc 或非空 space 命中任一 allowlist 才放行；两份 allowlist 都为空时
   仍 fail-closed。doc allowlist 的 `*` 表示所有文档；space allowlist 的 `*` 表示任意**非空**
-  space，不能让空 `space_id` 命中。配置变更通过重启生效。
+  space，不能让空 `space_id` 命中。PPT 还必须显式开启独立开关；未配置、空白或无效布尔值
+  均视为关闭，即使总开关和通配 allowlist 已开启也拒绝新的 PPT 事件。普通文档及 HTML
+  不受 PPT 开关影响；独立开关不能绕过总开关、allowlist 或原有权限检查。
+  总开关关闭、PPT 开关关闭或 allowlist 未命中时，对应的新请求返回 `accepted:false, reason:"disabled"`，
+  不落幂等终态、不入队；已接受请求优先重放原 event_id，即使之后关闭总开关或 PPT 开关也不重复入队；关开关不会取消已接受的任务。
+  PPT 的部署顺序是协议前置条件：先发布并升级会接收事件的全部 PPT-aware 插件及配套 CLI，
+  再部署支持 PPT 的 Server，最后部署会产生 `doc_kind=ppt` 的 Docs API 并开放前端入口。
+  前端入口开关不是服务端安全门禁；未确认消费者升级完毕时，保持 PPT 独立开关关闭。
+  消费端验证后才能开启 `OCTO_DOCS_BOT_MENTION_PPT_ENABLED=true`。开关只控制评论任务，
+  不控制 PPT 创建、编辑、协作或导出；配置变更通过重启 Server 生效。
 
 ### openclaw-channel-octo
 
@@ -124,13 +134,17 @@ docs-backend 在评论写入和实际编辑/回复时判定，`from_uid` 等上�
 - `inbound-queue.ts` 的队列键必须随会话键覆写，禁止合成 DM 形状后落入用户 DM 队列。
 - 服务端下发规范化 `thread_id = parent_id != "" ? parent_id : comment_id`；插件不得自行
   产生另一套规则。
-- session/queue key 使用同一个 canonical key：
-  `octo:doctask:{account_id}:{bot_uid}:{space_or_global}:{doc_id}:{thread_id}`。
-  每段须做无歧义编码或哈希，避免分隔符注入；同评论串串行、跨评论串可并行，但仍受
-  插件既有的 per-account 总并发上限约束，不得按 thread 无界创建执行 goroutine。
+- session/queue 共用规范化任务 scope，与插件 `src/doc-mention.ts` 保持一致：
+  - 普通文档及 HTML：`doctask:{escaped_doc_id}:{escaped_thread_id}`；
+  - PPT：`doctask:ppt:{escaped_doc_id}:{escaped_thread_id}`。
+  两个 ID 段先将反斜杠转义为双反斜杠，再将冒号转义为 `\:`。
+  会话键为 `agent:{agent_id}:octo:{normalized_account_id}:{scope}`，
+  队列键为 `{normalized_account_id}:{scope}`；由插件的 account 路由隔离 Bot，
+  `space_id` 不额外拼入任务 scope，文档/Space 授权仍由生产端和消费端检查。
+  同队列键串行；不同 key 不代表轮询器保证跨线程并行派发（当前轮询会等待 handler）。
 - 插件持久去重使用 `idempotency_key`，而不是仅用可能因崩溃重投而变化的 `event_id`；
   去重状态必须覆盖进程重启，TTL 不短于 `Robot.MessageExpire`。
-- ClawHub 发版与存量 bot 升级必须纳入发布计划；旧插件不识别新事件时不能开启服务端灰度。
+- ClawHub 发版与存量 bot 升级必须纳入发布计划；旧插件不识别 PPT 时不能部署/开放向已启用共享灰度投递 PPT 事件的生产端。
 
 ## Ingress contract
 
@@ -140,6 +154,7 @@ docs-backend 在评论写入和实际编辑/回复时判定，`from_uid` 等上�
 {
   "idempotency_key": "stable-id-for-this-comment-mention",
   "doc_id": "doc-id",
+  "doc_kind": "ppt",
   "comment_id": "comment-id",
   "parent_id": "optional-root-comment-id",
   "from_uid": "human-user-id",
@@ -152,6 +167,9 @@ docs-backend 在评论写入和实际编辑/回复时判定，`from_uid` 等上�
 
 字段规则：
 
+- 上述请求及下方事件示例为 PPT 变体；普通文档省略 `doc_kind`，HTML 使用 `html`。
+- `doc_kind` 可选，trim 并转小写后只接受空字符串、`html`、`ppt`；未知值返回
+  400 且 `field=doc_kind`。`html_ppt` 是存储类型，不能作为 wire kind。
 - 整个 request body 最大 32 KiB。
 - `idempotency_key`、`doc_id`、`comment_id`、`from_uid`、`bot_uid` 必填，trim 后
   1–256 bytes；`parent_id`、`space_id` 非空时不超过 256 bytes。
@@ -190,6 +208,7 @@ docs-backend 在评论写入和实际编辑/回复时判定，`from_uid` 等上�
   "event_data": {
     "idempotency_key": "stable-id-for-this-comment-mention",
     "doc_id": "doc-id",
+    "doc_kind": "ppt",
     "comment_id": "comment-id",
     "thread_id": "root-comment-id",
     "parent_id": "optional-root-comment-id",
@@ -205,6 +224,13 @@ docs-backend 在评论写入和实际编辑/回复时判定，`from_uid` 等上�
 
 可选字段为空时省略；`enqueued_at` 由 octo-server 生成。上述字段只许向后兼容地增补，
 不得改名或改变语义。
+
+`doc_kind` is optional: absent/empty preserves legacy Docs routing, `html`
+selects the HTML service, and `ppt` selects the dedicated Docs backend PPT API.
+PPT uses canonical `doc_meta.doc_id`; `html_ppt` is a storage type, not a wire
+alias. Consumers must isolate PPT session/queue scopes from legacy scopes and
+must not fall back to another service on an unknown kind. See
+`../ppt-comment-mention/brief.md` for the PPT rollout and identity contract.
 
 ## Failure handling
 
@@ -224,12 +250,14 @@ docs-backend 在评论写入和实际编辑/回复时判定，`from_uid` 等上�
 - octo-server 至少提供低基数指标：
   - `dmwork_doc_bot_mention_ingress_total{result}`，result 包含 accepted/replay/disabled/
     invalid/not_found/unauthorized/conflict/error；
+  - `dmwork_doc_bot_mention_ingress_by_kind_total{result,doc_kind}`，保持既有指标标签不变，
+    新指标的 doc_kind 仅为 legacy/html/ppt/unknown；未认证或请求校验失败归入 unknown；
   - `dmwork_doc_bot_mention_enqueue_total{result}`；
   - ingress/enqueue latency。
 - 插件至少提供 poll、claim、dispatch、retry、terminal、ack 指标，并能从
   `event_id + idempotency_key hash + bot_uid` 关联一次执行；不得把 doc/comment/user ID 放进
   metrics label。
-- 结构化日志记录 `event_id`、bot uid、结果和 idempotency key 的不可逆短 hash；不记录
+- 结构化日志记录 `event_id`、bot uid、规范化 `doc_kind`、结果和 idempotency key 的不可逆短 hash；不记录
   token、完整 text 或 URL。
 
 ## Out of scope

--- a/.octospec/tasks/ppt-comment-mention/brief.md
+++ b/.octospec/tasks/ppt-comment-mention/brief.md
@@ -1,0 +1,36 @@
+---
+type: Task
+title: "Task: PPT comment mention routing"
+description: Route PPT comment tasks through a default-off kind gate and the existing Bot event channel.
+tags: ["bot-api", "wire-contract", "test"]
+timestamp: 2026-09-10T00:00:00Z
+slug: ppt-comment-mention
+upstream: Mininglamp-OSS/octo-server#867
+source: self
+---
+
+# PPT comment mention routing
+
+Goal: accept the explicit `ppt` document kind and carry it through the authoritative comment event, preserving root-thread routing and deduplication namespaces.
+
+Load-bearing path: mention request normalization, PPT opt-in plus shared document mention gate, event payload/fingerprint and ingress observability. Authentication, bot eligibility and atomic queue delivery retain their existing implementation.
+
+Out of scope: PPT body edits, frontend, credentials, new endpoints and remote deployment.
+
+Acceptance: missing document kind keeps legacy behavior; `PPT` normalizes to `ppt`; unknown kinds fail validation; root and reply events retain the correct thread; PPT fingerprints differ from ordinary document fingerprints. PPT requires `OCTO_DOCS_BOT_MENTION_PPT_ENABLED=true` in addition to the existing `OCTO_DOCS_BOT_MENTION_ENABLED` and document/Space allowlist. The PPT switch defaults off; missing, blank or invalid boolean values fail closed even with a shared wildcard. Legacy/HTML tasks remain independent of the PPT switch. Disabled requests leave no terminal claim; previously accepted events replay even after either gate is disabled, and switching off does not cancel accepted tasks. Gate tests must cover both switch transitions, new requests after disable, allowlist misses and legacy/HTML compatibility. Run the full `modules/bot_mention` package with isolated MySQL and Redis, then independent review.
+
+Wire contract: `event_data.doc_kind` is absent for legacy Docs, `html` for the
+HTML service, or `ppt` for the dedicated Docs backend PPT API. PPT `doc_id` is
+the canonical `doc_meta.doc_id`, shared with the Docs metadata namespace; it is
+not the Bento JSON's internal deck ID. `html_ppt` is not accepted on the wire.
+The handler normalizes case/whitespace before enqueueing this field.
+
+The existing document allowlist remains a global business-ID gate, not an
+authorization grant. Both producer and consumer must retain document/Space
+permission checks. The companion plugin separates PPT session/queue scopes
+with its PPT kind prefix and uses the original root thread; the server's
+existing `(bot_uid, idempotency_key)` claim plus full-payload fingerprint remain
+unchanged. Rollout sequencing is a prerequisite: release and upgrade every consuming PPT-aware plugin and its CLI first, then deploy the PPT-aware Server, and only then deploy/open the Docs producer of `doc_kind=ppt` and frontend entry. Keep the PPT switch disabled until every relevant consumer is verified, then explicitly set `OCTO_DOCS_BOT_MENTION_PPT_ENABLED=true` and restart Server. Shared enabled gates and wildcard allowlists alone do not permit new PPT tasks. The frontend flag is not a server-side gate. Both mention switches are read at startup. This gate only controls comment task admission, not PPT creation, direct CLI/API editing, collaboration or export. Operators may stop new PPT tasks independently by disabling this switch and restarting Server.
+Ingress outcome logs include normalized `doc_kind`; the new
+`dmwork_doc_bot_mention_ingress_by_kind_total{result,doc_kind}` counter uses only
+legacy/html/ppt/unknown, preserving existing result-only metric series.

--- a/modules/bot_mention/api.go
+++ b/modules/bot_mention/api.go
@@ -80,7 +80,7 @@ func (m *BotMention) internalAuthMiddleware() wkhttp.HandlerFunc {
 			respondBotMentionUnauthorized(c)
 			c.Abort()
 			if m.metrics != nil {
-				m.metrics.ObserveIngress("unauthorized", time.Since(started))
+				m.metrics.ObserveIngress("unauthorized", metricKindUnknown, time.Since(started))
 			}
 			return
 		}
@@ -91,9 +91,10 @@ func (m *BotMention) internalAuthMiddleware() wkhttp.HandlerFunc {
 func (m *BotMention) create(c *wkhttp.Context) {
 	started := time.Now()
 	result := "error"
+	docKind := metricKindUnknown
 	defer func() {
 		if m.metrics != nil {
-			m.metrics.ObserveIngress(result, time.Since(started))
+			m.metrics.ObserveIngress(result, docKind, time.Since(started))
 		}
 	}()
 
@@ -110,6 +111,7 @@ func (m *BotMention) create(c *wkhttp.Context) {
 		return
 	}
 
+	docKind = mention.DocKind
 	claimKey := mentionClaimKey(mention.BotUID, mention.IdempotencyKey)
 	fingerprint := mentionFingerprint(mention)
 	existing, err := m.claims.Lookup(claimKey, fingerprint)
@@ -126,7 +128,7 @@ func (m *BotMention) create(c *wkhttp.Context) {
 		return
 	}
 
-	if !m.gate.Allows(mention.DocID, mention.SpaceID) {
+	if !m.gate.AllowsKind(mention.DocKind, mention.DocID, mention.SpaceID) {
 		result = "disabled"
 		m.logOutcome(mention, result, 0, claimKey)
 		c.Response(mentionIngressResponse{Accepted: false, Replay: false, Reason: "disabled"})
@@ -250,6 +252,7 @@ func decodeMentionRequest(c *wkhttp.Context) (mentionRequest, error) {
 func (m *BotMention) logOutcome(mention normalizedMention, result string, eventID int64, claimKey string) {
 	m.Info("bot mention ingress completed",
 		zap.String("result", result),
+		zap.String("doc_kind", mention.DocKind),
 		zap.Int64("event_id", eventID),
 		zap.String("bot_uid", mention.BotUID),
 		zap.String("idempotency_hash", mentionClaimLogHash(claimKey)),

--- a/modules/bot_mention/api_test.go
+++ b/modules/bot_mention/api_test.go
@@ -173,9 +173,10 @@ func (s *stubRobotService) counts() (exists, enqueues int) {
 }
 
 type fakeMetricRecorder struct {
-	mu       sync.Mutex
-	ingress  []string
-	enqueues []string
+	mu           sync.Mutex
+	ingress      []string
+	ingressKinds []string
+	enqueues     []string
 }
 
 type capturedLogEntry struct {
@@ -221,9 +222,10 @@ func (l *capturedLog) snapshot() []capturedLogEntry {
 	return append([]capturedLogEntry(nil), l.entries...)
 }
 
-func (m *fakeMetricRecorder) ObserveIngress(result string, _ time.Duration) {
+func (m *fakeMetricRecorder) ObserveIngress(result, kind string, _ time.Duration) {
 	m.mu.Lock()
 	m.ingress = append(m.ingress, result)
+	m.ingressKinds = append(m.ingressKinds, kind)
 	m.mu.Unlock()
 }
 
@@ -366,6 +368,48 @@ func decodeMentionError(t *testing.T, w *httptest.ResponseRecorder) mentionError
 		t.Fatalf("decode error %s: %v", w.Body.String(), err)
 	}
 	return response
+}
+
+func TestBotMentionPPTWireRouting(t *testing.T) {
+	claims := newClaimStore(newMemoryClaimBackend(), 7*24*time.Hour, deterministicTokens("ppt-lease"))
+	robots := &stubRobotService{exists: true, eventID: 4242}
+	gate := newFeatureGate(true, "space-1", "")
+	gate.pptEnabled = true
+	metrics := &fakeMetricRecorder{}
+	logger := &capturedLog{}
+	module := newTestBotMention(robots, claims, gate, metrics)
+	module.Log = logger
+	router := newMentionRouter(module)
+	body := []byte(`{"idempotency_key":"ppt-wire","doc_kind":" PPT ","doc_id":"d_ppt","comment_id":"13","parent_id":"12","from_uid":"human-1","bot_uid":"bot-1","text":"update title","space_id":"space-1"}`)
+	for _, replay := range []bool{false, true} {
+		response := doMentionRequest(t, router, "internal-secret", body)
+		if response.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+		}
+		got := decodeMentionResponse(t, response)
+		if !got.Accepted || got.Replay != replay {
+			t.Fatalf("response=%+v, replay=%v", got, replay)
+		}
+	}
+	metrics.mu.Lock()
+	kinds := append([]string(nil), metrics.ingressKinds...)
+	metrics.mu.Unlock()
+	if len(kinds) != 2 || kinds[0] != "ppt" || kinds[1] != "ppt" {
+		t.Fatalf("accepted/replayed PPT metric kinds=%v", kinds)
+	}
+	entries := logger.snapshot()
+	if len(entries) != 2 {
+		t.Fatalf("PPT outcome logs=%v; want accepted and replay", entries)
+	}
+	for i, result := range []string{"accepted", "replay"} {
+		if entries[i].fields["result"] != result || entries[i].fields["doc_kind"] != "ppt" {
+			t.Fatalf("PPT %s log=%v", result, entries[i].fields)
+		}
+	}
+	_, enqueues := robots.counts()
+	if enqueues != 1 || robots.eventType != "doc_comment_mention" || robots.eventData["doc_kind"] != "ppt" || robots.eventData["doc_id"] != "d_ppt" || robots.eventData["thread_id"] != "12" {
+		t.Fatalf("enqueues=%d type=%s data=%v", enqueues, robots.eventType, robots.eventData)
+	}
 }
 
 func TestBotMentionAcceptedAndReplay(t *testing.T) {
@@ -835,5 +879,98 @@ func TestBotMentionRecoversAmbiguousAtomicCommitAsReplay(t *testing.T) {
 	}
 	if notifications != 1 {
 		t.Fatalf("doorbell notifications = %d, want 1 after ambiguous commit recovery", notifications)
+	}
+}
+
+func TestBotMentionPPTEnvironmentGate(t *testing.T) {
+	for _, tt := range []struct {
+		name, global, ppt, spaces, docs string
+		allow, allowPPT                 bool
+	}{
+		{name: "unset global", ppt: "true", docs: "*"},
+		{name: "disabled global", global: "false", ppt: "true", docs: "*"},
+		{name: "invalid global", global: "bad", ppt: "true", docs: "*"},
+		{name: "unset PPT with existing wildcard", global: "true", docs: "*", allow: true},
+		{name: "disabled PPT leaves other kinds enabled", global: "true", ppt: "false", docs: "*", allow: true},
+		{name: "invalid PPT fails closed", global: "true", ppt: "bad", docs: "*", allow: true},
+		{name: "blank PPT fails closed", global: "true", ppt: "  ", docs: "*", allow: true},
+		{name: "empty allowlists", global: "true", ppt: "true"},
+		{name: "missed allowlists", global: "true", ppt: "true", spaces: "other", docs: "other"},
+		{name: "space allowlist", global: "true", ppt: "true", spaces: "space-1", allow: true, allowPPT: true},
+		{name: "doc allowlist", global: "true", ppt: "true", docs: "d_ppt", allow: true, allowPPT: true},
+		{name: "explicit PPT opt in with wildcard", global: "true", ppt: "true", docs: "*", allow: true, allowPPT: true},
+		{name: "normalized boolean", global: "true", ppt: " TRUE ", docs: "*", allow: true, allowPPT: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(featureEnabledEnv, tt.global)
+			t.Setenv("OCTO_DOCS_BOT_MENTION_PPT_ENABLED", tt.ppt)
+			t.Setenv(spaceAllowlistEnv, tt.spaces)
+			t.Setenv(documentAllowlistEnv, tt.docs)
+			for _, kind := range []string{"", "html", "ppt", " PPT ", "html_ppt", "pptx"} {
+				t.Run("kind="+kind, func(t *testing.T) {
+					claims := newClaimStore(newMemoryClaimBackend(), time.Hour, deterministicTokens("ppt-gate"))
+					robots := &stubRobotService{exists: true, eventID: 4242}
+					router := newMentionRouter(newTestBotMention(robots, claims, featureGateFromEnv(), &fakeMetricRecorder{}))
+					body := []byte(fmt.Sprintf(`{"idempotency_key":"ppt-gate","doc_kind":%q,"doc_id":"d_ppt","comment_id":"13","from_uid":"human-1","bot_uid":"bot-1","text":"update title","space_id":"space-1"}`, kind))
+					response := doMentionRequest(t, router, "internal-secret", body)
+					if kind == "html_ppt" || kind == "pptx" {
+						if response.Code != http.StatusBadRequest {
+							t.Fatalf("unsupported kind status=%d body=%s", response.Code, response.Body.String())
+						}
+					} else {
+						want := tt.allow
+						if kind == "ppt" || kind == " PPT " {
+							want = tt.allowPPT
+						}
+						got := decodeMentionResponse(t, response)
+						if response.Code != http.StatusOK || got.Accepted != want || got.Replay || (!want && got.Reason != "disabled") {
+							t.Fatalf("status=%d response=%+v wantAccepted=%v", response.Code, got, want)
+						}
+						if want {
+							return
+						}
+					}
+					if lookups, enqueues := robots.counts(); lookups != 0 || enqueues != 0 {
+						t.Fatalf("blocked request looked up bot %d times and enqueued %d events", lookups, enqueues)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestBotMentionPPTGateTransitionPreservesIdempotency(t *testing.T) {
+	for _, switchName := range []string{featureEnabledEnv, "OCTO_DOCS_BOT_MENTION_PPT_ENABLED"} {
+		t.Run(switchName, func(t *testing.T) {
+			t.Setenv(featureEnabledEnv, "true")
+			t.Setenv("OCTO_DOCS_BOT_MENTION_PPT_ENABLED", "true")
+			t.Setenv(spaceAllowlistEnv, "space-1")
+			t.Setenv(documentAllowlistEnv, "")
+			claims := newClaimStore(newMemoryClaimBackend(), time.Hour, deterministicTokens("ppt-transition"))
+			robots := &stubRobotService{exists: true, eventID: 4242}
+			body := []byte(`{"idempotency_key":"ppt-transition","doc_kind":"ppt","doc_id":"d_ppt","comment_id":"13","from_uid":"human-1","bot_uid":"bot-1","text":"update title","space_id":"space-1"}`)
+			for _, tt := range []struct{ enabled, accepted, replay bool }{
+				{false, false, false}, {true, true, false}, {false, true, true},
+			} {
+				t.Setenv(switchName, fmt.Sprint(tt.enabled))
+				// A new instance loads updated env, sharing the existing claim store.
+				router := newMentionRouter(newTestBotMention(robots, claims, featureGateFromEnv(), &fakeMetricRecorder{}))
+				response := doMentionRequest(t, router, "internal-secret", body)
+				got := decodeMentionResponse(t, response)
+				if response.Code != http.StatusOK || got.Accepted != tt.accepted || got.Replay != tt.replay || (tt.accepted && got.EventID != 4242) {
+					t.Fatalf("gate=%v status=%d response=%+v", tt.enabled, response.Code, got)
+				}
+				if !tt.enabled {
+					fresh := []byte(strings.ReplaceAll(string(body), `"ppt-transition"`, `"ppt-new"`))
+					got := decodeMentionResponse(t, doMentionRequest(t, router, "internal-secret", fresh))
+					if got.Accepted || got.Replay || got.Reason != "disabled" {
+						t.Fatalf("new request while disabled: %+v", got)
+					}
+				}
+			}
+			if lookups, enqueues := robots.counts(); lookups != 1 || enqueues != 1 {
+				t.Fatalf("lookups=%d enqueues=%d; want one accepted event across gate changes", lookups, enqueues)
+			}
+		})
 	}
 }

--- a/modules/bot_mention/config.go
+++ b/modules/bot_mention/config.go
@@ -19,6 +19,7 @@ const (
 	maxURLBytes         = 2048
 
 	featureEnabledEnv          = "OCTO_DOCS_BOT_MENTION_ENABLED"
+	pptEnabledEnv              = "OCTO_DOCS_BOT_MENTION_PPT_ENABLED"
 	spaceAllowlistEnv          = "OCTO_DOCS_BOT_MENTION_SPACE_ALLOWLIST"
 	documentAllowlistEnv       = "OCTO_DOCS_BOT_MENTION_DOC_ALLOWLIST"
 	internalTokenEnv           = "OCTO_DOCS_BOT_MENTION_TOKEN"
@@ -27,6 +28,9 @@ const (
 
 	// docKindHTML 标记 doc_id 是 octo-doc 的 slug(HTML 文档),而不是 docs-backend 的 docId。
 	docKindHTML = "html"
+	// PPT uses the canonical docs-backend doc_meta.doc_id, not a Bento deck ID
+	// or an HTML slug. html_ppt is the stored document type, not a wire alias.
+	docKindPPT = "ppt"
 )
 
 type mentionRequest struct {
@@ -39,14 +43,14 @@ type mentionRequest struct {
 	// 「文档真的不存在」无法区分,靠试错回退会把后者误判成 HTML 再失败一次。
 	//
 	// 空 = 默认 docs-backend 文档(doc/sheet/board),与加这个字段之前的行为一致。
-	DocKind        string `json:"doc_kind,omitempty"`
-	CommentID      string `json:"comment_id"`
-	ParentID       string `json:"parent_id,omitempty"`
-	FromUID        string `json:"from_uid"`
-	BotUID         string `json:"bot_uid"`
-	Text           string `json:"text"`
-	URL            string `json:"url,omitempty"`
-	SpaceID        string `json:"space_id,omitempty"`
+	DocKind   string `json:"doc_kind,omitempty"`
+	CommentID string `json:"comment_id"`
+	ParentID  string `json:"parent_id,omitempty"`
+	FromUID   string `json:"from_uid"`
+	BotUID    string `json:"bot_uid"`
+	Text      string `json:"text"`
+	URL       string `json:"url,omitempty"`
+	SpaceID   string `json:"space_id,omitempty"`
 }
 
 type normalizedMention struct {
@@ -97,7 +101,7 @@ func normalizeMentionRequest(req mentionRequest) (normalizedMention, error) {
 	//
 	// 静默降级成「普通文档」的代价是消费端拿 slug 去打 docs-backend 的 docId 接口,
 	// 报出来的是一个看不出根因的 404;拒在入口,调用方拼错立刻知道。
-	if normalized.DocKind != "" && normalized.DocKind != docKindHTML {
+	if normalized.DocKind != "" && normalized.DocKind != docKindHTML && normalized.DocKind != docKindPPT {
 		return normalizedMention{}, &requestValidationError{field: "doc_kind"}
 	}
 
@@ -189,9 +193,10 @@ func resolveBotMentionInternalToken(getenv func(string) string) (string, error) 
 }
 
 type featureGate struct {
-	enabled bool
-	spaces  map[string]struct{}
-	docs    map[string]struct{}
+	enabled    bool
+	pptEnabled bool
+	spaces     map[string]struct{}
+	docs       map[string]struct{}
 }
 
 func newFeatureGate(enabled bool, spaceAllowlist, documentAllowlist string) featureGate {
@@ -207,7 +212,19 @@ func featureGateFromEnv() featureGate {
 	if err != nil {
 		enabled = false
 	}
-	return newFeatureGate(enabled, os.Getenv(spaceAllowlistEnv), os.Getenv(documentAllowlistEnv))
+	gate := newFeatureGate(enabled, os.Getenv(spaceAllowlistEnv), os.Getenv(documentAllowlistEnv))
+	// ParseBool returns false for missing or invalid values: PPT requires opt-in.
+	gate.pptEnabled, _ = strconv.ParseBool(strings.TrimSpace(os.Getenv(pptEnabledEnv)))
+	return gate
+}
+
+// AllowsKind applies the PPT opt-in after request kind normalization. The shared
+// switch and allowlists are still required; legacy and HTML behavior is unchanged.
+func (g featureGate) AllowsKind(kind, docID, spaceID string) bool {
+	if kind == docKindPPT && !g.pptEnabled {
+		return false
+	}
+	return g.Allows(docID, spaceID)
 }
 
 func parseAllowlist(raw string) map[string]struct{} {

--- a/modules/bot_mention/config_test.go
+++ b/modules/bot_mention/config_test.go
@@ -329,3 +329,26 @@ func TestRequestValidationError(t *testing.T) {
 		t.Fatalf("invalidField(non-validation) = %q", got)
 	}
 }
+
+func TestPPTMentionRouting(t *testing.T) {
+	for _, tc := range []struct{ parent, thread string }{{"", "13"}, {"root-1", "root-1"}} {
+		req := mentionRequest{IdempotencyKey: "ppt-key", DocID: "deck", DocKind: " PPT ", CommentID: "13", ParentID: tc.parent, FromUID: "human", BotUID: "bot", Text: "change this"}
+		got, err := normalizeMentionRequest(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.DocKind != docKindPPT {
+			t.Fatalf("kind=%q", got.DocKind)
+		}
+		data := mentionEventData(got, 100)
+		if data["doc_kind"] != "ppt" || data["thread_id"] != tc.thread {
+			t.Fatalf("bad routing: %v", data)
+		}
+		fingerprint := mentionFingerprint(got)
+		legacy := got
+		legacy.DocKind = ""
+		if fingerprint == mentionFingerprint(legacy) {
+			t.Fatal("PPT collided with legacy namespace")
+		}
+	}
+}

--- a/modules/bot_mention/metrics.go
+++ b/modules/bot_mention/metrics.go
@@ -6,16 +6,21 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const metricKindUnknown = "unknown"
+
 type botMentionMetricRecorder interface {
-	ObserveIngress(result string, duration time.Duration)
+	ObserveIngress(result, docKind string, duration time.Duration)
 	ObserveEnqueue(result string, duration time.Duration)
 }
 
 type botMentionMetrics struct {
-	ingressTotal    *prometheus.CounterVec
-	enqueueTotal    *prometheus.CounterVec
-	ingressDuration *prometheus.HistogramVec
-	enqueueDuration *prometheus.HistogramVec
+	// Keep the result-only counter for existing dashboards; the by-kind series
+	// adds diagnostics without changing that public metric label contract.
+	ingressByKindTotal *prometheus.CounterVec
+	ingressTotal       *prometheus.CounterVec
+	enqueueTotal       *prometheus.CounterVec
+	ingressDuration    *prometheus.HistogramVec
+	enqueueDuration    *prometheus.HistogramVec
 }
 
 var defaultBotMentionMetrics = newBotMentionMetrics(prometheus.DefaultRegisterer)
@@ -25,6 +30,10 @@ func newBotMentionMetrics(registerer prometheus.Registerer) *botMentionMetrics {
 		return nil
 	}
 	metrics := &botMentionMetrics{
+		ingressByKindTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "dmwork_doc_bot_mention_ingress_by_kind_total",
+			Help: "Document comment bot mention ingress outcomes by normalized document kind.",
+		}, []string{"result", "doc_kind"}),
 		ingressTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "dmwork_doc_bot_mention_ingress_total",
 			Help: "Document comment bot mention ingress outcomes.",
@@ -45,6 +54,7 @@ func newBotMentionMetrics(registerer prometheus.Registerer) *botMentionMetrics {
 		}, []string{"result"}),
 	}
 	registerer.MustRegister(
+		metrics.ingressByKindTotal,
 		metrics.ingressTotal,
 		metrics.enqueueTotal,
 		metrics.ingressDuration,
@@ -53,12 +63,13 @@ func newBotMentionMetrics(registerer prometheus.Registerer) *botMentionMetrics {
 	return metrics
 }
 
-func (m *botMentionMetrics) ObserveIngress(result string, duration time.Duration) {
+func (m *botMentionMetrics) ObserveIngress(result, docKind string, duration time.Duration) {
 	if m == nil {
 		return
 	}
 	result = normalizeIngressMetricResult(result)
 	m.ingressTotal.WithLabelValues(result).Inc()
+	m.ingressByKindTotal.WithLabelValues(result, normalizeIngressMetricKind(docKind)).Inc()
 	m.ingressDuration.WithLabelValues(result).Observe(duration.Seconds())
 }
 
@@ -86,5 +97,16 @@ func normalizeEnqueueMetricResult(result string) string {
 		return result
 	default:
 		return "error"
+	}
+}
+
+func normalizeIngressMetricKind(kind string) string {
+	switch kind {
+	case "":
+		return "legacy"
+	case docKindHTML, docKindPPT:
+		return kind
+	default:
+		return metricKindUnknown
 	}
 }

--- a/modules/bot_mention/metrics_test.go
+++ b/modules/bot_mention/metrics_test.go
@@ -11,9 +11,9 @@ func TestBotMentionMetricsRegisterLowCardinalityResults(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	metrics := newBotMentionMetrics(registry)
 
-	metrics.ObserveIngress("accepted", 25*time.Millisecond)
-	metrics.ObserveIngress("not_found", 20*time.Millisecond)
-	metrics.ObserveIngress("unexpected-result", 10*time.Millisecond)
+	metrics.ObserveIngress("accepted", "ppt", 25*time.Millisecond)
+	metrics.ObserveIngress("not_found", "html", 20*time.Millisecond)
+	metrics.ObserveIngress("unexpected-result", "untrusted-doc-kind", 10*time.Millisecond)
 	metrics.ObserveEnqueue("accepted", 15*time.Millisecond)
 	metrics.ObserveEnqueue("unexpected-result", 5*time.Millisecond)
 
@@ -54,5 +54,39 @@ func TestBotMentionMetricsRegisterLowCardinalityResults(t *testing.T) {
 		if !got[name]["not_found"] {
 			t.Fatalf("metric %q results=%v, want distinct not_found outcome", name, got[name])
 		}
+	}
+}
+
+func TestBotMentionKindMetricsPreserveExistingSeries(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := newBotMentionMetrics(registry)
+	for _, kind := range []string{"", "html", "ppt", "user-controlled-value", "another-unknown"} {
+		metrics.ObserveIngress("disabled", kind, time.Millisecond)
+	}
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	kinds := map[string]float64{}
+	var legacyTotal float64
+	for _, family := range families {
+		for _, metric := range family.Metric {
+			switch family.GetName() {
+			case "dmwork_doc_bot_mention_ingress_total":
+				if len(metric.Label) != 1 || metric.Label[0].GetName() != "result" {
+					t.Fatal("existing label contract changed")
+				}
+				legacyTotal += metric.GetCounter().GetValue()
+			case "dmwork_doc_bot_mention_ingress_by_kind_total":
+				for _, label := range metric.Label {
+					if label.GetName() == "doc_kind" {
+						kinds[label.GetValue()] = metric.GetCounter().GetValue()
+					}
+				}
+			}
+		}
+	}
+	if legacyTotal != 5 || len(kinds) != 4 || kinds["legacy"] != 1 || kinds["html"] != 1 || kinds["ppt"] != 1 || kinds["unknown"] != 2 {
+		t.Fatalf("total=%v kind counts=%v", legacyTotal, kinds)
 	}
 }

--- a/modules/user/main_test.go
+++ b/modules/user/main_test.go
@@ -44,9 +44,5 @@ func TestMain(m *testing.M) {
 	}
 	code := m.Run()
 	stopRollout()
-	if err := cleanupTokenHTTPTestDatabases(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		code = 1
-	}
 	os.Exit(code)
 }

--- a/modules/user/token_http_cleanup_test.go
+++ b/modules/user/token_http_cleanup_test.go
@@ -1,0 +1,38 @@
+package user
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
+	rd "github.com/go-redis/redis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenHTTPFixtureReleasesResources(t *testing.T) {
+	var pool *sql.DB
+	var client *rd.Client
+	var databaseName string
+	require.True(t, t.Run("fixture", func(t *testing.T) {
+		_, ctx, _, _ := newTokenHTTPTestServer(t)
+		pool = ctx.DB().DB
+		_, client = auth.SessionStoreAndClientForContext(ctx)
+		require.NoError(t, pool.QueryRow("SELECT DATABASE()").Scan(&databaseName))
+		require.NoError(t, client.Ping().Err())
+	}))
+
+	deadline, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	assert.Error(t, pool.PingContext(deadline), "the fixture must close its MySQL pool before returning")
+	assert.Error(t, client.Ping().Err(), "the fixture must close its Redis session client before returning")
+	admin, err := sql.Open("mysql", "root:demo@tcp(127.0.0.1:3306)/information_schema?charset=utf8mb4&parseTime=true")
+	require.NoError(t, err)
+	defer admin.Close()
+	var remaining int
+	require.NoError(t, admin.QueryRowContext(deadline,
+		"SELECT COUNT(*) FROM information_schema.SCHEMATA WHERE SCHEMA_NAME = ?", databaseName).Scan(&remaining))
+	assert.Zero(t, remaining, "the fixture must delete only its own temporary database when its test ends")
+}

--- a/modules/user/token_http_ttl_test.go
+++ b/modules/user/token_http_ttl_test.go
@@ -3,12 +3,14 @@ package user
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -21,11 +23,6 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
 	"github.com/stretchr/testify/require"
 )
-
-var tokenHTTPTestDatabases struct {
-	sync.Mutex
-	names []string
-}
 
 func TestTokenDeadlineOverHTTP(t *testing.T) {
 	server, ctx, _, _ := newTokenHTTPTestServer(t)
@@ -329,16 +326,22 @@ func testNicknameUpdatePreservesFiniteTokenDeadlineOverHTTP(t *testing.T, server
 func newTokenHTTPTestServer(t *testing.T) (*libserver.Server, *config.Context, *User, *Manager) {
 	t.Helper()
 	databaseName := "octo_user_token_ttl_" + util.GenerUUID()[:12]
-	bootstrapConfig := config.New()
-	bootstrapConfig.Test = true
-	bootstrapConfig.DB.MySQLAddr = "root:demo@tcp(127.0.0.1:3306)/information_schema?charset=utf8mb4&parseTime=true"
-	bootstrap := config.NewContext(bootstrapConfig)
-	_, err := bootstrap.DB().Exec("CREATE DATABASE `" + databaseName + "` CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci")
+	bootstrap, err := sql.Open("mysql", "root:demo@tcp(127.0.0.1:3306)/information_schema?charset=utf8mb4&parseTime=true")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, bootstrap.Close()) })
+	createCtx, cancelCreate := context.WithTimeout(context.Background(), 30*time.Second)
+	_, err = bootstrap.ExecContext(createCtx, "CREATE DATABASE `"+databaseName+"` CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci")
+	cancelCreate()
 	require.NoError(t, err, "create isolated token TTL test database")
-	require.NoError(t, bootstrap.DB().DB.Close())
-	tokenHTTPTestDatabases.Lock()
-	tokenHTTPTestDatabases.names = append(tokenHTTPTestDatabases.names, databaseName)
-	tokenHTTPTestDatabases.Unlock()
+	// Register DROP first so LIFO cleanup stops the rollout and closes the
+	// fixture's clients before removing its database. TestMain cleanup used to
+	// run unbounded DROP statements after PASS, exhausting CI's package timeout.
+	t.Cleanup(func() {
+		dropCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_, err := bootstrap.ExecContext(dropCtx, "DROP DATABASE IF EXISTS `"+databaseName+"`")
+		require.NoError(t, err, "drop isolated token TTL test database %s", databaseName)
+	})
 
 	cfg := config.New()
 	cfg.Test = true
@@ -346,6 +349,7 @@ func newTokenHTTPTestServer(t *testing.T) (*libserver.Server, *config.Context, *
 	cfg.Cache.TokenCachePrefix = "token-http:" + util.GenerUUID() + ":"
 	cfg.Cache.UIDTokenCachePrefix = "token-http-uid:" + util.GenerUUID() + ":"
 	ctx := config.NewContext(cfg)
+	t.Cleanup(func() { require.NoError(t, ctx.DB().DB.Close()) })
 
 	// module.Setup must run the complete migration set, but octo-lib caches its
 	// module instances behind a process-wide sync.Once. Under CI's shuffled
@@ -370,6 +374,7 @@ func newTokenHTTPTestServer(t *testing.T) (*libserver.Server, *config.Context, *
 	server.GetRoute().UseGin(ctx.Tracer().GinMiddle())
 	ctx.SetHttpRoute(server.GetRoute())
 	store, client := auth.SessionStoreAndClientForContext(ctx)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
 	stopRollout, err := testsession.StartRollout(ctx, "token-http-test")
 	require.NoError(t, err)
 	t.Cleanup(stopRollout)
@@ -392,26 +397,4 @@ func newTokenHTTPTestServer(t *testing.T) (*libserver.Server, *config.Context, *
 		}
 	})
 	return server, ctx, userAPI, managerAPI
-}
-
-func cleanupTokenHTTPTestDatabases() error {
-	tokenHTTPTestDatabases.Lock()
-	names := append([]string(nil), tokenHTTPTestDatabases.names...)
-	tokenHTTPTestDatabases.names = nil
-	tokenHTTPTestDatabases.Unlock()
-	if len(names) == 0 {
-		return nil
-	}
-
-	cfg := config.New()
-	cfg.Test = true
-	cfg.DB.MySQLAddr = "root:demo@tcp(127.0.0.1:3306)/information_schema?charset=utf8mb4&parseTime=true"
-	bootstrap := config.NewContext(cfg)
-	defer bootstrap.DB().DB.Close()
-	for _, name := range names {
-		if _, err := bootstrap.DB().Exec("DROP DATABASE IF EXISTS `" + name + "`"); err != nil {
-			return fmt.Errorf("drop isolated token TTL database %s: %w", name, err)
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
## Summary

Route PPT comment mentions through the existing document Bot event channel and rollout controls. PPT requires an explicit default-off OCTO_DOCS_BOT_MENTION_PPT_ENABLED switch in addition to the existing OCTO_DOCS_BOT_MENTION_ENABLED and document/Space allowlists. Legacy and HTML mentions retain their existing behavior.

## Changes

- Accept normalized doc_kind=ppt alongside existing document kinds, retaining internal authentication, claim fingerprints, idempotency and atomic enqueue.
- Reject new PPT tasks when the PPT switch is missing, blank, false or invalid, even with an enabled shared wildcard. The PPT switch cannot bypass the global switch or allowlists. Preserve accepted-event replay after either switch is disabled; rejected new requests do not create terminal claims.
- Add bounded doc_kind observability while preserving existing metric names and result-only label contracts. Exercise accepted and replayed PPT requests through the real HTTP handler and assert the emitted metric and structured-log kind.
- Document matching wire kinds and plugin session/queue scopes. Content parsing and editing stay in Docs/CLI/plugin.
- Fix the existing user HTTP test fixture teardown exposed by CI: release each fixture's session Redis client and SQL pool before dropping its isolated schema, and bound CREATE/DROP operations. Remove deferred package-wide DROP after PASS; production user/auth behavior is unchanged.

## Testing

- Complete bot_mention package passed with `-race -count=1` against isolated MySQL/Redis; ordinary and HTML mention behavior, global/allowlist gates, unsupported kinds and idempotency are covered.
- Complete user package passed with `-race -shuffle=1789043091634441084 -count=1 -timeout=12m`: 804 test/subtest passes, 64 existing skips, zero failures. A new lifecycle regression fails on the old fixture and passes after the fix; `go vet ./modules/user` and independent review passed.
- Static checks and Linux arm64 build passed for the submitted source tree.
- Independent review verified PPT-specific admission, shared-gate behavior and cross-repository event contracts. Local final-image Bot acceptance follows the paired service deployment; no remote rollout is included.

## COMPREHENSION

1. **Load-bearing path:** Normalize the mention, replay existing claims, apply existing rollout controls, then atomically enqueue the original-thread event.
2. **Failure modes:** Consumers must support PPT before the matching feature is exposed. Existing-claim lookup remains before gating to preserve accepted replay. A new low-cardinality metric adds visibility without changing dashboards' existing label contract.
3. **Evidence:** Tests exercise real middleware, claims and queue behavior using disposable databases. PPT uses shared rollout controls and the same event delivery path as other supported document kinds.

## Checklist

- [x] Contribution and applicable octospec rules read
- [x] Tests and task brief updated
- [x] English Conventional Commit and PR description
- [x] No remote deployment included

## Related Issue

Closes #867

## Companion changes

https://github.com/Mininglamp-OSS/openclaw-channel-octo/pull/239

## PPT opt-in and rollout

The requester has selected the review's alternative resolution: restore a kind-scoped, default-off PPT gate. This supersedes the shared-gate-only proposal and the earlier requester-confirmation comment. No maintainer ratification of that earlier proposal is claimed.

- Configure `OCTO_DOCS_BOT_MENTION_PPT_ENABLED=true` on **Octo Server** to admit new PPT comment tasks. It is read at startup; missing, blank and invalid boolean values fail closed. Existing enabled wildcard allowlists alone cannot admit PPT.
- The shared `OCTO_DOCS_BOT_MENTION_ENABLED`, document/Space allowlists, internal authentication, producer/consumer document permissions and bot eligibility remain required. Legacy/HTML behavior is unchanged.
- Disable the PPT switch and restart Server to stop new PPT tasks independently. This does not cancel previously accepted tasks; prior accepted requests retain idempotent replay without another enqueue.
- The switch does not gate direct PPT create/read/edit/export APIs or collaboration. The frontend `VITE_DOCS_PPT_ENTRY` remains a separate product-entry control.
- Upgrade and verify every consuming PPT-aware plugin (#239) and CLI (#165) before enabling the PPT switch. Deploy Server with the switch off, complete the matching Docs migrations and deployment, then explicitly enable the PPT switch and frontend entry after consumer verification.

## Follow-up verification

- Added regressions fail on the previous shared-gate implementation: unset/disabled/invalid/blank PPT gate and the PPT-specific disable-enable-disable transition.
- Updated full isolated MySQL/Redis `bot_mention` race suite: **187 passed, 0 failed, 0 skipped**. Tests cover both gates, shared allowlist misses, legacy/HTML compatibility, normalized/invalid wire kinds, zero bot lookups/enqueues on rejection, first admission after prior rejection, and accepted replay after disable.
- `go vet ./modules/bot_mention` and Linux arm64 build passed. The PPT brief now carries the repository template frontmatter; its rollout requirements and the shared brief describe the same gate.
- At `ea62f528`, E2E shard 1 failed after the user suite printed PASS: TestMain remained in `cleanupTokenHTTPTestDatabases` / `DROP DATABASE`, and Go killed the process at 13m12s. The other three E2E shards, unit tests, build and lint passed. The fixture cleanup follow-up removes that unbounded post-suite operation. The old implementation passed locally on tmpfs, so the exact CI stall and its MySQL lock holder were not reproduced; the connection/schema lifetime regression was reproduced. New-head CI must be assessed independently. The separate Sprint check requires linked issue #867 to have Sprint W37 assigned on the Octo Board.

## Local integration validation

The previously tested frontend, Docs backend, CLI and plugin remain in the local 28084 preview. This follow-up deployed and verified Server `ea62f528` locally with commit, binary and image hashes recorded. Runtime checks passed with the PPT gate absent: new PPT tasks rejected, legacy/HTML still reached eligibility, and direct PPT create/read/write worked. With the gate enabled, PPT reached eligibility without queueing probe tasks. A separate real-Bot acceptance document passed anchored editing, preservation of other elements, original-thread reply, live browser sync and cold reload (zero page errors). Independent review completed, including correction and re-review of the deployment ordering and ConfigMap wording.

Docs backend changes in the companion follow-up are deployment documentation and ConfigMap comments only; its running production code remains identical. Original user modifications and Docker volumes are preserved. No remote test-cluster deployment or maintainer approval is claimed.

The subsequent CI teardown fix changes only three user test files; the local Server runtime above has identical production source and needs no image rebuild for that test-only change.
