### PR TITLE
feat(project): add collaboration roles

### DIFF
--- a/.octospec/journal/shared/project-collaboration-roles.md
+++ b/.octospec/journal/shared/project-collaboration-roles.md
@@ -1,0 +1,73 @@
+---
+type: Journal
+title: "Journal: project-collaboration-roles"
+description: Add project-scoped collaboration-role labels for human members while preserving owner/admin/member as the sole authorization model.
+tags: ["project", "collaboration-role", "acl", "migration", "maintenance", "testing"]
+timestamp: 2026-09-09T10:55:00+08:00
+# --- octospec extension fields ---
+task: project-collaboration-roles
+upstream: Mininglamp-OSS/octo-server#870
+source: self
+---
+
+# Journal: project-collaboration-roles
+
+## What was done
+
+- Added project-local collaboration-role definitions and many-to-many human-member
+  bindings without changing `octo_project_member.role`. The existing
+  owner/admin/member field remains the only project authorization input.
+- Seeded the fixed V1 built-ins (`产品`, `前端`, `后端`, `HR`) transactionally for
+  new Projects and through an idempotent, bounded backfill for existing Projects.
+- Added authenticated, UID-rate-limited catalog CRUD and member-binding APIs.
+  Owners manage custom definitions; owners and admins bind roles; ordinary members
+  cannot write. Built-ins are immutable and AI-agent roster rows always expose an
+  empty role list.
+- Added an independent `collaboration_role_epoch`, lifecycle cleanup, audit events,
+  bounded-cardinality metrics, configurable per-Project/per-member quotas, and a
+  default-off write flag (`OCTO_PROJECT_COLLABORATION_ROLE_ENABLED`).
+
+## Load-bearing boundaries
+
+- Collaboration roles are descriptive metadata only: binding, renaming, or deleting
+  one cannot alter permission roles or permission-derived capabilities.
+- Writes follow the existing lock order (Space seats, active Project, membership and
+  role rows), re-read the actor role under the Project lock, validate every selected
+  role in the same Project, and replace the set atomically.
+- Member removal clears bindings in the same lifecycle transaction; re-admission does
+  not restore stale labels. Project disband removes definitions and bindings through
+  the existing soft-close lifecycle.
+- Normalized names are lower-cased by the application and stored with
+  `utf8mb4_bin`: case-only variants collide, while accents remain distinct.
+
+## Review findings closed
+
+- The periodic integrity scan now keyset-pages the binding table before joining and
+  classifying violations. A healthy table therefore costs at most one configured page
+  per tick instead of a full-table scan.
+- Case-only display renames compare the locked model in Go, so `designer` to
+  `Designer` is a real update even under a case-insensitive display-name collation.
+- `normalized_name` now pins an accent-sensitive binary collation, allowing
+  `resume` and `résumé` to coexist while preserving case-insensitive uniqueness after
+  normalization.
+
+## Operational notes
+
+- The write gate defaults off. Rollback is to disable
+  `OCTO_PROJECT_COLLABORATION_ROLE_ENABLED`; reads and stored data remain available.
+- Maintenance uses the existing reconcile interval/limit and keeps a composite cursor
+  plus running total across ticks. Gauges are published only after a complete rotation.
+- Role-name and role-count limits are enforced before unbounded request or catalog
+  growth can reach storage.
+
+## Verification
+
+- `go test ./modules/project -run 'Test.*CollaborationRole' -count=1` and
+  `go test -race ./modules/project -run 'Test.*CollaborationRole' -count=1`
+  passed against local MySQL, Redis, and WuKongIM.
+- `go test ./modules/project -count=1` passed (81.4s) after resetting the dedicated
+  `test` schema in an otherwise idle shared test environment.
+- `go build ./...`, `go vet ./modules/project`,
+  `golangci-lint run ./modules/project/...`, `go test ./pkg/errcode ./pkg/i18n/...`,
+  `make i18n-extract-check`, `make i18n-lint`, `gofmt`, and `git diff --check`
+  passed. The live test-schema `normalized_name` column reports `utf8mb4_bin`.

--- a/.octospec/learnings/pending/project-collaboration-roles.md
+++ b/.octospec/learnings/pending/project-collaboration-roles.md
@@ -1,0 +1,43 @@
+---
+type: Learning
+title: "Page the base relation before filtering integrity violations"
+description: A LIMIT applied after anomaly predicates bounds returned violations, not the number of healthy rows examined by a periodic integrity scan.
+tags: ["database", "maintenance", "pagination", "performance", "review"]
+timestamp: 2026-09-09T10:55:00+08:00
+# --- octospec extension fields ---
+source: self
+origin_task: project-collaboration-roles
+status: pending
+candidate_rule: database
+---
+
+# Page the base relation before filtering integrity violations
+
+## Context
+
+A periodic collaboration-role integrity query initially joined the complete binding
+table, filtered down to invalid rows, and then applied `LIMIT`. That bounded the number
+of violations returned, but it did not bound work: on a healthy table, or whenever a
+page contained fewer than the requested number of violations, MySQL still examined the
+entire remaining keyspace on every maintenance tick and on every pod.
+
+## Rule of thumb
+
+For a recurring integrity scan whose anomalies are expected to be sparse:
+
+1. Keyset-page the base table by a stable unique key in a derived table or CTE.
+2. Join and evaluate integrity predicates only for those base rows.
+3. Persist the last examined base key, including healthy rows, across ticks.
+4. Accumulate the violation count privately and publish the gauge only after a full
+   rotation, so a page-local count is not presented as a table-wide count.
+5. Add a regression containing a valid row before an invalid row with `limit=1`; the
+   first page must return the valid row as examined rather than scanning ahead to the
+   violation.
+
+`LIMIT` is a work bound only when it is applied before the selective anomaly filter.
+
+## Why worth a rule
+
+Healthy production data is exactly the state in which a post-filter `LIMIT` provides
+the least protection. Recurring scans amplify that mistake by pod count and interval,
+so the query can become an avoidable full-table tax without changing functional output.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,19 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-09-09 — project-collaboration-roles
+
+- Added project-scoped, multi-select collaboration roles for human members while
+  preserving `owner/admin/member` as the sole authorization model.
+- Added four immutable built-ins, owner-managed custom definitions, owner/admin
+  member bindings, roster exposure, an independent epoch, lifecycle cleanup, audit,
+  metrics, quotas, and a default-off write gate.
+- Closed review findings around bounded integrity scans, case-only display renames,
+  and accent-sensitive normalized-name uniqueness.
+- Recorded the implementation and operational boundaries in
+  [journal](journal/shared/project-collaboration-roles.md); reusable pagination guidance
+  is staged in [learnings/pending](learnings/pending/project-collaboration-roles.md).
+
 ## 2026-09-06 — project-p0-foundation (PR #841 第一轮 review：TDD 修复 blocker 与 Q 项)
 
 - **Fixed (blocking)** — remove 批次中途解散丢弃已提交部分（errProjectGone 镜像 add 的

--- a/.octospec/tasks/project-collaboration-roles/brief.md
+++ b/.octospec/tasks/project-collaboration-roles/brief.md
@@ -1,0 +1,278 @@
+---
+type: Task
+title: "Task: project-collaboration-roles"
+description: Add project-scoped, multi-select collaboration-role labels for human members without changing project authorization roles.
+tags: ["project", "space", "acl", "wire-contract", "migration", "testing"]
+timestamp: 2026-09-09T00:00:00+08:00
+slug: project-collaboration-roles
+upstream: "Mininglamp-OSS/octo-server#870"
+source: self
+---
+
+# Task: project-collaboration-roles
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+## Goal
+
+Allow a Project to classify each **human** member with zero or more project-scoped
+collaboration roles, for example `产品`、`前端`、`后端`、`HR`. A Project has a small
+set of system-provided defaults and its owner may create custom roles. The roster
+and member-role picker render those labels as the prototype shows.
+
+This changes collaboration metadata only. It must not grant, revoke, or infer any
+authorization.
+
+## Background
+
+The existing `octo_project_member.role` is an authorization enum, not a job-title
+field:
+
+- `0=RoleCommon`、`1=RoleAdmin`、`2=RoleOwner` in `modules/project/model.go`.
+- It drives `canUpdateProject`、`canManageMembers`、`canChangeMemberRole`, owner
+  transfer and disband behavior in `modules/project/service.go`.
+- The existing member response exposes that integer as `role`; the project
+  response exposes server-derived `capabilities`. Neither field may be renamed,
+  repurposed, or derived from collaboration-role labels.
+- An AI agent is already a project seat, but roster data distinguishes it with
+  `robot` and `owner_uid`. The supplied prototype renders its collaboration role
+  as `-` and separately shows its AI-state attributes.
+
+Terminology is intentionally explicit:
+
+| Term | Examples | Security meaning |
+| --- | --- | --- |
+| Project member permission | 成员、管理员、负责人 | Existing authorization role; security boundary |
+| Collaboration role | 产品、前端、后端、HR | Project-local descriptive label only |
+| AI-agent state | 项目分身、云端运行、不可移除 | Existing agent lifecycle and presentation |
+| Platform-manager role | admin、superAdmin 等 | Outside this task |
+
+## Decisions
+
+### D1 — independent, project-scoped many-to-many model
+
+Add an immutable-ID role-definition entity and a membership association. A member
+may hold zero or more definitions from the same Project; a definition may be used
+by many members. Never store a comma-separated role name list in
+`octo_project_member`, and never use a role name as an identifier.
+
+Proposed tables:
+
+```text
+octo_project_collaboration_role
+  role_id, project_id, builtin_key, name, normalized_name, source, creator_uid,
+  created_at, updated_at
+
+octo_project_member_collaboration_role
+  project_id, uid, role_id, created_at
+```
+
+- The association primary key is `(project_id, uid, role_id)`.
+- A unique database constraint on `(project_id, normalized_name)` prevents
+  same-Project duplicates under concurrent creates. The normalization policy is
+  trim plus case-insensitive matching. The application stores the lower-cased
+  value under `utf8mb4_bin`, so accents remain distinct while case-only variants
+  collide; the collation is pinned rather than inherited from a deployment database.
+- `source` is `builtin` or `custom`. It is descriptive API data, not an
+  authorization grant.
+- `builtin_key` is non-empty only for a system-provided definition and is the
+  stable identity used by idempotent create/backfill; custom rows have an empty
+  key.
+- Add `octo_project.collaboration_role_epoch BIGINT NOT NULL DEFAULT 0` and
+  increment it atomically for a changed definition or association. Do **not**
+  reuse `member_epoch`: fleet/drive use it to detect membership changes.
+- Do not add foreign keys to soft-closed Project/member rows. Application writes
+  must instead validate active Project and active member state under the existing
+  transaction/lock discipline.
+
+### D2 — built-ins are templates, not RBAC presets
+
+The first release seeds these four immutable defaults for every new Project:
+`产品`、`前端`、`后端`、`HR`, matching the reviewed prototype. Each has a stable
+system key and `source=builtin`.
+
+Built-ins are selectable but cannot be renamed or deleted. A Project owner can
+create, rename, and delete custom definitions. Deleting a custom definition
+atomically removes its member associations; it does not affect the member's
+existing permission role.
+
+The V1 catalog is confirmed as exactly these four server-provided display names;
+V1 does not localize them by client language. Adding or translating a future
+built-in is a reviewed migration/backfill operation, not a client-side constant.
+
+### D3 — scope and permission matrix
+
+V1 permits role binding for humans only. A target whose roster row is `robot=1`
+cannot receive collaboration roles, including an empty/clear request through the
+new write endpoint. The roster returns an empty list for agents and the client
+renders `-`.
+
+| Operation | Project owner | Project admin | Common member | Space admin not in Project |
+| --- | ---:| ---:| ---:| ---:|
+| Read role catalog / roster labels | Yes | Yes | Yes | Existing roster-read widening only |
+| Bind or clear a member's labels | Yes | Yes | No | No |
+| Create, rename, delete custom definition | Yes | No | No | No |
+| Change `owner/admin/member` permission role | Existing rule | Existing rule | Existing rule | Existing rule |
+
+The handler must re-read the caller's Project permission role under the Project
+lock. Middleware/cache results may only be a cheap early refusal. A Space admin's
+existing read widening must not become Project write authority.
+
+### D4 — wire contract
+
+Keep existing fields byte-compatible. `MemberResp.role` remains the numeric
+permission role, and `Resp.capabilities` remains the server verdict on
+authorization.
+
+Extend each roster row with:
+
+```json
+"collaboration_roles": [
+  {"role_id": "...", "name": "前端", "source": "builtin"}
+]
+```
+
+Add these authenticated, UID-rate-limited routes under the existing
+`/v1/projects/:project_id` group:
+
+| Method and route | Contract |
+| --- | --- |
+| `GET /collaboration-roles` | Current visible definitions plus `collaboration_role_epoch` |
+| `POST /collaboration-roles` | Owner creates one custom definition |
+| `PUT /collaboration-roles/:role_id` | Owner renames one custom definition |
+| `DELETE /collaboration-roles/:role_id` | Owner deletes one custom definition and all its bindings |
+| `PUT /members/:uid/collaboration-roles` | Owner/admin replaces the target human member's complete `role_ids` set; `[]` clears it |
+
+Unknown, deleted, foreign-Project, duplicate, or built-in-as-mutable role IDs
+must be rejected without partial writes. The target's membership/agent eligibility
+should not disclose additional user facts to an unauthorized caller. New failures
+use `pkg/errcode/project.go`, `httperr.ResponseErrorL`, and zh-CN translations;
+no raw error responses.
+
+The catalog read uses the same `canViewMembers` rule as the roster; an ordinary
+Space member who is not in the Project cannot enumerate its role definitions.
+
+### D5 — transaction, lifecycle, and concurrency requirements
+
+- Every write takes locks in the established order: required active Space-member
+  seats, then active Project row, then current Project membership/role state.
+- Binding validates that the actor and target are active Project members and not
+  `removing=1`, that the target is human, and that all requested role definitions
+  are active definitions of this Project. It replaces the association set in one
+  transaction, then increments `collaboration_role_epoch` only when data changed.
+- Catalog mutation and binding serialize on the Project row. A role deleted while
+  another request tries to bind it resolves as one successful transaction and one
+  clean conflict/invalid-role response; it must never leave an orphan row.
+- On direct remove, leave, owner-following agent removal, and Space-removal
+  cascade, clear associations when the project seat starts closing, not after the
+  asynchronous group-cleanup worker finishes. Re-adding a member starts with no
+  collaboration roles.
+- Project disband makes role data unreadable with the Project. Retaining
+  historical rows is acceptable; this task does not introduce a Project restore
+  path.
+- Owner transfer and permission-role changes leave collaboration labels intact.
+
+### D6 — validation, limits, and observability
+
+- Names are required, trimmed, reject control characters, are bounded to 32
+  Unicode code points, and are unique
+  under the pinned normalization policy. Role definitions per Project and labels
+  per human member have configuration-backed limits (defaults: 50 total
+  definitions including built-ins, 8 labels per member).
+- Emit structured audit actions for definition create/rename/delete and binding
+  replace/clear. Record actor UID, Project/Space IDs, target UID where applicable,
+  role IDs/counts, and a low-cardinality action/reason; never log role names or a
+  request body.
+- Add low-cardinality metrics for write outcomes/rejections and a bounded
+  reconciliation scan for orphan associations or associations on inactive seats.
+  A non-zero orphan result is data-integrity work, not permission evidence.
+- Add `OCTO_PROJECT_COLLABORATION_ROLE_ENABLED`, default false. It gates only
+  these new writes; existing Project reads and all existing Project writes retain
+  their current behavior. Turning it off is the rollback: stored labels remain
+  readable and no data is deleted.
+
+## Rollout
+
+1. Land DDL, DAO, read contracts, metrics, and disabled write paths.
+2. Run an idempotent, bounded backfill that seeds the four built-ins for active
+   Projects. It must be restart-safe and record/alert failures; reads must not
+   create rows lazily.
+3. Verify duplicate-name, orphan-association, and backfill-completeness queries
+   in the target environment.
+4. Enable writes in a canary environment, then increase deployment scope while
+   monitoring rejection, audit, and reconciliation signals. The V1 switch is
+   process-wide; it does not claim per-Space targeting.
+5. Roll back by disabling only the new write flag. Do not drop the schema or
+   erase labels during incident rollback.
+
+## Load-bearing list
+
+- `modules/project/model.go`: the existing numeric permission roles and roster
+  response must remain semantically unchanged.
+- `modules/project/service.go` / `middleware.go`: server-derived capabilities,
+  in-transaction authorization re-read, cache invalidation, owner transfer, and
+  lock ordering are security contracts.
+- `modules/project/db.go`: active/`removing` predicates, member-epoch write
+  discipline, and production collation compatibility are load-bearing.
+- `modules/project/space_member_removal.go` and removal workers: a logically
+  removed member must not retain project-visible labels or regain them on re-add.
+- `modules/project/api.go` / `api_member.go`: AuthMiddleware then
+  SharedUIDRateLimiter, Project middleware, localized error envelope, and the
+  existing response fields are wire contracts.
+- `modules/project/audit.go` and metrics: no high-cardinality labels or user
+  content in operation telemetry.
+
+## Out of scope
+
+- Replacing platform-admin RBAC, `user.role`, manager-console admission, MFA, or
+  platform capability checks.
+- Granting data access, group membership, Bot permissions, or any automation
+  authority through collaboration roles.
+- Cross-Project, Space-wide, organization-wide, or external-member role
+  catalogs.
+- Assigning roles to AI agents, role-based mentions, role-based notification
+  rules, or automatic task routing.
+- Changing the existing owner/admin/member permission matrix or `member_epoch`
+  semantics.
+- A Project restore workflow or historical audit-search product.
+
+## Acceptance
+
+- [ ] A new Project has exactly the confirmed built-ins once; concurrent create
+      or backfill cannot duplicate them.
+- [ ] An owner can create a unique custom role, rename it, delete it, and bind it
+      to multiple human members. An admin can bind existing roles but cannot
+      mutate the catalog.
+- [ ] A human member can hold multiple labels; an explicit empty `role_ids` set
+      clears all labels. Repeating an identical set is an idempotent no-op.
+- [ ] The member roster returns the old numeric `role` unchanged and returns
+      complete `collaboration_roles` without N+1 database queries.
+- [ ] Common members and Space-only admins cannot write. Permission changes
+      between middleware and transaction commit are rechecked and refused.
+- [ ] A bot/agent, a missing or closing member, and a foreign-Project/deleted
+      role definition are rejected without partial association writes.
+- [ ] Concurrent bind/delete and bind/member-remove paths leave no orphan
+      association; re-admission does not restore old labels.
+- [ ] Direct remove, leave, Space removal, and owner-following agent cleanup
+      exercise every relevant association-clear path. Existing Project/group
+      cascade behavior remains unchanged.
+- [ ] `member_epoch` does not change for catalog or collaboration-label writes;
+      `collaboration_role_epoch` advances exactly once for each changed write.
+- [ ] All new failures use registered localized error codes; i18n extraction and
+      lint checks pass.
+- [ ] Focused Project tests cover the matrix and migration/backfill behavior;
+      integration tests run with MySQL, Redis, and WuKongIM. Broader tests are
+      selected after the final list of touched packages is known.
+- [ ] `git diff --check` passes and the PR describes this as non-authorizing
+      collaboration metadata, including the feature-flag rollback path.
+
+## Confirmed V1 defaults
+
+- Initial built-ins: `产品、前端、后端、HR`.
+- Built-in names are returned as server-owned display strings without locale
+  variants in this release.
+- Limits default to 50 definitions per Project (including built-ins) and 8 labels
+  per human member; both are environment-configurable.
+- This server task exposes catalog management and picker APIs. A separate
+  dedicated role-management screen is not required by the supplied prototype.

--- a/.octospec/tasks/project-collaboration-roles/context.yaml
+++ b/.octospec/tasks/project-collaboration-roles/context.yaml
@@ -1,0 +1,14 @@
+injected:
+  - id: error-handling
+    source: repo
+  - id: rate-limit
+    source: repo
+  - id: space-isolation
+    source: repo
+  - id: trust-boundary
+    source: repo
+  - id: testing
+    source: repo
+  - id: commit-style
+    source: repo
+brief: .octospec/tasks/project-collaboration-roles/brief.md

--- a/modules/project/api.go
+++ b/modules/project/api.go
@@ -163,6 +163,7 @@ func New(ctx *config.Context) *Project {
 // note added to that package's census.
 func (p *Project) Route(r *wkhttp.WKHttp) {
 	p.startReconcileWorker()
+	p.startCollaborationRoleMaintenance()
 	// 项目侧成员移除级联 worker（D5）。与 Space 那条清理工单各自独立：键不同、
 	// 扇出规模不同，且 Space 的步骤契约规定「任一步骤报错整单重跑」——挂在一起会
 	// 让项目侧的失败去重跑 Space 侧已成功的步骤。
@@ -206,6 +207,12 @@ func (p *Project) Route(r *wkhttp.WKHttp) {
 		projectScoped.POST("/:project_id/members/remove", p.removeMembersHandler)
 		projectScoped.POST("/:project_id/leave", p.leaveProjectHandler)
 		projectScoped.PUT("/:project_id/members/:uid/role", p.updateMemberRoleHandler)
+
+		projectScoped.GET("/:project_id/collaboration-roles", p.listCollaborationRolesHandler)
+		projectScoped.POST("/:project_id/collaboration-roles", p.createCollaborationRoleHandler)
+		projectScoped.PUT("/:project_id/collaboration-roles/:role_id", p.renameCollaborationRoleHandler)
+		projectScoped.DELETE("/:project_id/collaboration-roles/:role_id", p.deleteCollaborationRoleHandler)
+		projectScoped.PUT("/:project_id/members/:uid/collaboration-roles", p.replaceMemberCollaborationRolesHandler)
 	}
 }
 
@@ -518,21 +525,36 @@ func (p *Project) listMembersHandler(c *wkhttp.Context) {
 		respondQueryFailed(c)
 		return
 	}
+	uids := make([]string, 0, len(rows))
+	for _, member := range rows {
+		uids = append(uids, member.UID)
+	}
+	rolesByUID, err := p.db.memberCollaborationRoles(row.ProjectID, uids)
+	if err != nil {
+		p.Error("查询项目成员协作角色失败", zap.Error(err), zap.String("projectId", row.ProjectID))
+		respondQueryFailed(c)
+		return
+	}
 	resps := make([]*MemberResp, 0, len(rows))
 	for _, m := range rows {
+		roles := rolesByUID[m.UID]
+		if m.Robot == 1 {
+			roles = []CollaborationRoleResp{}
+		}
 		resps = append(resps, &MemberResp{
 			// D16 — the roster tells people and agents apart, and names each
 			// agent's owner, so a client can nest agents under their owner the
 			// way the Space directory does. Both come from LEFT JOINs, so a
 			// member with no user row reads as robot=0 and owner_uid="" rather
 			// than dropping out of the roster.
-			Robot:     m.Robot,
-			OwnerUID:  m.OwnerUID,
-			UID:       m.UID,
-			Name:      m.Name,
-			Role:      m.Role,
-			InviteUID: m.InviteUID,
-			CreatedAt: formatTime(m.CreatedAt),
+			Robot:              m.Robot,
+			OwnerUID:           m.OwnerUID,
+			UID:                m.UID,
+			Name:               m.Name,
+			Role:               m.Role,
+			InviteUID:          m.InviteUID,
+			CollaborationRoles: roles,
+			CreatedAt:          formatTime(m.CreatedAt),
 		})
 	}
 	c.Response(resps)
@@ -691,24 +713,25 @@ func (p *Project) disbandProjectHandler(c *wkhttp.Context) {
 // pinned section until the next list fetch.
 func (p *Project) toResp(m *Model, myRole, spaceRole, memberCount, agentCount int, pinned bool) *Resp {
 	return &Resp{
-		ProjectID:        m.ProjectID,
-		SpaceID:          m.SpaceID,
-		Name:             m.Name,
-		Description:      m.Description,
-		Logo:             m.Logo,
-		Creator:          m.Creator,
-		Discoverability:  m.Discoverability,
-		MaxMembers:       p.cfg.effectiveMaxMembers(m.MaxMembers),
-		MemberCount:      memberCount,
-		AgentCount:       agentCount,
-		MemberEpoch:      m.MemberEpoch,
-		Status:           m.Status,
-		AllMemberGroupNo: m.AllMemberGroupNo,
-		Pinned:           pinned,
-		MyRole:           myRole,
-		Capabilities:     capabilitiesFor(myRole, spaceRole),
-		CreatedAt:        formatTime(m.CreatedAt),
-		UpdatedAt:        formatTime(m.UpdatedAt),
+		ProjectID:              m.ProjectID,
+		SpaceID:                m.SpaceID,
+		Name:                   m.Name,
+		Description:            m.Description,
+		Logo:                   m.Logo,
+		Creator:                m.Creator,
+		Discoverability:        m.Discoverability,
+		MaxMembers:             p.cfg.effectiveMaxMembers(m.MaxMembers),
+		MemberCount:            memberCount,
+		AgentCount:             agentCount,
+		MemberEpoch:            m.MemberEpoch,
+		CollaborationRoleEpoch: m.CollaborationRoleEpoch,
+		Status:                 m.Status,
+		AllMemberGroupNo:       m.AllMemberGroupNo,
+		Pinned:                 pinned,
+		MyRole:                 myRole,
+		Capabilities:           capabilitiesFor(myRole, spaceRole),
+		CreatedAt:              formatTime(m.CreatedAt),
+		UpdatedAt:              formatTime(m.UpdatedAt),
 	}
 }
 

--- a/modules/project/api_collaboration_role.go
+++ b/modules/project/api_collaboration_role.go
@@ -1,0 +1,247 @@
+package project
+
+import (
+	"errors"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"go.uber.org/zap"
+)
+
+func (p *Project) requireCollaborationRoleWriteEnabled(c *wkhttp.Context, entry string) bool {
+	if p.cfg.CollaborationRoleEnabled {
+		return true
+	}
+	observeRejected(entry, reasonFlagOff)
+	observeCollaborationRoleWrite(entry, collaborationRoleOutcomeRejected)
+	httperr.ResponseErrorL(c, errcode.ErrProjectCollaborationRoleDisabled, nil, nil)
+	return false
+}
+
+func (p *Project) listCollaborationRolesHandler(c *wkhttp.Context) {
+	row := requestProject(c)
+	if row == nil {
+		p.Error("projectMiddleware 未注入项目行", zap.String("path", c.FullPath()))
+		respondQueryFailed(c)
+		return
+	}
+	if !canViewMembers(requestProjectRole(c), requestSpaceRole(c)) {
+		httperr.ResponseErrorL(c, errcode.ErrProjectNotMember, nil, nil)
+		return
+	}
+	roles, epoch, err := p.listCollaborationRoles(row.ProjectID)
+	if err != nil {
+		if errors.Is(err, errProjectGone) {
+			respondProjectNotFound(c)
+			return
+		}
+		p.Error("查询项目协作角色失败", zap.Error(err), zap.String("projectId", row.ProjectID))
+		respondQueryFailed(c)
+		return
+	}
+	c.Response(&collaborationRoleCatalogResp{CollaborationRoleEpoch: epoch, Roles: roles})
+}
+
+func (p *Project) createCollaborationRoleHandler(c *wkhttp.Context) {
+	if !p.requireCollaborationRoleWriteEnabled(c, entryCollaborationRoleCreate) {
+		return
+	}
+	row := requestProject(c)
+	if row == nil {
+		p.Error("projectMiddleware 未注入项目行", zap.String("path", c.FullPath()))
+		respondQueryFailed(c)
+		return
+	}
+	if requestProjectRole(c) != RoleOwner {
+		p.rejectCollaborationRoleWrite(c, entryCollaborationRoleCreate)
+		return
+	}
+	var req collaborationRoleNameReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondProjectRequestInvalid(c, "")
+		return
+	}
+	actorUID := c.GetLoginUID()
+	role, err := p.createCollaborationRole(row.ProjectID, row.SpaceID, actorUID, req.Name)
+	if err != nil {
+		p.respondCollaborationRoleWriteError(c, entryCollaborationRoleCreate, row.ProjectID, "", err)
+		return
+	}
+	observeCollaborationRoleWrite(entryCollaborationRoleCreate, collaborationRoleOutcomeChanged)
+	p.audit(auditCollaborationRoleCreate, actorUID, "", row.ProjectID, row.SpaceID, "",
+		zap.String("role_id", role.RoleID), zap.Int("role_count", 1))
+	c.Response(collaborationRoleToResp(*role))
+}
+
+func (p *Project) renameCollaborationRoleHandler(c *wkhttp.Context) {
+	if !p.requireCollaborationRoleWriteEnabled(c, entryCollaborationRoleRename) {
+		return
+	}
+	row := requestProject(c)
+	if row == nil {
+		p.Error("projectMiddleware 未注入项目行", zap.String("path", c.FullPath()))
+		respondQueryFailed(c)
+		return
+	}
+	if requestProjectRole(c) != RoleOwner {
+		p.rejectCollaborationRoleWrite(c, entryCollaborationRoleRename)
+		return
+	}
+	roleID := c.Param("role_id")
+	if roleID == "" {
+		respondParamInvalid(c, "role_id")
+		return
+	}
+	var req collaborationRoleNameReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondProjectRequestInvalid(c, "")
+		return
+	}
+	actorUID := c.GetLoginUID()
+	role, changed, err := p.renameCollaborationRole(
+		row.ProjectID, row.SpaceID, actorUID, roleID, req.Name)
+	if err != nil {
+		p.respondCollaborationRoleWriteError(c, entryCollaborationRoleRename, row.ProjectID, "", err)
+		return
+	}
+	outcome := collaborationRoleOutcomeNoop
+	if changed {
+		outcome = collaborationRoleOutcomeChanged
+		p.audit(auditCollaborationRoleRename, actorUID, "", row.ProjectID, row.SpaceID, "",
+			zap.String("role_id", role.RoleID), zap.Int("role_count", 1))
+	}
+	observeCollaborationRoleWrite(entryCollaborationRoleRename, outcome)
+	c.Response(collaborationRoleToResp(*role))
+}
+
+func (p *Project) deleteCollaborationRoleHandler(c *wkhttp.Context) {
+	if !p.requireCollaborationRoleWriteEnabled(c, entryCollaborationRoleDelete) {
+		return
+	}
+	row := requestProject(c)
+	if row == nil {
+		p.Error("projectMiddleware 未注入项目行", zap.String("path", c.FullPath()))
+		respondQueryFailed(c)
+		return
+	}
+	if requestProjectRole(c) != RoleOwner {
+		p.rejectCollaborationRoleWrite(c, entryCollaborationRoleDelete)
+		return
+	}
+	roleID := c.Param("role_id")
+	if roleID == "" {
+		respondParamInvalid(c, "role_id")
+		return
+	}
+	actorUID := c.GetLoginUID()
+	changed, err := p.deleteCollaborationRole(row.ProjectID, row.SpaceID, actorUID, roleID)
+	if err != nil {
+		p.respondCollaborationRoleWriteError(c, entryCollaborationRoleDelete, row.ProjectID, "", err)
+		return
+	}
+	outcome := collaborationRoleOutcomeNoop
+	if changed {
+		outcome = collaborationRoleOutcomeChanged
+		p.audit(auditCollaborationRoleDelete, actorUID, "", row.ProjectID, row.SpaceID, "",
+			zap.String("role_id", roleID), zap.Int("role_count", 1))
+	}
+	observeCollaborationRoleWrite(entryCollaborationRoleDelete, outcome)
+	c.ResponseOK()
+}
+
+func (p *Project) replaceMemberCollaborationRolesHandler(c *wkhttp.Context) {
+	if !p.requireCollaborationRoleWriteEnabled(c, entryCollaborationRoleBind) {
+		return
+	}
+	row := requestProject(c)
+	if row == nil {
+		p.Error("projectMiddleware 未注入项目行", zap.String("path", c.FullPath()))
+		respondQueryFailed(c)
+		return
+	}
+	if !canManageMembers(requestProjectRole(c)) {
+		p.rejectCollaborationRoleWrite(c, entryCollaborationRoleBind)
+		return
+	}
+	targetUID := c.Param("uid")
+	if targetUID == "" {
+		respondParamInvalid(c, "uid")
+		return
+	}
+	var req collaborationRoleBindingReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondProjectRequestInvalid(c, "")
+		return
+	}
+	actorUID := c.GetLoginUID()
+	changed, err := p.replaceMemberCollaborationRoles(
+		row.ProjectID, row.SpaceID, actorUID, targetUID, req.RoleIDs)
+	if err != nil {
+		p.respondCollaborationRoleWriteError(c, entryCollaborationRoleBind, row.ProjectID, targetUID, err)
+		return
+	}
+	outcome := collaborationRoleOutcomeNoop
+	if changed {
+		outcome = collaborationRoleOutcomeChanged
+		reason := "replace"
+		if len(req.RoleIDs) == 0 {
+			reason = "clear"
+		}
+		p.audit(auditCollaborationRoleBind, actorUID, targetUID, row.ProjectID, row.SpaceID, reason,
+			zap.Strings("role_ids", req.RoleIDs), zap.Int("role_count", len(req.RoleIDs)))
+	}
+	observeCollaborationRoleWrite(entryCollaborationRoleBind, outcome)
+	c.ResponseOK()
+}
+
+func (p *Project) rejectCollaborationRoleWrite(c *wkhttp.Context, entry string) {
+	observeRejected(entry, reasonPermissionDenied)
+	observeCollaborationRoleWrite(entry, collaborationRoleOutcomeRejected)
+	httperr.ResponseErrorL(c, errcode.ErrProjectPermissionDenied, nil, nil)
+}
+
+func (p *Project) respondCollaborationRoleWriteError(
+	c *wkhttp.Context, entry, projectID, targetUID string, err error,
+) {
+	observeCollaborationRoleWrite(entry, collaborationRoleOutcomeRejected)
+	switch {
+	case errors.Is(err, errActorNotSpaceMember):
+		observeRejected(entry, reasonNotSpaceMember)
+		httperr.ResponseErrorL(c, errcode.ErrProjectActorNotSpaceMember, nil, nil)
+	case errors.Is(err, errProjectGone):
+		observeRejected(entry, reasonProjectDisbanded)
+		respondProjectNotFound(c)
+	case errors.Is(err, errPermissionDenied):
+		observeRejected(entry, reasonPermissionDenied)
+		httperr.ResponseErrorL(c, errcode.ErrProjectPermissionDenied, nil, nil)
+	case errors.Is(err, errCollaborationRoleNameInvalid):
+		observeRejected(entry, reasonCollaborationRoleNameInvalid)
+		httperr.ResponseErrorL(c, errcode.ErrProjectCollaborationRoleNameInvalid, nil, i18n.Details{
+			"field": "name", "max_chars": maxCollaborationRoleNameChars,
+		})
+	case errors.Is(err, errCollaborationRoleInvalid):
+		observeRejected(entry, reasonCollaborationRoleInvalid)
+		httperr.ResponseErrorL(c, errcode.ErrProjectCollaborationRoleInvalid, nil, nil)
+	case errors.Is(err, errCollaborationRoleTargetInvalid), errors.Is(err, errNotSpaceMember):
+		observeRejected(entry, reasonCollaborationRoleTargetInvalid)
+		httperr.ResponseErrorL(c, errcode.ErrProjectCollaborationRoleTargetInvalid, nil, nil)
+	case errors.Is(err, errCollaborationRoleDuplicated):
+		observeRejected(entry, reasonCollaborationRoleDuplicated)
+		httperr.ResponseErrorL(c, errcode.ErrProjectCollaborationRoleDuplicated, nil, nil)
+	case errors.Is(err, errQuotaCollaborationRoles):
+		observeRejected(entry, reasonQuotaCollaborationRoles)
+		respondProjectQuota(c, errcode.ErrProjectQuotaCollaborationRoles,
+			p.cfg.CollaborationRoleMaxPerProject)
+	case errors.Is(err, errQuotaMemberCollaborationRoles):
+		observeRejected(entry, reasonQuotaMemberCollaborationRoles)
+		respondProjectQuota(c, errcode.ErrProjectQuotaMemberCollaborationRoles,
+			p.cfg.CollaborationRoleMaxPerMember)
+	default:
+		observeRejected(entry, outcomeStoreFailed)
+		p.Error("项目协作角色写入失败", zap.Error(err), zap.String("projectId", projectID),
+			zap.String("targetUid", targetUID), zap.String("entry", entry))
+		respondStoreFailed(c)
+	}
+}

--- a/modules/project/api_i18n_test.go
+++ b/modules/project/api_i18n_test.go
@@ -127,8 +127,8 @@ func TestProjectNoLegacyResponseError(t *testing.T) {
 // best-effort anomaly counter is a diagnostic, not the guarantee.
 func TestMemberEpochOnlyEverIncrements(t *testing.T) {
 	found := false
-	assignment := regexp.MustCompile(`member_epoch\s*=`)
-	increment := regexp.MustCompile(`member_epoch\s*=\s*member_epoch\s*\+\s*1`)
+	assignment := regexp.MustCompile(`\bmember_epoch\b\s*=`)
+	increment := regexp.MustCompile(`\bmember_epoch\b\s*=\s*\bmember_epoch\b\s*\+\s*1`)
 	setCall := regexp.MustCompile(`Set\(\s*"member_epoch"`)
 	setMap := regexp.MustCompile(`"member_epoch"\s*:`)
 
@@ -170,10 +170,10 @@ func TestMemberEpochOnlyEverIncrements(t *testing.T) {
 // in an error string is fine; that is why this does not simply ban the identifier.
 func TestIsOfficialHasNoWriter(t *testing.T) {
 	for _, col := range projectInsertColumns {
-		if col == "is_official" || col == "active_name" || col == "member_epoch" {
+		if col == "is_official" || col == "active_name" || col == "member_epoch" || col == "collaboration_role_epoch" {
 			t.Errorf("projectInsertColumns contains %q; is_official has no P0 writer (D6), "+
-				"active_name is a generated column (MySQL 3105), and member_epoch may only be "+
-				"written as member_epoch + 1", col)
+				"active_name is a generated column (MySQL 3105), and epochs may only be "+
+				"written through their atomic increment statements", col)
 		}
 	}
 

--- a/modules/project/api_test.go
+++ b/modules/project/api_test.go
@@ -57,6 +57,7 @@ func TestMain(m *testing.M) {
 	// The feature gate is fail-closed, so every write case would 403 without this. The
 	// OFF behaviour is asserted by a case that flips p.cfg on a private router.
 	_ = os.Setenv(envCreateEnabled, "true")
+	_ = os.Setenv(envCollaborationRoleEnabled, "true")
 
 	srv, ctx := testutil.NewTestServer()
 	// testutil.NewTestServer does not install an ErrorRenderer (main.go does), and without
@@ -312,13 +313,15 @@ func TestSchemaColumnsMatchSpaceAndUser(t *testing.T) {
 			"  (TABLE_NAME='space_member' AND COLUMN_NAME IN ('space_id','uid')) OR " +
 			"  (TABLE_NAME='user' AND COLUMN_NAME='uid') OR " +
 			"  (TABLE_NAME='octo_project' AND COLUMN_NAME IN ('space_id','project_id','creator')) OR " +
-			"  (TABLE_NAME='octo_project_member' AND COLUMN_NAME IN ('space_id','uid','project_id')))",
+			"  (TABLE_NAME='octo_project_member' AND COLUMN_NAME IN ('space_id','uid','project_id')) OR " +
+			"  (TABLE_NAME='octo_project_collaboration_role' AND COLUMN_NAME IN ('project_id','role_id','creator_uid')) OR " +
+			"  (TABLE_NAME='octo_project_member_collaboration_role' AND COLUMN_NAME IN ('project_id','uid','role_id')))",
 	).Load(&cols)
 	require.NoError(t, err)
 	require.NotEmpty(t, cols)
 
-	// Both project tables must be present: NotEmpty alone would pass if
-	// octo_project_member were renamed away and only the legacy rows came back.
+	// Every project table must be present: NotEmpty alone would pass if one were
+	// renamed away and only the legacy rows came back.
 	tables := map[string]bool{}
 	for _, c := range cols {
 		tables[c.Table] = true
@@ -329,6 +332,10 @@ func TestSchemaColumnsMatchSpaceAndUser(t *testing.T) {
 	}
 	assert.True(t, tables["octo_project"], "octo_project columns must be in the result")
 	assert.True(t, tables["octo_project_member"], "octo_project_member columns must be in the result")
+	assert.True(t, tables["octo_project_collaboration_role"],
+		"octo_project_collaboration_role columns must be in the result")
+	assert.True(t, tables["octo_project_member_collaboration_role"],
+		"octo_project_member_collaboration_role columns must be in the result")
 }
 
 // TestJoinAcrossSpaceMemberAndUserHasNoCollationError runs the shape the reconcile scan
@@ -444,7 +451,8 @@ func TestMigrationUpDownUpLeavesNoResidue(t *testing.T) {
 		var n int
 		require.NoError(t, db.QueryRow(
 			"SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() "+
-				"AND TABLE_NAME IN ('octo_project','octo_project_member')").Scan(&n))
+				"AND TABLE_NAME IN ('octo_project','octo_project_member',"+
+				"'octo_project_collaboration_role','octo_project_member_collaboration_role')").Scan(&n))
 		return n
 	}
 	// generatedColumns counts the STORED generated column, and indexOverGenerated the
@@ -464,16 +472,25 @@ func TestMigrationUpDownUpLeavesNoResidue(t *testing.T) {
 				"AND TABLE_NAME = 'octo_project' AND INDEX_NAME = 'uk_octo_project_space_active_name'").Scan(&n))
 		return n
 	}
+	collaborationEpochColumns := func() int {
+		var n int
+		require.NoError(t, db.QueryRow(
+			"SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() "+
+				"AND TABLE_NAME = 'octo_project' AND COLUMN_NAME = 'collaboration_role_epoch'").Scan(&n))
+		return n
+	}
 
 	assertApplied := func(stage string) {
-		assert.Equal(t, 2, tableCount(), "%s: both tables must exist", stage)
+		assert.Equal(t, 4, tableCount(), "%s: project and collaboration-role tables must exist", stage)
 		assert.Equal(t, 1, generatedColumns(), "%s: active_name must be a generated column", stage)
 		assert.Greater(t, indexOverGenerated(), 0, "%s: the unique index over active_name must exist", stage)
+		assert.Equal(t, 1, collaborationEpochColumns(), "%s: collaboration_role_epoch must exist", stage)
 	}
 	assertGone := func(stage string) {
 		assert.Equal(t, 0, tableCount(), "%s: the Down section must leave no residue", stage)
 		assert.Equal(t, 0, generatedColumns(), "%s: no generated column may survive Down", stage)
 		assert.Equal(t, 0, indexOverGenerated(), "%s: no index may survive Down", stage)
+		assert.Equal(t, 0, collaborationEpochColumns(), "%s: no collaboration epoch may survive Down", stage)
 	}
 
 	// Starting state: sql-migrate applied Up during setup.
@@ -529,6 +546,7 @@ var projectMigrationFiles = []string{
 	"sql/20260907000001_project_provisioning.sql",
 	"sql/20260907000002_project_all_member_group.sql",
 	"sql/20260908000001_project_user_setting.sql",
+	"sql/20260909000001_project_collaboration_role.sql",
 }
 
 // applyProjectMigration executes one section of every migration file this module

--- a/modules/project/audit.go
+++ b/modules/project/audit.go
@@ -8,14 +8,18 @@ import (
 // eventually, into whatever queries those logs, so a typo must not become a new
 // action silently.
 const (
-	auditCreate       = "project.create"
-	auditUpdate       = "project.update"
-	auditDisband      = "project.disband"
-	auditMemberAdd    = "project.member_add"
-	auditMemberRemove = "project.member_remove"
-	auditLeave        = "project.leave"
-	auditRoleChange   = "project.role_change"
-	auditCascade      = "project.space_cascade"
+	auditCreate                  = "project.create"
+	auditUpdate                  = "project.update"
+	auditDisband                 = "project.disband"
+	auditMemberAdd               = "project.member_add"
+	auditMemberRemove            = "project.member_remove"
+	auditLeave                   = "project.leave"
+	auditRoleChange              = "project.role_change"
+	auditCollaborationRoleCreate = "project.collaboration_role_create"
+	auditCollaborationRoleRename = "project.collaboration_role_rename"
+	auditCollaborationRoleDelete = "project.collaboration_role_delete"
+	auditCollaborationRoleBind   = "project.collaboration_role_bind"
+	auditCascade                 = "project.space_cascade"
 )
 
 // Audit reasons that are not tied to one call site. Same low-cardinality rule as

--- a/modules/project/collaboration_role_maintenance.go
+++ b/modules/project/collaboration_role_maintenance.go
@@ -1,0 +1,162 @@
+package project
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+var (
+	collaborationRoleMaintenanceOnce    sync.Once
+	collaborationRoleMaintenanceRunning atomic.Bool
+	collaborationRoleBackfillCursor     atomic.Int64
+	collaborationRoleIntegrityState     collaborationRoleIntegrityScanState
+)
+
+type collaborationRoleIntegrityScanState struct {
+	mu        sync.Mutex
+	projectID string
+	uid       string
+	roleID    string
+	running   int
+}
+
+func (s *collaborationRoleIntegrityScanState) resume() (string, string, string, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.projectID, s.uid, s.roleID, s.running
+}
+
+func (s *collaborationRoleIntegrityScanState) save(
+	projectID, uid, roleID string, running int, completed bool,
+) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if completed {
+		s.projectID, s.uid, s.roleID, s.running = "", "", "", 0
+		return
+	}
+	s.projectID, s.uid, s.roleID, s.running = projectID, uid, roleID, running
+}
+
+// startCollaborationRoleMaintenance runs the restart-safe built-in backfill and
+// the association-integrity check on the existing bounded reconciliation cadence.
+func (p *Project) startCollaborationRoleMaintenance() {
+	collaborationRoleMaintenanceOnce.Do(func() {
+		p.ctx.Schedule(jitter(p.cfg.ReconcileInterval), p.runCollaborationRoleMaintenance)
+	})
+}
+
+func (p *Project) runCollaborationRoleMaintenance() {
+	if !collaborationRoleMaintenanceRunning.CompareAndSwap(false, true) {
+		return
+	}
+	defer collaborationRoleMaintenanceRunning.Store(false)
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			collaborationRoleMaintenanceFailures.WithLabelValues("panic").Inc()
+			p.Error("项目协作角色维护任务 panic", zap.Any("recover", recovered))
+		}
+	}()
+
+	p.backfillBuiltinCollaborationRoles()
+	p.scanCollaborationRoleIntegrity()
+}
+
+func (p *Project) backfillBuiltinCollaborationRoles() {
+	afterID := collaborationRoleBackfillCursor.Load()
+	projects, err := p.db.collaborationRoleBackfillPage(afterID, p.cfg.ReconcileLimit)
+	if err != nil {
+		collaborationRoleMaintenanceFailures.WithLabelValues("backfill_query").Inc()
+		p.Warn("查询待补齐内置协作角色的项目失败", zap.Error(err))
+		return
+	}
+	missing := 0
+	for _, project := range projects {
+		changed := false
+		err := retryOnLockConflict(func() error {
+			var attemptErr error
+			changed, attemptErr = p.backfillBuiltinCollaborationRolesOnce(project.ProjectID)
+			return attemptErr
+		})
+		if err != nil {
+			missing++
+			collaborationRoleMaintenanceFailures.WithLabelValues("backfill_write").Inc()
+			p.Warn("补齐项目内置协作角色失败", zap.Error(err), zap.String("projectId", project.ProjectID))
+			continue
+		}
+		if changed {
+			missing++
+		}
+	}
+	collaborationRoleBackfillPending.Set(float64(missing))
+	if len(projects) < p.cfg.ReconcileLimit {
+		collaborationRoleBackfillCursor.Store(0)
+	} else {
+		collaborationRoleBackfillCursor.Store(projects[len(projects)-1].ID)
+	}
+}
+
+func (p *Project) backfillBuiltinCollaborationRolesOnce(projectID string) (bool, error) {
+	tx, err := p.db.session.Begin()
+	if err != nil {
+		return false, fmt.Errorf("project: begin collaboration role backfill: %w", err)
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	project, err := p.db.lockActiveProjectTx(tx, projectID)
+	if err != nil {
+		return false, err
+	}
+	if project == nil {
+		return false, nil
+	}
+	changed, err := p.db.seedBuiltinCollaborationRolesTx(tx, projectID, time.Now().UTC())
+	if err != nil {
+		return false, err
+	}
+	if changed {
+		if err := p.db.bumpCollaborationRoleEpochTx(tx, projectID); err != nil {
+			return false, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("project: commit collaboration role backfill: %w", err)
+	}
+	if changed {
+		collaborationRoleBackfilled.Inc()
+	}
+	return changed, nil
+}
+
+func (p *Project) scanCollaborationRoleIntegrity() {
+	projectID, uid, roleID, total := collaborationRoleIntegrityState.resume()
+	rows, err := p.db.collaborationRoleIntegrityPage(
+		projectID, uid, roleID, p.cfg.ReconcileLimit)
+	if err != nil {
+		collaborationRoleMaintenanceFailures.WithLabelValues("integrity_scan").Inc()
+		p.Warn("扫描项目协作角色关联完整性失败", zap.Error(err))
+		return
+	}
+	for _, row := range rows {
+		if row.Violating {
+			total++
+		}
+	}
+	completed := len(rows) < p.cfg.ReconcileLimit
+	if len(rows) > 0 {
+		last := rows[len(rows)-1]
+		projectID, uid, roleID = last.ProjectID, last.UID, last.RoleID
+	}
+	if completed {
+		collaborationRoleIntegrityViolations.Set(float64(total))
+	}
+	collaborationRoleIntegrityState.save(projectID, uid, roleID, total, completed)
+	if completed && total > 0 {
+		p.Error("发现项目协作角色孤儿关联或非活跃成员关联",
+			zap.Int("violations", total), zap.Int("page_limit", p.cfg.ReconcileLimit))
+	}
+}

--- a/modules/project/collaboration_role_test.go
+++ b/modules/project/collaboration_role_test.go
@@ -1,0 +1,490 @@
+package project
+
+import (
+	"encoding/json"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time RED: the production wire type does not exist before this task.
+// Once it does, the HTTP cases below remain the behavioural contract.
+var _ CollaborationRoleResp
+
+func TestCollaborationRoleEpochOnlyEverIncrements(t *testing.T) {
+	found := false
+	assignment := regexp.MustCompile(`\bcollaboration_role_epoch\b\s*=`)
+	increment := regexp.MustCompile(`\bcollaboration_role_epoch\b\s*=\s*\bcollaboration_role_epoch\b\s*\+\s*1`)
+	for _, file := range moduleSourceFiles(t) {
+		cleaned := readStripped(t, file)
+		for _, match := range assignment.FindAllStringIndex(cleaned, -1) {
+			window := cleaned[match[0]:min(match[1]+90, len(cleaned))]
+			if !increment.MatchString(window) {
+				t.Errorf("modules/project/%s assigns collaboration_role_epoch non-monotonically: %q",
+					file, strings.TrimSpace(window))
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("no collaboration_role_epoch increment statement found")
+	}
+}
+
+type collaborationRoleWire struct {
+	RoleID     string `json:"role_id"`
+	BuiltinKey string `json:"builtin_key"`
+	Name       string `json:"name"`
+	Source     string `json:"source"`
+}
+
+type collaborationRoleCatalogWire struct {
+	CollaborationRoleEpoch int64                   `json:"collaboration_role_epoch"`
+	Roles                  []collaborationRoleWire `json:"roles"`
+}
+
+type collaborationRoleMemberWire struct {
+	UID                string                  `json:"uid"`
+	Role               int                     `json:"role"`
+	CollaborationRoles []collaborationRoleWire `json:"collaboration_roles"`
+}
+
+func getCollaborationRoleCatalog(t *testing.T, projectID, token string) collaborationRoleCatalogWire {
+	t.Helper()
+	// Kept as a local decode helper so the test asserts the wire contract rather
+	// than reaching into the production response type.
+	w := doJSON(t, testSrv, http.MethodGet,
+		"/v1/projects/"+projectID+"/collaboration-roles", token, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	var got collaborationRoleCatalogWire
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	return got
+}
+
+func roleByName(t *testing.T, roles []collaborationRoleWire, name string) collaborationRoleWire {
+	t.Helper()
+	for _, role := range roles {
+		if role.Name == name {
+			return role
+		}
+	}
+	t.Fatalf("role %q not found in %+v", name, roles)
+	return collaborationRoleWire{}
+}
+
+func rosterMember(t *testing.T, projectID, token, uid string) collaborationRoleMemberWire {
+	t.Helper()
+	w := doJSON(t, testSrv, http.MethodGet, "/v1/projects/"+projectID+"/members", token, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	var rows []collaborationRoleMemberWire
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &rows))
+	for _, row := range rows {
+		if row.UID == uid {
+			return row
+		}
+	}
+	t.Fatalf("member %q not found in roster", uid)
+	return collaborationRoleMemberWire{}
+}
+
+func createCollaborationRole(t *testing.T, projectID, token, name string) collaborationRoleWire {
+	t.Helper()
+	w := doJSON(t, testSrv, http.MethodPost,
+		"/v1/projects/"+projectID+"/collaboration-roles", token,
+		map[string]any{"name": name})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	var got collaborationRoleWire
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	require.NotEmpty(t, got.RoleID)
+	return got
+}
+
+func renameCollaborationRole(t *testing.T, projectID, roleID, token, name string) collaborationRoleWire {
+	t.Helper()
+	w := doJSON(t, testSrv, http.MethodPut,
+		"/v1/projects/"+projectID+"/collaboration-roles/"+roleID, token,
+		map[string]any{"name": name})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	var got collaborationRoleWire
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	return got
+}
+
+func TestCollaborationRoleLifecycleDoesNotChangeProjectAuthorization(t *testing.T) {
+	srv, _ := setup(t)
+	ownerToken, tokens, created := projectWithMembers(t, srv, "m1")
+	memberEpoch := epochOf(t, created.ProjectID)
+
+	catalog := getCollaborationRoleCatalog(t, created.ProjectID, ownerToken)
+	require.Len(t, catalog.Roles, 4)
+	for _, name := range []string{"产品", "前端", "后端", "HR"} {
+		role := roleByName(t, catalog.Roles, name)
+		assert.Equal(t, "builtin", role.Source)
+		assert.NotEmpty(t, role.BuiltinKey)
+	}
+
+	designer := createCollaborationRole(t, created.ProjectID, ownerToken, "设计")
+	assert.Equal(t, "custom", designer.Source)
+	assert.Empty(t, designer.BuiltinKey)
+
+	w := doJSON(t, srv, http.MethodPut,
+		"/v1/projects/"+created.ProjectID+"/members/m1/collaboration-roles", ownerToken,
+		map[string]any{"role_ids": []string{
+			roleByName(t, catalog.Roles, "前端").RoleID,
+			designer.RoleID,
+		}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	member := rosterMember(t, created.ProjectID, ownerToken, "m1")
+	assert.Equal(t, RoleCommon, member.Role, "collaboration labels must not alter authorization")
+	require.Len(t, member.CollaborationRoles, 2)
+	assert.Equal(t, memberEpoch, epochOf(t, created.ProjectID),
+		"collaboration labels must not move member_epoch")
+
+	boundCatalog := getCollaborationRoleCatalog(t, created.ProjectID, ownerToken)
+	w = doJSON(t, srv, http.MethodPut,
+		"/v1/projects/"+created.ProjectID+"/members/m1/collaboration-roles", ownerToken,
+		map[string]any{"role_ids": []string{designer.RoleID, roleByName(t, catalog.Roles, "前端").RoleID}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	idempotentCatalog := getCollaborationRoleCatalog(t, created.ProjectID, ownerToken)
+	assert.Equal(t, boundCatalog.CollaborationRoleEpoch, idempotentCatalog.CollaborationRoleEpoch,
+		"replacing with the same set must be an epoch no-op")
+
+	renamed := renameCollaborationRole(t, created.ProjectID, designer.RoleID, ownerToken, "交互设计")
+	assert.Equal(t, "交互设计", renamed.Name)
+	member = rosterMember(t, created.ProjectID, ownerToken, "m1")
+	assert.Equal(t, "交互设计", roleByName(t, member.CollaborationRoles, "交互设计").Name)
+
+	w = doJSON(t, srv, http.MethodDelete,
+		"/v1/projects/"+created.ProjectID+"/collaboration-roles/"+designer.RoleID, ownerToken, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	member = rosterMember(t, created.ProjectID, ownerToken, "m1")
+	assert.Len(t, member.CollaborationRoles, 1, "deleting a definition must remove its bindings")
+
+	w = doJSON(t, srv, http.MethodPut,
+		"/v1/projects/"+created.ProjectID+"/members/m1/collaboration-roles", ownerToken,
+		map[string]any{"role_ids": []string{}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Empty(t, rosterMember(t, created.ProjectID, ownerToken, "m1").CollaborationRoles)
+
+	// The labelled ordinary member still has ordinary-member capabilities.
+	detail := doJSON(t, srv, http.MethodGet, "/v1/projects/"+created.ProjectID, tokens["m1"], nil)
+	require.Equal(t, http.StatusOK, detail.Code)
+	project := decodeResp(t, detail)
+	assert.Equal(t, RoleCommon, project.MyRole)
+	assert.False(t, project.Capabilities.CanManageMember)
+	assert.False(t, project.Capabilities.CanChangeRole)
+
+	after := getCollaborationRoleCatalog(t, created.ProjectID, ownerToken)
+	assert.Greater(t, after.CollaborationRoleEpoch, catalog.CollaborationRoleEpoch)
+}
+
+func TestCollaborationRolePermissionMatrixAndBuiltinProtection(t *testing.T) {
+	srv, _ := setup(t)
+	ownerToken, tokens, created := projectWithMembers(t, srv, "admin1", "member1")
+	w := doJSON(t, srv, http.MethodPut,
+		"/v1/projects/"+created.ProjectID+"/members/admin1/role", ownerToken,
+		map[string]any{"role": RoleAdmin})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	catalog := getCollaborationRoleCatalog(t, created.ProjectID, ownerToken)
+	frontend := roleByName(t, catalog.Roles, "前端")
+
+	// Admins may bind an existing role.
+	w = doJSON(t, srv, http.MethodPut,
+		"/v1/projects/"+created.ProjectID+"/members/member1/collaboration-roles", tokens["admin1"],
+		map[string]any{"role_ids": []string{frontend.RoleID}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	// Admins may not change the role catalog.
+	w = doJSON(t, srv, http.MethodPost,
+		"/v1/projects/"+created.ProjectID+"/collaboration-roles", tokens["admin1"],
+		map[string]any{"name": "设计"})
+	assertProjectErrorCode(t, w, "err.server.project.permission_denied")
+
+	// Ordinary members may neither self-assign nor assign another member.
+	w = doJSON(t, srv, http.MethodPut,
+		"/v1/projects/"+created.ProjectID+"/members/member1/collaboration-roles", tokens["member1"],
+		map[string]any{"role_ids": []string{frontend.RoleID}})
+	assertProjectErrorCode(t, w, "err.server.project.permission_denied")
+
+	// Built-ins are selectable but immutable.
+	w = doJSON(t, srv, http.MethodPut,
+		"/v1/projects/"+created.ProjectID+"/collaboration-roles/"+frontend.RoleID, ownerToken,
+		map[string]any{"name": "客户端"})
+	assertProjectErrorCode(t, w, "err.server.project.collaboration_role_invalid")
+	w = doJSON(t, srv, http.MethodDelete,
+		"/v1/projects/"+created.ProjectID+"/collaboration-roles/"+frontend.RoleID, ownerToken, nil)
+	assertProjectErrorCode(t, w, "err.server.project.collaboration_role_invalid")
+}
+
+func TestCollaborationRoleDuplicateIsNormalizedWithinProject(t *testing.T) {
+	srv, _ := setup(t)
+	ownerToken, _, created := projectWithMembers(t, srv)
+	createCollaborationRole(t, created.ProjectID, ownerToken, "  Designer  ")
+
+	w := doJSON(t, srv, http.MethodPost,
+		"/v1/projects/"+created.ProjectID+"/collaboration-roles", ownerToken,
+		map[string]any{"name": "designer"})
+	assertProjectErrorCode(t, w, "err.server.project.collaboration_role_duplicated")
+}
+
+func TestCollaborationRoleCaseOnlyRenameUpdatesDisplayName(t *testing.T) {
+	srv, _ := setup(t)
+	ownerToken, _, created := projectWithMembers(t, srv)
+	designer := createCollaborationRole(t, created.ProjectID, ownerToken, "designer")
+	before := getCollaborationRoleCatalog(t, created.ProjectID, ownerToken)
+
+	renamed := renameCollaborationRole(t, created.ProjectID, designer.RoleID, ownerToken, "Designer")
+	assert.Equal(t, "Designer", renamed.Name)
+
+	after := getCollaborationRoleCatalog(t, created.ProjectID, ownerToken)
+	assert.Equal(t, "Designer", roleByName(t, after.Roles, "Designer").Name)
+	assert.Equal(t, before.CollaborationRoleEpoch+1, after.CollaborationRoleEpoch,
+		"a case-only display-name rename is a real catalog change")
+}
+
+func TestCollaborationRoleNormalizedNameKeepsAccentsDistinct(t *testing.T) {
+	srv, _ := setup(t)
+	ownerToken, _, created := projectWithMembers(t, srv)
+
+	plain := createCollaborationRole(t, created.ProjectID, ownerToken, "resume")
+	accented := createCollaborationRole(t, created.ProjectID, ownerToken, "résumé")
+
+	assert.NotEqual(t, plain.RoleID, accented.RoleID)
+	catalog := getCollaborationRoleCatalog(t, created.ProjectID, ownerToken)
+	assert.Equal(t, plain.RoleID, roleByName(t, catalog.Roles, "resume").RoleID)
+	assert.Equal(t, accented.RoleID, roleByName(t, catalog.Roles, "résumé").RoleID)
+}
+
+func TestCollaborationRolesAreClearedWhenMemberLeavesAndNotRestored(t *testing.T) {
+	srv, p := setup(t)
+	ownerToken, _, created := projectWithMembers(t, srv, "m1")
+	catalog := getCollaborationRoleCatalog(t, created.ProjectID, ownerToken)
+	product := roleByName(t, catalog.Roles, "产品")
+
+	w := doJSON(t, srv, http.MethodPut,
+		"/v1/projects/"+created.ProjectID+"/members/m1/collaboration-roles", ownerToken,
+		map[string]any{"role_ids": []string{product.RoleID}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	w = doJSON(t, srv, http.MethodPost,
+		"/v1/projects/"+created.ProjectID+"/members/remove", ownerToken,
+		map[string]any{"uids": []string{"m1"}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	drainRemovalCascade(t, p)
+
+	w = doJSON(t, srv, http.MethodPost,
+		"/v1/projects/"+created.ProjectID+"/members/add", ownerToken,
+		map[string]any{"uids": []string{"m1"}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	member := rosterMember(t, created.ProjectID, ownerToken, "m1")
+	assert.Empty(t, member.CollaborationRoles,
+		"re-admission must not restore labels from the previous seat lifecycle")
+}
+
+func TestCollaborationRoleRejectsInvalidSetsAndAgents(t *testing.T) {
+	srv, _ := setup(t)
+	ownerToken, _, created := projectWithMembers(t, srv, "m1")
+	catalog := getCollaborationRoleCatalog(t, created.ProjectID, ownerToken)
+	frontend := roleByName(t, catalog.Roles, "前端")
+
+	w := doJSON(t, srv, http.MethodPut,
+		"/v1/projects/"+created.ProjectID+"/members/m1/collaboration-roles", ownerToken,
+		map[string]any{"role_ids": []string{frontend.RoleID, frontend.RoleID}})
+	assertProjectErrorCode(t, w, "err.server.project.collaboration_role_invalid")
+
+	w = doJSON(t, srv, http.MethodPut,
+		"/v1/projects/"+created.ProjectID+"/members/m1/collaboration-roles", ownerToken,
+		map[string]any{"role_ids": []string{"missing-role"}})
+	assertProjectErrorCode(t, w, "err.server.project.collaboration_role_invalid")
+
+	seedAgent(t, spaceA, "agent1", "owner1", "octo_hosted")
+	w = doJSON(t, srv, http.MethodPost,
+		"/v1/projects/"+created.ProjectID+"/members/add", ownerToken,
+		map[string]any{"uids": []string{"agent1"}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	w = doJSON(t, srv, http.MethodPut,
+		"/v1/projects/"+created.ProjectID+"/members/agent1/collaboration-roles", ownerToken,
+		map[string]any{"role_ids": []string{frontend.RoleID}})
+	assertProjectErrorCode(t, w, "err.server.project.collaboration_role_target_invalid")
+	assert.Empty(t, rosterMember(t, created.ProjectID, ownerToken, "agent1").CollaborationRoles)
+}
+
+func TestCollaborationRoleWriteFlagDoesNotHideReads(t *testing.T) {
+	_, p := setup(t)
+	ownerToken, _, created := projectWithMembers(t, testSrv)
+	p.cfg.CollaborationRoleEnabled = false
+	r := mountProject(t, p)
+
+	w := doOn(t, r, http.MethodGet,
+		"/v1/projects/"+created.ProjectID+"/collaboration-roles", ownerToken, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	w = doOn(t, r, http.MethodPost,
+		"/v1/projects/"+created.ProjectID+"/collaboration-roles", ownerToken,
+		map[string]any{"name": "设计"})
+	assertProjectErrorCode(t, w, "err.server.project.collaboration_role_disabled")
+}
+
+func TestCollaborationRoleQuotasAreConfigBacked(t *testing.T) {
+	_, p := setup(t)
+	ownerToken, _, created := projectWithMembers(t, testSrv, "m1")
+	p.cfg.CollaborationRoleMaxPerProject = len(builtinCollaborationRoles) + 1
+	p.cfg.CollaborationRoleMaxPerMember = 1
+	r := mountProject(t, p)
+
+	first := doOn(t, r, http.MethodPost,
+		"/v1/projects/"+created.ProjectID+"/collaboration-roles", ownerToken,
+		map[string]any{"name": "设计"})
+	require.Equal(t, http.StatusOK, first.Code, "body: %s", first.Body.String())
+	var custom collaborationRoleWire
+	require.NoError(t, json.Unmarshal(first.Body.Bytes(), &custom))
+
+	w := doOn(t, r, http.MethodPost,
+		"/v1/projects/"+created.ProjectID+"/collaboration-roles", ownerToken,
+		map[string]any{"name": "测试"})
+	assertProjectErrorCode(t, w, "err.server.project.quota_collaboration_roles")
+
+	catalog := getCollaborationRoleCatalog(t, created.ProjectID, ownerToken)
+	w = doOn(t, r, http.MethodPut,
+		"/v1/projects/"+created.ProjectID+"/members/m1/collaboration-roles", ownerToken,
+		map[string]any{"role_ids": []string{custom.RoleID, roleByName(t, catalog.Roles, "产品").RoleID}})
+	assertProjectErrorCode(t, w, "err.server.project.quota_member_collaboration_roles")
+}
+
+func TestConcurrentCollaborationRoleCreateKeepsNormalizedNameUnique(t *testing.T) {
+	srv, _ := setup(t)
+	ownerToken, _, created := projectWithMembers(t, srv)
+
+	responses := make(chan *struct {
+		code int
+		body string
+	}, 2)
+	var wg sync.WaitGroup
+	for _, name := range []string{"Designer", " designer "} {
+		wg.Add(1)
+		go func(name string) {
+			defer wg.Done()
+			w := doJSON(t, srv, http.MethodPost,
+				"/v1/projects/"+created.ProjectID+"/collaboration-roles", ownerToken,
+				map[string]any{"name": name})
+			responses <- &struct {
+				code int
+				body string
+			}{code: w.Code, body: w.Body.String()}
+		}(name)
+	}
+	wg.Wait()
+	close(responses)
+
+	ok, conflict := 0, 0
+	for response := range responses {
+		switch response.code {
+		case http.StatusOK:
+			ok++
+		case http.StatusBadRequest:
+			var envelope struct {
+				Error struct {
+					Code string `json:"code"`
+				} `json:"error"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(response.body), &envelope))
+			if envelope.Error.Code == "err.server.project.collaboration_role_duplicated" {
+				conflict++
+			}
+		}
+	}
+	assert.Equal(t, 1, ok)
+	assert.Equal(t, 1, conflict)
+}
+
+func TestBuiltinCollaborationRoleBackfillIsBoundedAndIdempotent(t *testing.T) {
+	_, p := setup(t)
+	ownerToken, _, created := projectWithMembers(t, testSrv)
+	before := getCollaborationRoleCatalog(t, created.ProjectID, ownerToken)
+	product := roleByName(t, before.Roles, "产品")
+
+	_, err := testCtx.DB().DeleteFrom("octo_project_collaboration_role").
+		Where("project_id = ? AND role_id = ?", created.ProjectID, product.RoleID).
+		Exec()
+	require.NoError(t, err)
+
+	p.cfg.ReconcileLimit = 1
+	collaborationRoleBackfillCursor.Store(0)
+	p.backfillBuiltinCollaborationRoles()
+	after := getCollaborationRoleCatalog(t, created.ProjectID, ownerToken)
+	require.Len(t, after.Roles, len(builtinCollaborationRoles))
+	assert.Equal(t, before.CollaborationRoleEpoch+1, after.CollaborationRoleEpoch)
+
+	p.backfillBuiltinCollaborationRoles()
+	idempotent := getCollaborationRoleCatalog(t, created.ProjectID, ownerToken)
+	assert.Equal(t, after.CollaborationRoleEpoch, idempotent.CollaborationRoleEpoch)
+}
+
+func TestCollaborationRoleIntegrityPageBoundsRowsBeforeFiltering(t *testing.T) {
+	srv, p := setup(t)
+	ownerToken, _, created := projectWithMembers(t, srv, "m1")
+	frontend := roleByName(t,
+		getCollaborationRoleCatalog(t, created.ProjectID, ownerToken).Roles, "前端")
+
+	w := doJSON(t, srv, http.MethodPut,
+		"/v1/projects/"+created.ProjectID+"/members/m1/collaboration-roles", ownerToken,
+		map[string]any{"role_ids": []string{frontend.RoleID}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	// Sort the invalid row after the valid m1 row. A bounded scan with limit=1
+	// must inspect only m1 on the first page; filtering violations before LIMIT
+	// would skip m1 and scan ahead until it found zz_missing_member.
+	_, err := testCtx.DB().InsertBySql(
+		"INSERT INTO `octo_project_member_collaboration_role` "+
+			"(project_id, uid, role_id, created_at) VALUES (?, ?, ?, NOW(3))",
+		created.ProjectID, "zz_missing_member", frontend.RoleID,
+	).Exec()
+	require.NoError(t, err)
+
+	first, err := p.db.collaborationRoleIntegrityPage("", "", "", 1)
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	assert.Equal(t, "m1", first[0].UID)
+	assert.False(t, first[0].Violating)
+
+	second, err := p.db.collaborationRoleIntegrityPage(
+		first[0].ProjectID, first[0].UID, first[0].RoleID, 1)
+	require.NoError(t, err)
+	require.Len(t, second, 1)
+	assert.Equal(t, "zz_missing_member", second[0].UID)
+	assert.True(t, second[0].Violating)
+
+	// The scheduled scan keeps the composite cursor and running total across
+	// ticks, then resets only after a complete rotation. This prevents a fixed
+	// first page from hiding violations later in the keyspace.
+	collaborationRoleIntegrityState.save("", "", "", 0, true)
+	p.cfg.ReconcileLimit = 1
+	p.scanCollaborationRoleIntegrity()
+	projectID, uid, roleID, total := collaborationRoleIntegrityState.resume()
+	assert.Equal(t, created.ProjectID, projectID)
+	assert.Equal(t, "m1", uid)
+	assert.NotEmpty(t, roleID)
+	assert.Zero(t, total)
+
+	p.scanCollaborationRoleIntegrity()
+	projectID, uid, roleID, total = collaborationRoleIntegrityState.resume()
+	assert.Equal(t, created.ProjectID, projectID)
+	assert.Equal(t, "zz_missing_member", uid)
+	assert.NotEmpty(t, roleID)
+	assert.Equal(t, 1, total)
+
+	p.scanCollaborationRoleIntegrity()
+	projectID, uid, roleID, total = collaborationRoleIntegrityState.resume()
+	assert.Empty(t, projectID)
+	assert.Empty(t, uid)
+	assert.Empty(t, roleID)
+	assert.Zero(t, total)
+}

--- a/modules/project/config.go
+++ b/modules/project/config.go
@@ -21,7 +21,8 @@ const (
 	// getter in modules/common. Moving it there later is one function; the call
 	// site (createEnabled) does not change. The cost of env is that flipping it
 	// needs a rolling restart in both directions.
-	envCreateEnabled = "OCTO_PROJECT_CREATE_ENABLED"
+	envCreateEnabled            = "OCTO_PROJECT_CREATE_ENABLED"
+	envCollaborationRoleEnabled = "OCTO_PROJECT_COLLABORATION_ROLE_ENABLED"
 
 	// envReconcileEnabled gates ONLY the reconcile scans that JOIN the legacy Space tables
 	// (`space`, `space_member`, `space_member_removal_cleanup`) — I1 violations, abandoned
@@ -49,15 +50,17 @@ const (
 	// Turn it on once the collation conversion recorded in the brief has completed.
 	envReconcileEnabled = "OCTO_PROJECT_RECONCILE_ENABLED"
 
-	envMaxPerSpace    = "OCTO_PROJECT_MAX_PER_SPACE"
-	envMaxPerCreator  = "OCTO_PROJECT_MAX_PER_CREATOR_PER_SPACE"
-	envMaxMembers     = "OCTO_PROJECT_MAX_MEMBERS"
-	envMaxPinned      = "OCTO_PROJECT_MAX_PINNED"
-	envMaxDailyCreate = "OCTO_PROJECT_MAX_DAILY_CREATE"
-	envMemberBatchMax = "OCTO_PROJECT_MEMBER_BATCH_MAX"
-	envDayBoundaryTZ  = "OCTO_PROJECT_DAY_BOUNDARY_TZ"
-	envReconcileEvery = "OCTO_PROJECT_RECONCILE_INTERVAL"
-	envReconcileLimit = "OCTO_PROJECT_RECONCILE_LIMIT"
+	envMaxPerSpace                    = "OCTO_PROJECT_MAX_PER_SPACE"
+	envMaxPerCreator                  = "OCTO_PROJECT_MAX_PER_CREATOR_PER_SPACE"
+	envMaxMembers                     = "OCTO_PROJECT_MAX_MEMBERS"
+	envMaxPinned                      = "OCTO_PROJECT_MAX_PINNED"
+	envMaxDailyCreate                 = "OCTO_PROJECT_MAX_DAILY_CREATE"
+	envMemberBatchMax                 = "OCTO_PROJECT_MEMBER_BATCH_MAX"
+	envCollaborationRoleMaxPerProject = "OCTO_PROJECT_COLLABORATION_ROLE_MAX_PER_PROJECT"
+	envCollaborationRoleMaxPerMember  = "OCTO_PROJECT_COLLABORATION_ROLE_MAX_PER_MEMBER"
+	envDayBoundaryTZ                  = "OCTO_PROJECT_DAY_BOUNDARY_TZ"
+	envReconcileEvery                 = "OCTO_PROJECT_RECONCILE_INTERVAL"
+	envReconcileLimit                 = "OCTO_PROJECT_RECONCILE_LIMIT"
 	// envAllMemberGroupAdmitGrace tunes how long a freshly written project seat is
 	// exempt from I4 scan B. The brief calls the window configurable and the first
 	// implementation hard-coded it; the value that matters is deployment-shaped
@@ -84,7 +87,9 @@ const (
 	// defaultMemberBatchMax bounds one add/remove request structurally, on top of
 	// any byte cap: a well-formed payload of ten thousand uids would otherwise turn
 	// a single request into ten thousand membership transactions.
-	defaultMemberBatchMax = 200
+	defaultMemberBatchMax                 = 200
+	defaultCollaborationRoleMaxPerProject = 50
+	defaultCollaborationRoleMaxPerMember  = 8
 	// defaultDayBoundaryTZ is the business timezone the per-day creation window is
 	// computed in. Rows store UTC; only the window boundary is localized, so the
 	// quota resets at local midnight rather than at 08:00 local.
@@ -116,19 +121,22 @@ const (
 
 // Config is the resolved per-process configuration.
 type Config struct {
-	CreateEnabled bool
+	CreateEnabled            bool
+	CollaborationRoleEnabled bool
 	// ReconcileEnabled gates the three scans that JOIN legacy Space tables. See
 	// envReconcileEnabled for why it is separate from CreateEnabled and why its scope is narrow.
-	ReconcileEnabled  bool
-	MaxPerSpace       int
-	MaxPerCreator     int
-	MaxMembers        int
-	MaxPinned         int
-	MaxDailyCreate    int
-	MemberBatchMax    int
-	DayBoundary       *time.Location
-	ReconcileInterval time.Duration
-	ReconcileLimit    int
+	ReconcileEnabled               bool
+	MaxPerSpace                    int
+	MaxPerCreator                  int
+	MaxMembers                     int
+	MaxPinned                      int
+	MaxDailyCreate                 int
+	MemberBatchMax                 int
+	CollaborationRoleMaxPerProject int
+	CollaborationRoleMaxPerMember  int
+	DayBoundary                    *time.Location
+	ReconcileInterval              time.Duration
+	ReconcileLimit                 int
 	// AllMemberGroupAdmitGrace exempts a project seat written within this window
 	// from I4 scan B, because the admitter runs AFTER the seat transaction commits
 	// (D12) and there is therefore a real interval in which the seat exists and
@@ -157,17 +165,20 @@ func loadConfig() Config {
 	}
 	provisioning, _ := loadProvisioningConfig(os.Getenv)
 	return Config{
-		CreateEnabled:     envBool(envCreateEnabled, false),
-		ReconcileEnabled:  envBool(envReconcileEnabled, false),
-		MaxPerSpace:       envPositiveInt(envMaxPerSpace, defaultMaxPerSpace),
-		MaxPerCreator:     envPositiveInt(envMaxPerCreator, defaultMaxPerCreator),
-		MaxMembers:        envPositiveInt(envMaxMembers, defaultMaxMembers),
-		MaxPinned:         envPositiveInt(envMaxPinned, defaultMaxPinned),
-		MaxDailyCreate:    envPositiveInt(envMaxDailyCreate, defaultMaxDailyCreate),
-		MemberBatchMax:    envPositiveInt(envMemberBatchMax, defaultMemberBatchMax),
-		DayBoundary:       loc,
-		ReconcileInterval: envDuration(envReconcileEvery, defaultReconcileInterval),
-		ReconcileLimit:    envPositiveInt(envReconcileLimit, defaultReconcileLimit),
+		CreateEnabled:                  envBool(envCreateEnabled, false),
+		CollaborationRoleEnabled:       envBool(envCollaborationRoleEnabled, false),
+		ReconcileEnabled:               envBool(envReconcileEnabled, false),
+		MaxPerSpace:                    envPositiveInt(envMaxPerSpace, defaultMaxPerSpace),
+		MaxPerCreator:                  envPositiveInt(envMaxPerCreator, defaultMaxPerCreator),
+		MaxMembers:                     envPositiveInt(envMaxMembers, defaultMaxMembers),
+		MaxPinned:                      envPositiveInt(envMaxPinned, defaultMaxPinned),
+		MaxDailyCreate:                 envPositiveInt(envMaxDailyCreate, defaultMaxDailyCreate),
+		MemberBatchMax:                 envPositiveInt(envMemberBatchMax, defaultMemberBatchMax),
+		CollaborationRoleMaxPerProject: envPositiveInt(envCollaborationRoleMaxPerProject, defaultCollaborationRoleMaxPerProject),
+		CollaborationRoleMaxPerMember:  envPositiveInt(envCollaborationRoleMaxPerMember, defaultCollaborationRoleMaxPerMember),
+		DayBoundary:                    loc,
+		ReconcileInterval:              envDuration(envReconcileEvery, defaultReconcileInterval),
+		ReconcileLimit:                 envPositiveInt(envReconcileLimit, defaultReconcileLimit),
 		AllMemberGroupAdmitGrace: envDuration(
 			envAllMemberGroupAdmitGrace, defaultAllMemberGroupAdmitGrace),
 		MetricsInterval: envDuration(envMetricsEvery, defaultMetricsInterval),

--- a/modules/project/db.go
+++ b/modules/project/db.go
@@ -20,10 +20,10 @@ import (
 //     has no P0 writer by design. A reflective column list derives from struct
 //     fields, so it would start writing either one the moment somebody adds the
 //     field — and `is_official` would then be written with a value that happens to
-//     equal the default, making the regression invisible. `member_epoch` is
-//     likewise absent from the insert list: it takes the DDL default, so the ONLY
-//     statement in this package that writes that column is `member_epoch =
-//     member_epoch + 1`, which is what makes monotonicity checkable by grep.
+//     equal the default, making the regression invisible. `member_epoch` and
+//     `collaboration_role_epoch` are likewise absent from the insert list: they
+//     take the DDL defaults, so their only writers are atomic `epoch = epoch + 1`
+//     statements, which makes monotonicity checkable by grep.
 //
 //  2. **dbr backtick asymmetry.** Update / InsertInto / DeleteFrom take the bare
 //     table name (dbr quotes it); From / Select need manual backticks. Getting it
@@ -40,7 +40,7 @@ func NewDB(ctx *config.Context) *DB {
 }
 
 // projectInsertColumns is the write-side column list for octo_project. See the
-// type comment for why active_name / is_official / member_epoch are absent.
+// type comment for why active_name / is_official / both epoch columns are absent.
 var projectInsertColumns = []string{
 	"project_id", "space_id", "name", "description", "logo", "creator",
 	"discoverability", "max_members", "status",
@@ -82,7 +82,7 @@ func (d *DB) queryByProjectID(projectID string) (*Model, error) {
 	var models []*Model
 	_, err := d.session.SelectBySql(
 		"SELECT id, project_id, space_id, name, description, logo, creator, "+
-			"discoverability, max_members, member_epoch, status, all_member_group_no, "+
+			"discoverability, max_members, member_epoch, collaboration_role_epoch, status, all_member_group_no, "+
 			"created_at, updated_at "+
 			"FROM `octo_project` WHERE project_id = ? LIMIT 1", projectID,
 	).Load(&models)
@@ -105,7 +105,7 @@ func (d *DB) lockActiveProjectTx(tx *dbr.Tx, projectID string) (*Model, error) {
 	var models []*Model
 	_, err := tx.SelectBySql(
 		"SELECT id, project_id, space_id, name, description, logo, creator, "+
-			"discoverability, max_members, member_epoch, status, all_member_group_no, "+
+			"discoverability, max_members, member_epoch, collaboration_role_epoch, status, all_member_group_no, "+
 			"created_at, updated_at "+
 			"FROM `octo_project` WHERE project_id = ? AND status = ? FOR UPDATE",
 		projectID, StatusNormal,
@@ -287,7 +287,7 @@ func (d *DB) countCreatedInWindowTx(tx *dbr.Tx, creator string, from, to time.Ti
 // guard EXPLAINs the string production executes rather than a copy of it, and a
 // copy passes forever once the two drift.
 const sqlListVisibleInSpace = "SELECT p.project_id, p.space_id, p.name, p.description, p.logo, p.creator, " +
-	"p.discoverability, p.max_members, p.member_epoch, p.status, " +
+	"p.discoverability, p.max_members, p.member_epoch, p.collaboration_role_epoch, p.status, " +
 	// all_member_group_no on the LIST route too. The wire contract defines
 	// "" as "no group provisioned", so omitting the column here made every
 	// listed project claim it has none — the detail route and the list route

--- a/modules/project/db_collaboration_role.go
+++ b/modules/project/db_collaboration_role.go
@@ -1,0 +1,348 @@
+package project
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/gocraft/dbr/v2"
+)
+
+type collaborationRoleBindingRow struct {
+	UID        string `db:"uid"`
+	RoleID     string `db:"role_id"`
+	BuiltinKey string `db:"builtin_key"`
+	Name       string `db:"name"`
+	Source     string `db:"source"`
+}
+
+type collaborationRoleProjectRow struct {
+	ID        int64  `db:"id"`
+	ProjectID string `db:"project_id"`
+}
+
+type collaborationRoleIntegrityRow struct {
+	ProjectID string `db:"project_id"`
+	UID       string `db:"uid"`
+	RoleID    string `db:"role_id"`
+	Violating bool   `db:"violating"`
+}
+
+func (d *DB) seedBuiltinCollaborationRolesTx(tx *dbr.Tx, projectID string, now time.Time) (bool, error) {
+	var existingKeys []string
+	_, err := tx.SelectBySql(
+		"SELECT builtin_key FROM `octo_project_collaboration_role` "+
+			"WHERE project_id = ? AND source = ? FOR UPDATE",
+		projectID, CollaborationRoleSourceBuiltin,
+	).Load(&existingKeys)
+	if err != nil {
+		return false, fmt.Errorf("project: lock builtin collaboration roles: %w", err)
+	}
+	existing := make(map[string]struct{}, len(existingKeys))
+	for _, key := range existingKeys {
+		existing[key] = struct{}{}
+	}
+	changed := false
+	for _, role := range builtinCollaborationRoles {
+		if _, ok := existing[role.Key]; ok {
+			continue
+		}
+		_, err := tx.InsertBySql(
+			"INSERT INTO `octo_project_collaboration_role` "+
+				"(role_id, project_id, builtin_key, name, normalized_name, source, creator_uid, created_at, updated_at) "+
+				"VALUES (?, ?, ?, ?, ?, ?, '', ?, ?)",
+			util.GenerUUID(), projectID, role.Key, role.Name,
+			normalizeCollaborationRoleName(role.Name), CollaborationRoleSourceBuiltin, now, now,
+		).Exec()
+		if err != nil {
+			return false, fmt.Errorf("project: seed builtin collaboration role %s: %w", role.Key, err)
+		}
+		changed = true
+	}
+	return changed, nil
+}
+
+func (d *DB) collaborationRoleBackfillPage(afterID int64, limit int) ([]collaborationRoleProjectRow, error) {
+	var projects []collaborationRoleProjectRow
+	_, err := d.session.SelectBySql(
+		"SELECT id, project_id FROM `octo_project` "+
+			"WHERE status = ? AND id > ? ORDER BY id LIMIT ?",
+		StatusNormal, afterID, limit,
+	).Load(&projects)
+	if err != nil {
+		return nil, fmt.Errorf("project: query collaboration role backfill page: %w", err)
+	}
+	return projects, nil
+}
+
+// collaborationRoleIntegrityPage inspects at most limit association rows. The
+// LIMIT belongs to the primary-key-ordered base page, before any joins or
+// violation predicate, so a healthy table cannot turn this maintenance query
+// into a recurring full-table scan.
+func (d *DB) collaborationRoleIntegrityPage(
+	cursorProjectID, cursorUID, cursorRoleID string, limit int,
+) ([]*collaborationRoleIntegrityRow, error) {
+	var rows []*collaborationRoleIntegrityRow
+	_, err := d.session.SelectBySql(
+		"SELECT b.project_id, b.uid, b.role_id, "+
+			"(p.project_id IS NOT NULL AND p.status = ? AND "+
+			"(r.role_id IS NULL OR m.uid IS NULL OR m.status <> ? OR m.removing <> 0)) AS violating "+
+			"FROM ("+
+			"SELECT project_id, uid, role_id "+
+			"FROM `octo_project_member_collaboration_role` "+
+			"WHERE (project_id, uid, role_id) > (?, ?, ?) "+
+			"ORDER BY project_id, uid, role_id LIMIT ?"+
+			") b "+
+			"LEFT JOIN `octo_project` p ON p.project_id = b.project_id "+
+			"LEFT JOIN `octo_project_collaboration_role` r "+
+			"ON r.project_id = b.project_id AND r.role_id = b.role_id "+
+			"LEFT JOIN `octo_project_member` m "+
+			"ON m.project_id = b.project_id AND m.uid = b.uid "+
+			"ORDER BY b.project_id, b.uid, b.role_id",
+		StatusNormal, MemberStatusActive,
+		cursorProjectID, cursorUID, cursorRoleID, limit,
+	).Load(&rows)
+	if err != nil {
+		return nil, fmt.Errorf("project: query collaboration role integrity page: %w", err)
+	}
+	return rows, nil
+}
+
+func (d *DB) collaborationRoleCatalog(projectID string) ([]CollaborationRoleModel, int64, error) {
+	tx, err := d.session.Begin()
+	if err != nil {
+		return nil, 0, fmt.Errorf("project: begin collaboration role catalog read: %w", err)
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	var epochs []int64
+	_, err = tx.SelectBySql(
+		"SELECT collaboration_role_epoch FROM `octo_project` WHERE project_id = ? AND status = ?",
+		projectID, StatusNormal,
+	).Load(&epochs)
+	if err != nil {
+		return nil, 0, fmt.Errorf("project: query collaboration role epoch: %w", err)
+	}
+	if len(epochs) == 0 {
+		return nil, 0, errProjectGone
+	}
+
+	var roles []CollaborationRoleModel
+	_, err = tx.SelectBySql(
+		"SELECT role_id, project_id, IFNULL(builtin_key, '') AS builtin_key, name, "+
+			"normalized_name, source, creator_uid, created_at, updated_at "+
+			"FROM `octo_project_collaboration_role` WHERE project_id = ? "+
+			"ORDER BY CASE builtin_key "+
+			"WHEN 'product' THEN 1 WHEN 'frontend' THEN 2 WHEN 'backend' THEN 3 WHEN 'hr' THEN 4 ELSE 5 END, "+
+			"created_at ASC, role_id ASC",
+		projectID,
+	).Load(&roles)
+	if err != nil {
+		return nil, 0, fmt.Errorf("project: list collaboration roles: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, 0, fmt.Errorf("project: commit collaboration role catalog read: %w", err)
+	}
+	if roles == nil {
+		roles = []CollaborationRoleModel{}
+	}
+	return roles, epochs[0], nil
+}
+
+func (d *DB) countCollaborationRolesTx(tx *dbr.Tx, projectID string) (int, error) {
+	var count int
+	err := tx.SelectBySql(
+		"SELECT COUNT(*) FROM `octo_project_collaboration_role` WHERE project_id = ? FOR SHARE",
+		projectID,
+	).LoadOne(&count)
+	if err != nil {
+		return 0, fmt.Errorf("project: count collaboration roles: %w", err)
+	}
+	return count, nil
+}
+
+func (d *DB) insertCustomCollaborationRoleTx(tx *dbr.Tx, role *CollaborationRoleModel) error {
+	_, err := tx.InsertBySql(
+		"INSERT INTO `octo_project_collaboration_role` "+
+			"(role_id, project_id, builtin_key, name, normalized_name, source, creator_uid, created_at, updated_at) "+
+			"VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?)",
+		role.RoleID, role.ProjectID, role.Name, role.NormalizedName, role.Source,
+		role.CreatorUID, role.CreatedAt, role.UpdatedAt,
+	).Exec()
+	if err != nil {
+		return fmt.Errorf("project: insert custom collaboration role: %w", err)
+	}
+	return nil
+}
+
+func (d *DB) lockCollaborationRoleTx(tx *dbr.Tx, projectID, roleID string) (*CollaborationRoleModel, error) {
+	var roles []*CollaborationRoleModel
+	_, err := tx.SelectBySql(
+		"SELECT role_id, project_id, IFNULL(builtin_key, '') AS builtin_key, name, "+
+			"normalized_name, source, creator_uid, created_at, updated_at "+
+			"FROM `octo_project_collaboration_role` "+
+			"WHERE project_id = ? AND role_id = ? FOR UPDATE",
+		projectID, roleID,
+	).Load(&roles)
+	if err != nil {
+		return nil, fmt.Errorf("project: lock collaboration role: %w", err)
+	}
+	if len(roles) == 0 {
+		return nil, nil
+	}
+	return roles[0], nil
+}
+
+func (d *DB) updateCollaborationRoleTx(
+	tx *dbr.Tx, projectID, roleID, name, normalizedName string, now time.Time,
+) error {
+	_, err := tx.Update("octo_project_collaboration_role").
+		Set("name", name).
+		Set("normalized_name", normalizedName).
+		Set("updated_at", now).
+		Where("project_id = ? AND role_id = ? AND source = ?",
+			projectID, roleID, CollaborationRoleSourceCustom).
+		Exec()
+	if err != nil {
+		return fmt.Errorf("project: update collaboration role: %w", err)
+	}
+	return nil
+}
+
+func (d *DB) deleteCollaborationRoleTx(tx *dbr.Tx, projectID, roleID string) (bool, error) {
+	if _, err := tx.DeleteFrom("octo_project_member_collaboration_role").
+		Where("project_id = ? AND role_id = ?", projectID, roleID).
+		Exec(); err != nil {
+		return false, fmt.Errorf("project: delete collaboration role bindings: %w", err)
+	}
+	res, err := tx.DeleteFrom("octo_project_collaboration_role").
+		Where("project_id = ? AND role_id = ? AND source = ?",
+			projectID, roleID, CollaborationRoleSourceCustom).
+		Exec()
+	if err != nil {
+		return false, fmt.Errorf("project: delete collaboration role: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("project: delete collaboration role affected rows: %w", err)
+	}
+	return affected > 0, nil
+}
+
+func (d *DB) lockCollaborationRoleIDsTx(
+	tx *dbr.Tx, projectID string, roleIDs []string,
+) (map[string]struct{}, error) {
+	roles := make(map[string]struct{}, len(roleIDs))
+	if len(roleIDs) == 0 {
+		return roles, nil
+	}
+	var found []string
+	_, err := tx.SelectBySql(
+		"SELECT role_id FROM `octo_project_collaboration_role` "+
+			"WHERE project_id = ? AND role_id IN ? FOR SHARE",
+		projectID, roleIDs,
+	).Load(&found)
+	if err != nil {
+		return nil, fmt.Errorf("project: validate collaboration role ids: %w", err)
+	}
+	for _, roleID := range found {
+		roles[roleID] = struct{}{}
+	}
+	return roles, nil
+}
+
+func (d *DB) replaceMemberCollaborationRolesTx(
+	tx *dbr.Tx, projectID, uid string, roleIDs []string, now time.Time,
+) (bool, error) {
+	var current []string
+	_, err := tx.SelectBySql(
+		"SELECT role_id FROM `octo_project_member_collaboration_role` "+
+			"WHERE project_id = ? AND uid = ? ORDER BY role_id FOR UPDATE",
+		projectID, uid,
+	).Load(&current)
+	if err != nil {
+		return false, fmt.Errorf("project: lock member collaboration roles: %w", err)
+	}
+	if sameStringSet(current, roleIDs) {
+		return false, nil
+	}
+	if _, err := tx.DeleteFrom("octo_project_member_collaboration_role").
+		Where("project_id = ? AND uid = ?", projectID, uid).
+		Exec(); err != nil {
+		return false, fmt.Errorf("project: clear member collaboration roles: %w", err)
+	}
+	for _, roleID := range roleIDs {
+		_, err := tx.InsertInto("octo_project_member_collaboration_role").
+			Columns("project_id", "uid", "role_id", "created_at").
+			Values(projectID, uid, roleID, now).
+			Exec()
+		if err != nil {
+			return false, fmt.Errorf("project: bind member collaboration role: %w", err)
+		}
+	}
+	return true, nil
+}
+
+func (d *DB) deleteMemberCollaborationRolesTx(
+	tx *dbr.Tx, projectID string, uids []string,
+) (bool, error) {
+	if len(uids) == 0 {
+		return false, nil
+	}
+	res, err := tx.DeleteFrom("octo_project_member_collaboration_role").
+		Where("project_id = ? AND uid IN ?", projectID, uids).
+		Exec()
+	if err != nil {
+		return false, fmt.Errorf("project: clear closing member collaboration roles: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("project: clear closing member collaboration roles affected rows: %w", err)
+	}
+	return affected > 0, nil
+}
+
+func (d *DB) bumpCollaborationRoleEpochTx(tx *dbr.Tx, projectID string) error {
+	_, err := tx.UpdateBySql(
+		"UPDATE `octo_project` SET collaboration_role_epoch = collaboration_role_epoch + 1 "+
+			"WHERE project_id = ? AND status = ?",
+		projectID, StatusNormal,
+	).Exec()
+	if err != nil {
+		return fmt.Errorf("project: bump collaboration role epoch: %w", err)
+	}
+	return nil
+}
+
+func (d *DB) memberCollaborationRoles(
+	projectID string, uids []string,
+) (map[string][]CollaborationRoleResp, error) {
+	byUID := make(map[string][]CollaborationRoleResp, len(uids))
+	for _, uid := range uids {
+		byUID[uid] = []CollaborationRoleResp{}
+	}
+	if len(uids) == 0 {
+		return byUID, nil
+	}
+	var rows []collaborationRoleBindingRow
+	_, err := d.session.SelectBySql(
+		"SELECT b.uid, r.role_id, IFNULL(r.builtin_key, '') AS builtin_key, r.name, r.source "+
+			"FROM `octo_project_member_collaboration_role` b "+
+			"INNER JOIN `octo_project_collaboration_role` r "+
+			"ON r.project_id = b.project_id AND r.role_id = b.role_id "+
+			"WHERE b.project_id = ? AND b.uid IN ? "+
+			"ORDER BY b.uid, CASE r.builtin_key "+
+			"WHEN 'product' THEN 1 WHEN 'frontend' THEN 2 WHEN 'backend' THEN 3 WHEN 'hr' THEN 4 ELSE 5 END, "+
+			"r.created_at ASC, r.role_id ASC",
+		projectID, uids,
+	).Load(&rows)
+	if err != nil {
+		return nil, fmt.Errorf("project: list member collaboration roles: %w", err)
+	}
+	for _, row := range rows {
+		byUID[row.UID] = append(byUID[row.UID], CollaborationRoleResp{
+			RoleID: row.RoleID, BuiltinKey: row.BuiltinKey, Name: row.Name, Source: row.Source,
+		})
+	}
+	return byUID, nil
+}

--- a/modules/project/metrics.go
+++ b/modules/project/metrics.go
@@ -20,30 +20,40 @@ const metricNamespace = "project"
 // you that one of them forgot to check I1. Adding a path without adding its entry
 // value here is the failure this label exists to expose.
 const (
-	entryMemberAdd      = "member_add"
-	entryRoleChange     = "role_change"
-	entryCreateOwner    = "create_owner_seat"
-	entryLeave          = "leave"
-	entryMemberRemove   = "member_remove"
-	entryProjectCreate  = "project_create"
-	entryProjectUpdate  = "project_update"
-	entryProjectDisband = "project_disband"
-	entryProjectSetting = "project_setting"
+	entryMemberAdd               = "member_add"
+	entryRoleChange              = "role_change"
+	entryCreateOwner             = "create_owner_seat"
+	entryLeave                   = "leave"
+	entryMemberRemove            = "member_remove"
+	entryProjectCreate           = "project_create"
+	entryProjectUpdate           = "project_update"
+	entryProjectDisband          = "project_disband"
+	entryProjectSetting          = "project_setting"
+	entryCollaborationRoleCreate = "collaboration_role_create"
+	entryCollaborationRoleRename = "collaboration_role_rename"
+	entryCollaborationRoleDelete = "collaboration_role_delete"
+	entryCollaborationRoleBind   = "collaboration_role_bind"
 )
 
 // Rejection reasons. Low-cardinality enum; never a free-form message.
 const (
-	reasonNotSpaceMember   = "not_space_member"
-	reasonQuotaMembers     = "quota_members"
-	reasonQuotaPerSpace    = "quota_per_space"
-	reasonQuotaPerCreator  = "quota_per_creator"
-	reasonQuotaDailyCreate = "quota_daily_create"
-	reasonQuotaPinned      = "quota_pinned"
-	reasonProjectDisbanded = "project_disbanded"
-	reasonFlagOff          = "flag_off"
-	reasonPermissionDenied = "permission_denied"
-	reasonLastOwner        = "last_owner"
-	reasonNameDuplicated   = "name_duplicated"
+	reasonNotSpaceMember                 = "not_space_member"
+	reasonQuotaMembers                   = "quota_members"
+	reasonQuotaPerSpace                  = "quota_per_space"
+	reasonQuotaPerCreator                = "quota_per_creator"
+	reasonQuotaDailyCreate               = "quota_daily_create"
+	reasonQuotaPinned                    = "quota_pinned"
+	reasonProjectDisbanded               = "project_disbanded"
+	reasonFlagOff                        = "flag_off"
+	reasonPermissionDenied               = "permission_denied"
+	reasonLastOwner                      = "last_owner"
+	reasonNameDuplicated                 = "name_duplicated"
+	reasonCollaborationRoleNameInvalid   = "collaboration_role_name_invalid"
+	reasonCollaborationRoleInvalid       = "collaboration_role_invalid"
+	reasonCollaborationRoleTargetInvalid = "collaboration_role_target_invalid"
+	reasonCollaborationRoleDuplicated    = "collaboration_role_duplicated"
+	reasonQuotaCollaborationRoles        = "quota_collaboration_roles"
+	reasonQuotaMemberCollaborationRoles  = "quota_member_collaboration_roles"
 	// reasonProvisioningEnqueue is the outbox-write failure inside project creation.
 	// Separate from a generic store failure because this slice is what made create
 	// depend on that write at all; see errProvisioningEnqueueFailed.
@@ -52,6 +62,12 @@ const (
 	// (D3/D15). One reason label, matching the single error code: splitting it
 	// here would put on a dashboard the distinctions the wire deliberately hides.
 	reasonAgentNotEligible = "agent_not_eligible"
+)
+
+const (
+	collaborationRoleOutcomeChanged  = "changed"
+	collaborationRoleOutcomeNoop     = "noop"
+	collaborationRoleOutcomeRejected = "rejected"
 )
 
 var (
@@ -66,6 +82,32 @@ var (
 		Help: "Refused project writes, labeled by entry point and reason. " +
 			"The entry breakdown is what exposes a write path that skipped invariant I1.",
 	}, []string{"entry", "reason"})
+
+	collaborationRoleWrites = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricNamespace,
+		Name:      "collaboration_role_writes_total",
+		Help:      "Project collaboration-role write attempts by bounded action and outcome.",
+	}, []string{"action", "outcome"})
+	collaborationRoleBackfillPending = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: metricNamespace,
+		Name:      "collaboration_role_backfill_pending",
+		Help:      "Active projects missing built-in collaboration roles in the latest bounded page.",
+	})
+	collaborationRoleBackfilled = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: metricNamespace,
+		Name:      "collaboration_role_backfilled_total",
+		Help:      "Projects whose built-in collaboration-role catalog was repaired by the bounded backfill.",
+	})
+	collaborationRoleIntegrityViolations = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: metricNamespace,
+		Name:      "collaboration_role_integrity_violations",
+		Help:      "Orphan collaboration-role bindings or bindings on inactive seats across the latest completed bounded cursor rotation.",
+	})
+	collaborationRoleMaintenanceFailures = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricNamespace,
+		Name:      "collaboration_role_maintenance_failures_total",
+		Help:      "Failed collaboration-role backfill or integrity-scan operations.",
+	}, []string{"operation"})
 
 	// projectTotal / memberTotal are refreshed on the sparse metrics tick.
 	projectTotal = promauto.NewGauge(prometheus.GaugeOpts{
@@ -194,6 +236,10 @@ var (
 // observeRejected records one refused write.
 func observeRejected(entry, reason string) {
 	writeRejected.WithLabelValues(entry, reason).Inc()
+}
+
+func observeCollaborationRoleWrite(action, outcome string) {
+	collaborationRoleWrites.WithLabelValues(action, outcome).Inc()
 }
 
 // ---------------------------------------------------------------------------

--- a/modules/project/model.go
+++ b/modules/project/model.go
@@ -91,17 +91,18 @@ const (
 // It likewise has no IsOfficial field: no P0 code path writes that column, and
 // leaving it out of the model is what makes that checkable rather than aspirational.
 type Model struct {
-	ID              int64  `db:"id"`
-	ProjectID       string `db:"project_id"`
-	SpaceID         string `db:"space_id"`
-	Name            string `db:"name"`
-	Description     string `db:"description"`
-	Logo            string `db:"logo"`
-	Creator         string `db:"creator"`
-	Discoverability int    `db:"discoverability"`
-	MaxMembers      int    `db:"max_members"`
-	MemberEpoch     int64  `db:"member_epoch"`
-	Status          int    `db:"status"`
+	ID                     int64  `db:"id"`
+	ProjectID              string `db:"project_id"`
+	SpaceID                string `db:"space_id"`
+	Name                   string `db:"name"`
+	Description            string `db:"description"`
+	Logo                   string `db:"logo"`
+	Creator                string `db:"creator"`
+	Discoverability        int    `db:"discoverability"`
+	MaxMembers             int    `db:"max_members"`
+	MemberEpoch            int64  `db:"member_epoch"`
+	CollaborationRoleEpoch int64  `db:"collaboration_role_epoch"`
+	Status                 int    `db:"status"`
 	// AllMemberGroupNo is this project's all-member group, or "" when it has
 	// none yet. "" is the sentinel and the column is NOT NULL, so every
 	// predicate in the feature is written `= ''` / `!= ''` (see D5).
@@ -211,6 +212,14 @@ type roleReq struct {
 	TransferTo string `json:"transfer_to"`
 }
 
+type collaborationRoleNameReq struct {
+	Name string `json:"name"`
+}
+
+type collaborationRoleBindingReq struct {
+	RoleIDs []string `json:"role_ids"`
+}
+
 // ---------- API responses ----------
 
 // Resp is the Project payload returned by list and detail.
@@ -244,9 +253,10 @@ type Resp struct {
 	// messages, so it costs a seat.
 	MemberCount int `json:"member_count"`
 	// AgentCount is the number of active AI agent seats.
-	AgentCount  int   `json:"agent_count"`
-	MemberEpoch int64 `json:"member_epoch"`
-	Status      int   `json:"status"`
+	AgentCount             int   `json:"agent_count"`
+	MemberEpoch            int64 `json:"member_epoch"`
+	CollaborationRoleEpoch int64 `json:"collaboration_role_epoch"`
+	Status                 int   `json:"status"`
 	// AllMemberGroupNo is this project's all-member group, or "" when it has
 	// none yet (provisioning failed and has not been retried; see D4). A client
 	// showing an entry point to the group must handle "" rather than assuming.
@@ -295,8 +305,38 @@ type MemberResp struct {
 	// OwnerUID is the agent's owner (robot.creator_uid); empty for a person and
 	// for an agent whose owner row is gone. It is the join key the client uses
 	// to nest an agent under its owner.
-	OwnerUID  string `json:"owner_uid"`
-	CreatedAt string `json:"created_at"`
+	OwnerUID           string                  `json:"owner_uid"`
+	CollaborationRoles []CollaborationRoleResp `json:"collaboration_roles"`
+	CreatedAt          string                  `json:"created_at"`
+}
+
+const (
+	CollaborationRoleSourceBuiltin = "builtin"
+	CollaborationRoleSourceCustom  = "custom"
+)
+
+type CollaborationRoleModel struct {
+	RoleID         string    `db:"role_id"`
+	ProjectID      string    `db:"project_id"`
+	BuiltinKey     string    `db:"builtin_key"`
+	Name           string    `db:"name"`
+	NormalizedName string    `db:"normalized_name"`
+	Source         string    `db:"source"`
+	CreatorUID     string    `db:"creator_uid"`
+	CreatedAt      time.Time `db:"created_at"`
+	UpdatedAt      time.Time `db:"updated_at"`
+}
+
+type CollaborationRoleResp struct {
+	RoleID     string `json:"role_id"`
+	BuiltinKey string `json:"builtin_key,omitempty"`
+	Name       string `json:"name"`
+	Source     string `json:"source"`
+}
+
+type collaborationRoleCatalogResp struct {
+	CollaborationRoleEpoch int64                   `json:"collaboration_role_epoch"`
+	Roles                  []CollaborationRoleResp `json:"roles"`
 }
 
 // GroupResp is one row of the project group list.

--- a/modules/project/service.go
+++ b/modules/project/service.go
@@ -532,6 +532,13 @@ func (p *Project) createProjectOnce(in createInput) (*Model, error) {
 		}
 		return nil, err
 	}
+	// Collaboration roles are descriptive metadata, not authorization. Seed the
+	// built-in catalog in the same transaction as the project so a successful
+	// create never exposes a partially initialized catalog. The built-in key's
+	// unique constraint makes retries and the bounded backfill idempotent.
+	if _, err := p.db.seedBuiltinCollaborationRolesTx(tx, model.ProjectID, now); err != nil {
+		return nil, err
+	}
 	if _, err := p.db.admitMemberTx(tx, &MemberModel{
 		ProjectID: model.ProjectID,
 		UID:       in.Creator,
@@ -1940,6 +1947,18 @@ func (p *Project) beginRemovalWithAgentsTx(
 			return false, nil, err
 		}
 		closedAgents = append(closedAgents, agentUID)
+	}
+	closingUIDs := make([]string, 0, 1+len(closedAgents))
+	closingUIDs = append(closingUIDs, targetUID)
+	closingUIDs = append(closingUIDs, closedAgents...)
+	rolesCleared, err := p.db.deleteMemberCollaborationRolesTx(tx, projectID, closingUIDs)
+	if err != nil {
+		return false, nil, err
+	}
+	if rolesCleared {
+		if err := p.db.bumpCollaborationRoleEpochTx(tx, projectID); err != nil {
+			return false, nil, err
+		}
 	}
 
 	if err := p.db.bumpMemberEpochTx(tx, projectID, now); err != nil {

--- a/modules/project/service_collaboration_role.go
+++ b/modules/project/service_collaboration_role.go
@@ -1,0 +1,400 @@
+package project
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+)
+
+const maxCollaborationRoleNameChars = 32
+
+var (
+	errCollaborationRoleNameInvalid   = errors.New("project: collaboration role name is invalid")
+	errCollaborationRoleInvalid       = errors.New("project: collaboration role is invalid")
+	errCollaborationRoleTargetInvalid = errors.New("project: collaboration role target is invalid")
+	errCollaborationRoleDuplicated    = errors.New("project: collaboration role name already exists")
+	errQuotaCollaborationRoles        = errors.New("project: collaboration role quota reached")
+	errQuotaMemberCollaborationRoles  = errors.New("project: member collaboration role quota reached")
+)
+
+type builtinCollaborationRole struct {
+	Key  string
+	Name string
+}
+
+var builtinCollaborationRoles = []builtinCollaborationRole{
+	{Key: "product", Name: "产品"},
+	{Key: "frontend", Name: "前端"},
+	{Key: "backend", Name: "后端"},
+	{Key: "hr", Name: "HR"},
+}
+
+func normalizeCollaborationRoleName(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+func validateCollaborationRoleName(name string) (string, string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" || utf8.RuneCountInString(name) > maxCollaborationRoleNameChars {
+		return "", "", errCollaborationRoleNameInvalid
+	}
+	for _, r := range name {
+		if unicode.IsControl(r) {
+			return "", "", errCollaborationRoleNameInvalid
+		}
+	}
+	return name, normalizeCollaborationRoleName(name), nil
+}
+
+func validateCollaborationRoleIDs(roleIDs []string, max int) ([]string, error) {
+	if roleIDs == nil {
+		return nil, errCollaborationRoleInvalid
+	}
+	seen := make(map[string]struct{}, len(roleIDs))
+	out := make([]string, 0, len(roleIDs))
+	for _, roleID := range roleIDs {
+		roleID = strings.TrimSpace(roleID)
+		if roleID == "" || len(roleID) > 40 {
+			return nil, errCollaborationRoleInvalid
+		}
+		if _, exists := seen[roleID]; exists {
+			return nil, errCollaborationRoleInvalid
+		}
+		seen[roleID] = struct{}{}
+		out = append(out, roleID)
+	}
+	if len(out) > max {
+		return nil, errQuotaMemberCollaborationRoles
+	}
+	return out, nil
+}
+
+func sameStringSet(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	leftCopy := append([]string(nil), left...)
+	rightCopy := append([]string(nil), right...)
+	sort.Strings(leftCopy)
+	sort.Strings(rightCopy)
+	for i := range leftCopy {
+		if leftCopy[i] != rightCopy[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func collaborationRoleToResp(role CollaborationRoleModel) CollaborationRoleResp {
+	return CollaborationRoleResp{
+		RoleID: role.RoleID, BuiltinKey: role.BuiltinKey, Name: role.Name, Source: role.Source,
+	}
+}
+
+func (p *Project) listCollaborationRoles(projectID string) ([]CollaborationRoleResp, int64, error) {
+	roles, epoch, err := p.db.collaborationRoleCatalog(projectID)
+	if err != nil {
+		return nil, 0, err
+	}
+	result := make([]CollaborationRoleResp, 0, len(roles))
+	for _, role := range roles {
+		result = append(result, collaborationRoleToResp(role))
+	}
+	return result, epoch, nil
+}
+
+func (p *Project) createCollaborationRole(
+	projectID, spaceID, actorUID, rawName string,
+) (*CollaborationRoleModel, error) {
+	name, normalizedName, err := validateCollaborationRoleName(rawName)
+	if err != nil {
+		return nil, err
+	}
+	var role *CollaborationRoleModel
+	err = retryOnLockConflict(func() error {
+		var attemptErr error
+		role, attemptErr = p.createCollaborationRoleOnce(projectID, spaceID, actorUID, name, normalizedName)
+		return attemptErr
+	})
+	return role, err
+}
+
+func (p *Project) createCollaborationRoleOnce(
+	projectID, spaceID, actorUID, name, normalizedName string,
+) (*CollaborationRoleModel, error) {
+	now := time.Now().UTC()
+	tx, err := p.db.session.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("project: begin create collaboration role: %w", err)
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	if err := p.requireSpaceSeatsTx(tx, spaceID, actorUID); err != nil {
+		return nil, err
+	}
+	project, err := p.db.lockActiveProjectTx(tx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	if project == nil || project.SpaceID != spaceID {
+		return nil, errProjectGone
+	}
+	actorRole, err := p.actorRoleTx(tx, projectID, actorUID)
+	if err != nil {
+		return nil, err
+	}
+	if actorRole != RoleOwner {
+		return nil, errPermissionDenied
+	}
+	count, err := p.db.countCollaborationRolesTx(tx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	if count >= p.cfg.CollaborationRoleMaxPerProject {
+		return nil, errQuotaCollaborationRoles
+	}
+	role := &CollaborationRoleModel{
+		RoleID: util.GenerUUID(), ProjectID: projectID, Name: name,
+		NormalizedName: normalizedName, Source: CollaborationRoleSourceCustom,
+		CreatorUID: actorUID, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := p.db.insertCustomCollaborationRoleTx(tx, role); err != nil {
+		if isDuplicateKeyErr(err) {
+			return nil, errCollaborationRoleDuplicated
+		}
+		return nil, err
+	}
+	if err := p.db.bumpCollaborationRoleEpochTx(tx, projectID); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("project: commit create collaboration role: %w", err)
+	}
+	return role, nil
+}
+
+func (p *Project) renameCollaborationRole(
+	projectID, spaceID, actorUID, roleID, rawName string,
+) (*CollaborationRoleModel, bool, error) {
+	name, normalizedName, err := validateCollaborationRoleName(rawName)
+	if err != nil {
+		return nil, false, err
+	}
+	var role *CollaborationRoleModel
+	var changed bool
+	err = retryOnLockConflict(func() error {
+		var attemptErr error
+		role, changed, attemptErr = p.renameCollaborationRoleOnce(
+			projectID, spaceID, actorUID, roleID, name, normalizedName)
+		return attemptErr
+	})
+	return role, changed, err
+}
+
+func (p *Project) renameCollaborationRoleOnce(
+	projectID, spaceID, actorUID, roleID, name, normalizedName string,
+) (*CollaborationRoleModel, bool, error) {
+	now := time.Now().UTC()
+	tx, err := p.db.session.Begin()
+	if err != nil {
+		return nil, false, fmt.Errorf("project: begin rename collaboration role: %w", err)
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	if err := p.requireSpaceSeatsTx(tx, spaceID, actorUID); err != nil {
+		return nil, false, err
+	}
+	project, err := p.db.lockActiveProjectTx(tx, projectID)
+	if err != nil {
+		return nil, false, err
+	}
+	if project == nil || project.SpaceID != spaceID {
+		return nil, false, errProjectGone
+	}
+	actorRole, err := p.actorRoleTx(tx, projectID, actorUID)
+	if err != nil {
+		return nil, false, err
+	}
+	if actorRole != RoleOwner {
+		return nil, false, errPermissionDenied
+	}
+	role, err := p.db.lockCollaborationRoleTx(tx, projectID, roleID)
+	if err != nil {
+		return nil, false, err
+	}
+	if role == nil || role.Source != CollaborationRoleSourceCustom {
+		return nil, false, errCollaborationRoleInvalid
+	}
+	// The table's display-name collation is intentionally case-insensitive for
+	// ordinary reads. Compare the locked values in Go so a display-only rename
+	// such as designer -> Designer is not mistaken for a no-op by SQL collation.
+	changed := role.Name != name || role.NormalizedName != normalizedName
+	if changed {
+		if err := p.db.updateCollaborationRoleTx(tx, projectID, roleID, name, normalizedName, now); err != nil {
+			if isDuplicateKeyErr(err) {
+				return nil, false, errCollaborationRoleDuplicated
+			}
+			return nil, false, err
+		}
+		if err := p.db.bumpCollaborationRoleEpochTx(tx, projectID); err != nil {
+			return nil, false, err
+		}
+		role.Name = name
+		role.NormalizedName = normalizedName
+		role.UpdatedAt = now
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, false, fmt.Errorf("project: commit rename collaboration role: %w", err)
+	}
+	return role, changed, nil
+}
+
+func (p *Project) deleteCollaborationRole(
+	projectID, spaceID, actorUID, roleID string,
+) (bool, error) {
+	var changed bool
+	err := retryOnLockConflict(func() error {
+		var attemptErr error
+		changed, attemptErr = p.deleteCollaborationRoleOnce(projectID, spaceID, actorUID, roleID)
+		return attemptErr
+	})
+	return changed, err
+}
+
+func (p *Project) deleteCollaborationRoleOnce(
+	projectID, spaceID, actorUID, roleID string,
+) (bool, error) {
+	tx, err := p.db.session.Begin()
+	if err != nil {
+		return false, fmt.Errorf("project: begin delete collaboration role: %w", err)
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	if err := p.requireSpaceSeatsTx(tx, spaceID, actorUID); err != nil {
+		return false, err
+	}
+	project, err := p.db.lockActiveProjectTx(tx, projectID)
+	if err != nil {
+		return false, err
+	}
+	if project == nil || project.SpaceID != spaceID {
+		return false, errProjectGone
+	}
+	actorRole, err := p.actorRoleTx(tx, projectID, actorUID)
+	if err != nil {
+		return false, err
+	}
+	if actorRole != RoleOwner {
+		return false, errPermissionDenied
+	}
+	role, err := p.db.lockCollaborationRoleTx(tx, projectID, roleID)
+	if err != nil {
+		return false, err
+	}
+	if role == nil || role.Source != CollaborationRoleSourceCustom {
+		return false, errCollaborationRoleInvalid
+	}
+	changed, err := p.db.deleteCollaborationRoleTx(tx, projectID, roleID)
+	if err != nil {
+		return false, err
+	}
+	if changed {
+		if err := p.db.bumpCollaborationRoleEpochTx(tx, projectID); err != nil {
+			return false, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("project: commit delete collaboration role: %w", err)
+	}
+	return changed, nil
+}
+
+func (p *Project) replaceMemberCollaborationRoles(
+	projectID, spaceID, actorUID, targetUID string, rawRoleIDs []string,
+) (bool, error) {
+	roleIDs, err := validateCollaborationRoleIDs(rawRoleIDs, p.cfg.CollaborationRoleMaxPerMember)
+	if err != nil {
+		return false, err
+	}
+	var changed bool
+	err = retryOnLockConflict(func() error {
+		var attemptErr error
+		changed, attemptErr = p.replaceMemberCollaborationRolesOnce(
+			projectID, spaceID, actorUID, targetUID, roleIDs)
+		return attemptErr
+	})
+	return changed, err
+}
+
+func (p *Project) replaceMemberCollaborationRolesOnce(
+	projectID, spaceID, actorUID, targetUID string, roleIDs []string,
+) (bool, error) {
+	now := time.Now().UTC()
+	tx, err := p.db.session.Begin()
+	if err != nil {
+		return false, fmt.Errorf("project: begin replace member collaboration roles: %w", err)
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	held, err := p.lockSeatsTx(tx, spaceID, actorUID, nil, []string{targetUID})
+	if err != nil {
+		return false, err
+	}
+	project, err := p.db.lockActiveProjectTx(tx, projectID)
+	if err != nil {
+		return false, err
+	}
+	if project == nil || project.SpaceID != spaceID {
+		return false, errProjectGone
+	}
+	actorRole, err := p.actorRoleTx(tx, projectID, actorUID)
+	if err != nil {
+		return false, err
+	}
+	if !canManageMembers(actorRole) {
+		return false, errPermissionDenied
+	}
+	if targetUID == "" || !held[targetUID] {
+		return false, errCollaborationRoleTargetInvalid
+	}
+	target, err := p.db.queryMemberTx(tx, projectID, targetUID)
+	if err != nil {
+		return false, err
+	}
+	if target == nil || target.Status != MemberStatusActive || target.Removing != 0 {
+		return false, errCollaborationRoleTargetInvalid
+	}
+	class, err := p.db.queryAgentClassTx(tx, targetUID)
+	if err != nil {
+		return false, err
+	}
+	if class.IsBot {
+		return false, errCollaborationRoleTargetInvalid
+	}
+	validRoles, err := p.db.lockCollaborationRoleIDsTx(tx, projectID, roleIDs)
+	if err != nil {
+		return false, err
+	}
+	if len(validRoles) != len(roleIDs) {
+		return false, errCollaborationRoleInvalid
+	}
+	changed, err := p.db.replaceMemberCollaborationRolesTx(tx, projectID, targetUID, roleIDs, now)
+	if err != nil {
+		return false, err
+	}
+	if changed {
+		if err := p.db.bumpCollaborationRoleEpochTx(tx, projectID); err != nil {
+			return false, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("project: commit replace member collaboration roles: %w", err)
+	}
+	return changed, nil
+}

--- a/modules/project/space_member_removal.go
+++ b/modules/project/space_member_removal.go
@@ -497,6 +497,18 @@ func (p *Project) deactivateSeatForCascade(projectID, spaceID, uid, operatorUID,
 			}
 			removingAgents = append(removingAgents, agentUID)
 		}
+		closingUIDs := make([]string, 0, 1+len(removingAgents))
+		closingUIDs = append(closingUIDs, uid)
+		closingUIDs = append(closingUIDs, removingAgents...)
+		rolesCleared, err := p.db.deleteMemberCollaborationRolesTx(tx, projectID, closingUIDs)
+		if err != nil {
+			return false, err
+		}
+		if rolesCleared {
+			if err := p.db.bumpCollaborationRoleEpochTx(tx, projectID); err != nil {
+				return false, err
+			}
+		}
 		// Only when a row actually changed. The step is re-run on every job retry, so
 		// an unconditional bump would inflate the epoch on no-op reruns and break the
 		// "a no-op does not change the epoch" rule clients cache against.

--- a/modules/project/sql/20260909000001_project_collaboration_role.sql
+++ b/modules/project/sql/20260909000001_project_collaboration_role.sql
@@ -1,0 +1,42 @@
+-- +migrate Up
+
+ALTER TABLE `octo_project`
+  ADD COLUMN `collaboration_role_epoch` BIGINT NOT NULL DEFAULT 0
+    COMMENT '协作角色目录或成员绑定每次真实变更 +1；与 member_epoch 权限/席位纪元分离'
+    AFTER `member_epoch`;
+
+CREATE TABLE `octo_project_collaboration_role` (
+  `role_id`         VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '协作角色稳定 ID',
+  `project_id`      VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '所属项目',
+  `builtin_key`     VARCHAR(40)  NULL                 COMMENT '内置角色稳定键；自定义角色为 NULL',
+  `name`            VARCHAR(64)  NOT NULL DEFAULT '' COMMENT '展示名称',
+  `normalized_name` VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin
+                                  NOT NULL DEFAULT '' COMMENT 'trim+小写后的项目内唯一名称；保留重音差异',
+  `source`          VARCHAR(16)  NOT NULL DEFAULT '' COMMENT 'builtin/custom；不承载权限',
+  `creator_uid`     VARCHAR(40)  NOT NULL DEFAULT '' COMMENT '自定义角色创建者；内置为空',
+  `created_at`      DATETIME(3)  NOT NULL,
+  `updated_at`      DATETIME(3)  NOT NULL,
+  PRIMARY KEY (`role_id`),
+  UNIQUE KEY `uk_octo_project_collab_role_name` (`project_id`, `normalized_name`),
+  UNIQUE KEY `uk_octo_project_collab_role_builtin` (`project_id`, `builtin_key`),
+  KEY `idx_octo_project_collab_role_project` (`project_id`, `created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `octo_project_member_collaboration_role` (
+  `project_id` VARCHAR(40) NOT NULL DEFAULT '' COMMENT '项目 ID',
+  `uid`        VARCHAR(40) NOT NULL DEFAULT '' COMMENT '真人项目成员 uid',
+  `role_id`    VARCHAR(40) NOT NULL DEFAULT '' COMMENT '协作角色 ID',
+  `created_at` DATETIME(3) NOT NULL,
+  PRIMARY KEY (`project_id`, `uid`, `role_id`),
+  KEY `idx_octo_project_member_collab_role_role` (`project_id`, `role_id`, `uid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- 存量项目不在 DDL 事务中做无界 INSERT ... SELECT。应用启动后的有界维护任务
+-- 每轮最多处理 OCTO_PROJECT_RECONCILE_LIMIT 个项目，并依靠
+-- (project_id, builtin_key) 唯一键保证多实例并发和重试幂等。
+
+-- +migrate Down
+
+DROP TABLE IF EXISTS `octo_project_member_collaboration_role`;
+DROP TABLE IF EXISTS `octo_project_collaboration_role`;
+ALTER TABLE `octo_project` DROP COLUMN `collaboration_role_epoch`;

--- a/pkg/errcode/project.go
+++ b/pkg/errcode/project.go
@@ -80,6 +80,22 @@ var (
 		DefaultMessage: "Invalid project member role.",
 		SafeDetailKeys: []string{"field"},
 	})
+	ErrProjectCollaborationRoleNameInvalid = register(codes.Code{
+		ID:             "err.server.project.collaboration_role_name_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The collaboration role name is invalid.",
+		SafeDetailKeys: []string{"field", "max_chars"},
+	})
+	ErrProjectCollaborationRoleInvalid = register(codes.Code{
+		ID:             "err.server.project.collaboration_role_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The collaboration role is invalid.",
+	})
+	ErrProjectCollaborationRoleTargetInvalid = register(codes.Code{
+		ID:             "err.server.project.collaboration_role_target_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The collaboration role target is invalid.",
+	})
 
 	// ---- permission / policy (403) -------------------------------------------
 
@@ -105,6 +121,11 @@ var (
 		ID:             "err.server.project.disabled",
 		HTTPStatus:     http.StatusForbidden,
 		DefaultMessage: "The project feature has been disabled by the administrator.",
+	})
+	ErrProjectCollaborationRoleDisabled = register(codes.Code{
+		ID:             "err.server.project.collaboration_role_disabled",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Project collaboration-role changes are disabled.",
 	})
 	// ErrProjectMemberNotSpaceMember is the I1 rejection: the TARGET uid is not
 	// an active member of the project's Space. Checked inside the request
@@ -183,6 +204,18 @@ var (
 		DefaultMessage: "This project has reached its member limit.",
 		SafeDetailKeys: []string{"max"},
 	})
+	ErrProjectQuotaCollaborationRoles = register(codes.Code{
+		ID:             "err.server.project.quota_collaboration_roles",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "This project has reached its collaboration role limit.",
+		SafeDetailKeys: []string{"max"},
+	})
+	ErrProjectQuotaMemberCollaborationRoles = register(codes.Code{
+		ID:             "err.server.project.quota_member_collaboration_roles",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "This member has reached the collaboration role limit.",
+		SafeDetailKeys: []string{"max"},
+	})
 	// ErrProjectQuotaDailyCreate covers the per-user per-day creation cap.
 	ErrProjectQuotaDailyCreate = register(codes.Code{
 		ID:             "err.server.project.quota_daily_create",
@@ -217,6 +250,11 @@ var (
 		ID:             "err.server.project.name_duplicated",
 		HTTPStatus:     http.StatusConflict,
 		DefaultMessage: "A project with this name already exists in this space.",
+	})
+	ErrProjectCollaborationRoleDuplicated = register(codes.Code{
+		ID:             "err.server.project.collaboration_role_duplicated",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "A collaboration role with this name already exists in the project.",
 	})
 	// ErrProjectLastOwnerMustTransfer covers the last owner leaving or being
 	// demoted without naming a successor. The transfer and the departure happen

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -1464,6 +1464,15 @@ other = "所选的 AI 分身中有无法加入本项目的，请调整后重试�
 ["err.server.project.role_invalid"]
 other = "项目成员角色无效。"
 
+["err.server.project.collaboration_role_name_invalid"]
+other = "项目协作角色名称无效。"
+
+["err.server.project.collaboration_role_invalid"]
+other = "项目协作角色无效。"
+
+["err.server.project.collaboration_role_target_invalid"]
+other = "该成员不能设置项目协作角色。"
+
 ["err.server.project.permission_denied"]
 other = "你没有权限执行此操作。"
 
@@ -1472,6 +1481,9 @@ other = "你不是该项目的成员。"
 
 ["err.server.project.disabled"]
 other = "项目功能已被管理员关闭。"
+
+["err.server.project.collaboration_role_disabled"]
+other = "项目协作角色修改功能已关闭。"
 
 ["err.server.project.actor_not_space_member"]
 other = "你已不是该空间的有效成员。"
@@ -1491,6 +1503,12 @@ other = "你在该空间创建的项目数量已达上限。"
 ["err.server.project.quota_members"]
 other = "该项目的成员数量已达上限。"
 
+["err.server.project.quota_collaboration_roles"]
+other = "该项目的协作角色数量已达上限。"
+
+["err.server.project.quota_member_collaboration_roles"]
+other = "该成员的协作角色数量已达上限。"
+
 ["err.server.project.quota_daily_create"]
 other = "你今天创建的项目数量已达上限。"
 
@@ -1502,6 +1520,9 @@ other = "项目成员不存在。"
 
 ["err.server.project.name_duplicated"]
 other = "该空间内已存在同名项目。"
+
+["err.server.project.collaboration_role_duplicated"]
+other = "该项目内已存在同名协作角色。"
 
 ["err.server.project.last_owner_must_transfer"]
 other = "请先转让拥有者身份，再退出或降级。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -813,6 +813,21 @@ other = "One or more selected AI agents cannot join this project."
 ["err.server.project.batch_too_large"]
 other = "Too many members in a single request."
 
+["err.server.project.collaboration_role_disabled"]
+other = "Project collaboration-role changes are disabled."
+
+["err.server.project.collaboration_role_duplicated"]
+other = "A collaboration role with this name already exists in the project."
+
+["err.server.project.collaboration_role_invalid"]
+other = "The collaboration role is invalid."
+
+["err.server.project.collaboration_role_name_invalid"]
+other = "The collaboration role name is invalid."
+
+["err.server.project.collaboration_role_target_invalid"]
+other = "The collaboration role target is invalid."
+
 ["err.server.project.disabled"]
 other = "The project feature has been disabled by the administrator."
 
@@ -846,8 +861,14 @@ other = "You do not have permission to perform this operation."
 ["err.server.project.query_failed"]
 other = "Failed to query project data."
 
+["err.server.project.quota_collaboration_roles"]
+other = "This project has reached its collaboration role limit."
+
 ["err.server.project.quota_daily_create"]
 other = "You have created too many projects today."
+
+["err.server.project.quota_member_collaboration_roles"]
+other = "This member has reached the collaboration role limit."
 
 ["err.server.project.quota_members"]
 other = "This project has reached its member limit."


### PR DESCRIPTION
## Summary

Add project-scoped collaboration-role labels for human members without changing the existing `owner` / `admin` / `member` authorization model.

## Related Issue

Fixes #870

## Linked Spec

`.octospec/tasks/project-collaboration-roles/brief.md`

## Changes

- Add immutable built-in definitions (`产品`, `前端`, `后端`, `HR`), owner-managed custom definitions, and human-member multi-select bindings.
- Add catalog CRUD and binding routes under the existing authenticated, UID-rate-limited Project scope; preserve authorization roles and capabilities unchanged.
- Seed/backfill built-ins idempotently, clear bindings on membership lifecycle transitions, expose bindings on the roster, and keep agents unassignable with an empty roster value.
- Add independent role epoch, audit events, quotas, metrics, a default-off write flag, localized errors, migration coverage, and bounded integrity maintenance scans.
- Close review findings for base-row pagination before anomaly filtering, case-only display renames, and accent-sensitive normalized-name uniqueness.

## Testing

- [x] `go test ./modules/project -run 'Test.*CollaborationRole' -count=1`
- [x] `go test -race ./modules/project -run 'Test.*CollaborationRole' -count=1`
- [x] `go test ./modules/project -count=1`
- [x] `go build ./...`
- [x] `go vet ./modules/project`
- [x] `golangci-lint run ./modules/project/...`
- [x] `go test ./pkg/errcode ./pkg/i18n/...`
- [x] `make i18n-extract-check`
- [x] `make i18n-lint`
- [x] `gofmt` and `git diff --check`
- [x] Manually queried the test migration: `normalized_name` uses `utf8mb4_bin`.

## Rollback

Set `OCTO_PROJECT_COLLABORATION_ROLE_ENABLED=false` to stop all collaboration-role writes. Existing authorization behavior is unchanged; reads and stored metadata remain available. Database rollback is not required for the feature gate rollback.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**

   It introduces a project-local descriptive catalog and member-binding relation. `octo_project_member.role` remains the only role used for authorization, and each write re-reads that authorization role under the Project lock. The roster adds a separate `collaboration_roles` field; agents always receive an empty list.

2. **What could break because of it (dependents + failure mode)?**

   A failed migration or incorrectly ordered lifecycle/locking change could leave missing built-ins, stale bindings, deadlock retries, or a stale client epoch. A post-filter maintenance limit could become a recurring table scan as the binding table grows. The implementation seeds/backfills idempotently, validates and replaces bindings transactionally, clears them during seat removal, uses a separate atomic epoch, and keyset-pages base binding rows before evaluating violations. The default-off write gate is the operational rollback control.

3. **How do you know it works (specific test/repro/trace)?**

   The Project package passed against local MySQL, Redis, and WuKongIM, including the collaboration-role HTTP/DB/lifecycle suite and race run. Regressions cover authorization separation, owner/admin/member permissions, built-in immutability, duplicate/case-only/accented names, agents, quotas, concurrent creates, lifecycle cleanup, bounded backfill, and the integrity-page work bound. Build, vet, lint, i18n, formatting, and diff gates also pass; the test schema confirms `utf8mb4_bin` on `normalized_name`.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
