### PR TITLE
fix(space): list only octo_hosted bots in the space directory

### DIFF
--- a/.octospec/journal/shared/space-directory-octo-hosted-only.md
+++ b/.octospec/journal/shared/space-directory-octo-hosted-only.md
@@ -1,0 +1,49 @@
+---
+type: Journal
+title: "Journal: space-directory-octo-hosted-only"
+description: Tightens GET /v1/space/directory so only octo_hosted bots owned by an eligible human in the same Space appear as agents.
+tags: ["space", "isolation", "directory", "bot", "wire-contract", "testing"]
+timestamp: 2026-09-09T21:00:00+08:00
+# --- octospec extension fields ---
+task: space-directory-octo-hosted-only
+upstream: "product follow-up to space-cloud-agents-by-owner"
+source: user
+---
+
+# Journal: space-directory-octo-hosted-only
+
+## What was done
+
+`GET /v1/space/directory` previously treated every non-`self_hosted` bot as a
+visible cloud agent. That included empty hosting (never reported), retracted
+hosting, and third-party `<vendor>_hosted` slugs. Product now wants only
+platform-hosted clones: `robot.agent_hosting = 'octo_hosted'`.
+
+A visible bot must also belong to an eligible human in the same Space. That
+owner join already existed on the agent query; this change copies it onto the
+keyword `matched_bot` subquery so a bot owned by another bot cannot surface
+anyone by name. The handler still fail-closes agents whose `creator_uid` is
+missing from the human owner index.
+
+Project agent eligibility, AI Team grouping, members/space_bots, and leftover
+test accounts such as `ProjectApiTest` were left alone.
+
+## Tests
+
+- Directory handler tests now pin unreported / withdrawn / vendor / self_hosted
+  / creator-is-bot exclusions, keep `hosting_reported_at: null` for
+  `octo_hosted` with no timestamp, and require `only_with_agents=true` to keep
+  only humans who own at least one `octo_hosted` bot.
+- Keyword tests pin that vendor, empty, self-hosted, and nested-bot names do
+  not match.
+- `golangci-lint run ./modules/space/...` was clean.
+- CI unit lane (`ci/run-unit-tests.sh`) passed. Directory e2e passed once
+  against the local MySQL/Redis/WuKongIM stack; a later full-package rerun
+  collided with other worktrees dropping the shared `test` database.
+
+## Learning
+
+Two SQL statements that define the same “visible bot” set (keyword owner match
+and agent details) must share the hosting predicate **and** the human-owner
+join. Matching only `creator_uid <> ''` on the keyword side lets a bot-owned
+bot’s name pull a row that the agent query would drop.

--- a/.octospec/learnings/pending/space-directory-octo-hosted-only.md
+++ b/.octospec/learnings/pending/space-directory-octo-hosted-only.md
@@ -1,0 +1,41 @@
+---
+type: Learning
+title: "Keep dual directory SQLs on the same visible-bot predicate"
+description: A keyword subquery and an agent-detail query that claim to describe the same visible-bot set must share hosting and human-owner joins, not just a non-empty creator_uid check.
+tags: ["space", "directory", "sql", "testing"]
+timestamp: 2026-09-09T21:00:00+08:00
+# --- octospec extension fields ---
+source: self
+origin_task: space-directory-octo-hosted-only
+status: pending
+candidate_rule: space-isolation
+---
+
+# Keep dual directory SQLs on the same visible-bot predicate
+
+## Context
+
+`GET /v1/space/directory` loads humans and agents in two statements. The agent
+query already required `octo_hosted` plus an eligible human owner in the same
+Space. The keyword owner-match subquery originally only required
+`creator_uid <> ''` and relied on the outer human list. A bot whose creator
+was itself a bot could still match by name even though it could never appear
+in `agents`.
+
+## Rule of thumb
+
+When two queries define one presentation set:
+
+1. Copy the full visibility predicate (hosting, owner human-ness, Space
+   membership, system-account exclusion) into both statements.
+2. Pin a creator-is-bot / empty-creator case on both the default listing and
+   `keyword`.
+3. Do not treat “the outer query is humans-only” as enough; that only hides
+   the owner row, it does not stop a name match from being computed on an
+   ineligible bot.
+
+## Why worth a rule
+
+The contacts directory will keep growing filters (`keyword`, caps, hosting).
+Each new filter that is applied in only one of the two SQLs becomes a silent
+visibility leak or a count mismatch.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,18 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-09-09 — space-directory-octo-hosted-only
+
+- Tightened `GET /v1/space/directory` so `agents` / `agent_count` /
+  `only_with_agents` / `keyword` count only `octo_hosted` bots owned by an
+  eligible human in the same Space.
+- Copied the agent-query owner join onto the keyword subquery so a bot whose
+  creator is itself a bot cannot surface anyone.
+- Recorded the contract change in
+  [journal](journal/shared/space-directory-octo-hosted-only.md); the dual-SQL
+  visible-bot predicate is staged in
+  [learnings/pending](learnings/pending/space-directory-octo-hosted-only.md).
+
 ## 2026-09-09 — project-collaboration-roles
 
 - Added project-scoped, multi-select collaboration roles for human members while

--- a/.octospec/tasks/space-directory-octo-hosted-only/brief.md
+++ b/.octospec/tasks/space-directory-octo-hosted-only/brief.md
@@ -1,0 +1,137 @@
+---
+type: Task
+title: "Task: space-directory-octo-hosted-only"
+description: GET /v1/space/directory lists only octo_hosted bots that belong to an eligible human in the same Space.
+tags: ["space", "isolation", "wire-contract", "testing", "commit"]
+timestamp: 2026-09-09T00:00:00+08:00
+slug: space-directory-octo-hosted-only
+upstream: product follow-up to space-cloud-agents-by-owner
+source: user
+---
+
+# Task: space-directory-octo-hosted-only
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+## Goal
+
+Change only `GET /v1/space/directory`.
+
+A bot appears in `agents` (and counts toward `agent_count`) if and only if
+**both** are true:
+
+1. **Platform-hosted** — `robot.agent_hosting = 'octo_hosted'`.
+2. **Owned by an eligible human in this Space** — `robot.creator_uid` is a
+   non-empty uid of an active human Space member (`user.robot = 0`,
+   `user.status = 1`, `is_destroy <> 2`, `space_member.status = 1`, not a
+   system account). Otherwise the bot is dropped: no owner row, no hanging
+   agent on someone else.
+
+Empty hosting, retracted hosting, `self_hosted`, and third-party
+`<vendor>_hosted` slugs must not appear.
+
+This supersedes the hosting clause of `space-cloud-agents-by-owner`
+(`agent_hosting <> 'self_hosted'`). The human-owner rule is not new: the
+existing agent query already INNER JOINs the creator as a human in the same
+Space and the handler fail-closes if the owner is missing from the human list.
+This task keeps that rule, pins the missing "creator is itself a bot" case, and
+makes the keyword subquery use the same owner predicate.
+
+## Background
+
+The live directory returned test bots with `hosting: ""` (never reported)
+alongside `octo_hosted` clones. Product intent is now: only hosted bots, meaning
+`octo_hosted`, and only when they hang off a real human.
+
+Hosting is still self-reported via `POST /v1/bot/register`. Create paths do not
+write the column, so a newly minted platform bot is invisible until its first
+hosting report. That disappearance is accepted.
+
+`agent_hosting` remains a display filter, never an authz or tenancy signal.
+
+### Human-owner filter (already in `queryDirectoryAgents`)
+
+```text
+r.creator_uid <> ''
+INNER JOIN space_member owner_sm
+  ON owner_sm.space_id = bot_sm.space_id
+ AND owner_sm.uid = r.creator_uid
+ AND owner_sm.status = 1
+INNER JOIN user owner_u
+  ON owner_u.uid = owner_sm.uid
+ AND owner_u.robot = 0
+ AND owner_u.status = 1
+ AND COALESCE(owner_u.is_destroy, 0) <> 2
+AND owner_sm.uid NOT IN SystemBotList
+```
+
+Go assembly then attaches an agent only when `creator_uid` is in the human
+owner index; otherwise it is discarded (no ownerless top-level row).
+
+That already drops:
+
+| Case | Why it is dropped |
+|---|---|
+| `creator_uid = ''` | `creator_uid <> ''` |
+| Creator not in this Space | `owner_sm` INNER JOIN |
+| Creator is a bot (`user.robot = 1`) | `owner_u.robot = 0` |
+| Creator inactive / destroyed | `owner_u.status` / `is_destroy` |
+| Creator is a system account | `NOT IN SystemBotList` |
+| Owner missing from the human query | handler fail-close |
+
+The keyword owner-match subquery must use the same joins. Today it only checks
+`creator_uid <> ''` and relies on the outer human list; this task makes the
+visible-bot definition identical in both SQLs.
+
+## Load-bearing list
+
+- **`space` / `isolation`** — directory is a Space-scoped cross-member read.
+  Auth chain, `space_id` query selector, and Space middleware stay unchanged.
+- **`wire-contract`** — `agents` / `agent_count` / `agents_truncated` /
+  `only_with_agents` / `keyword` now operate on the `octo_hosted` + eligible
+  human-owner set. Response shape is unchanged. Bots still never appear as
+  top-level rows.
+- **`testing`** — rewrite assertions that currently require unreported /
+  withdrawn / vendor bots to appear; pin creator-is-bot and empty-creator
+  exclusions on both the default listing and `keyword`.
+- **`commit`** — English Conventional Commits.
+
+## Out of scope
+
+- Project agent eligibility (`classifyAgentsTx` / `members/add`).
+- AI Team grouping (`cloud_clone` is already `octo_hosted`).
+- Authoritative provision-source column.
+- New error codes, migrations, or rate-limit changes.
+- Cleaning leftover Space members such as `ProjectApiTest`.
+- `GET /v1/space/:id/members` and `/v1/robot/space_bots`.
+- Frontend.
+
+## Acceptance
+
+**Visible bot predicate (`modules/space` only)**
+
+- `octo_hosted` + eligible human owner in this Space → appears, including when
+  `agent_reported_hosting_at` is NULL (JSON `null`, not omitted).
+- `agent_hosting = ''` (never reported) → hidden.
+- `agent_hosting = ''` with a reported timestamp (retracted) → hidden.
+- `self_hosted` → hidden.
+- `vendor_hosted` (any other slug) → hidden.
+- `creator_uid = ''` → hidden, even if `octo_hosted`.
+- Creator is not a Space member → hidden (no ownerless row).
+- Creator `user.robot = 1` → hidden.
+- Creator inactive, destroyed, or a system account → hidden.
+- `agent_count` / `agents_truncated` / the per-owner 50-cap count only the
+  visible set.
+- `only_with_agents=true` keeps a human only when that human owns at least one
+  visible bot.
+- `keyword` matches visible Bot names only. Names of hidden bots (wrong
+  hosting or no eligible human owner) must not surface anyone.
+
+**Gates**
+
+- `go test ./modules/space/ -count=1 -run 'TestSpaceDirectory|TestQueryDirectory|TestDirectory'`
+- `golangci-lint run ./modules/space/...` if available.
+- Diff does not touch `modules/project/**`.
+- No new SQL files under `modules/*/sql/`.
+- No new error codes.

--- a/.octospec/tasks/space-directory-octo-hosted-only/context.yaml
+++ b/.octospec/tasks/space-directory-octo-hosted-only/context.yaml
@@ -1,0 +1,13 @@
+injected:
+  - id: space-isolation
+    source: repo
+  - id: error-handling
+    source: repo
+  - id: rate-limit
+    source: repo
+  - id: testing
+    source: repo
+  - id: commit-style
+    source: repo
+brief: .octospec/tasks/space-directory-octo-hosted-only/brief.md
+notes: project eligibility is out of scope; this task only changes GET /v1/space/directory.

--- a/modules/space/api_directory.go
+++ b/modules/space/api_directory.go
@@ -41,9 +41,10 @@ type directoryAgentResp struct {
 }
 
 // listDirectory returns each active human in a verified Space with the
-// non-self-hosted user bots they own. The hosting value is self-reported by a
-// bot, so this endpoint uses it solely as a display filter, never as an authz
-// or tenancy signal.
+// octo_hosted user bots they own. A bot with no eligible human owner in this
+// Space is omitted. The hosting value is self-reported by a bot, so this
+// endpoint uses it solely as a display filter, never as an authz or tenancy
+// signal.
 func (s *Space) listDirectory(c *wkhttp.Context) {
 	spaceID := c.Query("space_id")
 	if spaceID == "" {

--- a/modules/space/api_directory_test.go
+++ b/modules/space/api_directory_test.go
@@ -188,14 +188,20 @@ func TestSpaceDirectoryReturnsHumanOwnersAndCloudAgents(t *testing.T) {
 	seedDirectoryBot(t, spaceID, testutil.UID, "bot-unreported", "Unreported", "no report", "", nil, 1, 1)
 	seedDirectoryBot(t, spaceID, testutil.UID, "bot-withdrawn", "Withdrawn", "was reported", "", &withdrawnAt, 1, 1)
 	seedDirectoryBot(t, spaceID, "owner-real-name", "bot-octo", "Octo Bot", "cloud", "octo_hosted", &reportedAt, 1, 1)
+	seedDirectoryBot(t, spaceID, "owner-real-name", "bot-octo-null-ts", "Octo Null TS", "cloud no ts", "octo_hosted", nil, 1, 1)
 	seedDirectoryBot(t, spaceID, "owner-real-name", "bot-vendor", "Vendor Bot", "third party", "vendor_hosted", &reportedAt, 1, 1)
-	seedDirectoryFriend(t, testutil.UID, "bot-vendor")
+	seedDirectoryFriend(t, testutil.UID, "bot-octo")
 
 	seedDirectoryBot(t, spaceID, "owner-real-name", "bot-local", "Local", "excluded", "self_hosted", &reportedAt, 1, 1)
 	seedDirectoryBot(t, spaceID, "owner-real-name", "bot-inactive", "Inactive", "excluded", "octo_hosted", &reportedAt, 0, 1)
 	seedDirectoryBot(t, spaceID, "owner-real-name", "bot-removed", "Removed", "excluded", "octo_hosted", &reportedAt, 1, 0)
 	seedDirectoryBot(t, spaceID, "owner-real-name", "bot-outside", "Outside", "excluded", "octo_hosted", &reportedAt, 1, -1)
 	seedDirectoryBot(t, spaceID, "owner-missing", "bot-orphan", "Orphan", "excluded", "octo_hosted", &reportedAt, 1, 1)
+
+	// Creator is itself a bot: octo_hosted but not owned by a human.
+	seedDirectoryUser(t, "bot-as-owner", "Bot As Owner", 1, 1, 0)
+	seedDirectoryMember(t, spaceID, "bot-as-owner", 0, 1)
+	seedDirectoryBot(t, spaceID, "bot-as-owner", "bot-nested", "Nested", "excluded", "octo_hosted", &reportedAt, 1, 1)
 
 	seedDirectoryUser(t, "owner-inactive", "Inactive Owner", 0, 0, 0)
 	seedDirectoryMember(t, spaceID, "owner-inactive", 0, 1)
@@ -212,14 +218,9 @@ func TestSpaceDirectoryReturnsHumanOwnersAndCloudAgents(t *testing.T) {
 	require.Len(t, resp.Data, 4, "only active non-system humans are directory rows")
 
 	caller := findDirectoryMember(t, resp.Data, testutil.UID)
-	require.Equal(t, int64(2), caller.AgentCount)
+	require.Equal(t, int64(0), caller.AgentCount, "empty and retracted hosting must not count as cloud agents")
 	require.False(t, caller.AgentsTruncated)
-	require.Len(t, caller.Agents, 2)
-	require.Nil(t, findDirectoryAgent(t, caller.Agents, "bot-unreported").HostingReportedAt)
-	withdrawn := findDirectoryAgent(t, caller.Agents, "bot-withdrawn")
-	require.Equal(t, "", withdrawn.Hosting)
-	require.NotNil(t, withdrawn.HostingReportedAt)
-	require.Equal(t, "2026-09-04 11:00:00", *withdrawn.HostingReportedAt)
+	require.Empty(t, caller.Agents)
 
 	owner := findDirectoryMember(t, resp.Data, "owner-real-name")
 	require.Equal(t, "Real Name", owner.Name, "directory name must follow MemberDetailModel.DisplayName")
@@ -227,12 +228,16 @@ func TestSpaceDirectoryReturnsHumanOwnersAndCloudAgents(t *testing.T) {
 		"directory and members endpoints must share the display-name fallback chain")
 	require.Equal(t, int64(2), owner.AgentCount)
 	require.Len(t, owner.Agents, 2)
-	vendor := findDirectoryAgent(t, owner.Agents, "bot-vendor")
-	require.True(t, vendor.IsFriend)
-	require.Equal(t, "vendor_hosted", vendor.Hosting)
-	require.NotNil(t, vendor.HostingReportedAt)
-	require.Equal(t, "2026-09-03 10:00:00", *vendor.HostingReportedAt)
-	require.Equal(t, "cloud", findDirectoryAgent(t, owner.Agents, "bot-octo").Description)
+	octo := findDirectoryAgent(t, owner.Agents, "bot-octo")
+	require.True(t, octo.IsFriend)
+	require.Equal(t, "octo_hosted", octo.Hosting)
+	require.Equal(t, "cloud", octo.Description)
+	require.NotNil(t, octo.HostingReportedAt)
+	require.Equal(t, "2026-09-03 10:00:00", *octo.HostingReportedAt)
+	nullTS := findDirectoryAgent(t, owner.Agents, "bot-octo-null-ts")
+	require.False(t, nullTS.IsFriend)
+	require.Equal(t, "octo_hosted", nullTS.Hosting)
+	require.Nil(t, nullTS.HostingReportedAt)
 
 	placeholder := findDirectoryMember(t, resp.Data, "owner-placeholder")
 	require.Equal(t, memberDisplayNamePlaceholderPrefix+"owner-placeholder", placeholder.Name)
@@ -247,8 +252,15 @@ func TestSpaceDirectoryReturnsHumanOwnersAndCloudAgents(t *testing.T) {
 
 	for _, member := range resp.Data {
 		require.NotEqual(t, "fileHelper", member.UID)
+		require.NotEqual(t, "bot-as-owner", member.UID, "a bot must not appear as a directory owner row")
 		for _, agent := range member.Agents {
-			require.NotContains(t, []string{"bot-local", "bot-inactive", "bot-removed", "bot-outside", "bot-orphan", "bot-inactive-owner", "bot-destroyed-owner", "bot-empty-owner"}, agent.UID)
+			require.NotContains(t, []string{
+				"bot-unreported", "bot-withdrawn", "bot-vendor", "bot-local",
+				"bot-inactive", "bot-removed", "bot-outside", "bot-orphan",
+				"bot-nested", "bot-as-owner",
+				"bot-inactive-owner", "bot-destroyed-owner", "bot-empty-owner",
+			}, agent.UID)
+			require.Equal(t, "octo_hosted", agent.Hosting)
 		}
 	}
 
@@ -265,10 +277,9 @@ func TestSpaceDirectoryReturnsHumanOwnersAndCloudAgents(t *testing.T) {
 	}, testutil.Token)
 	require.Equal(t, http.StatusOK, onlyWithAgents.Code, onlyWithAgents.Body.String())
 	filtered := decodeDirectoryResponse(t, onlyWithAgents)
-	require.Len(t, filtered.Data, 2)
-	for _, member := range filtered.Data {
-		require.Positive(t, member.AgentCount)
-	}
+	require.Len(t, filtered.Data, 1, "only humans who own octo_hosted bots remain")
+	require.Equal(t, "owner-real-name", filtered.Data[0].UID)
+	require.Positive(t, filtered.Data[0].AgentCount)
 }
 
 func TestSpaceDirectoryKeywordFiltersHumanAndVisibleBotNames(t *testing.T) {
@@ -288,6 +299,18 @@ func TestSpaceDirectoryKeywordFiltersHumanAndVisibleBotNames(t *testing.T) {
 	seedDirectoryUser(t, "owner-local-only", "Carol", 0, 1, 0)
 	seedDirectoryMember(t, spaceID, "owner-local-only", 0, 1)
 	seedDirectoryBot(t, spaceID, "owner-local-only", "bot-local-keyword", "Needle Local", "", "self_hosted", nil, 1, 1)
+
+	seedDirectoryUser(t, "owner-vendor-only", "Dave", 0, 1, 0)
+	seedDirectoryMember(t, spaceID, "owner-vendor-only", 0, 1)
+	seedDirectoryBot(t, spaceID, "owner-vendor-only", "bot-vendor-keyword", "Needle Vendor", "", "vendor_hosted", nil, 1, 1)
+
+	seedDirectoryUser(t, "owner-empty-only", "Eve", 0, 1, 0)
+	seedDirectoryMember(t, spaceID, "owner-empty-only", 0, 1)
+	seedDirectoryBot(t, spaceID, "owner-empty-only", "bot-empty-keyword", "Needle Empty", "", "", nil, 1, 1)
+
+	seedDirectoryUser(t, "bot-as-owner-kw", "Bot Owner", 1, 1, 0)
+	seedDirectoryMember(t, spaceID, "bot-as-owner-kw", 0, 1)
+	seedDirectoryBot(t, spaceID, "bot-as-owner-kw", "bot-nested-keyword", "Needle Nested", "", "octo_hosted", nil, 1, 1)
 
 	seedDirectoryUser(t, "owner-literal", "Literal Owner", 0, 1, 0)
 	seedDirectoryMember(t, spaceID, "owner-literal", 0, 1)
@@ -333,6 +356,27 @@ func TestSpaceDirectoryKeywordFiltersHumanAndVisibleBotNames(t *testing.T) {
 	}, testutil.Token)
 	require.Equal(t, http.StatusOK, localBotName.Code, localBotName.Body.String())
 	require.Empty(t, decodeDirectoryResponse(t, localBotName).Data, "self-hosted Bot names must not match")
+
+	vendorBotName := getSpaceDirectory(t, srv, testCtx, url.Values{
+		"space_id": {spaceID},
+		"keyword":  {"Needle Vendor"},
+	}, testutil.Token)
+	require.Equal(t, http.StatusOK, vendorBotName.Code, vendorBotName.Body.String())
+	require.Empty(t, decodeDirectoryResponse(t, vendorBotName).Data, "vendor-hosted Bot names must not match")
+
+	emptyBotName := getSpaceDirectory(t, srv, testCtx, url.Values{
+		"space_id": {spaceID},
+		"keyword":  {"Needle Empty"},
+	}, testutil.Token)
+	require.Equal(t, http.StatusOK, emptyBotName.Code, emptyBotName.Body.String())
+	require.Empty(t, decodeDirectoryResponse(t, emptyBotName).Data, "unreported Bot names must not match")
+
+	nestedBotName := getSpaceDirectory(t, srv, testCtx, url.Values{
+		"space_id": {spaceID},
+		"keyword":  {"Needle Nested"},
+	}, testutil.Token)
+	require.Equal(t, http.StatusOK, nestedBotName.Code, nestedBotName.Body.String())
+	require.Empty(t, decodeDirectoryResponse(t, nestedBotName).Data, "bots owned by another bot must not match")
 
 	literalName := getSpaceDirectory(t, srv, testCtx, url.Values{
 		"space_id": {spaceID},

--- a/modules/space/db_directory.go
+++ b/modules/space/db_directory.go
@@ -8,6 +8,11 @@ import (
 
 const directoryAgentsPerOwner = 50
 
+// directoryAgentHostingOctoHosted is the only self-reported hosting value the
+// Space directory treats as a visible cloud agent. This is not an authz
+// signal: any holder of the bot's bf_ token can claim the value.
+const directoryAgentHostingOctoHosted = "octo_hosted"
+
 // The legacy user and space_member tables can carry a different collation from
 // migration-created user_verification. Pin the completed display expression so
 // keyword matching remains valid on both schema shapes without changing the
@@ -20,7 +25,7 @@ const directoryOwnerDisplayNameExpr = "(COALESCE(NULLIF(u.name, ''), NULLIF(uv.r
 func (d *DB) queryDirectoryOwners(ctx context.Context, spaceID, keyword string) ([]*directoryOwnerModel, error) {
 	var owners []*directoryOwnerModel
 	systemBots := spacepkg.SystemBotList()
-	args := make([]interface{}, 0, 6)
+	args := make([]interface{}, 0, 8)
 	query := `
 		SELECT
 			sm.uid,
@@ -40,18 +45,28 @@ func (d *DB) queryDirectoryOwners(ctx context.Context, spaceID, keyword string) 
 			INNER JOIN robot r
 				ON r.robot_id=bot_sm.uid
 				AND r.status=1
-				AND r.agent_hosting<>'self_hosted'
+				AND r.agent_hosting='` + directoryAgentHostingOctoHosted + `'
 			INNER JOIN ` + "`user`" + ` bot_u
 				ON bot_u.uid=r.robot_id
 				AND bot_u.robot=1
+			INNER JOIN space_member owner_sm
+				ON owner_sm.space_id=bot_sm.space_id
+				AND owner_sm.uid=r.creator_uid
+				AND owner_sm.status=1
+			INNER JOIN ` + "`user`" + ` owner_u
+				ON owner_u.uid=owner_sm.uid
+				AND owner_u.robot=0
+				AND owner_u.status=1
+				AND COALESCE(owner_u.is_destroy, 0)<>2
 			WHERE bot_sm.space_id=?
 				AND bot_sm.status=1
 				AND r.creator_uid<>''
 				AND bot_sm.uid NOT IN ?
+				AND owner_sm.uid NOT IN ?
 				AND IFNULL(bot_u.name, '') LIKE ?` + likeEscapeClause + `
 		) matched_bot ON matched_bot.creator_uid=sm.uid
 		`
-		args = append(args, spaceID, systemBots, buildLikePattern(keyword))
+		args = append(args, spaceID, systemBots, systemBots, buildLikePattern(keyword))
 	}
 	query += `
 		WHERE sm.space_id=?
@@ -78,9 +93,11 @@ func (d *DB) queryDirectoryOwners(ctx context.Context, spaceID, keyword string) 
 }
 
 // queryDirectoryAgents returns at most directoryAgentsPerOwner details per
-// eligible owner while retaining the exact count for that owner. agent_hosting
-// is bot self-reported telemetry and therefore filters this presentation only;
-// it must never be reused for authorization or other security decisions.
+// eligible owner while retaining the exact count for that owner. Only
+// octo_hosted bots with an eligible human owner in this Space are visible.
+// agent_hosting is bot self-reported telemetry and therefore filters this
+// presentation only; it must never be reused for authorization or other
+// security decisions.
 func (d *DB) queryDirectoryAgents(ctx context.Context, spaceID, loginUID, keyword string) ([]*directoryAgentModel, error) {
 	var agents []*directoryAgentModel
 	systemBots := spacepkg.SystemBotList()
@@ -96,7 +113,7 @@ func (d *DB) queryDirectoryAgents(ctx context.Context, spaceID, loginUID, keywor
 			INNER JOIN robot r
 				ON r.robot_id=bot_sm.uid
 				AND r.status=1
-				AND r.agent_hosting<>'self_hosted'
+				AND r.agent_hosting='` + directoryAgentHostingOctoHosted + `'
 			INNER JOIN ` + "`user`" + ` bot_u
 				ON bot_u.uid=r.robot_id
 				AND bot_u.robot=1


### PR DESCRIPTION
## Summary

Tighten `GET /v1/space/directory` so the contacts directory only lists platform-hosted bots (`robot.agent_hosting = 'octo_hosted'`) that belong to an eligible human in the same Space.

Previously the filter was `agent_hosting <> 'self_hosted'`, so empty hosting, retracted hosting, and third-party `<vendor>_hosted` slugs appeared in `agents` and counted toward `agent_count`. Product now wants only `octo_hosted`. Newly minted bots that have not reported hosting yet stay hidden until the first register; that disappearance is accepted.

## Related Issue

Product follow-up to the cloud-agent directory (`space-cloud-agents-by-owner` / #842). No standalone issue number.

## Linked Spec

`.octospec/tasks/space-directory-octo-hosted-only/brief.md`

## Changes

- Agent and keyword-owner SQL now require `agent_hosting = 'octo_hosted'` instead of `<> 'self_hosted'`.
- Keyword `matched_bot` subquery uses the same human-owner join as the agent query (active human in this Space, not a system account), so a bot whose creator is itself a bot cannot surface anyone by name.
- Tests pin unreported / withdrawn / vendor / self_hosted / creator-is-bot exclusions, keep `hosting_reported_at: null` for `octo_hosted` with no timestamp, and require `only_with_agents=true` to keep only humans who own at least one `octo_hosted` bot.
- Project eligibility, AI Team grouping, and `members` / `space_bots` are unchanged.

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified

```
go test ./modules/space/ -count=1 -run 'TestSpaceDirectory|TestQueryDirectory|TestDirectory'
golangci-lint run ./modules/space/...
ci/run-unit-tests.sh
```

Directory e2e passed against local MySQL/Redis/WuKongIM. A later full-package rerun collided with other local worktrees dropping the shared `test` database; that is an environment issue, not this filter.

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   `GET /v1/space/directory` is a Space-scoped cross-member read. The visible-bot set is now `octo_hosted` **and** `creator_uid` is an eligible human member of the same Space. `agent_count`, the per-owner 50-cap window, `agents_truncated`, `only_with_agents`, and `keyword` all use that set. Hosting remains self-reported telemetry, not an authz signal. Auth / rate-limit / Space middleware are unchanged.

2. **What could break** because of it (dependents + failure mode)?

   Clients that rendered empty-hosting or vendor-hosted bots in the directory right column will stop seeing them. A just-minted platform bot is invisible until it reports `octo_hosted`. `only_with_agents=true` returns fewer humans. Project `members/add` still excludes only `self_hosted`, so a caller can still seat a bot the directory picker no longer shows; that divergence is explicit out of scope. `agent_hosting` can still be spoofed by anyone holding the bot's `bf_` token.

3. **How do you know it works** (specific test/repro/trace)?

   `TestSpaceDirectoryReturnsHumanOwnersAndCloudAgents` now expects empty/retracted/vendor/self_hosted/nested-bot UIDs absent, two `octo_hosted` agents on the real-name owner (including a null `hosting_reported_at`), and `only_with_agents=true` returning that owner only. Keyword tests assert `Needle Vendor` / `Needle Empty` / `Needle Nested` / `Needle Local` return no rows. Both directory SQLs concatenate the `directoryAgentHostingOctoHosted` const; the extra keyword `systemBots` bind matches the new owner `NOT IN` placeholder.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
