### PR TITLE
fix(opanalytics): scope daily ETL lock per target DB to stop cross-env starvation

### DIFF
--- a/modules/opanalytics/api_test.go
+++ b/modules/opanalytics/api_test.go
@@ -65,7 +65,7 @@ func resetUIDRateLimit(t *testing.T, ctx *config.Context) {
 	if keys, err := rds.Keys("ratelimit:uid:*").Result(); err == nil && len(keys) > 0 {
 		_ = rds.Del(keys...).Err()
 	}
-	_ = rds.Del(etlRunLockKey).Err()
+	_ = rds.Del(etlRunLockKeyFor(ctx.GetConfig().DB.MySQLAddr)).Err()
 }
 
 func setSuperAdminToken(t *testing.T, ctx *config.Context) {

--- a/modules/opanalytics/etl_lock.go
+++ b/modules/opanalytics/etl_lock.go
@@ -8,14 +8,35 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	rd "github.com/go-redis/redis"
+	"github.com/go-sql-driver/mysql"
 )
 
-// etlRunLockKey 每日 ETL 的分布式互斥锁 key。多副本部署时同一时刻只允许一个实例
+// etlRunLockKeyBase 每日 ETL 分布式互斥锁 key 的前缀。多副本部署时同一时刻只允许一个实例
 // 真正执行 RunIncremental，避免 N 实例同跑同一轮造成的重复压力/锁竞争(验收④)。
+//
+// 真正使用的 key 由 etlRunLockKeyFor 在此前缀后追加 ETL 目标库名(见其注释)。
 //
 // 注:correctness 还有第二道保险——runChunk 内对水位行 `SELECT ... FOR UPDATE`
 // 串行化，故即便锁因 TTL 过期出现短暂并发，消息仍精确一次累加。
-const etlRunLockKey = "opanalytics:etl:run"
+const etlRunLockKeyBase = "opanalytics:etl:run"
+
+// etlRunLockKeyFor 按 ETL 目标库名给锁 key 追加命名空间，返回 "opanalytics:etl:run:<dbname>"。
+//
+// 为什么必须按库隔离:多套环境(如 im_test / im_dev)可能**共用同一个 Redis**，而本锁 key
+// 若是固定常量，则不同库的 ETL 调度器会在同一时刻抢同一把锁——只有一个能跑，另一个被误判为
+// "已有实例在跑"而跳过。结果是某库的当日增量迟迟不被物化(2026-09-09 事故即此:im_dev 抢到锁
+// 空转，im_test 被饿死，其 octo_fact_channel_daily 当日分区缺失)。以目标库名区分后:同库多副本
+// 仍互斥(同 key)，不同库互不干扰(不同 key)。
+//
+// dsn 取自 cfg.DB.MySQLAddr(完整 go-sql-driver DSN)。无法解析或库名为空时回退到裸前缀，
+// 保持与历史行为一致(安全兜底，不因解析失败而让锁 key 变空/异常)。
+func etlRunLockKeyFor(dsn string) string {
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil || cfg.DBName == "" {
+		return etlRunLockKeyBase
+	}
+	return etlRunLockKeyBase + ":" + cfg.DBName
+}
 
 // etlRunLockTTL 锁租约。执行期间由 scheduler/手动触发路径定期续租，用于覆盖首次全量回填
 // 这类可能超过单个 TTL 的长任务；若进程崩溃，TTL 仍会自动释放锁。
@@ -40,8 +61,10 @@ end
 `)
 
 // etlLock 用 Redis SET NX EX + Lua CAS-DEL 实现的单实例 ETL 互斥锁(仿 modules/oidc 的 RedisTickLock)。
+// key 按 ETL 目标库命名空间隔离(见 etlRunLockKeyFor)，故仅同库多副本互斥。
 type etlLock struct {
 	client *rd.Client
+	key    string
 }
 
 func newETLLock(ctx *config.Context) *etlLock {
@@ -51,12 +74,12 @@ func newETLLock(ctx *config.Context) *etlLock {
 		o.WriteTimeout = 3 * time.Second
 		o.DialTimeout = 3 * time.Second
 	})
-	return &etlLock{client: client}
+	return &etlLock{client: client, key: etlRunLockKeyFor(ctx.GetConfig().DB.MySQLAddr)}
 }
 
 // Acquire 用 SET NX EX 原子抢锁。返回 (true,nil)=抢到, (false,nil)=别人持锁, (_,err)=Redis 故障。
 func (l *etlLock) Acquire(token string) (bool, error) {
-	ok, err := l.client.SetNX(etlRunLockKey, token, etlRunLockTTL).Result()
+	ok, err := l.client.SetNX(l.key, token, etlRunLockTTL).Result()
 	if err != nil {
 		return false, fmt.Errorf("opanalytics: etl lock acquire: %w", err)
 	}
@@ -65,7 +88,7 @@ func (l *etlLock) Acquire(token string) (bool, error) {
 
 // Release 走 Lua CAS-DEL，只在 token 匹配时释放(token 不匹配/已过期均视为正常，不报错)。
 func (l *etlLock) Release(token string) error {
-	_, err := luaReleaseETLLock.Run(l.client, []string{etlRunLockKey}, token).Result()
+	_, err := luaReleaseETLLock.Run(l.client, []string{l.key}, token).Result()
 	if err != nil && !errors.Is(err, rd.Nil) {
 		return fmt.Errorf("opanalytics: etl lock release: %w", err)
 	}
@@ -74,7 +97,7 @@ func (l *etlLock) Release(token string) error {
 
 // Renew 在当前 token 仍持有锁时延长租约。返回 false 表示锁已过期或 owner 已变化。
 func (l *etlLock) Renew(token string) (bool, error) {
-	res, err := luaRenewETLLock.Run(l.client, []string{etlRunLockKey}, token, etlRunLockTTL.Milliseconds()).Result()
+	res, err := luaRenewETLLock.Run(l.client, []string{l.key}, token, etlRunLockTTL.Milliseconds()).Result()
 	if err != nil && !errors.Is(err, rd.Nil) {
 		return false, fmt.Errorf("opanalytics: etl lock renew: %w", err)
 	}

--- a/modules/opanalytics/etl_lock_test.go
+++ b/modules/opanalytics/etl_lock_test.go
@@ -1,0 +1,53 @@
+package opanalytics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestEtlRunLockKeyFor 覆盖锁 key 按目标库命名空间隔离的派生逻辑(2026-09-09 跨库饿死事故的修复)。
+func TestEtlRunLockKeyFor(t *testing.T) {
+	cases := []struct {
+		name string
+		dsn  string
+		want string
+	}{
+		{
+			name: "test env db",
+			dsn:  "user:pass@tcp(10.0.0.1:3306)/im_test?charset=utf8mb4&parseTime=true&loc=Local",
+			want: "opanalytics:etl:run:im_test",
+		},
+		{
+			name: "dev env db distinct from test",
+			dsn:  "user:pass@tcp(10.0.0.1:3306)/im_dev?charset=utf8mb4&parseTime=true&loc=Local",
+			want: "opanalytics:etl:run:im_dev",
+		},
+		{
+			name: "no params still parses db name",
+			dsn:  "user:pass@tcp(db:3306)/im_prod",
+			want: "opanalytics:etl:run:im_prod",
+		},
+		{
+			name: "unparseable dsn falls back to bare base",
+			dsn:  "not a valid dsn",
+			want: etlRunLockKeyBase,
+		},
+		{
+			name: "empty db name falls back to bare base",
+			dsn:  "user:pass@tcp(db:3306)/",
+			want: etlRunLockKeyBase,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, etlRunLockKeyFor(tc.dsn))
+		})
+	}
+
+	// 核心不变量:不同库派生出不同 key，否则共用同一 Redis 时会互相抢锁饿死。
+	assert.NotEqual(t,
+		etlRunLockKeyFor("u:p@tcp(h:3306)/im_test"),
+		etlRunLockKeyFor("u:p@tcp(h:3306)/im_dev"),
+		"per-db lock keys must differ so co-located envs do not starve each other")
+}


### PR DESCRIPTION
## What

Scope the daily `opanalytics` ETL distributed lock **per target database** instead of using one global constant key.

- `etl_lock.go`: replace the constant `etlRunLockKey` with a base prefix + `etlRunLockKeyFor(dsn)`, which appends the DB name parsed from `cfg.DB.MySQLAddr` → `opanalytics:etl:run:<dbname>`. Falls back to the bare prefix on an unparseable / db-less DSN (preserves prior behavior as a safe default). `etlLock` now carries the resolved `key`, used in `Acquire`/`Release`/`Renew`.
- `etl_lock_test.go`: unit test covering key derivation, the fallback cases, and the cross-env distinctness invariant.
- `api_test.go`: test-setup lock cleanup now deletes the per-db key the code actually uses.

## Why

Two environments sharing one Redis (e.g. `im_test` + `im_dev`) both fire the `30 1 * * *` cron and contend for the single fixed lock key. The loser skips its run entirely although it targets a different DB, so that env's daily partition never materializes. See the linked issue for the 2026-09-09 incident.

## Behavior change

- Replicas of the **same** env still serialize (same DB → same key) — the original multi-replica protection is intact.
- **Distinct** envs no longer block each other (different DB → different key).
- Not a correctness change: `runChunk`'s `SELECT ... FOR UPDATE` watermark guard already ensures exactly-once accumulation regardless of lock contention. This only changes mutual-exclusion scope.

## Verification

- `go build ./modules/opanalytics/` — ok
- `go vet ./modules/opanalytics/` — clean
- `go test ./modules/opanalytics/ -run TestEtlRunLockKeyFor` — pass


Fixes #883
