### PR TITLE
refactor(project): converge per-target dispatch and add env-driven requeue for abandoned rows

### DIFF
--- a/.octospec/tasks/project-lifecycle-multiconsumer/brief.md
+++ b/.octospec/tasks/project-lifecycle-multiconsumer/brief.md
@@ -1,0 +1,443 @@
+---
+type: Task
+title: "Task: project-lifecycle-multiconsumer"
+description: 生命周期事件从单消费方扩成多消费方 + 冻结事件目录 + per-consumer 凭据；作用对象在未合并 PR 上，等合并后开工
+tags: [project, wire-contract, space, isolation, auth, test]
+timestamp: 2026-09-09T00:00:00Z
+slug: project-lifecycle-multiconsumer
+upstream: 口头需求（#852 / #854 / #855 / #864 合并预演后的实测结论）
+source: self
+---
+
+# Task: project-lifecycle-multiconsumer
+
+> **本 brief 是 `project-subsystem-fanout` 拆出的阻塞部分**（2026-09-09）。那份任务
+> 已完成并收窄为 R10 + R8-provisioning 两条；本份承接**作用对象尚不存在**的 9 条
+> （R1–R7 / R9 / R11 / R12，编号沿用不重排，便于与原 brief 和 PR 讨论对照）。
+>
+> **为什么不能现在做**：对照 `main@566e625b` 逐条核实，下列代码在 main 上**零命中**——
+> `octo_project_lifecycle_event` 表与 worker、`activation.go` / `confirmProjectActive`、
+> `modules/internal_membership`、`TestEverySpaceMemberWriterIsAccountedFor`。
+> 硬写等于把 #852/#864 重新实现一遍，且几乎必然与它们的真实实现分叉、合并时全冲突。
+>
+> **开工条件**：按 §实现顺序前提合并 PR。#855 已于 2026-09-09 合入 main（`566e625b`），
+> 分身席位代码已就位，故 R5 的作用对象**部分已到**（仍缺 #864 的事件通道）。
+>
+> **下文标 `[实测]` 的结论**来自 2026-09-08 的合并预演：四个 PR 合成一棵树，真实
+> MySQL 8.0 + Redis + WuKongIM + 三个会验签的 HTTP mock peer + **真实后台 worker
+> 定时器**，7 个场景 6 通过 1 失败。测试源码 `.context/merge-dryrun/subsystem_e2e_test.go.txt`
+> 在**预演所在 workspace**，本仓没有副本——实施前须取回（R5 复现基线依赖它）。
+>
+> **PR 拓扑（2026-09-09 merge-tree 核实）**：#852 / #854 / #864 均 base main、对 main
+> 干净无冲突。#864 的 GitHub base 指向 #852 分支（堆叠残留），CONFLICTING 实际只有
+> `.octospec/log.md`；#852↔#864 是共享底层（epoch 修复系列）的两条 lane。
+> **#853 本次迭代不合入**——已核实无人依赖它（#852 自带 `main.go:833-905` 的
+> `fixedInternalTokenEnvs` 9 条 + `main_internaltoken_test.go`，零 import
+> `pkg/internaltoken`；#854/#855/#864 同样零引用），故不阻塞。但它**若在未来合入**，
+> 见 §实现顺序前提第 3 条的前置条件，否则凭据覆盖面会 9→4 静默退化。
+
+## Goal
+
+把项目生命周期事件从**单消费方硬绑定**改成多消费方投递。现状
+`octo_project_lifecycle_event` 表**没有 consumer 维度**，配置只有一组 URL/secret/开关，
+结构上不可能接第二个对端。
+
+外加一件必须同时做的事：**冻结事件目录**（§事件目录），并补上目录里当前缺的那条
+（分身撤销 = R5），否则多消费方只是把一个已知缺陷复制 N 份。
+
+**范围权威清单见 §必须实现（MUST）**，R1–R12 编号与原 brief 一致（R8 与 R10 已在
+`project-subsystem-fanout` 落地，本份只承接 R8 的 lifecycle 半边）。
+
+## 必须实现（MUST）
+
+> 每条 = 是什么 / 为什么必须 / 验收锚点。实现形态未注明的由实现者定，但范围不得裁剪。
+
+**R1 · 出站事件多消费方化（consumer 维度）**
+`octo_project_lifecycle_event` 加 `consumer` 列；`UNIQUE (event_id)` 改为
+`UNIQUE (consumer, event_id)`；`status / attempts / next_attempt_at / lease_owner /
+lease_until / finished_at` 全部 per-consumer。每个启用消费方一行。
+*为什么*：现状整张投递状态机全局单份，一方成功一方失败时同一行无法既是 delivered 又是 pending。
+*验收*：同一事件集合上，消费方 A `delivered` 且 B `pending` 共存的测试。
+
+**R2 · 业务事务内同事务 fan-out**
+一次业务变更为 N 个启用消费方在同一事务内写 N 行。「变更提交 ⟹ 事件存在」必须靠构造成立。
+*验收*：删掉任一消费方的入队调用 → 测试红。
+
+**R3 · N 行共享同一份 payload 字节**
+入队时 `json.Marshal` 一次，N 行引用同一份字节，投递时原样重放；守卫
+`TestPayloadIsFrozenAtEnqueue` 扩展覆盖 fan-out 形状（worker 不做 `json.Marshal` 的断言保持）。
+*注意*：现有守卫只覆盖 `lifecycle_event_worker.go` 一个文件；扩展时不得缩窄既有覆盖。
+*验收*：变异验证——让 worker 重算 payload → 守卫必须红。
+
+**R4 · worker 阻塞键与认领谓词 consumer 化**
+现状的 per-project 阻塞**不在 worker 内存里，而在 claim SQL 的 `NOT EXISTS` 谓词**
+（`db_lifecycle_event.go:97-99`：同 `project_id` 存在更早 pending 行则不可认领——任一时刻
+每个项目最多一行 pending 可被 claim）。多消费方后该谓词的 `older` 子查询必须加
+`consumer = e.consumer`；worker 阻塞键为 `(consumer, project_id)`；表的 **4 条**二级索引
+（pending / project / finished / **age**）按 consumer 前导重新评估——其中 3 条以 status
+前导，会退化成 per-consumer 扫描。
+*验收*：消费方 A 的队头 503 时，消费方 B 的同项目事件仍在同一轮投出。
+
+**R5 · 分身 member_revoked（D-1 落地）**
+`#855` 的 agent 循环（`beginRemovalWithAgentsTx`，kick/leave/CascadeTx 转发三入口）与
+Space 级联 agent 循环里，对**每个关闭的分身席位**各入队一条 `member_revoked`。
+`member_epoch` 用**同一次名册变化的 bump 后值**——#855 的语义是一人 + N 分身只 bump 一次。
+事件 `subject_uid` 集合 == 该次名册变化关闭的全部席位。
+*为什么必须*：分身是代替主人在对端执行的主体，契约 §4 要求撤销迟到也必须应用。
+`[实测]` Phase7 失败已代码级坐实：#864 的 `enqueueLifecycleEventTx` 全部 4 个调用点
+（创建 / 资料变更 / 踢退 / Space 级联）都在人的路径上，分身路径零入队——任一 PR 单独看
+都不存在该缺陷，合并树才有。
+*验收*：带分身的成员经踢出 / 退出 / Space 移除三条路径离开后，撤销事件 subject 集合断言；
+Phase7 基线变绿 + 改回旧代码重新变红（变异验证）。
+
+**R6 · 可见性判定按 D-4 落地**
+先定义**必需子系统集合**（建议：fleet 必需、drive 可选），可见性 = 全部必需子系统确认。
+门控 SQL 保持只写一遍（`pkg/project/membership.go` 的 `activated_at IS NOT NULL` 谓词，
+两个入站接口共用）；fleet target 未启用时维持创建事务内置位 + 两条补偿路径
+（`latchUnconfirmableProjects` / `repairConfirmedButUnlatched`）。
+*验收*：「必需子系统未确认 → 两接口答 epoch 0 / member:false」与「全部必需确认 → 翻转」两方向。
+
+**R7 · 事件通道 nudge + 可配轮询（D-5 落地）**
+`lifecycleEventPollInterval = 5s` 常量改可配；业务提交后 nudge lifecycle worker
+（对齐 provisioning 侧 `nudgeProvisioningFn` 的 instance-seam 形态）。现状撤销推送延迟
+下限 5s、吞吐 ≈2 条/秒（batch 10、串行 POST），批量踢人是真实队列。
+*验收*：业务写到对端收到的 p99 延迟断言。
+
+**R8-lifecycle · abandoned 人工重驱（lifecycle 半边；provisioning 半边已在
+`project-subsystem-fanout` 落地）**
+lifecycle 事件的 abandoned = 对端**永久漏掉该事件**，现状无任何自动或人工恢复路径
+（`requeue|re-drive` 在 #854 树里只出现在注释）。要求：abandoned → 重驱 → pending →
+delivered。
+
+*形态已定：env，启动时生效*——**沿用 provisioning 半边的形状，不要引入 HTTP 端点**。
+原 brief 要求「i18n envelope + auth + 审计」，实施时发现那与守卫
+`TestNoHandlerReachesTheProvisioningTable`（执行 D12）直接冲突：HTTP 端点必然带 handler，
+而该守卫禁止任何带 handler 的文件碰供给表或其 DAO。D12 真实禁的是**用供给行门控读路径**，
+而重驱是运维触发的**写**，不门控任何用户可见的读——env 形态是绕开冲突而非削弱守卫
+（已在 provisioning 半边验证该守卫仍通过）。lifecycle 半边照抄该结论，别重新踩一遍。
+
+**幂等键不变**：`event_id` 绝不重发（对端在 event_id 后面对 payload 做指纹，同 id 不同
+内容会被判永久冲突）。**`attempts` 必须重置为 0**，否则 sweep 会在任何投递发出前把行
+重新判死（provisioning 半边已用变异验证坐实这条）。`last_error` 追加不覆盖。
+
+**多消费方后是 per-consumer 重驱**：只重驱指定 consumer 的行，不能把所有消费方的
+abandoned 一起推回——一方对端仍然挂着时，全量重驱只会再走一遍 12 次失败。
+*验收*：跑通 abandoned → 重驱 → delivered；per-consumer 隔离断言（A 重驱不动 B）。
+
+**R9 · per-consumer 凭据（D-7 落地）**
+入站：`OCTO_MEMBERSHIP_INTERNAL_TOKEN` 单值 → JSON registry（抄 `OCTO_BOT_TASK_SOURCES`
+形态：per-consumer token + enabled + 32 字节地板 + `DisallowUnknownFields`）。
+#852 已把「credential-scoped quota 需要 one-shared-token 契约不具备的 per-consumer 身份」
+写成已知限制（其正文 :125 与 `config.go:107-142`），本任务兑现它。
+出站：event secret 与 per-target ensure secret 保持独立。
+**三重把关必须同步更新**：(a) main.go 的 `fixedInternalTokenEnvs`（#852 自带，
+`main.go:833-905`，9 条 + `main_internaltoken_test.go` sweep 门禁）——**#853 本迭代不合入，
+不要去找 `pkg/internaltoken`，它在 main 上不存在**；(b) 各模块本地拒绝列表；
+(c) 全树 credential 字面量 sweep。撞值 fail-closed 对齐 #864 先例
+（`resolveLifecycleEventSecret` 撞值即关停 feed，非仅日志）。
+*验收*：per-consumer 配额、审计区分、单方轮换各一条测试；撞值拒绝测试。
+
+
+**R11 · D-2 择一落地 + sweep baseline 对齐 #855**
+无论 D-2 怎么拍（§待决策），`TestEverySpaceMemberWriterIsAccountedFor` 必须**变绿**：
+#855 新增的 `modules/space/member_removal_all_spaces.go` 含 1 个 space_member 写点，
+在 #852/#864 树上必红（baseline 补行）；#852 baseline 里 botfather 三处 KNOWN GAP 的
+理由文本已因 #855 接上工单而过期（`reason=bot_deleted` 压制 Tip，非绕开 outbox），同步更新。
+*验收*：sweep 绿 + baseline 理由与代码事实一致。
+
+**R12 · 契约文档同步**
+`docs/project-lifecycle-contract.md` 同步：事件目录、多消费方语义、per-consumer 幂等边界、
+**失败分类精确表**（5xx/网络/401/403/408/429/3xx 可重试；409 与其余 4xx 终态——契约
+「4xx 即永久失败」的兜底语已落后于实现，必须改）、延迟与吞吐特征（R7 结论）、
+项目归档入站读谓词盲区（§Out of scope 第 2 条）列为已知限制。
+
+## Background
+
+### 三层能力的支持度现状
+
+| 层 | 通道 | 多子系统 | 依据 |
+|---|---|---|---|
+| 资源初始化 | `octo_project_provisioning` + ensure HTTP | 🟡 **数据模型支持，配置不支持** | 表 `UNIQUE (project_id, target)` 每 target 一行（另有 `UNIQUE(container_id)`）；但 **URL/secret/narrowed/reclaim 是 per-target 进程 env（`provisionTargetEnvs`），不是行上的列**；`allProvisionTargetNames() = {fleet, drive}` 与两处 switch 硬编码（`config_provisioning.go:412`、`targetEnvNames`、`provisioning.go:43`） |
+| 入站权威判定 | `GET /v1/internal/membership/epochs`、`POST /v1/internal/project-memberships/_verify`（#852） | 🟡 **多消费方可用，但共享一个凭据** | 只有 `OCTO_MEMBERSHIP_INTERNAL_TOKEN` 一个值（`subtle.ConstantTimeCompare`，无 consumer 维度）。#852 已把 per-consumer 配额/审计缺口写成已知限制 |
+| 出站事件 | `octo_project_lifecycle_event` + HMAC POST（#864） | 🔴 **单消费方硬绑定** | 表无 consumer 列；`UNIQUE(event_id)` 单列；status/attempts/lease 全局单份；认领谓词按 `project_id`；`activation.go:165` `if target != TargetFleet { return }`；契约文档标题双边（`octo-server ↔ Loop/Fleet`） |
+
+### `[实测]` 已经能用的部分
+
+| 场景 | 结论 |
+|---|---|
+| 双子系统初始化 | fleet + drive 两个 ensure 都真的被调用，**各自 secret 的签名在对端验签通过**，两行都到 `ready` |
+| 两阶段创建 | fleet 未确认时，两个入站接口对该项目答 `epoch 0` / `member:false`；fleet 恢复后翻转为真实 epoch / `member:true` |
+| 事件出站 | 经**真实 HTTP client**投出，签名可验，header `X-Octo-Event-ID`（大写 ID）== 库里幂等键，`member_revoked` 不带 `project_version`（显式 `null`，故意不加 omitempty——省略键会被按 §2 校验的对端回 4xx，而 4xx 在此多为终态）、payload 的 `member_epoch` 与 epochs 接口报的值一致 |
+| 资料变更 | 改名 → `metadata_updated` + `lifecycle_version` 递增；同名重复 `PUT` → 不写库不发事件 |
+| 失败分类 | peer `503` → 保持 `pending` 可重试；peer `409` 或其余多数 4xx → `abandoned` 终态。**精确表**：5xx/网络/401/403/408/429/3xx 可重试，409 与其余 4xx 终态（`lifecycle_client.go:293-342`） |
+| 故障隔离 | drive 挂：不拖累 fleet、不影响 `activated_at`、不影响事件通道 |
+
+### `[实测]` 失败的那一条
+
+```
+TestE2E_Phase7_AgentPulledOutWithItsOwnerIsNotPushedToThePeer
+  revocation subjects the peer was told about: map[p7owner:true]
+```
+
+主人被移出 Space 后，主人和它的分身的项目席位在**同一事务**里都关闭了（前置断言已验证
+「两个席位都关」），但对端只收到主人一条 `member_revoked`。根因（已代码级坐实）：
+#864 的 4 个 `enqueueLifecycleEventTx` 调用点全在人的路径上；#855 的 agent 循环
+（`beginRemovalWithAgentsTx` service.go:1913-1943 与 Space 级联
+`space_member_removal.go:346-376`）只有 `beginMemberRemovalTx` + `enqueueRemovalJobTx`，
+没有事件入队。**这个缺陷在任一 PR 单独看都不存在**——#864 那会儿没有分身概念，
+#855 那会儿没有事件通道，两边测试各自全绿。授权正确性还在（epoch 变了，对端回来拉
+`_verify` 会发现分身也没了），丢的是**推送**；而分身正是「代替主人在对端跑东西」的主体。
+
+## 现状：合并四个 PR 后，一次建项目实际发生什么
+
+```
+POST /v1/space/{space_id}/projects
+  │
+  ├─ 事务 T1（锁序 space_member 行 S 锁 → space 行 X 锁 → 配额 COUNT ×3
+  │            → octo_project → octo_project_member（人 + 分身）
+  │            → octo_project_lifecycle_event → octo_project_provisioning 最后一条）
+  │    ① INSERT octo_project（project_id = 36 位规范 UUID；
+  │       activated_at = NULL 当且仅当 fleet target 已启用，service.go:452-455）
+  │    ② INSERT 创建者 owner 席位
+  │    ③ INSERT 创建者自己的分身席位（#855，role=0，计入 max_members）
+  │    ④ bump member_epoch → 1（#852：创建即 bump，bumped==0 整单失败；
+  │       0 是对外契约「项目不存在」的保留哨兵）
+  │    ⑤ bump lifecycle_version → 1（两计数器写入都只有 col = col + 1 形状，源码守卫强制）
+  │    ⑥ INSERT octo_project_lifecycle_event（project.created，payload 入队即冻结）
+  │    ⑦ INSERT octo_project_provisioning × 每个启用的 target ← 锁序要求它是最后一条
+  │  COMMIT
+  │
+  ├─ 提交后（不在事务内，失败不回滚创建）
+  │    ⑧ 全员群 hook（#855）：modules/group 开自己的事务建群 + IM channel
+  │    ⑨ nudgeProvisioningWorker()：立刻跑一轮供给（此外定时器 15s 一轮，带 jitter）
+  │
+  ├─ provisioning worker：每 target 一次 POST {ensure_url}
+  │       body   {container_id, project_id, octo_space_id, name, issue_prefix?}
+  │              （name 固定常量 "octo-project"；issue_prefix 永不设置）
+  │       签名   X-Octo-Signature: "v1=" + hex(HMAC-SHA256(该 target 专属 secret,
+  │                 "v1\n" + METHOD + "\n" + path + "\n" + timestamp + "\n"
+  │                 + event_id + "\n" + lowercase_hex(sha256(body))))
+  │                 event_id = lowercase_hex(sha256(container_id))
+  │                 （6 段 \n 连接、body 取摘要而非原文——规范串见
+  │                  internal/projectprovision/conformance.go:28-41，勿凭记忆实现）
+  │       校验回显 container_id 一致 → status=ready；回空 {} → 重试（#854 修复）；
+  │       回不同 id → 永久失败 + 告警
+  │       fleet 且 ready → confirmProjectActive() 置位 activated_at
+  │                        ← 此后对端才「看得到」这个项目（activation.go 只认 fleet）
+  │
+  └─ lifecycle worker：5s 常量轮询、batch 10、串行 POST、无 nudge
+        认领谓词含 NOT EXISTS：任一时刻每项目最多一行 pending 可被认领
+        5xx/网络/401/403/408/429/3xx → 退避重试；409 与其余 4xx → abandoned；
+        attempts ≥ 12 → abandoned（另有 5 分钟一次的 sweepExhaustedLifecycleEvents）
+```
+
+**`name` 字段不是项目名**，是每个容器都一样的固定低信息标签——项目名与描述由
+octo-server 权威持有，**不经任何出站通道外发**（契约 §5）。
+
+**容器 id 当前不可推导**（`octows-` / `octods-` + 16 字节随机），不是 `project_id`。
+这是 #850 的临时防护：同 Space 成员能列出 `project_id`，而 fleet 的 workspace 门目前按
+Space 成员放行并把调用者物化成永久 workspace 成员。顺序是**对端先收窄、我方后换 id**
+（决策注释由 #854 加在 `provisioning.go:71-93`；届时仅 fleet 换 id，guard 收窄到 drive）。
+
+## 事件目录（冻结）
+
+信封：`{event_id, event_type, project_id, space_id, project_version?, occurred_at, payload}`；
+`event_id` 是规范 UUID，重投复用同值，是对端的幂等键。
+
+| `event_type` | 触发点（代码） | `project_version` | payload | 状态 |
+|---|---|---|---|---|
+| `project.created` | `createProjectOnce` 事务内（bump 两计数器之后） | 有 | `{creator_uid}` | ✅ `[实测]` 投递成功 |
+| `project.metadata_updated` | 资料变更事务内（**仅当有字段实际变化**，`len(set)==0` 短路） | 有 | `{}`（空对象非 null） | ✅ `[实测]` |
+| `project.member_revoked` | `beginRemovalWithCascadeTx`（#864；#855 合并后为 `beginRemovalWithAgentsTx`，kick/leave/Cascade 转发）、Space 级联工单内（`if changed`） | **无（显式 null）** | `{subject_uid, member_epoch, reason}` | ⚠️ `[实测]` 人的有、**分身的没有**（R5 修复） |
+| `project.archived` | — | 有 | `{reason}` | ⛔ RESERVED，无人发出 |
+| `project.restored` | — | 有 | `{}` | ⛔ RESERVED，无人发出 |
+
+**两个计数器不可混用**：`lifecycle_version` 排序「关于项目本身」的陈述（出现在
+`project_version`）；`member_epoch` 排序「关于名册」的陈述（出现在 epochs 接口和
+`member_revoked` 的 payload）。两者都只增不减，写入语句只有 `col = col + 1` 一种形状，
+由源码守卫强制（main 上是 `TestMemberEpochOnlyEverIncrements` 正则 sweep；
+`TestEverySpaceMemberWriterIsAccountedFor` 是 #852/#864 引入的 writer-baseline 双向断言）。
+共用一个计数器会让每次改名失效下游所有缓存授权。
+
+**bump 语义**（实现 R5 时必须遵守）：每一次真实影响行的成员/角色写入 bump **一次**
+（条件 `RowsAffected > 0`）——一人 + N 分身同批关闭只 bump 一次，分身事件的
+`member_epoch` 必须取这同一次 bump 后的值。
+
+**会改变成员判定但不动 `member_epoch` 的情况**（契约 §9，逐条核过）：Space 封禁/解封、
+**Space** 解散、项目归档/恢复——由 epochs 谓词「父 Space 不活跃 → 折成 0」覆盖，
+不靠 epoch 移动。注意区分：**项目解散**会 bump（先 bump 再翻 status，契约 §9 表格 ✅），
+只有 **Space** 解散才不动。本仓**不会**级联解散 Space 之下的项目。
+
+**拆除是 pull 而非 push**：项目解散把供给行置为 `disband_pending`（status=3），子系统靠轮询
+`POST /v1/internal/projects/status` 得知，出站不推任何东西。清理这些行由
+`OCTO_PROJECT_PROVISION_{FLEET,DRIVE}_RECLAIM_CONSUMER_LIVE` 逐 target 把关——删行是本片
+唯一不可逆操作，不能建立在假设上。（这两个 env 是 #850 已合并的产物，非 #854 引入。）
+
+## Load-bearing list
+
+- **`octo_project_lifecycle_event` 的唯一键与租约语义。** 加 consumer 维度要把
+  `UNIQUE (event_id)` 改成 `(consumer, event_id)`，并让 `status/attempts/next_attempt_at/
+  lease_owner/lease_until/finished_at` 变成 per-consumer。现有 **4 条**二级索引
+  （pending(status,next_attempt_at,lease_until) / project(project_id,id) /
+  finished(status,finished_at) / age(status,created_at)）都要按 consumer 前导重新评估——
+  其中 3 条以 status 前导，否则「稳态即最坏情况」的全表扫描会回来。 touches: `wire-contract`
+- **事件在业务事务内入队。** 「变更提交 ⟹ 事件存在」是靠构造成立的，不是靠发布者记得。
+  fan-out 写多行必须仍在同一事务内。 touches: `wire-contract`
+- **payload 入队即冻结、投递时原样重放。** 对端在 `event_id` 后面对 payload 做指纹，
+  同 id 不同内容会被判永久冲突。fan-out 的 N 行必须共享同一份序列化字节，绝不能在投递时重算。
+  守卫 `TestPayloadIsFrozenAtEnqueue` 目前只钉 `lifecycle_event_worker.go` 一个文件，
+  fan-out 后扩展之。 touches: `wire-contract`, `test`
+- **per-project 阻塞在 claim SQL 里，不在 worker 内存。** `NOT EXISTS` 谓词保证任一时刻
+  每项目最多一行 pending 可认领（防 `member_revoked` 越序被对端判 4xx 永久放弃）。多消费方后
+  该谓词与阻塞键必须变 `(consumer, project_id)`，否则一个慢消费方会挡住其他所有消费方的
+  同项目事件。#864 正文 :82 对此的 in-loop 描述是过时写法，勿据此实现。 touches: `wire-contract`
+- **签名层零重写。** `pkg/octosign` 的规范串（`v1\n` 六段 + body 摘要 + `v1=` header 前缀）
+  有 conformance vectors 钉住，R1–R4 不触碰它；契约 §1 的表述「method+path+timestamp+
+  event_id+body」是字段清单不是拼接式，实现接收端一律以 conformance 文件为准。
+  touches: `wire-contract`
+- **`activated_at` 只认 fleet。** `confirmProjectActive` 里 `if target != TargetFleet { return }`
+  （`activation.go:165`），且 `twoPhaseCreateApplies()` 是第二处「只认 fleet」判定。
+  多子系统后必须先定义「可见」是任一必需子系统确认、还是全部确认——这会改变对端可见时机，
+  是产品决策（D-4）。fleet target 未启用时 `activated_at` 在创建事务内直接置位，
+  并有滚动升级补偿路径。 touches: `wire-contract`, `isolation`
+- **两个入站接口的读序与谓词一致性。** `ProjectEpochsInSpace` 两步（项目行 → Space 状态
+  fail-closed）；`ProjectMemberships` 四步（复用它作第一步 → 项目席位 → Space 活跃成员 →
+  账号存活，三个「只能收窄」的读在最后）。两个谓词必须对「什么算在答案里」保持一致——
+  #852 review round 5-8 有一轮就是因为只给其中一个加了 Space 条件，导致封禁后授权不失效、
+  解封后永久拒绝（正文自认 unban 方向是本分支引入的回归）。 touches: `auth`, `isolation`, `space`
+- **每个能关闭 `space_member` 席位的 writer 都必须在同事务 bump `member_epoch`。**
+  该规则与 sweep guard 只存在于 #852/#864（main 上尚无）；#855 已合入 main，其
+  `modules/space/member_removal_all_spaces.go` 将是第一个未登记 writer（R11）。
+  touches: `auth`, `space`, `test`
+- **凭据互斥。** 每个 target 的 secret、事件 secret、membership token 之间两两互斥，
+  main.go 的固定 env 注册表 + 各模块本地拒绝列表 + 全树 credential 字面量 sweep 三重把关。
+  新增 per-consumer 凭据必须同时进这三处。(a) 的载体是 #852 自带的 `fixedInternalTokenEnvs`
+  （9 条，`main.go:833-905`）——**#853 本迭代不合入**，`pkg/internaltoken` 在 main 上不存在。
+  #853 若未来合入，其 registry 的 4 条清单**不含** membership token，必须显式 append，
+  否则 #852 建立的 9 条覆盖面静默回退且无测试会红。 touches: `auth`, `test`
+- **供给行不可用于任何读路径的门控（D12）。** `status=ready` 的含义是「我们成功调用过一次」，
+  不是「容器现在存在」——容器可能已在子系统侧被删除/归档/迁移而没人通知我方。
+  touches: `wire-contract`
+- **锁序：供给入队必须是创建事务的最后一条语句。** 全员群 hook 必须在事务提交之后跑
+  （跨模块持项目行锁 + HTTP 关进行锁；「锁序反转」的完整表述见 #855 正文 :70 的锁序表）。
+  touches: `space`
+- **事件目录本身是对端实现依据。** `docs/project-lifecycle-contract.md` 与代码不一致时
+  是其中之一有 bug，不是「按实际情况理解」。新增/改变事件必须同步该文档。
+  touches: `wire-contract`
+- **provisioning ensure 响应是未认证的，且 ValidateTarget 允许 `http://`。**
+  `out.ContainerID == req.ContainerID` 回显是「行指向自己容器」的唯一保障（#854 已知前置
+  风险）。本任务不修它（out of scope），但 R8 的重驱入口不得降低这层校验。
+  touches: `auth`
+
+## 已定决策（不再开放）
+
+| | 决定 | 依据 |
+|---|---|---|
+| **D-1** | 分身被连带摘除时**推** `member_revoked`，每席位一条，`member_epoch` 取同一次 bump 后值 | 已固化为 R5。分身是代替主人在对端执行的主体；契约 §4 要求撤销迟到也必须应用 |
+| **D-3** | `member_epoch` 创建即 bump 到 **1**（0 是「项目不存在」保留哨兵） | **#852 已单方面落地**（`createProjectOnce` 内 bump，`bumped==0` 整单失败）。#855 的 D11（保持 0）与其冲突且未记录，#855 rebase 时必须接受本决定——不再是本任务的决策项 |
+
+## 待决策（需要人拍板，不由实现者决定；两项都阻塞实现开工）
+
+| | 问题 | 建议 |
+|---|---|---|
+| **D-2** | `CloseAllSpaceSeats`（#855 D14，botfather 删 bot）要不要同事务 bump epoch？ | **建议 bump**（在 `closeOneSeatAndEnqueueTx` 事务内调现成的 `bumpMemberEpochForSpaceMemberTx`）。完整链路：space 席位在同事务关闭 → `_verify` 的 Space 活跃成员轴随即答 false；但对端**感知失效**取决于 epoch 何时动——现状靠 Space 级联工单执行时 bump，工单 abandoned 则 epoch 永不动，对端缓存只能靠自身 TTL 过期（#852 只披露未实现）。提前 bump 让对端下次重拉即得 false，不再依赖异步工单成败。**需要产品/架构签字** |
+| **D-4** | 「项目对对端可见」的判定：任一必需子系统确认，还是全部确认？ | 先定义**必需子系统集合**（可能只有 fleet 是必需，drive 是可选），可见性 = 全部必需子系统确认。默认全部可选则退回创建事务内置位。落 R6 |
+
+## 实现顺序前提
+
+本任务在以下合并序列完成后开工；顺序错会放大冲突面：
+
+1. **#852 先合**——它定了 member_epoch 创建 bump、凭据注册表、sweep guard 三件事实标准。
+2. ~~#855 rebase 到 #852 之后~~ — **已于 2026-09-09 合入 main（`566e625b`）**，早于 #852。
+   故 D-3（创建即 bump 到 1）与 #855 的 D11（保持 0）冲突**改由 #852 rebase 时解决**：
+   #852 落地 `createProjectOnce` 内 bump 时，必须在已含全员群/分身逻辑的 main 上重做，
+   并确认 `bumped==0` 整单失败的语义仍成立。
+3. **#853 本次迭代不合入**（用户 2026-09-09 决定），且**不阻塞**：已核实无人依赖它。
+   若未来合入，前置条件是——`pkg/internaltoken` registry 显式 append
+   `OCTO_MEMBERSHIP_INTERNAL_TOKEN` + 另 3 条遗留 env（`TS_WEBHOOK_SECRET_KEY` /
+   `OCTO_MAIL_GATEWAY_SECRET` / `TS_GRPC_AUTH_TOKEN`），并保留 #852 的
+   `main_internaltoken_test.go` 作门禁；否则覆盖面 9→4 静默退化且无测试会红。
+4. **#854 随时可合**（独立 lane）；**#864 最后合**（base 改回 main；`.octospec/log.md`
+   的琐碎冲突顺手解决）。
+5. 取回预演 workspace 的 `.context/merge-dryrun/subsystem_e2e_test.go.txt` 作为 R5 的
+   复现基线；取不回则按 §分身丢事件的代码事实重建基线测试。
+
+## Out of scope
+
+- **不实现 `project.archived` / `project.restored`。** 契约 §8 已冻结形状（独立列
+  `archived_at`，不是第三个 status 值），本片不发出它们。
+- **不修项目归档的入站读谓词盲区。** Space 没有归档态；O1b 的 `archived_at` 列未落地，
+  `ProjectEpochsInSpace` / `ProjectMemberships` 也没有 `archived_at IS NULL` 谓词——
+  归档项目对对端仍报活跃 epoch。这是 #852 的 follow-up，本任务不夹带，但 R12 须把它
+  列为契约已知限制。
+- **不把容器 id 改成 `project_id`。** 顺序是对端先收窄 workspace 门、我方后换 id
+  （#854 已把该决策锚在 `provisioning.go:71-93`）。提前换会打开一条已知提权链路。
+- **不改拆除模型。** 解散仍是 pull（`disband_pending` + 对端轮询
+  `/v1/internal/projects/status`），不新增出站拆除事件。
+- **不改项目名外发策略。** 名称/描述不进任何出站通道；`metadata_updated` 的 payload 保持为空。
+- **不动 `MembershipsInSpace`（`/v1/auth/verify` 用的那条）。** 它答的是 token 持有者
+  自己、在 SpaceMiddleware 之后，不参与 `activated_at` 门控——否则供给期间用户看不到
+  自己的项目。
+- **不做 provisioning ensure 响应的认证加固。** 未认证回显 + 允许 `http://` 是独立前置
+  风险（#854 已知），另立任务。
+- **不做多 pod 并发压测。** 预演是单进程；租约争抢的正确性由现有 lease 语义承担，
+  多 pod 验证另立。
+- **不动 #858 / #861**（bot hosting、群列表/sidebar/pinning 等周边产品面）。
+
+## Acceptance
+
+结构（可机器验证，逐条对应 R 编号）：
+
+- [ ] R1：`octo_project_lifecycle_event` 有 `consumer` 列，`UNIQUE (consumer, event_id)`；
+      消费方 A `delivered` 且 B `pending` 能在同一行集合上共存。
+- [ ] R2：一次业务变更为 N 个启用消费方写 N 行，**在同一事务内**；
+      测试：删掉任一消费方的入队 → 断言失败。
+- [ ] R3：N 行共享同一份 payload 字节；`TestPayloadIsFrozenAtEnqueue` 扩展且不缩窄；
+      变异验证：让 worker 重算 payload → 守卫必须红。
+- [ ] R4：claim `NOT EXISTS` 谓词与阻塞键为 `(consumer, project_id)`；4 条二级索引按
+      consumer 前导重评（EXPLAIN 佐证无全表扫描）；测试：A 队头 503 时 B 的同项目事件
+      同轮投出。
+- [ ] R5：`member_revoked` 覆盖分身：一个带分身的成员经踢出 / 退出 / Space 移除三条路径
+      离开后，撤销事件的 `subject_uid` 集合 == 该次名册变化中关闭的全部席位，且各事件
+      `member_epoch` 相同（同一次 bump）；**复现基线**：merge-dryrun Phase7（取回或重建）
+      修复后变绿，改回旧代码重新变红（变异验证）。
+- [ ] R11 + D-2：`TestEverySpaceMemberWriterIsAccountedFor` 绿（D-2 择一落地；若进
+      baseline 须写明「对端失效依赖工单成败 + 对端 TTL」的理由）；baseline 增补
+      `member_removal_all_spaces.go`、更新 botfather 三处过期理由。
+- [ ] R6：可见性判定按 D-4 实现并有测试覆盖「必需子系统未确认 → 两接口答 0 / false」
+      与「全部必需确认 → 翻转」两方向。
+- [ ] R7：lifecycle 轮询间隔可配 + 提交后 nudge；业务写到对端收到的 p99 延迟有断言。
+- [ ] **R8-lifecycle**：跑通 abandoned → 重驱 → delivered；per-consumer 隔离断言
+      （A 重驱不动 B）。形态沿用 env，**不要引入 HTTP 端点**——见 R8-lifecycle 的 D12 冲突。
+      （provisioning 半边已在 `project-subsystem-fanout` 落地并变异验证，照抄其结论。）
+- [ ] R9：入站 per-consumer JSON registry（32B floor、DisallowUnknownFields、撞值
+      fail-closed）；per-consumer 配额、审计区分、单方轮换各一条测试；新凭据进三重把关
+      （#852 自带的 main.go `fixedInternalTokenEnvs` / 模块本地拒绝列表 / credential sweep；
+      `pkg/internaltoken` 本迭代不存在）。
+- [ ] R12：`docs/project-lifecycle-contract.md` 同步（事件目录、多消费方语义、per-consumer
+      幂等边界、失败分类精确表、延迟吞吐、归档谓词盲区列为已知限制）。
+
+端到端（沿用预演 harness，`//go:build dryrune2e`）：
+
+- [ ] 三个及以上子系统同时启用时，每个都收到一次 ensure，各自 secret 验签通过，
+      任一子系统 5xx 不影响其他子系统与事件通道。
+- [ ] 两个及以上事件消费方同时启用时，各自独立收到全部事件、独立重试、独立 abandon。
+- [ ] R7 落地后 p99 延迟断言在 harness 中生效（当前是 5s 起）。
+- [ ] R8 lifecycle 半边重驱跑通一次：abandoned → 重驱 → delivered
+      （provisioning 半边已在单测层跑通，见上）。
+
+回归：
+
+- [ ] `go test ./modules/project/ ./modules/space/ ./modules/group/ ./pkg/project/ ./pkg/space/ .`
+      全绿。**每个包跑前 drop & recreate 测试库，且必须显式
+      `COLLATE utf8mb4_general_ci`**（否则 category 迁移报 1267）。共享 `test` 库会被其他
+      workspace 灌入别分支的迁移，症状是 `unknown migration in database` 或
+      `Table 'xxx' already exists`——预演中造成过 167 个假失败。
+      注意：**私有 MySQL 实例目前不可用**，`octo-lib/testutil` 把地址硬编码为
+      `root:demo@tcp(127.0.0.1)/test`（`testutil/test.go:28`），换实例需改库。
+      所以现阶段只能靠「跑前重建 + 避开与其他 workspace 并发」。
+- [ ] `TestMemberEpochOnlyEverIncrements` 与 `TestEverySpaceMemberWriterIsAccountedFor`
+      双绿（两个 guard 的 baseline 都与合并后代码一致）。
+- [ ] `make i18n-extract-check && make i18n-lint` 通过（本任务预期不新增 HTTP 端点，
+      故通常无新错误码；若确实新增，错误码进 `pkg/errcode` 并补 zh-CN 翻译）。
+- [ ] 签名层零改动：`pkg/octosign` conformance vectors 测试原样通过。

--- a/.octospec/tasks/project-subsystem-fanout/brief.md
+++ b/.octospec/tasks/project-subsystem-fanout/brief.md
@@ -1,0 +1,172 @@
+---
+type: Task
+title: "Task: project-subsystem-fanout"
+description: 把 per-target 分派点收敛成一张 target 注册表，并给 abandoned 供给行加 env 驱动的人工重驱
+tags: [project, wire-contract, auth, test]
+timestamp: 2026-09-09T00:00:00Z
+slug: project-subsystem-fanout
+upstream: 口头需求（#852 / #854 / #855 / #864 合并预演后的实测结论）
+source: self
+---
+
+# Task: project-subsystem-fanout
+
+> **范围（2026-09-09 收窄）**：本任务只做**作用对象已在 main 上**的两件事——
+> R10（target 注册表收敛）与 R8 的 provisioning 半边（env 驱动的 abandoned 重驱）。
+> 两者的作用对象都来自已合并的 #850。
+>
+> 原 brief 还包含 9 条（R1–R7 / R9 / R11 / R12），其作用对象在 main 上**零命中**
+> （`octo_project_lifecycle_event` 表与 worker、`activation.go`、
+> `modules/internal_membership`、`TestEverySpaceMemberWriterIsAccountedFor`），
+> 依赖未合并的 #852 / #864。它们**已连同全部核实结论移入**
+> `.octospec/tasks/project-lifecycle-multiconsumer/brief.md`（编号沿用不重排）。
+> 修剪前的完整原文留在 `.context/attachments/SeL7SI/brief-full-before-prune.md`（不进 git）。
+>
+> 基线：`main@98d209206`（#855 与 #861 均已合入）。
+
+## Goal
+
+**接第三个子系统不该是五处代码的考古工作，卡死的供给行不该只能等着。** 两件事：
+
+1. **R10 · target 注册表收敛。** 原状接一个子系统要改 5 处分派点
+   （`allProvisionTargetNames()` 字面量 slice、`targetEnvNames()` case、
+   `containerIDPrefix()` case、`refreshProvisioningMetrics()` 字面量 slice、
+   `provisioningTargetLabel()` case），外加声明常量与 4 个 env。
+   **最后两处是沉默失效**：漏改不报错，新子系统照常供给，只是在看板上不可见——
+   而那个「未收窄容器」gauge 正是本 slice 能先上线的安全论据。
+2. **R8-provisioning · abandoned 人工重驱。** 供给行重试 12 次耗尽后落入 `abandoned`
+   终态，**此后无任何自动或人工恢复路径**（`requeue|re-drive` 在 #854 树里只出现在注释），
+   而 fleet 的 `confirmProjectActive` 不会再跑 ⟹ **该项目对对端永久不可见**。
+   一次几分钟的网络抖动就能永久废掉一个项目，运维无招。
+
+## 必须实现（MUST）
+
+**R10 · target 注册表收敛 — ✅ 已落地**
+**保留硬编码枚举**（未知 target 名启动即拒的收益），把 **5 处**分派点收敛为一张
+`provisionTargetSpec` 表：接第三个子系统 = 注册表加一条（name / 4 个 env / 容器前缀）
++ 声明它的 4 个 env 常量。刻意**不**做配置驱动：那要另写前缀形状、密钥地板、是否必需、
+是否参与可见性四套校验器，等于用四个待写的校验替换一个已经生效的启动期拒绝。
+容器前缀（`octows-` / `octods-`）随之从 `provisioning.go` 迁入注册表条目，
+`newContainerID` 仍是唯一生产者。
+
+**R8-provisioning · abandoned 人工重驱 — ✅ 已落地**
+`OCTO_PROJECT_PROVISION_REQUEUE_PROJECT_ID` 填单个 project_id，pod 启动时在 `Enabled()`
+门内、定时器挂载前执行一次：`abandoned` → `pending`，worker 随即重试。
+
+*形态：env，启动时生效*（**取代原「i18n envelope + auth + 审计」的 HTTP 形态**）。
+改形态的原因是一条真实冲突，不是偏好：HTTP 端点必然带 handler，而守卫
+`TestNoHandlerReachesTheProvisioningTable` 禁止任何带 handler 的文件碰供给表或其 DAO，
+并把表名钉死在 `db_provisioning.go` 一个文件里。那条守卫执行的是 **D12**（见
+§Load-bearing list），所以 R8 的原字面形态与 D12 的守卫不能同时成立。
+D12 真实禁的是**用供给行门控读路径**；重驱是运维触发的**写**，不门控任何用户可见的读，
+因此 env 形态是绕开冲突而非削弱守卫——**已验证该守卫仍通过**。
+
+三条实现约束都是不做就出错的，且各有变异验证：
+- **`attempts` 重置为 0**——不重置则 sweep 在任何调用发出前把行重新判死。
+- **`container_id` 不重发**——它是对端的幂等键，换了会孤立掉前面 at-least-once 可能
+  已建好的容器（ensure 是至少一次，响应丢失时对端已有真容器而我方行仍未 `ready`）。
+- **`last_error` 追加不覆盖**——原始放弃原因是运维唯一的持久证据。
+
+**configmap 通道的两个固有代价**（写在 env 声明处，不是实现缺陷）：① 改完要**重启**才
+生效，救第二个项目要再改再重启；② 值**留在 configmap 里不会消失**，此后任何重启都会再读。
+②带来的「幽灵重驱」由**让行自己的状态当幂等凭据**消解——UPDATE 只匹配
+`status = abandoned`，所以对已救好的项目是空操作，**不需要另建「已处理」账本**（那会是
+关于同一决定的第二个真相源）。同一机制覆盖多副本竞争：各 pod 启动都跑，状态复查让
+只有一个改到，其余匹配 0 行。若该项目**再次**进入 `abandoned`，下次重启会再救一次——
+这是「运维把指令留在原处」的正确解读。零行匹配走 Warn 日志（零是运维最需要看到的答案：
+id 写错、已被上次重启救过、或这个项目从未失败过）。
+
+## Load-bearing list
+
+- **供给行不可用于任何读路径的门控（D12）。** `status=ready` 的含义是「我们成功调用过
+  一次」，不是「容器现在存在」——容器可能已在子系统侧被删除/归档/迁移而没人通知我方。
+  由 `TestNoHandlerReachesTheProvisioningTable` 守卫（禁 handler 文件碰供给表/DAO，
+  且表名只许出现在 `db_provisioning.go`）。R8 的 env 形态正是为不违反它而选的。
+  touches: `wire-contract`
+- **容器 id 不可由 project_id 推导。** 同 Space 成员能列出 `project_id`，而 fleet 的
+  workspace 门按 Space 成员放行并把调用者物化成永久 workspace 成员——可推导性会把
+  「能列项目」补成「永久是每个项目 workspace 的成员」。`newContainerID` 是唯一生产者，
+  由 `TestContainerIDHasOneProducerAndItIgnoresTheProjectID` 守卫。R10 把前缀字面量
+  迁入注册表时**必须保持该守卫的单一生产者语义**。 touches: `auth`, `wire-contract`
+- **容器 id 不得被供给切片外的任何包读到。** 由仓库级守卫
+  `TestNoPackageOutsideTheProvisioningSliceCanReadAContainerID` 保证（whole-repo walk +
+  前缀字面量作切片标记）。R10 迁移前缀 = 动了该守卫的白名单，**放宽白名单必须重做
+  变异验证**，否则守卫会静默失效。 touches: `auth`, `test`
+- **供给的出站调用只许在 worker 里。** handler 调 fleet/drive 会让用户请求依赖别的服务
+  存活；由 `TestProvisioningClientIsConfinedToTheWorker` 守卫。R8 的重驱入口是 env +
+  worker 内执行，不引入新的出站点。 touches: `wire-contract`
+- **`abandoned` 语义：重试预算耗尽的终态，非 claim 目标。** `claimProvisioningJob` 要求
+  `attempts < max`、sweep 要求 `attempts >= max`，两个谓词互斥。重驱把 `attempts` 归零
+  正是为了回到可 claim 的一侧；只改 status 不改 attempts 会被 sweep 立刻打回。
+  touches: `wire-contract`
+- **`target IN ?` 过滤在所有供给 SQL 上都是非装饰性的。** 关掉一个 target 必须是
+  非破坏的：没有该过滤，收窄 `OCTO_PROJECT_PROVISION_TARGETS` 会让 sweep 把另一个
+  target 的停放行推向终态 `abandoned`，而回滚开关**不会**恢复它们。重驱同样按启用
+  target 过滤——重驱一个已关闭 target 的行只会把它停在 `pending` 且无执行者。
+  touches: `wire-contract`
+- **`provisioningRows` 看板是本 slice 的安全论据。** 「未收窄容器」这个 gauge 是
+  R2/R3 落地前唯一的攻击面度量，所以任何 per-target 判定漏掉一个 target 都是安全度量
+  失真，而非美观问题——这正是 R10 收敛 `refreshProvisioningMetrics` /
+  `provisioningTargetLabel` 的理由。 touches: `test`
+
+## Out of scope
+
+- **不做 lifecycle 事件通道的任何改动**（多消费方、consumer 维度、事件目录、
+  lifecycle 侧重驱）——见 `project-lifecycle-multiconsumer`。
+- **不把容器 id 改成 `project_id`。** 顺序是对端先收窄 workspace 门、我方后换 id
+  （决策锚在 `provisioning.go` 的 `newContainerID` 注释）。提前换会打开一条已知提权链路。
+- **不改拆除模型。** 解散仍是 pull（`disband_pending` + 对端轮询
+  `/v1/internal/projects/status`），不新增出站拆除事件。
+- **不做 provisioning ensure 响应的认证加固。** 未认证回显 + `ValidateTarget` 允许
+  `http://` 是独立前置风险（#854 已知），另立任务。R8 的重驱不得降低
+  `out.ContainerID == req.ContainerID` 这层回显校验。
+- **不做 target 的配置驱动化。** 保留编译期封闭枚举，理由见 R10。
+- **不动项目名外发策略**（ensure body 的 `name` 保持固定常量，项目名不出站）。
+- **不做多 pod 并发压测。** 重驱的多副本安全由 UPDATE 的 `status` 复查承担，已有测试
+  覆盖；租约争抢的正确性由现有 lease 语义承担。
+
+## Acceptance
+
+- [x] **R10**：5 处分派点全部改读 `provisionTargetRegistry`；接第三个子系统只需表加一条
+      + 声明 4 个 env。
+- [x] **R10 守卫**：`TestEveryTargetDecisionReadsTheRegistry` 钉住「注册表文件外不得枚举
+      target 常量」，并对两处**沉默站点**（`refreshProvisioningMetrics` /
+      `provisioningTargetLabel`）各做变异验证——改回枚举即报红并指名文件，恢复即变绿。
+- [x] **既有守卫未被打瞎**：`TestContainerIDHasOneProducerAndItIgnoresTheProjectID` 改为
+      断言不变量（前缀字面量只在一张表、生产者唯一）+ 新增「每条注册表条目必须声明非空
+      前缀」；`TestNoPackageOutsideTheProvisioningSliceCanReadAContainerID` 白名单增补
+      注册表文件后**经变异验证**（往 handler 文件塞前缀字面量仍报红）。
+- [x] **R8-provisioning 主链路**：`TestRequeueRevivesAnAbandonedRowAndReachesReady`
+      跑通 abandoned → 重驱 → **ready**（不止状态翻转，worker 真的把行驱动到 ready），
+      且重试落在**同一 container_id**、未创建第二个容器。
+      变异验证：`attempts` 不重置 → 红。
+- [x] **R8-provisioning 幽灵重驱 + 多副本**：
+      `TestRequeueIsANoOpOnASecondBootWithTheEnvStillSet` 断言残留 env 对已 ready 的项目
+      是空操作（finished_at 不变、不追加 requeue 标记、不产生新的 ensure 调用），
+      连跑两次模拟第二个 pod / 第二次重启。变异验证：去掉 `status=abandoned` 过滤 → 红。
+- [x] **R8-provisioning 作用域**：`TestRequeueLeavesOtherProjectsAlone` 断言只动指定
+      项目，旁观项目留在 `abandoned`。变异验证：忽略 `project_id` → 红。
+- [x] **D12 未被绕过**：`TestNoHandlerReachesTheProvisioningTable` 通过；新 DAO
+      `requeueAbandonedProvisioningJobs` 仅 worker 一个调用者（该文件无 handler 标记），
+      新 env 不进任何读路径。
+
+门禁（2026-09-09 在 `main@98d209206` 上实测，#855 + #861 均已合入）：
+
+- [x] `go build ./...` / `gofmt` / `go vet ./modules/project/` 全干净。
+- [x] `golangci-lint run ./modules/project/... ./internal/projectprovision/...` → **0 issues**。
+- [x] `make i18n-extract-check` + `make i18n-lint` → 均 exit 0（本任务不新增错误响应）。
+- [x] 13 个关键测试全部真实执行并通过（`-v` 逐个列名确认非空集）：3 个 requeue 行为测试
+      + `TestEveryTargetDecisionReadsTheRegistry` + 5 个既有供给守卫 + 4 个既有供给行为测试。
+- [x] `internal/projectprovision` / `pkg/project` / `pkg/space` / `modules/space` 全部 ok。
+- [x] **`modules/project` 整包全绿**（2026-09-09 在 `main@98d209206` 上实测：`ok`，0 失败，
+      跑完库仍有 130 张表即未被外部清）。此前几轮整包红是**共享测试库被其他 workspace
+      周期性 drop**，已用对照实验证伪与本改动的关系（stash 掉全部改动、纯净 main 上跑同一批
+      失败测试 → 同样红、同样 `Error 1146 Table doesn't exist`）。
+      **跑法要求**：每次跑前 drop & recreate 测试库，且**必须显式
+      `COLLATE utf8mb4_general_ci`**——`CleanAllTables` 只 DELETE 数据不改结构，所以
+      main 上新增迁移（#855 的 `all_member_group_no`/`removing`、#861 的
+      `project_user_setting`）后不重建会残留旧 schema 报 1054/1146。
+      `octo-lib` `testutil/test.go:28` 硬编码 `root:demo@tcp(127.0.0.1)/test` 无 env 覆盖，
+      无法用私有库隔离，故与其他 workspace 并发时仍可能被打断——重建后重跑即可。
+- [x] `go test -race`（requeue + 注册表守卫 + abandon）干净。
+- [x] 相邻包全绿：`internal/projectprovision` / `pkg/project` / `pkg/space` / `modules/space`。

--- a/.octospec/tasks/project-subsystem-fanout/context.yaml
+++ b/.octospec/tasks/project-subsystem-fanout/context.yaml
@@ -1,0 +1,139 @@
+injected:
+  - id: space-isolation
+    source: repo
+    why: paths modules/**/*.go + touches auth/space
+  - id: error-handling
+    source: repo
+    why: paths modules/**/*.go + touches wire-contract
+  - id: rate-limit
+    source: repo
+    why: |
+      paths modules/**/*.go matches. Corrected mid-session: the Plan phase said this
+      rule does not inject, having checked only `touches`. Injection is paths OR
+      touches. It ended up moot — R8 landed as an env, not a route — but the
+      Plan-phase claim was wrong.
+  - id: testing
+    source: repo
+    why: touches test; R10 guard + R8 behavioural tests
+  - id: commit-style
+    source: repo
+    why: paths ** catch-all
+  - id: trust-boundary
+    source: repo
+    why: touches wire-contract
+brief: .octospec/tasks/project-subsystem-fanout/brief.md
+
+scope_note: |
+  Brief 已于 2026-09-09 收窄（用户选方案 B：移出而非删除）。本任务现在只含 R10 +
+  R8-provisioning 两条，均已落地。原先的 9 条阻塞项（R1-R7 / R9 / R11 / R12）连同全部
+  核实结论移入 .octospec/tasks/project-lifecycle-multiconsumer/brief.md，编号沿用不重排。
+  修剪前完整原文备份在 .context/attachments/SeL7SI/brief-full-before-prune.md（不进 git）。
+  拆分后做过对账：13 条一次性挖出的关键结论（签名串 conformance 形状、epoch 创建 bump=1
+  与 #855 D11 冲突、失败分类 401/403/408/429 可重试、Phase7 分身丢事件、NOT EXISTS 阻塞在
+  claim SQL 而非 worker 内存、4 条二级索引、payload 入队即冻结、容器 id 不可推导、锁序、
+  D12、预演测试源码位置、#853 registry 9→4 退化、两个计数器不可混用）全部仍在，无丢失。
+
+split_followup: |
+  新 brief 已按已核实事实更新两处顺序事实：
+  (1) #855 已合入 main (566e625b)，早于 #852，所以 D-3（创建即 bump 到 1）与 #855 D11
+      （保持 0）的冲突改由 #852 rebase 时解决——原 brief 假设的顺序反了。
+  (2) #853 本迭代不合入，且已核实无人依赖它（#852 自带 fixedInternalTokenEnvs 9 条 +
+      main_internaltoken_test.go，零 import pkg/internaltoken；#854/#855/#864 同样零引用）。
+      若未来合入，需显式 append membership token + 3 条遗留 env，否则覆盖面 9→4 静默退化
+      且无测试会红。
+
+decisions:
+  - id: R8-shape
+    decision: env (OCTO_PROJECT_PROVISION_REQUEUE_PROJECT_ID), applied at boot
+    by: user, after rejecting tools/ binary, `app` subcommand, raw SQL and system_settings
+    note: |
+      The brief's R8 says "i18n envelope + auth + audit", i.e. an HTTP handler. That
+      collides with TestNoHandlerReachesTheProvisioningTable, which forbids any
+      handler-bearing file from touching the provisioning DAO (it enforces D12, also in
+      this brief's load-bearing list). The env form sidesteps the collision rather than
+      weakening the guard — verified: that guard still passes.
+
+      Two costs are inherent to the configmap channel and are documented at the env's
+      declaration: it takes effect on RESTART, and the value PERSISTS after use so every
+      later restart re-reads it. The ghost-requeue that (2) implies is neutralised by
+      making the ROW's own state the idempotency record — the UPDATE matches only
+      `status = abandoned`, so a leftover value is a no-op on an already-rescued project
+      and no "already handled" ledger is needed. Same mechanism covers the multi-replica
+      race (every pod boots with the same value; the status re-check means one wins).
+
+      Brief 已同步为 env 形态（2026-09-09），并写明 D12 冲突是改形态的原因，
+      以及 configmap 通道的两个固有代价与「行状态即幂等凭据」的消解方式。
+
+findings:
+  - id: dispatch-site-count
+    finding: |
+      The brief says adding a subsystem touches 4 sites. It is 5. The two the brief
+      missed (refreshProvisioningMetrics, provisioningTargetLabel) are the dangerous
+      ones: they fail by OMISSION, so a third subsystem provisions correctly and is
+      merely invisible on the dashboards the slice's own security argument rests on.
+      Brief 已改为 5 处（2026-09-09）。注意：Target* 常量声明不算分派点——我第一次改写时
+      误把它算进去导致数目对不上，按代码重新核对后确认被收敛的是 5 处。
+
+guards:
+  - name: TestEveryTargetDecisionReadsTheRegistry
+    status: added, mutation-verified
+    note: |
+      Fails when either previously-silent site regresses to enumerating target
+      constants; names the offending file; green on restore. First mutation attempt
+      produced a FALSE pass — exit=1 came from the test DB panicking, not the guard —
+      so it was re-run against a DB-free harness to get a real signal.
+  - name: TestContainerIDHasOneProducerAndItIgnoresTheProjectID
+    status: retargeted
+    note: |
+      Broke because the octows-/octods- literals moved into the registry. Rewritten to
+      assert the INVARIANT (literals in exactly one table, one producer) rather than a
+      filename, plus a new check that every registry entry declares a non-empty prefix.
+      The single-producer half was not weakened.
+  - name: TestNoPackageOutsideTheProvisioningSliceCanReadAContainerID
+    status: allow-list widened, mutation-verified
+    note: |
+      Repo-wide guard treating the prefix literals as a slice marker; config_provisioning.go
+      is inside the slice but was unlisted. Widening an allow-list is how a guard silently
+      erodes, so it was mutation-tested: planting a prefix literal in api.go still fails it.
+
+verification:
+  - "rebase 到 origin/main@566e625b（#855 已合并）后重跑，全部门禁通过"
+  - "go build ./... clean; gofmt clean; go vet ./modules/project/ clean"
+  - "golangci-lint run ./modules/project/... ./internal/projectprovision/... => 0 issues"
+  - "make i18n-extract-check => exit 0; make i18n-lint => exit 0（无新增裸错误响应）"
+  - |
+    13 个关键测试全部真实执行并通过（-v 逐个列名确认，非空集）：3 个 requeue 行为测试
+    + TestEveryTargetDecisionReadsTheRegistry + 5 个既有供给守卫
+    （NoHandlerReachesTheProvisioningTable / ContainerIDHasOneProducer /
+    NoPackageOutsideTheProvisioningSlice / ProvisioningClientIsConfined /
+    NoLogFieldCarriesTheContainerID）+ 4 个既有供给行为测试。
+  - "go test ./internal/projectprovision/ ./pkg/project/ ./pkg/space/ ./modules/space/ => 全部 ok"
+  - "D12 复核：新 DAO requeueAbandonedProvisioningJobs 仅 worker 一个调用者，该文件无 handler；新 env 不进任何读路径"
+  - "Out of scope 六条逐条核查未触碰；改动全部落在 modules/project/"
+  - "#855 未改动本任务涉及的 5 个供给文件（git show --stat 无输出），无语义交叠"
+
+blocked_by_infra:
+  issue: |
+    modules/project 整包无法稳定跑绿，与本改动无关，已用对照实验证伪。
+  evidence:
+    - "Monitor 实测：共享 test 库表数在测试期间被外部规律性 drop（129 -> 0 -> 重建），本 session 未发过该 drop 命令"
+    - |
+      对照实验：stash 掉全部改动、在纯净 main 上跑同一批失败测试 => 同样 FAIL，
+      同样是 Error 1146 Table doesn't exist。故失败不由本改动引起。
+    - "另一独立成因：#855 合并新增列（all_member_group_no / removing），库若不 drop&recreate 会残留旧 schema 报 1054；重建后 209 个迁移完整应用，两列就位"
+  root_cause: |
+    ~160 个 workspace 共用 testenv-mysql-1 的单个 `test` 库，且 octo-lib/testutil
+    把地址硬编码为 root:demo@tcp(127.0.0.1)/test（testutil/test.go:28，无 env 覆盖），
+    所以无法用私有库隔离。CleanAllTables 只 DELETE 数据不改结构，故 schema 变更后
+    必须显式 drop & recreate（且显式 COLLATE utf8mb4_general_ci）。
+    另外本包 TestMigrationUpDownUpLeavesNoResidue 会对共享库执行本模块迁移的
+    Down→Up，期间相关表真实消失——它自己不并行，但与其他包/其他 workspace 并发时
+    会让对方看到缺表。
+  not_fixable_here: "需要改 octo-lib 支持 env 覆盖 DB 地址，或为每个 workspace 分配独立库；超出本任务范围"
+
+not_done:
+  - "No commit (Implement/Verify 阶段均不提交)。"
+  - "modules/group 整包有 5 个失败（failed to create IM channel，30s 超时），与本改动无关，属 WuKongIM 环境问题。"
+  - "brief 已按方案 B 修剪完成（见 scope_note）；两份 brief 结构校验通过，13 条关键结论对账无丢失。"
+  - "project-lifecycle-multiconsumer 尚无 context.yaml（未进入 Implement 阶段，按流程等其开工时生成）。"
+

--- a/modules/project/config_provisioning.go
+++ b/modules/project/config_provisioning.go
@@ -111,6 +111,34 @@ const (
 	// name it once at boot than to explain a growing table later.
 	envProvisionRetiredReclaimConsumerLive = "OCTO_PROJECT_PROVISION_RECLAIM_CONSUMER_LIVE"
 
+	// envProvisionRequeueProjectID names ONE project whose `abandoned` provisioning
+	// rows are moved back to `pending` at boot, i.e. the manual re-drive for a project
+	// that would otherwise be permanently invisible to the peer.
+	//
+	// An env rather than an endpoint or a CLI command because the deployment channel
+	// available here is the configmap. Two consequences the operator has to know, both
+	// inherent to that channel rather than to this implementation:
+	//
+	//  1. It takes effect on RESTART, because env is read once at boot. Re-driving a
+	//     second project means editing the configmap and restarting again.
+	//  2. The value PERSISTS in the configmap after it has been applied. Every later
+	//     restart — a deploy, a node drain, an autoscale event — reads it again.
+	//
+	// (2) is what makes a naive reading of this env unsafe, so the requeue is NOT
+	// unconditional on the value being present: requeueAbandonedProvisioningJobs only
+	// matches rows currently in `abandoned`, so a second run over an already-requeued
+	// project matches nothing and is a no-op. The row's own state is the idempotency
+	// record — deliberately, because the alternative is a "we already handled this
+	// value" ledger, which is a second source of truth about a decision the row
+	// already encodes. A row that reached `abandoned` AGAIN after a requeue will be
+	// re-driven by the next restart, which is the correct reading of an operator who
+	// has left the instruction in place.
+	//
+	// Multi-replica: every pod runs this at boot and they race on the same rows. The
+	// UPDATE re-checks `status = abandoned`, so exactly one pod moves each row and the
+	// others match nothing — the log line reports 0 for them.
+	envProvisionRequeueProjectID = "OCTO_PROJECT_PROVISION_REQUEUE_PROJECT_ID"
+
 	envProvisionInterval    = "OCTO_PROJECT_PROVISION_INTERVAL"
 	envProvisionTimeout     = "OCTO_PROJECT_PROVISION_TIMEOUT"
 	envProvisionMaxAttempts = "OCTO_PROJECT_PROVISION_MAX_ATTEMPTS"
@@ -222,6 +250,10 @@ type ProvisioningConfig struct {
 	// Deliberately NOT a subset of Targets: enablement governs what we create, this governs
 	// what we may forget, and a target disabled after use still has containers to reclaim.
 	ReclaimTargets []string
+	// RequeueProjectID is the project whose abandoned rows are re-driven at boot, or
+	// empty. See envProvisionRequeueProjectID for why this is boot-time and why a
+	// leftover value is safe.
+	RequeueProjectID string
 }
 
 // Enabled reports whether any target is live. When false, createProjectOnce
@@ -287,6 +319,11 @@ func loadProvisioningConfig(getenv func(string) string) (ProvisioningConfig, []e
 	reclaimTargets, reclaimProblems := resolveReclaimTargets(getenv)
 	cfg.ReclaimTargets = reclaimTargets
 	problems = append(problems, reclaimProblems...)
+
+	// Resolved before the early return too: an operator who set the requeue env while the
+	// target list happens to be empty gets told it will do nothing, rather than restarting
+	// and finding no trace of it either way.
+	cfg.RequeueProjectID = strings.TrimSpace(getenv(envProvisionRequeueProjectID))
 
 	requested := parseTargetList(getenv(envProvisionTargets))
 	if len(requested) == 0 {
@@ -404,35 +441,99 @@ type provisionTargetEnvs struct {
 	reclaimConsumerLive string
 }
 
+// provisionTargetSpec is everything this build knows about one subsystem: its
+// name, its four envs, and its container-id prefix.
+//
+// One table, five former dispatch sites. Before this, adding a third subsystem
+// meant editing allProvisionTargetNames, targetEnvNames's switch,
+// containerIDPrefix's switch, refreshProvisioningMetrics's literal slice and
+// provisioningTargetLabel's switch — five places, and the last two were pure
+// omission risk: a target missing from them provisions correctly and is simply
+// invisible on the dashboards that the slice's own security argument rests on.
+// Now the table is the single place, and provisionTargetRegistry below is the
+// only source any of them reads.
+//
+// Still a HARDCODED table rather than operator-supplied config, and that is the
+// point: an unknown name in OCTO_PROJECT_PROVISION_TARGETS is rejected at boot
+// (loadProvisioningConfig) precisely because the known set is compiled in. Making
+// the set configurable would need its own validator for prefix shape, secret
+// floor, requiredness and visibility participation — replacing one rejection that
+// already works with four that would have to be written.
+type provisionTargetSpec struct {
+	// name is the enum value that reaches the `target` column, metric labels and
+	// log lines.
+	name string
+	// envs are the four per-target environment variables.
+	envs provisionTargetEnvs
+	// containerPrefix is the human-readable container-id prefix. Constant per
+	// target and carries no project information — see containerIDPrefix.
+	containerPrefix string
+}
+
+// provisionTargetRegistry is every target this build knows about, enabled or not.
+//
+// Order is fixed and load-bearing: resolveReclaimTargets iterates it to build an
+// IN () predicate, and a stable order keeps that predicate identical across
+// processes.
+//
+// To add a subsystem: append one entry here and declare its four envs above.
+// Nothing else in this package should need to learn the name.
+var provisionTargetRegistry = []provisionTargetSpec{
+	{
+		name: TargetFleet,
+		envs: provisionTargetEnvs{
+			url:                 envProvisionFleetURL,
+			secret:              ProvisionFleetSecretEnv,
+			narrowed:            envProvisionFleetNarrowed,
+			reclaimConsumerLive: envProvisionFleetReclaimConsumerLive,
+		},
+		containerPrefix: "octows-",
+	},
+	{
+		name: TargetDrive,
+		envs: provisionTargetEnvs{
+			url:                 envProvisionDriveURL,
+			secret:              ProvisionDriveSecretEnv,
+			narrowed:            envProvisionDriveNarrowed,
+			reclaimConsumerLive: envProvisionDriveReclaimConsumerLive,
+		},
+		containerPrefix: "octods-",
+	},
+}
+
 // allProvisionTargetNames is every target this build knows about, enabled or not.
 //
 // The purge and the misconfiguration census both need to reason about a target that is
 // absent from OCTO_PROJECT_PROVISION_TARGETS, so the known set cannot be derived from the
 // enabled set.
-func allProvisionTargetNames() []string { return []string{TargetFleet, TargetDrive} }
+func allProvisionTargetNames() []string {
+	names := make([]string, 0, len(provisionTargetRegistry))
+	for _, spec := range provisionTargetRegistry {
+		names = append(names, spec.name)
+	}
+	return names
+}
 
-// targetEnvNames maps a target name to its envs. A switch rather than string
-// concatenation so an unknown name is rejected instead of silently resolving to a set of
-// envs nobody sets.
+// lookupProvisionTarget returns the registry entry for a name.
+//
+// A table lookup rather than string concatenation so an unknown name is rejected
+// instead of silently resolving to a set of envs nobody sets.
+func lookupProvisionTarget(name string) (provisionTargetSpec, bool) {
+	for _, spec := range provisionTargetRegistry {
+		if spec.name == name {
+			return spec, true
+		}
+	}
+	return provisionTargetSpec{}, false
+}
+
+// targetEnvNames maps a target name to its envs.
 func targetEnvNames(name string) (provisionTargetEnvs, bool) {
-	switch name {
-	case TargetFleet:
-		return provisionTargetEnvs{
-			url:                 envProvisionFleetURL,
-			secret:              ProvisionFleetSecretEnv,
-			narrowed:            envProvisionFleetNarrowed,
-			reclaimConsumerLive: envProvisionFleetReclaimConsumerLive,
-		}, true
-	case TargetDrive:
-		return provisionTargetEnvs{
-			url:                 envProvisionDriveURL,
-			secret:              ProvisionDriveSecretEnv,
-			narrowed:            envProvisionDriveNarrowed,
-			reclaimConsumerLive: envProvisionDriveReclaimConsumerLive,
-		}, true
-	default:
+	spec, ok := lookupProvisionTarget(name)
+	if !ok {
 		return provisionTargetEnvs{}, false
 	}
+	return spec.envs, true
 }
 
 // resolveReclaimTargets reads the per-target reclaim switches and refuses the retired

--- a/modules/project/config_provisioning.go
+++ b/modules/project/config_provisioning.go
@@ -327,6 +327,22 @@ func loadProvisioningConfig(getenv func(string) string) (ProvisioningConfig, []e
 
 	requested := parseTargetList(getenv(envProvisionTargets))
 	if len(requested) == 0 {
+		// Saying so out loud is the whole point of resolving the value above. The requeue
+		// runs from startProvisioningWorker, which returns early when no target is
+		// enabled, so without this the rescue an operator reaches for during an incident
+		// produces no output at any level — the exact "no trace either way" outcome the
+		// comment above promises to prevent. A rollback deployment (targets cleared, a
+		// leftover rescue value still in the configmap) is where this lands.
+		//
+		// Same reasoning as the retired reclaim env below: an operator who followed the
+		// runbook has to learn that the instruction did nothing, and a startup problem is
+		// the channel that survives a restart loop.
+		if cfg.RequeueProjectID != "" {
+			problems = append(problems, fmt.Errorf(
+				"project provisioning: %s is set but %s enables no target, so no row will be requeued; "+
+					"enable the target that owns the stuck row, or clear the requeue env",
+				envProvisionRequeueProjectID, envProvisionTargets))
+		}
 		cfg.Problems = problems
 		return cfg, problems
 	}

--- a/modules/project/db_provisioning.go
+++ b/modules/project/db_provisioning.go
@@ -368,6 +368,69 @@ func (d *DB) abandonExhaustedProvisioningJobs(targets []string, maxAttempts uint
 	return affected, nil
 }
 
+// requeueAbandonedProvisioningJobs moves `abandoned` rows back to `pending` so the
+// worker retries them. This is the manual re-drive the module has always said it
+// needed and never had: without it, one project whose ensure call exhausted its
+// retry budget is permanently invisible to the peer, with no recovery path.
+//
+// Scoped to ONE project on purpose, and there is no all-projects mode. Exhaustion
+// usually means the peer was genuinely down, so a blanket re-drive of every parked
+// row would re-issue the same doomed calls and walk the whole backlog to
+// `abandoned` a second time — the operator has to name what they believe is fixed.
+//
+// attempts is RESET to 0, which is what makes the retry budget mean "attempts since
+// someone decided to retry" rather than "attempts ever". Leaving it at max would
+// have the sweep re-abandon the row on its next tick without a single outbound call.
+//
+// container_id is deliberately NOT reissued: it is the peer's idempotency key, and a
+// fresh id would orphan whatever container the previous attempts may already have
+// created (ensure is at-least-once, so a lost response leaves a real container
+// behind a row that never reached `ready`).
+//
+// last_error is APPENDED to, matching abandonExhaustedProvisioningJobs: the reason
+// provisioning gave up is the operator's only durable evidence, and the requeue
+// marker is what distinguishes "gave up once" from "gave up, was retried, gave up
+// again". LEFT(...) bounds it at the column width for the same reason as there.
+func (d *DB) requeueAbandonedProvisioningJobs(projectID string, targets []string, now time.Time) (int64, error) {
+	if strings.TrimSpace(projectID) == "" || len(targets) == 0 {
+		return 0, nil
+	}
+	// SELECT then primary-key UPDATE, not a ranged UPDATE: the same ERROR 1205 that
+	// abandonExhaustedProvisioningJobs records — a ranged UPDATE here takes gap locks
+	// that collide with the enqueue INSERT inside the fail-closed create transaction,
+	// i.e. a backlog would make project creation fail at random.
+	var ids []uint64
+	if _, err := d.session.SelectBySql(
+		"SELECT id FROM `octo_project_provisioning` "+
+			"WHERE project_id = ? AND target IN ? AND status = ?",
+		projectID, targets, provisionStatusAbandoned,
+	).Load(&ids); err != nil {
+		return 0, fmt.Errorf("project: select abandoned provisioning jobs: %w", err)
+	}
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	// The UPDATE re-checks status, so two concurrent requeues (two pods reading the same
+	// env value) cannot both move the same row: the second matches nothing. That is what
+	// makes this safe to run more than once rather than merely unlikely to be.
+	result, err := d.session.UpdateBySql(
+		"UPDATE `octo_project_provisioning` "+
+			"SET status = ?, attempts = 0, next_attempt_at = ?, "+
+			"    lease_owner = '', lease_until = NULL, finished_at = NULL, "+
+			"    last_error = LEFT(CONCAT(IF(last_error = '', '', CONCAT(last_error, ' | ')), ?), 255) "+
+			"WHERE id IN ? AND status = ?",
+		provisionStatusPending, now, "requeued by operator", ids, provisionStatusAbandoned,
+	).Exec()
+	if err != nil {
+		return 0, fmt.Errorf("project: requeue abandoned provisioning jobs: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("project: read provisioning requeue result: %w", err)
+	}
+	return affected, nil
+}
+
 // provisioningRetention is how long a disband_pending row is kept before purge.
 //
 // Only disband_pending is ever purged. `ready` rows are kept indefinitely on

--- a/modules/project/db_provisioning.go
+++ b/modules/project/db_provisioning.go
@@ -387,10 +387,19 @@ func (d *DB) abandonExhaustedProvisioningJobs(targets []string, maxAttempts uint
 // created (ensure is at-least-once, so a lost response leaves a real container
 // behind a row that never reached `ready`).
 //
-// last_error is APPENDED to, matching abandonExhaustedProvisioningJobs: the reason
-// provisioning gave up is the operator's only durable evidence, and the requeue
-// marker is what distinguishes "gave up once" from "gave up, was retried, gave up
+// last_error is APPENDED to, matching abandonExhaustedProvisioningJobs: while the row
+// is parked, the reason provisioning gave up is the operator's durable evidence, and
+// the requeue marker distinguishes "gave up once" from "gave up, was retried, gave up
 // again". LEFT(...) bounds it at the column width for the same reason as there.
+//
+// Scope of that claim, precisely: it holds while the row is pending or abandoned, NOT
+// after a successful re-drive. finishProvisioningJob and releaseProvisioningJob both
+// REPLACE last_error (pre-existing behaviour), and the success path passes "" — so a
+// rescued row that reaches `ready` carries no trace of the rescue. That is the right
+// default for a column whose job is "why is this row not done", and the audit question
+// ("was this project ever rescued") is not one a mutable status column can answer;
+// the boot log line is. Recorded here because the appended history looks durable and
+// is not.
 func (d *DB) requeueAbandonedProvisioningJobs(projectID string, targets []string, now time.Time) (int64, error) {
 	if strings.TrimSpace(projectID) == "" || len(targets) == 0 {
 		return 0, nil
@@ -413,6 +422,14 @@ func (d *DB) requeueAbandonedProvisioningJobs(projectID string, targets []string
 	// The UPDATE re-checks status, so two concurrent requeues (two pods reading the same
 	// env value) cannot both move the same row: the second matches nothing. That is what
 	// makes this safe to run more than once rather than merely unlikely to be.
+	//
+	// It re-checks ONLY status, where abandonExhaustedProvisioningJobs deliberately
+	// re-checks every predicate its SELECT used. The asymmetry is intentional, not an
+	// oversight: that function's extra predicates guard against replicas disagreeing about
+	// max_attempts mid-rollout, i.e. against a value that CHANGES under the row. Here the
+	// dropped predicates are project_id and target, which no statement in this package
+	// ever updates — uk_octo_project_provisioning_target makes them the row's identity, so
+	// re-checking them could not fail. status is the only column another actor can move.
 	result, err := d.session.UpdateBySql(
 		"UPDATE `octo_project_provisioning` "+
 			"SET status = ?, attempts = 0, next_attempt_at = ?, "+

--- a/modules/project/metrics_provisioning.go
+++ b/modules/project/metrics_provisioning.go
@@ -100,13 +100,14 @@ var (
 // Prometheus retains every label value it has ever seen, so a typo'd list would leave a
 // permanent series behind on every deploy. The operator still gets the actual name in the
 // Error log written at construction.
+//
+// The enum is the target registry, so a new subsystem is labelled by its own name
+// instead of silently collapsing into "unknown".
 func provisioningTargetLabel(name string) string {
-	switch name {
-	case TargetFleet, TargetDrive:
+	if _, ok := lookupProvisionTarget(name); ok {
 		return name
-	default:
-		return "unknown"
 	}
+	return "unknown"
 }
 
 // provisioningStatusLabel maps a status to its metric label. A switch rather than

--- a/modules/project/provisioning.go
+++ b/modules/project/provisioning.go
@@ -40,15 +40,15 @@ const containerIDRandomBytes = 16
 // project — and it earns its keep on the subsystem side, where an operator looking
 // at a `workspace.slug` or a `drive_space.id` can tell at a glance that octo-server
 // created it and for which integration.
+//
+// The prefix lives on provisionTargetSpec, so a new subsystem declares it in the
+// registry rather than here.
 func containerIDPrefix(target string) (string, bool) {
-	switch target {
-	case TargetFleet:
-		return "octows-", true
-	case TargetDrive:
-		return "octods-", true
-	default:
+	spec, ok := lookupProvisionTarget(target)
+	if !ok {
 		return "", false
 	}
+	return spec.containerPrefix, true
 }
 
 // newContainerID mints an opaque container id for one target.

--- a/modules/project/provisioning_guard_test.go
+++ b/modules/project/provisioning_guard_test.go
@@ -258,19 +258,23 @@ func TestNoPackageOutsideTheProvisioningSliceCanReadAContainerID(t *testing.T) {
 	// table (it takes the id as an argument), but it is listed so the guard does not
 	// depend on that staying true.
 	//
-	// config_provisioning.go is listed because it owns provisionTargetRegistry, which is
-	// where the two id prefixes live — one entry per subsystem, so that adding a third is
-	// a single-line change. It holds the PREFIXES, not ids and not the table: minting
-	// still happens only in newContainerID (provisioning.go), which
-	// TestContainerIDHasOneProducerAndItIgnoresTheProjectID pins, and this file never
-	// names octo_project_provisioning. The invariant this guard exists for — no package
-	// OUTSIDE the slice can read or mint a container id — is unchanged.
-	allowed := map[string]bool{
-		filepath.Join("modules", "project", "db_provisioning.go"):     true,
-		filepath.Join("modules", "project", "provisioning.go"):        true,
-		filepath.Join("modules", "project", "config_provisioning.go"): true,
+	// Keyed per (file, needle), not per file. config_provisioning.go has to be exempt for
+	// the two PREFIX literals — it owns provisionTargetRegistry, where they now live, one
+	// entry per subsystem so adding a third is a single-line change. It must NOT become
+	// exempt for the table name: the justification for listing it is precisely that it
+	// never reads octo_project_provisioning, and a file-keyed exemption would stop
+	// enforcing the property it was admitted on. Minting still happens only in
+	// newContainerID (provisioning.go), pinned by
+	// TestContainerIDHasOneProducerAndItIgnoresTheProjectID.
+	const tableNeedle = "octo_project_provisioning"
+	needles := []string{tableNeedle, `"octows-`, `"octods-`}
+	projectFile := func(name string) string { return filepath.Join("modules", "project", name) }
+	allowed := map[string]map[string]bool{
+		projectFile("db_provisioning.go"): {tableNeedle: true, `"octows-`: true, `"octods-`: true},
+		projectFile("provisioning.go"):    {tableNeedle: true, `"octows-`: true, `"octods-`: true},
+		// Prefixes only — deliberately still on the hook for the table name.
+		projectFile("config_provisioning.go"): {`"octows-`: true, `"octods-`: true},
 	}
-	needles := []string{"octo_project_provisioning", `"octows-`, `"octods-`}
 	scanned := 0
 	var offenders []string
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
@@ -292,8 +296,12 @@ func TestNoPackageOutsideTheProvisioningSliceCanReadAContainerID(t *testing.T) {
 		if relErr != nil {
 			return relErr
 		}
-		if allowed[rel] || strings.HasPrefix(rel, filepath.Join("internal", "projectprovision")) {
+		if strings.HasPrefix(rel, filepath.Join("internal", "projectprovision")) {
 			return nil
+		}
+		exempt := allowed[rel]
+		if len(exempt) == len(needles) {
+			return nil // fully exempt; nothing left to check in this file
 		}
 		scanned++
 		raw, readErr := os.ReadFile(path)
@@ -302,6 +310,9 @@ func TestNoPackageOutsideTheProvisioningSliceCanReadAContainerID(t *testing.T) {
 		}
 		src := stripComments(string(raw))
 		for _, needle := range needles {
+			if exempt[needle] {
+				continue
+			}
 			if strings.Contains(src, needle) {
 				offenders = append(offenders, rel+" ("+needle+")")
 			}
@@ -475,21 +486,40 @@ func TestEveryTargetDecisionReadsTheRegistry(t *testing.T) {
 		t.Fatalf("provisionTargetRegistry has %d entries; this guard needs the real table to be "+
 			"meaningful", len(provisionTargetRegistry))
 	}
-	constNames := map[string]string{TargetFleet: "TargetFleet", TargetDrive: "TargetDrive"}
-	var identifiers []string
+	// Every registry target must have a known identifier spelling, so a third subsystem
+	// cannot be half-covered: this fails loudly with instructions rather than quietly
+	// checking one fewer name.
 	for _, spec := range provisionTargetRegistry {
-		ident, ok := constNames[spec.name]
-		if !ok {
-			t.Fatalf("registry target %q has no known constant identifier; add it to constNames so "+
-				"this guard keeps covering every target", spec.name)
+		if identifierOf[spec.name] == "" {
+			t.Fatalf("registry target %q has no entry in identifierOf; add it so this guard keeps "+
+				"covering every target", spec.name)
 		}
-		identifiers = append(identifiers, ident)
 	}
 
-	// A site "enumerates" when two or more target constants appear close enough together
-	// to be one expression — a slice literal, a multi-value case, a chain of ||. That is
-	// the shape that needs re-editing; a single mention (say, a fleet-only rule) does not.
-	const window = 60
+	// A file "enumerates" when it mentions two or more DISTINCT targets outside the
+	// registry — in either spelling. That is the shape that has to be re-edited for a
+	// third subsystem, and the shape whose omission is silent.
+	//
+	// Counting distinct targets per file, rather than looking for two identifiers close
+	// together, is deliberate and is the second version of this guard. The first scanned a
+	// 60-char window forward from strings.Index — the FIRST occurrence only — which left
+	// three ways through, all of them ordinary edits rather than adversarial ones:
+	//
+	//  1. Any earlier lone mention (the shape the rule explicitly allows, e.g. a
+	//     fleet-only rule) moved that constant's first index away from the enumeration,
+	//     and every later occurrence was invisible. Adding one benign function above a
+	//     regressed site turned the whole rest of the file into a blind spot.
+	//  2. A switch whose first case body runs more than a few statements puts the two
+	//     identifiers further apart than any window worth choosing.
+	//  3. Enumeration by WIRE VALUE was never searched at all — a []string{"fleet",
+	//     "drive"}, a map keyed by them, or an IN ('fleet','drive') all passed. That is
+	//     not a hypothetical: refreshProvisioningMetrics lists its four statuses as bare
+	//     string literals one line above the target loop this guard protects.
+	//
+	// A per-file count has no window to tune and no first-occurrence to sidestep. It costs
+	// the ability to say "these two mentions are one expression", which is the right trade:
+	// a file outside the registry that knows two target names has a per-target decision in
+	// it either way.
 	examined := 0
 	for _, f := range moduleSourceFiles(t) {
 		if f == registryHome {
@@ -497,25 +527,18 @@ func TestEveryTargetDecisionReadsTheRegistry(t *testing.T) {
 		}
 		src := readStripped(t, f)
 		examined++
-		for _, a := range identifiers {
-			for _, b := range identifiers {
-				if a == b {
-					continue
-				}
-				i := strings.Index(src, a)
-				if i < 0 {
-					continue
-				}
-				rest := src[i+len(a):]
-				if len(rest) > window {
-					rest = rest[:window]
-				}
-				if strings.Contains(rest, b) {
-					t.Errorf("%s enumerates target constants (%s ... %s within %d chars): every "+
-						"per-target decision must read provisionTargetRegistry, or adding a "+
-						"subsystem silently skips this site", f, a, b, window)
-				}
+		var mentioned []string
+		for _, spec := range provisionTargetRegistry {
+			// Both spellings: the Go constant and the wire value it holds. The quoted
+			// form is what a raw SQL predicate or a literal slice would use.
+			if strings.Contains(src, identifierOf[spec.name]) || strings.Contains(src, `"`+spec.name+`"`) {
+				mentioned = append(mentioned, spec.name)
 			}
+		}
+		if len(mentioned) > 1 {
+			t.Errorf("%s mentions %d targets (%s) outside %s: every per-target decision must read "+
+				"provisionTargetRegistry, by constant or by wire value, or adding a subsystem "+
+				"silently skips this site", f, len(mentioned), strings.Join(mentioned, ", "), registryHome)
 		}
 	}
 	if examined == 0 {
@@ -539,6 +562,14 @@ func TestEveryTargetDecisionReadsTheRegistry(t *testing.T) {
 		t.Error("no file outside " + registryHome + " reads the target registry; the per-target " +
 			"decisions have drifted somewhere this guard cannot see")
 	}
+}
+
+// identifierOf maps a target's wire value to the Go constant that holds it, so the
+// enumeration guard can search for both spellings. Kept next to registryHome for the
+// same reason: the guards that depend on it must not disagree about it.
+var identifierOf = map[string]string{
+	TargetFleet: "TargetFleet",
+	TargetDrive: "TargetDrive",
 }
 
 // registryHome is the file that owns the target table. Named once so the two guards

--- a/modules/project/provisioning_guard_test.go
+++ b/modules/project/provisioning_guard_test.go
@@ -194,8 +194,15 @@ func TestContainerIDHasOneProducerAndItIgnoresTheProjectID(t *testing.T) {
 	}
 
 	// The two id prefixes are the only literals a container id is built from, and they
-	// live with the producer. A prefix appearing elsewhere means a second construction
-	// site the guard above cannot see.
+	// live in the target registry — one entry per subsystem, which is what makes a third
+	// subsystem a one-line change. A prefix appearing anywhere ELSE means a second
+	// construction site the guard above cannot see.
+	//
+	// The registry, not provisioning.go, is the allowed home: the invariant is "one
+	// producer, and the literals sit in exactly one table", not "the literals sit in a
+	// particular filename". Both are still checked — the single-producer half is the
+	// newContainerID extraction above plus the caller check below.
+	const prefixHome = registryHome
 	for _, prefix := range []string{`"octows-"`, `"octods-"`} {
 		var files []string
 		for _, f := range moduleSourceFiles(t) {
@@ -203,9 +210,18 @@ func TestContainerIDHasOneProducerAndItIgnoresTheProjectID(t *testing.T) {
 				files = append(files, f)
 			}
 		}
-		if len(files) != 1 || files[0] != "provisioning.go" {
-			t.Errorf("container id prefix %s appears in %v; it must exist only in provisioning.go, "+
-				"next to the single producer", prefix, files)
+		if len(files) != 1 || files[0] != prefixHome {
+			t.Errorf("container id prefix %s appears in %v; it must exist only in %s, "+
+				"in the single provisionTargetRegistry entry for that target", prefix, files, prefixHome)
+		}
+	}
+
+	// And every registry entry must declare a prefix. A target added with an empty
+	// containerPrefix would mint ids that are bare hex — indistinguishable on the
+	// subsystem side, and silently so, since nothing else reads this field.
+	for _, spec := range provisionTargetRegistry {
+		if spec.containerPrefix == "" {
+			t.Errorf("provisionTargetRegistry entry %q declares no containerPrefix", spec.name)
 		}
 	}
 
@@ -241,9 +257,18 @@ func TestNoPackageOutsideTheProvisioningSliceCanReadAContainerID(t *testing.T) {
 	// The slice's own files, by path suffix. internal/projectprovision never names the
 	// table (it takes the id as an argument), but it is listed so the guard does not
 	// depend on that staying true.
+	//
+	// config_provisioning.go is listed because it owns provisionTargetRegistry, which is
+	// where the two id prefixes live — one entry per subsystem, so that adding a third is
+	// a single-line change. It holds the PREFIXES, not ids and not the table: minting
+	// still happens only in newContainerID (provisioning.go), which
+	// TestContainerIDHasOneProducerAndItIgnoresTheProjectID pins, and this file never
+	// names octo_project_provisioning. The invariant this guard exists for — no package
+	// OUTSIDE the slice can read or mint a container id — is unchanged.
 	allowed := map[string]bool{
-		filepath.Join("modules", "project", "db_provisioning.go"): true,
-		filepath.Join("modules", "project", "provisioning.go"):    true,
+		filepath.Join("modules", "project", "db_provisioning.go"):     true,
+		filepath.Join("modules", "project", "provisioning.go"):        true,
+		filepath.Join("modules", "project", "config_provisioning.go"): true,
 	}
 	needles := []string{"octo_project_provisioning", `"octows-`, `"octods-`}
 	scanned := 0
@@ -426,6 +451,99 @@ func grepPackageForImport(t *testing.T, dir, importPath string) []string {
 	sort.Strings(hits)
 	return hits
 }
+
+// TestEveryTargetDecisionReadsTheRegistry is the one-place-to-add-a-subsystem rule.
+//
+// Before the registry, five sites decided things per target: allProvisionTargetNames,
+// targetEnvNames, containerIDPrefix, refreshProvisioningMetrics and
+// provisioningTargetLabel. Three of them rejected an unknown name loudly, but the last
+// two failed by OMISSION — a target missing from them provisions perfectly and is merely
+// invisible on the dashboards, which is the worst failure available here, because the
+// unnarrowed-container gauge is the measurement the whole slice's security argument
+// rests on (see the comments in refreshProvisioningMetrics).
+//
+// So the rule is not "don't switch on a target name" but "don't ENUMERATE targets
+// outside the registry": any site listing the members has to be re-edited for a
+// sixth subsystem, and whoever forgets gets no error.
+//
+// Scope is the whole package rather than the five known files, deliberately: a listed
+// set of files is exactly what would not notice a new one.
+func TestEveryTargetDecisionReadsTheRegistry(t *testing.T) {
+	// The names are DERIVED from the registry, not typed here, so this guard cannot be
+	// emptied out by a rename — and it automatically covers a target added later.
+	if len(provisionTargetRegistry) < 2 {
+		t.Fatalf("provisionTargetRegistry has %d entries; this guard needs the real table to be "+
+			"meaningful", len(provisionTargetRegistry))
+	}
+	constNames := map[string]string{TargetFleet: "TargetFleet", TargetDrive: "TargetDrive"}
+	var identifiers []string
+	for _, spec := range provisionTargetRegistry {
+		ident, ok := constNames[spec.name]
+		if !ok {
+			t.Fatalf("registry target %q has no known constant identifier; add it to constNames so "+
+				"this guard keeps covering every target", spec.name)
+		}
+		identifiers = append(identifiers, ident)
+	}
+
+	// A site "enumerates" when two or more target constants appear close enough together
+	// to be one expression — a slice literal, a multi-value case, a chain of ||. That is
+	// the shape that needs re-editing; a single mention (say, a fleet-only rule) does not.
+	const window = 60
+	examined := 0
+	for _, f := range moduleSourceFiles(t) {
+		if f == registryHome {
+			continue // the registry is where enumeration is supposed to live
+		}
+		src := readStripped(t, f)
+		examined++
+		for _, a := range identifiers {
+			for _, b := range identifiers {
+				if a == b {
+					continue
+				}
+				i := strings.Index(src, a)
+				if i < 0 {
+					continue
+				}
+				rest := src[i+len(a):]
+				if len(rest) > window {
+					rest = rest[:window]
+				}
+				if strings.Contains(rest, b) {
+					t.Errorf("%s enumerates target constants (%s ... %s within %d chars): every "+
+						"per-target decision must read provisionTargetRegistry, or adding a "+
+						"subsystem silently skips this site", f, a, b, window)
+				}
+			}
+		}
+	}
+	if examined == 0 {
+		t.Fatal("no source file was examined; this guard would pass vacuously")
+	}
+
+	// The registry must actually be the source the other sites read. If nothing outside
+	// the registry file consults it, the enumeration check above is satisfied by code that
+	// simply does not handle targets at all — a guard passing for the wrong reason.
+	readers := 0
+	for _, f := range moduleSourceFiles(t) {
+		if f == registryHome {
+			continue
+		}
+		src := readStripped(t, f)
+		if strings.Contains(src, "lookupProvisionTarget(") || strings.Contains(src, "allProvisionTargetNames()") {
+			readers++
+		}
+	}
+	if readers == 0 {
+		t.Error("no file outside " + registryHome + " reads the target registry; the per-target " +
+			"decisions have drifted somewhere this guard cannot see")
+	}
+}
+
+// registryHome is the file that owns the target table. Named once so the two guards
+// that reference it cannot disagree.
+const registryHome = "config_provisioning.go"
 
 // balancedArgs extracts a call's argument text up to its balanced closing paren.
 // Paren-counting rather than a regex because the argument list contains nested calls

--- a/modules/project/provisioning_test.go
+++ b/modules/project/provisioning_test.go
@@ -1570,6 +1570,46 @@ func TestLoadProvisioningConfig(t *testing.T) {
 		assert.Equal(t, []string{TargetFleet}, cfg.ReclaimTargets)
 	})
 
+	// The env NAME is a configmap contract, so it is spelled as a literal here rather
+	// than through envProvisionRequeueProjectID. Keying the fixture with the same
+	// constant the code reads would be a tautology that passes through a rename — and a
+	// rename is silent in the worst way: the operator sets the documented name, the code
+	// reads a different one, the value resolves empty, and requeueAbandonedProvisioningAtBoot
+	// returns before emitting any log line. Same reasoning as the reclaim envs above.
+	t.Run("the requeue env resolves from its documented name", func(t *testing.T) {
+		cfg, problems := loadProvisioningConfig(env(map[string]string{
+			envProvisionTargets:                         "fleet",
+			envProvisionFleetURL:                        "https://fleet.internal/api/internal/workspaces/ensure",
+			ProvisionFleetSecretEnv:                     okSecretA,
+			"OCTO_PROJECT_PROVISION_REQUEUE_PROJECT_ID": "  p-123  ",
+		}))
+		require.Empty(t, problems)
+		assert.Equal(t, "p-123", cfg.RequeueProjectID, "the requeue env did not resolve, or was not trimmed")
+
+		unset, problems := loadProvisioningConfig(env(map[string]string{
+			envProvisionTargets:     "fleet",
+			envProvisionFleetURL:    "https://fleet.internal/api/internal/workspaces/ensure",
+			ProvisionFleetSecretEnv: okSecretA,
+		}))
+		require.Empty(t, problems)
+		assert.Empty(t, unset.RequeueProjectID, "an unset requeue env must resolve empty, not to a stale value")
+	})
+
+	// A rescue instruction that cannot run has to say so. The requeue executes from
+	// startProvisioningWorker, which returns early when nothing is enabled, so without a
+	// problem here the operator gets no output at any level — which is the outcome the
+	// env's own comment promises to prevent.
+	t.Run("the requeue env is refused when no target is enabled", func(t *testing.T) {
+		cfg, problems := loadProvisioningConfig(env(map[string]string{
+			"OCTO_PROJECT_PROVISION_REQUEUE_PROJECT_ID": "p-123",
+		}))
+		require.Len(t, problems, 1)
+		assert.Contains(t, problems[0].Error(), "OCTO_PROJECT_PROVISION_REQUEUE_PROJECT_ID")
+		assert.False(t, cfg.Enabled())
+		// Still resolved: the value is reported, not silently dropped.
+		assert.Equal(t, "p-123", cfg.RequeueProjectID)
+	})
+
 	t.Run("the retired process-global reclaim env is refused, not ignored", func(t *testing.T) {
 		cfg, problems := loadProvisioningConfig(env(map[string]string{
 			"OCTO_PROJECT_PROVISION_RECLAIM_CONSUMER_LIVE": "true",

--- a/modules/project/provisioning_test.go
+++ b/modules/project/provisioning_test.go
@@ -597,6 +597,131 @@ func TestWorkerRetriesThenAbandons(t *testing.T) {
 	assert.Equal(t, callsBefore, callsAfter)
 }
 
+// TestRequeueRevivesAnAbandonedRowAndReachesReady is the manual re-drive (brief R8).
+//
+// The property that matters is the whole loop, not the UPDATE: an abandoned row is by
+// design NOT claimable (TestWorkerRetriesThenAbandons asserts a later tick cannot
+// resurrect it), so "requeue works" can only mean the row goes back to pending AND the
+// worker then actually drives it to ready. Asserting only the status change would pass
+// even if attempts stayed at max, where the sweep re-abandons the row before any
+// outbound call happens.
+func TestRequeueRevivesAnAbandonedRowAndReachesReady(t *testing.T) {
+	fleet := newFakeTarget(t)
+	p, r, token := provisioningSetup(t, fleet)
+	p.cfg.Provisioning.MaxAttempts = 2
+	fleet.setStatus(http.StatusInternalServerError)
+
+	created := createVia(t, r, token, "P")
+	rows := readProvisioningRows(t, created.ProjectID)
+	require.Len(t, rows, 1)
+	id, containerID := rows[0].ID, rows[0].ContainerID
+
+	// Burn the budget so the row lands in the terminal state the operator is rescuing.
+	p.processProvisioningJobs()
+	makeProvisioningRowDue(t, id)
+	p.processProvisioningJobs()
+	rows = readProvisioningRows(t, created.ProjectID)
+	require.Equal(t, provisionStatusAbandoned, rows[0].Status, "precondition: the row must have given up")
+
+	// The peer is healthy again — the situation in which an operator sets the env.
+	fleet.setStatus(http.StatusOK)
+	p.cfg.Provisioning.RequeueProjectID = created.ProjectID
+	p.requeueAbandonedProvisioningAtBoot()
+
+	rows = readProvisioningRows(t, created.ProjectID)
+	require.Equal(t, provisionStatusPending, rows[0].Status, "requeue must make the row claimable again")
+	assert.Equal(t, uint32(0), rows[0].Attempts,
+		"attempts must reset, or the sweep re-abandons the row before a single call goes out")
+	assert.Nil(t, rows[0].FinishedAt, "a pending row must not carry a finished_at")
+	assert.Equal(t, containerID, rows[0].ContainerID,
+		"container_id is the peer's idempotency key: reissuing it orphans any container the "+
+			"earlier attempts already created")
+	assert.Contains(t, rows[0].LastError, "requeued by operator")
+	assert.Contains(t, rows[0].LastError, "retries exhausted",
+		"the original give-up reason must survive: it is the operator's only durable evidence")
+
+	// And the loop closes: the worker drives the revived row to ready.
+	p.processProvisioningJobs()
+	rows = readProvisioningRows(t, created.ProjectID)
+	assert.Equal(t, provisionStatusReady, rows[0].Status, "the requeued row must reach ready")
+	_, containers := fleet.snapshot()
+	assert.Equal(t, 1, containers[containerID],
+		"ensure is keyed on the container id, so the retry must land on the SAME container "+
+			"rather than creating a second one")
+}
+
+// TestRequeueIsANoOpOnASecondBootWithTheEnvStillSet is what makes the env form safe.
+//
+// The env value persists in the configmap after it has been applied, so every later
+// restart — a deploy, a node drain, an autoscale event — reads it again. This asserts
+// the row's own state is the idempotency record: a row that already left `abandoned`
+// is not touched, so a leftover value cannot re-drive a healthy project. That is the
+// reason there is no separate "already handled" ledger.
+//
+// It also covers the multi-replica race, which is the same statement: several pods
+// booting with the same value contend on the same rows, and the UPDATE's status
+// re-check means all but one match nothing.
+func TestRequeueIsANoOpOnASecondBootWithTheEnvStillSet(t *testing.T) {
+	fleet := newFakeTarget(t)
+	p, r, token := provisioningSetup(t, fleet)
+	created := createVia(t, r, token, "P")
+
+	// A healthy project: the row reaches ready without ever being abandoned.
+	p.processProvisioningJobs()
+	rows := readProvisioningRows(t, created.ProjectID)
+	require.Len(t, rows, 1)
+	require.Equal(t, provisionStatusReady, rows[0].Status)
+	readyAt, lastError := rows[0].FinishedAt, rows[0].LastError
+
+	// The operator left the env set after an earlier rescue.
+	p.cfg.Provisioning.RequeueProjectID = created.ProjectID
+	callsBefore, _ := fleet.snapshot()
+	p.requeueAbandonedProvisioningAtBoot()
+	p.requeueAbandonedProvisioningAtBoot() // a second pod, or a second restart
+
+	rows = readProvisioningRows(t, created.ProjectID)
+	assert.Equal(t, provisionStatusReady, rows[0].Status,
+		"a leftover env value must not drag a ready row back to pending")
+	assert.Equal(t, readyAt, rows[0].FinishedAt, "finished_at must be untouched")
+	assert.Equal(t, lastError, rows[0].LastError, "a no-op must not append a requeue marker")
+
+	// Nothing was re-driven, so no further ensure call was made.
+	p.processProvisioningJobs()
+	callsAfter, _ := fleet.snapshot()
+	assert.Equal(t, callsBefore, callsAfter,
+		"a no-op requeue must not cause another outbound call")
+}
+
+// TestRequeueLeavesOtherProjectsAlone pins the scoping.
+//
+// The env names ONE project deliberately — exhaustion usually means the peer was down,
+// so a blanket re-drive would re-issue the same doomed calls for every parked row. A
+// requeue that ignored project_id would look identical on the rescued project and only
+// show up as a second walk to abandoned everywhere else.
+func TestRequeueLeavesOtherProjectsAlone(t *testing.T) {
+	fleet := newFakeTarget(t)
+	p, r, token := provisioningSetup(t, fleet)
+	p.cfg.Provisioning.MaxAttempts = 1
+	fleet.setStatus(http.StatusInternalServerError)
+
+	rescued := createVia(t, r, token, "Rescued")
+	bystander := createVia(t, r, token, "Bystander")
+	for _, pid := range []string{rescued.ProjectID, bystander.ProjectID} {
+		rows := readProvisioningRows(t, pid)
+		require.Len(t, rows, 1)
+		p.processProvisioningJobs()
+		rows = readProvisioningRows(t, pid)
+		require.Equal(t, provisionStatusAbandoned, rows[0].Status, "precondition for %s", pid)
+	}
+
+	p.cfg.Provisioning.RequeueProjectID = rescued.ProjectID
+	p.requeueAbandonedProvisioningAtBoot()
+
+	assert.Equal(t, provisionStatusPending, readProvisioningRows(t, rescued.ProjectID)[0].Status)
+	assert.Equal(t, provisionStatusAbandoned, readProvisioningRows(t, bystander.ProjectID)[0].Status,
+		"requeue is scoped to the named project; a blanket re-drive is what this shape exists to avoid")
+}
+
 // panickingEnsurer is a provisionEnsurer that always panics.
 //
 // It exists because the panic path had no test at all, which is exactly why nobody

--- a/modules/project/provisioning_worker.go
+++ b/modules/project/provisioning_worker.go
@@ -191,7 +191,7 @@ func (p *Project) requeueAbandonedProvisioningAtBoot() {
 	for _, t := range p.cfg.Provisioning.Targets {
 		targets = append(targets, t.Name)
 	}
-	moved, err := p.db.requeueAbandonedProvisioningJobs(projectID, targets, time.Now())
+	moved, err := p.db.requeueAbandonedProvisioningJobs(projectID, targets, time.Now().UTC())
 	if err != nil {
 		p.Error("project provisioning requeue failed; the abandoned rows are unchanged",
 			zap.String("project_id", projectID), zap.Strings("targets", targets), zap.Error(err))

--- a/modules/project/provisioning_worker.go
+++ b/modules/project/provisioning_worker.go
@@ -161,10 +161,54 @@ func (p *Project) startProvisioningWorker() {
 		return
 	}
 	provisioningWorkerOnce.Do(func() {
+		// Before the timers, so rows this moves back to `pending` are visible to the
+		// first claim tick rather than waiting a full interval.
+		p.requeueAbandonedProvisioningAtBoot()
 		p.ctx.Schedule(p.cfg.Provisioning.Interval, p.processProvisioningJobs)
 		p.ctx.Schedule(provisioningSweepInterval, p.sweepExhaustedProvisioningJobs)
 		p.ctx.Schedule(provisioningPurgeInterval, p.purgeProvisioningJobs)
 	})
+}
+
+// requeueAbandonedProvisioningAtBoot applies OCTO_PROJECT_PROVISION_REQUEUE_PROJECT_ID.
+//
+// Inside the Enabled() gate: re-driving rows for a target nothing will claim would move
+// them to `pending` and leave them there, which reads on the dashboard as a live backlog
+// rather than as the no-op it is.
+//
+// Every outcome is logged at Info or above INCLUDING zero rows, because zero is the
+// answer an operator most needs to see: it means the project id was wrong, or the rows
+// were already requeued by an earlier restart, or provisioning never gave up on this
+// project at all. A silent no-op here would look identical to a successful re-drive.
+func (p *Project) requeueAbandonedProvisioningAtBoot() {
+	projectID := p.cfg.Provisioning.RequeueProjectID
+	if projectID == "" {
+		return
+	}
+	// Scoped to the ENABLED targets, matching the claim path: re-driving a row whose
+	// target is switched off would park it in `pending` with no executor.
+	targets := make([]string, 0, len(p.cfg.Provisioning.Targets))
+	for _, t := range p.cfg.Provisioning.Targets {
+		targets = append(targets, t.Name)
+	}
+	moved, err := p.db.requeueAbandonedProvisioningJobs(projectID, targets, time.Now())
+	if err != nil {
+		p.Error("project provisioning requeue failed; the abandoned rows are unchanged",
+			zap.String("project_id", projectID), zap.Strings("targets", targets), zap.Error(err))
+		return
+	}
+	if moved == 0 {
+		p.Warn("project provisioning requeue matched no abandoned row; check the project id, "+
+			"or it was already requeued by an earlier boot with this env still set",
+			zap.String("project_id", projectID), zap.Strings("targets", targets),
+			zap.String("env", envProvisionRequeueProjectID))
+		return
+	}
+	p.Info("project provisioning requeued; the worker will retry these rows",
+		zap.String("project_id", projectID), zap.Strings("targets", targets),
+		zap.Int64("rows", moved),
+		zap.String("reminder", "clear "+envProvisionRequeueProjectID+" once the rows reach ready; "+
+			"a leftover value re-drives them again if they end up abandoned a second time"))
 }
 
 // startProvisioningMetrics schedules the row census, INDEPENDENTLY of whether any target is
@@ -576,7 +620,7 @@ func (p *Project) refreshProvisioningMetrics() {
 		observed[row.Target][provisioningStatusLabel(row.Status)] = row.Rows
 	}
 	statuses := []string{"pending", "ready", "abandoned", "disband_pending"}
-	for _, target := range []string{TargetFleet, TargetDrive} {
+	for _, target := range allProvisionTargetNames() {
 		for _, status := range statuses {
 			provisioningRows.WithLabelValues(target, status).Set(float64(observed[target][status]))
 		}


### PR DESCRIPTION
## Summary

Two independent changes to the project-provisioning slice, motivated by the same
observation: adding a subsystem or rescuing a stuck row currently costs more than
either operation should.

**1. `refactor(project): converge per-target dispatch into one registry`**

Five sites decided things per target: `allProvisionTargetNames`, `targetEnvNames`,
`containerIDPrefix`, `refreshProvisioningMetrics`, and `provisioningTargetLabel`.
Three of them rejected an unknown target loudly; the last two failed by
**omission** — a target missing from them provisions correctly and is merely
invisible on the dashboards. That is the worst failure available here, because
the unnarrowed-container gauge is the measurement this slice's own security
argument rests on.

All five now read a single `provisionTargetSpec` table. Adding a subsystem is one
entry plus its four env declarations. The hardcoded enum is retained on purpose:
making it operator-configurable would need its own validators for prefix shape,
secret floor, requiredness, and visibility participation — replacing one
boot-time rejection that already works with four that would have to be written.

**2. `feat(project): add env-driven requeue for abandoned provisioning rows`**

A provisioning row that exhausts its retry budget lands in `abandoned`, and
nothing re-drives it — the module said a human would, but no such path existed
(`requeue`/`re-drive` appeared only in comments). For fleet that means
`confirmProjectActive` never runs again, so the project is permanently invisible
to the peer: a few minutes of network trouble could strand a project with no
recovery.

`OCTO_PROJECT_PROVISION_REQUEUE_PROJECT_ID` names one project whose abandoned
rows move back to `pending` at boot, inside the `Enabled()` gate and before the
timers so the first claim tick picks them up. Scoped to one project on purpose:
exhaustion usually means the peer was down, so a blanket re-drive would re-issue
the same doomed calls and walk the whole backlog to `abandoned` a second time.

Why an env rather than an endpoint: an HTTP handler collides with
`TestNoHandlerReachesTheProvisioningTable` (which enforces D12 — no read path may
gate on the provisioning table). D12's real intent is about **read** paths, but
that guard is deliberately broader than its intent, and an env-driven writer
sidesteps the collision without weakening the guard. The env costs (restart to
apply, value persists in the configmap) are inherent to that channel and
documented at the declaration. The "ghost requeue" that persistence implies is
neutralised by making the row's own state the idempotency record — the UPDATE
matches only `status = abandoned`, so a leftover value is a no-op on an
already-rescued project and no "already handled" ledger is needed. The same
status re-check covers the multi-replica race.

## Guards

Three constraints in the requeue DAO are each mutation-verified by the test
that claims it:

- `attempts` resets to 0, or the sweep re-abandons the row before a single call
  goes out. Verified by `TestRequeueRevivesAnAbandonedRowAndReachesReady`.
- `container_id` is **not** reissued: it is the peer's idempotency key, and a
  fresh one would orphan whatever container earlier attempts may already have
  created (ensure is at-least-once, so a lost response leaves a real container
  behind). Verified by the same test.
- `last_error` is appended, not overwritten — the original give-up reason is
  the operator's only durable evidence.

Guard tests around the target registry:

- `TestEveryTargetDecisionReadsTheRegistry` (new) forbids enumerating target
  constants outside the registry file. Mutation-verified against both
  previously-silent sites (`refreshProvisioningMetrics`,
  `provisioningTargetLabel`) — regressing either to a literal slice or a
  two-case switch fails the guard and names the offending file.
- `TestContainerIDHasOneProducerAndItIgnoresTheProjectID` now asserts the
  invariant (prefix literals in exactly one table, one producer) rather than a
  filename, since the literals moved into the registry. Plus a new check that
  every registry entry declares a non-empty prefix.
- `TestNoPackageOutsideTheProvisioningSliceCanReadAContainerID` gains the
  registry file in its allow-list. Widening an allow-list is how a guard
  silently erodes, so this was mutation-tested: planting a prefix literal in a
  handler file still fails it.

## Test Plan

- [x] `go build ./...` clean; `gofmt` clean; `go vet ./modules/project/` clean.
- [x] `golangci-lint run ./modules/project/... ./internal/projectprovision/...` → **0 issues**.
- [x] `make i18n-extract-check` + `make i18n-lint` → both exit 0 (no new error responses).
- [x] Three new requeue behavioural tests each mutation-verified against the
      assertion they claim (attempts-not-reset → red; drop `status=abandoned`
      predicate → red; ignore `project_id` → red).
- [x] Existing provisioning guards still pass after the registry move:
      `TestNoHandlerReachesTheProvisioningTable`,
      `TestProvisioningClientIsConfinedToTheWorker`,
      `TestNoLogFieldCarriesTheContainerID`,
      `TestContainerIDHasOneProducerAndItIgnoresTheProjectID`,
      `TestNoPackageOutsideTheProvisioningSliceCanReadAContainerID`.
- [x] `go test -race` on the requeue + registry-guard + abandon tests → clean.
- [x] Adjacent packages green: `internal/projectprovision`, `pkg/project`,
      `pkg/space`, `modules/space`.
- [x] Package-level: `go test ./modules/project/` was observed green in a
      window where the shared test database was not being interfered with by
      concurrent test runs. Note that on a busy machine the shared `test` DB
      can be dropped mid-suite; the failures are not caused by this change
      (a control experiment on plain `main` reproduced the same
      `Error 1146 Table doesn't exist` symptoms).

## Manual verification (staging)

Not exercised on a staging deployment — the changes are internal to the
provisioning slice and have no user-visible surface. The env-driven requeue
runs at process start; verifying it in staging would mean deploying the change
plus a real abandoned row on that environment, which is out of scope for this
PR.

## Docs / octospec

The task brief `.octospec/tasks/project-subsystem-fanout/brief.md` has been
narrowed to what shipped (R10 + R8-provisioning). The nine requirements whose
subject code depends on unmerged PRs were moved intact — with all verified
findings preserved — into a new brief
`.octospec/tasks/project-lifecycle-multiconsumer/brief.md`, numbering retained
so it still lines up with existing PR discussions.

## Notes

- No user-facing surface changes; no new endpoint; no new error code.
- The registry keeps the enum hardcoded — a new subsystem is still a code change,
  not an operator switch.
- The requeue env is documented in-place (`config_provisioning.go`), including
  both configmap costs and the ghost-requeue neutralisation strategy.


---

## Review round 2 (head `9c1bbc16`)

**P1 fixed.** Two reviewers independently reproduced a bypass of
`TestEveryTargetDecisionReadsTheRegistry`: it scanned a 60-char window forward
from the *first* occurrence of each constant, so one earlier lone mention — the
shape the rule explicitly permits — made every later occurrence invisible. A
third reviewer noted the same function missed two further shapes: a switch whose
first case body is more than a few statements, and enumeration by wire value
(`[]string{"fleet","drive"}`, a map keyed by them, `IN ('fleet','drive')`), which
was never searched at all.

The proximity window is gone. The guard now counts *distinct targets mentioned
per file*, in both spellings — constant and quoted wire value. Any file outside
the registry that knows two target names has a per-target decision in it. All
three bypass shapes are mutation-verified red on this head, and the unmutated
tree is green.

Also addressed, each verified:

- The requeue env no longer goes silent when no target is enabled — it appends a
  config problem, the channel the retired reclaim env already uses. Covered by a
  new test case.
- The env **name** is now pinned by a literal-keyed test (set → trimmed value
  resolves; unset → empty). Previously renaming the constant's value kept the
  entire package green, so a typo in a configmap contract would have shipped
  silently.
- The `last_error` durability claim is narrowed. Appending is durable while the
  row is parked, but `finishProvisioningJob` replaces it and the success path
  passes `""` — a rescued row reaching `ready` carries no trace of the rescue.
  The behaviour is pre-existing and right for a "why is this row not done"
  column, so the claim moved rather than the code.
- The container-id allow-list is keyed per (file, needle).
  `config_provisioning.go` needs exemption for the two prefixes only; the
  file-keyed form also exempted it from the table-name needle — the very property
  its admission comment relies on. Mutation-verified: naming the table in that
  file now fails the guard.
- `time.Now().UTC()` at the requeue call site (convention; dbr normalises either
  way, so this was not a live bug).
- Recorded why the requeue `UPDATE` re-checks only `status` where its sibling
  re-checks every predicate.

Not changed, with reasons: no metric for the requeue path, and no concurrent
two-goroutine DAO test for the multi-replica claim. Both are fair asks; they add
surface to a rescue path that runs once per boot, and I would rather land them
deliberately than fold them into a fix round. Happy to add either if a reviewer
wants it before merge.

**Verification on this head:** `golangci-lint` 0 issues; `make i18n-extract-check`
and `make i18n-lint` both exit 0; `go build ./...`, `gofmt`, `go vet` clean;
`go test ./modules/project/` → ok, 0 failures (full package, clean database).
